### PR TITLE
fix: auto-fallback for unsupported TLS impersonate profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Fixed
 
+- TLS 伪装 profile 自动回退：配置的 `impersonate_profile` 不被 curl-impersonate 支持时，自动降级到最近的可用 Chrome 版本（如 `chrome137` → `chrome136`）
+- FFI transport 硬编码 `"chrome136"` 改为使用统一解析的 profile（`getResolvedProfile()`）
 - `getModels()` 死代码：`allModels` 作用域修复，消除不可达分支
 - `reloadAllConfigs()` 异步 lazy import 改为同步直接导入，避免日志时序不准
 - 模型合并 reasoning efforts 判断逻辑从 `length > 1` 改为显式标志

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -69,6 +69,7 @@ const CHROME_TLS_ARGS: string[] = [
 let _resolved: string | null = null;
 let _isImpersonate = false;
 let _tlsArgs: string[] | null = null;
+let _resolvedProfile = "chrome136";
 
 /**
  * Resolve the curl binary path. Result is cached after first call.
@@ -105,10 +106,45 @@ export function resolveCurlBinary(): string {
   return _resolved;
 }
 
+/** Test if a specific --impersonate profile is accepted by the binary. */
+function testProfile(binary: string, profile: string): boolean {
+  try {
+    execFileSync(binary, ["--impersonate", profile, "-V"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find a working impersonate profile.
+ * Tries the configured profile first, then descends Chrome versions.
+ */
+function resolveProfile(binary: string, configured: string): string | null {
+  if (testProfile(binary, configured)) return configured;
+
+  const match = configured.match(/^chrome(\d+)/);
+  if (!match) return null;
+
+  const ver = parseInt(match[1], 10);
+  for (let v = ver - 1; v >= ver - 10 && v > 0; v--) {
+    const candidate = `chrome${v}`;
+    if (testProfile(binary, candidate)) {
+      console.warn(`[TLS] Profile "${configured}" not supported, using "${candidate}"`);
+      return candidate;
+    }
+  }
+  return null;
+}
+
 /**
  * Detect if curl-impersonate supports the --impersonate flag.
- * If supported, returns ["--impersonate", profile] which replaces CHROME_TLS_ARGS.
- * Otherwise returns the manual CHROME_TLS_ARGS.
+ * Validates the configured profile and auto-falls back to the nearest
+ * supported Chrome version if needed.
  */
 function detectImpersonateSupport(binary: string): string[] {
   try {
@@ -117,9 +153,14 @@ function detectImpersonateSupport(binary: string): string[] {
       timeout: 5000,
     });
     if (helpOutput.includes("--impersonate")) {
-      const profile = getConfig().tls.impersonate_profile ?? "chrome136";
-      console.log(`[TLS] Using --impersonate ${profile}`);
-      return ["--impersonate", profile];
+      const configured = getConfig().tls.impersonate_profile ?? "chrome136";
+      const profile = resolveProfile(binary, configured);
+      if (profile) {
+        _resolvedProfile = profile;
+        console.log(`[TLS] Using --impersonate ${profile}`);
+        return ["--impersonate", profile];
+      }
+      console.warn("[TLS] No supported impersonate profile found, using manual TLS args");
     }
   } catch {
     // --help failed, fall back to manual args
@@ -220,6 +261,15 @@ export function isImpersonate(): boolean {
 }
 
 /**
+ * Get the resolved impersonate profile (e.g. "chrome136").
+ * Used by FFI transport which needs the profile name directly.
+ */
+export function getResolvedProfile(): string {
+  getChromeTlsArgs(); // ensure detection has run
+  return _resolvedProfile;
+}
+
+/**
  * Get the detected proxy URL (or null if no proxy).
  * Used by LibcurlFfiTransport which needs the URL directly (not CLI args).
  */
@@ -234,4 +284,5 @@ export function resetCurlBinaryCache(): void {
   _resolved = null;
   _isImpersonate = false;
   _tlsArgs = null;
+  _resolvedProfile = "chrome136";
 }

--- a/src/tls/libcurl-ffi-transport.ts
+++ b/src/tls/libcurl-ffi-transport.ts
@@ -12,7 +12,7 @@ import { resolve } from "path";
 import { existsSync } from "fs";
 import type { IKoffiLib, IKoffiCType, IKoffiRegisteredCallback, KoffiFunction } from "koffi";
 import type { TlsTransport, TlsTransportResponse } from "./transport.js";
-import { getProxyUrl } from "./curl-binary.js";
+import { getProxyUrl, getResolvedProfile } from "./curl-binary.js";
 
 // ── libcurl constants ──────────────────────────────────────────────
 
@@ -450,7 +450,7 @@ export class LibcurlFfiTransport implements TlsTransport {
     if (!easy) throw new Error("curl_easy_init() returned null");
 
     // Impersonate Chrome — 0 = don't inject default headers (we control them)
-    b.curl_easy_impersonate(easy, "chrome136", 0);
+    b.curl_easy_impersonate(easy, getResolvedProfile(), 0);
 
     b.curl_easy_setopt_str(easy, CURLOPT_URL, url);
     b.curl_easy_setopt_long(easy, CURLOPT_NOSIGNAL, 1);


### PR DESCRIPTION
## Summary

- curl-impersonate skips Chrome versions when TLS fingerprint is unchanged (e.g. `chrome137` doesn't exist — `chrome136` covers it). Previously configuring an unsupported profile caused `curl: (43) Unknown impersonation target` at runtime
- `detectImpersonateSupport()` now validates the configured profile by test-running `curl --impersonate <profile> -V`, and auto-descends to the nearest supported Chrome version
- FFI transport unified to use `getResolvedProfile()` instead of hardcoded `"chrome136"`

## Test plan

- [ ] `npm run build` compiles cleanly
- [ ] Start with `impersonate_profile: chrome137` → logs `[TLS] Profile "chrome137" not supported, using "chrome136"`
- [ ] Start with `impersonate_profile: chrome136` → logs `[TLS] Using --impersonate chrome136` (no fallback needed)
- [ ] `curl http://localhost:8080/health` returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)