### PR TITLE
fix: Docker 容器自动检测宿主机代理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `ClaudeCodeSetup.tsx` 文件名与导出名不一致，重命名为 `AnthropicSetup.tsx`
 - Dashboard 模型偏好从硬编码 `gpt-5.2-codex` 改为使用 `codex` 别名
 - 构建脚本 `vite build --root web` 兼容性问题，改用 `npm run build:web`
+- Docker 容器内代理自动检测失败：`detectLocalProxy()` 现在同时探测 `127.0.0.1`（裸机）和 `host.docker.internal`（Docker 容器→宿主机），零配置即生效
 
 ## [v0.8.0](https://github.com/icebear0828/codex-proxy/releases/tag/v0.8.0) - 2026-02-24
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   codex-proxy:
     build: .
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "${PORT:-8080}:8080"
     volumes:

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -187,12 +187,20 @@ const PROXY_PORTS = [
   { port: 10808, proto: "socks5" },// v2ray SOCKS5
 ];
 
+/**
+ * Hosts to probe for proxy detection.
+ * 127.0.0.1 — bare-metal / host machine.
+ * host.docker.internal — Docker container → host machine
+ * (DNS lookup fails on bare-metal → ENOTFOUND → handled by error callback, <5ms).
+ */
+const PROXY_HOSTS = ["127.0.0.1", "host.docker.internal"];
+
 let _proxyUrl: string | null | undefined; // undefined = not yet detected
 
-/** Probe a TCP port on localhost. Resolves true if a server is listening. */
-function probePort(port: number, timeoutMs = 500): Promise<boolean> {
+/** Probe a TCP port on the given host. Resolves true if a server is listening. */
+function probePort(host: string, port: number, timeoutMs = 500): Promise<boolean> {
   return new Promise((resolve) => {
-    const sock = createConnection({ host: "127.0.0.1", port }, () => {
+    const sock = createConnection({ host, port }, () => {
       sock.destroy();
       resolve(true);
     });
@@ -203,15 +211,17 @@ function probePort(port: number, timeoutMs = 500): Promise<boolean> {
 }
 
 /**
- * Detect a local proxy by probing common ports.
+ * Detect a local proxy by probing common ports on localhost and Docker host.
  * Called once at startup, result is cached.
  */
 async function detectLocalProxy(): Promise<string | null> {
-  for (const { port, proto } of PROXY_PORTS) {
-    if (await probePort(port)) {
-      const url = `${proto}://127.0.0.1:${port}`;
-      console.log(`[Proxy] Auto-detected local proxy: ${url}`);
-      return url;
+  for (const host of PROXY_HOSTS) {
+    for (const { port, proto } of PROXY_PORTS) {
+      if (await probePort(host, port)) {
+        const url = `${proto}://${host}:${port}`;
+        console.log(`[Proxy] Auto-detected local proxy: ${url}`);
+        return url;
+      }
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Docker 容器内 `127.0.0.1` 是容器自身 loopback，无法探测宿主机代理端口
- `detectLocalProxy()` 现在同时探测 `127.0.0.1`（裸机）和 `host.docker.internal`（Docker 容器→宿主机）
- `docker-compose.yml` 添加 `extra_hosts` 确保 Linux Docker Engine 也能解析 `host.docker.internal`

## Changes

- `src/tls/curl-binary.ts` — `probePort()` 增加 `host` 参数，新增 `PROXY_HOSTS` 双层循环探测
- `docker-compose.yml` — 添加 `extra_hosts: host.docker.internal:host-gateway`
- `CHANGELOG.md` — 添加 Fixed 条目

## Test plan

- [x] `npm run build` 编译通过
- [x] 设备 B Docker `docker compose up --build -d` 启动成功
- [x] 容器日志确认：`[Proxy] Auto-detected local proxy: http://host.docker.internal:7890`
- [ ] 裸机启动确认 `host.docker.internal` DNS 失败不影响正常探测（ENOTFOUND <5ms）

🤖 Generated with [Claude Code](https://claude.com/claude-code)