### PR TITLE
feat: accept tool/function messages across all protocols

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -117,7 +117,9 @@ export function createChatRoutes(
           role: m.role,
           content: typeof m.content === "string"
             ? m.content
-            : m.content.filter((p) => p.type === "text" && p.text).map((p) => p.text!).join("\n"),
+            : m.content == null
+              ? ""
+              : m.content.filter((p) => p.type === "text" && p.text).map((p) => p.text!).join("\n"),
         })),
         model: codexRequest.model,
         isStreaming: req.stream,

--- a/src/types/gemini.ts
+++ b/src/types/gemini.ts
@@ -8,6 +8,15 @@ import { z } from "zod";
 const GeminiPartSchema = z.object({
   text: z.string().optional(),
   thought: z.boolean().optional(),
+  // Function calling fields (accepted for compatibility, not forwarded to Codex)
+  functionCall: z.object({
+    name: z.string(),
+    args: z.record(z.unknown()).optional(),
+  }).optional(),
+  functionResponse: z.object({
+    name: z.string(),
+    response: z.record(z.unknown()).optional(),
+  }).optional(),
 });
 
 const GeminiContentSchema = z.object({
@@ -32,6 +41,20 @@ export const GeminiGenerateContentRequestSchema = z.object({
   contents: z.array(GeminiContentSchema).min(1),
   systemInstruction: GeminiContentSchema.optional(),
   generationConfig: GeminiGenerationConfigSchema.optional(),
+  // Tool-related fields (accepted for compatibility, not forwarded to Codex)
+  tools: z.array(z.object({
+    functionDeclarations: z.array(z.object({
+      name: z.string(),
+      description: z.string().optional(),
+      parameters: z.record(z.unknown()).optional(),
+    })).optional(),
+  }).passthrough()).optional(),
+  toolConfig: z.object({
+    functionCallingConfig: z.object({
+      mode: z.enum(["AUTO", "NONE", "ANY"]).optional(),
+      allowedFunctionNames: z.array(z.string()).optional(),
+    }).optional(),
+  }).optional(),
 });
 
 export type GeminiGenerateContentRequest = z.infer<


### PR DESCRIPTION
## Summary

- Accept OpenAI tool messages (both new `tools`/`tool_calls`/`role:tool` and legacy `functions`/`function_call`/`role:function` formats)
- Accept Anthropic `tool_use`/`tool_result` content blocks and `tools`/`tool_choice` request fields
- Accept Gemini `functionCall`/`functionResponse` parts and `tools`/`toolConfig` request fields
- Gracefully degrade: flatten all tool messages into `[Tool Call]`/`[Tool Result]` text for Codex backend (which doesn't support tool calls)
- Fix nullable `content` handling in session hashing

## Changed Files (7)

| File | Change |
|------|--------|
| `src/types/openai.ts` | Add `tool`/`function` roles, `tool_calls`/`function_call` fields, `tools`/`functions` request fields |
| `src/translation/openai-to-codex.ts` | Flatten tool/function messages to text |
| `src/routes/chat.ts` | Handle nullable content in session hashing |
| `src/types/anthropic.ts` | Add `tool_use`/`tool_result` content blocks, `tools`/`tool_choice` |
| `src/translation/anthropic-to-codex.ts` | Flatten tool blocks to text |
| `src/types/gemini.ts` | Add `functionCall`/`functionResponse` parts, `tools`/`toolConfig` |
| `src/translation/gemini-to-codex.ts` | Flatten function parts to text |

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] New format `tool_calls` + `role:tool` streaming works
- [x] Legacy `function_call` + `role:function` streaming works
- [x] Normal requests without tools still work (regression)
- [x] Non-streaming with tool messages works

🤖 Generated with [Claude Code](https://claude.com/claude-code)