### PR TITLE
fix: normalize tool schemas missing properties field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Fixed
 
+- 工具 schema 缺少 `properties` 字段导致 400 错误：MCP 工具发送 `{"type":"object"}` 无 `properties` 时，Codex 后端拒绝请求；现在所有格式转换器（OpenAI/Anthropic/Gemini）统一注入 `properties: {}`（感谢 @lookvincent 发现此问题，PR #22）
 - 额度窗口刷新后 Dashboard 仍显示累计 Token：本地计数器从未按窗口重置，现在 `refreshStatus()` 每次 acquire/getAccounts 时检查 `window_reset_at`，过期自动归零窗口计数器
 - 空响应重试循环中账号双重释放：外层 catch 使用原始 `entryId` 而非当前活跃账号，导致换号重试失败时 double-release（`proxy-handler.ts`）
 - `apply-update.ts` 模型比较不再误报删除：静态提取只含 2 个硬编码模型，与 YAML 的 24 个比较会产生 22 个假删除，现在只报新增

--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -9,6 +9,18 @@ import type { ChatCompletionRequest } from "../types/openai.js";
 import type { AnthropicMessagesRequest } from "../types/anthropic.js";
 import type { GeminiGenerateContentRequest } from "../types/gemini.js";
 
+// ── Helpers ─────────────────────────────────────────────────────
+
+/** OpenAI requires `properties` when schema `type` is `"object"`. */
+function normalizeSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  if (schema.type === "object" && !("properties" in schema)) {
+    return { ...schema, properties: {} };
+  }
+  return schema;
+}
+
 // ── Codex Responses API tool format ─────────────────────────────
 
 export interface CodexToolDefinition {
@@ -30,7 +42,7 @@ export function openAIToolsToCodex(
       name: t.function.name,
     };
     if (t.function.description) def.description = t.function.description;
-    if (t.function.parameters) def.parameters = t.function.parameters;
+    if (t.function.parameters) def.parameters = normalizeSchema(t.function.parameters);
     return def;
   });
 }
@@ -59,7 +71,7 @@ export function openAIFunctionsToCodex(
       name: f.name,
     };
     if (f.description) def.description = f.description;
-    if (f.parameters) def.parameters = f.parameters;
+    if (f.parameters) def.parameters = normalizeSchema(f.parameters);
     return def;
   });
 }
@@ -75,7 +87,7 @@ export function anthropicToolsToCodex(
       name: t.name,
     };
     if (t.description) def.description = t.description;
-    if (t.input_schema) def.parameters = t.input_schema;
+    if (t.input_schema) def.parameters = normalizeSchema(t.input_schema);
     return def;
   });
 }
@@ -110,7 +122,7 @@ export function geminiToolsToCodex(
           name: fd.name,
         };
         if (fd.description) def.description = fd.description;
-        if (fd.parameters) def.parameters = fd.parameters;
+        if (fd.parameters) def.parameters = normalizeSchema(fd.parameters);
         defs.push(def);
       }
     }


### PR DESCRIPTION
## Summary

- MCP tools with no parameters send `{"type":"object"}` without `properties`, causing Codex backend to return 400
- Added shared `normalizeSchema()` helper that injects `properties: {}` when missing
- Applied consistently across all four format converters (OpenAI tools, OpenAI functions, Anthropic, Gemini)

Thanks to @lookvincent for identifying this issue (PR #22).

## Test plan

- [ ] Claude Code on device C: call MCP tools with no parameters, verify no 400 error
- [ ] Verify tools with existing parameters still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)