### PR TITLE
fix: inject empty properties into anthropic tool schemas to satisfy o…

### DIFF
--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -24,7 +24,7 @@ export interface CodexToolDefinition {
 export function openAIToolsToCodex(
   tools: NonNullable<ChatCompletionRequest["tools"]>,
 ): CodexToolDefinition[] {
-  return tools.map((t) => {
+  return tools.map((t: any) => {
     const def: CodexToolDefinition = {
       type: "function",
       name: t.function.name,
@@ -53,7 +53,7 @@ export function openAIToolChoiceToCodex(
 export function openAIFunctionsToCodex(
   functions: NonNullable<ChatCompletionRequest["functions"]>,
 ): CodexToolDefinition[] {
-  return functions.map((f) => {
+  return functions.map((f: any) => {
     const def: CodexToolDefinition = {
       type: "function",
       name: f.name,
@@ -69,13 +69,19 @@ export function openAIFunctionsToCodex(
 export function anthropicToolsToCodex(
   tools: NonNullable<AnthropicMessagesRequest["tools"]>,
 ): CodexToolDefinition[] {
-  return tools.map((t) => {
+  return tools.map((t: any) => {
     const def: CodexToolDefinition = {
       type: "function",
       name: t.name,
     };
     if (t.description) def.description = t.description;
-    if (t.input_schema) def.parameters = t.input_schema;
+    if (t.input_schema) {
+      const params = { ...t.input_schema };
+      if (params.type === "object" && !("properties" in params)) {
+        params.properties = {};
+      }
+      def.parameters = params;
+    }
     return def;
   });
 }


### PR DESCRIPTION
The Issue: Claude Code sends MCP tools with no parameters as an input_schema containing just {"type": "object"}. However, when the proxy converts this to the Codex/OpenAI format, OpenAI strictly requires the properties field if type is "object". Since it was missing, the API returned the 400 Bad Request schema error.

The Fix: I modified src/translation/tool-format.ts to automatically inject "properties": {} for any matching input_schema missing it when translating Anthropic requests.