### PR TITLE
🎨 Palette: Improve accessibility and focus visibility for icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-05-14 - [Accessible Icon Buttons and Focus Visibility]
+**Learning:** Icon-only buttons often lack descriptive labels for screen readers and visible focus indicators for keyboard-only users. Using 'aria-label' with localized strings and 'focus-visible' utility classes (e.g., 'focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none') provides a significant accessibility boost without impacting mouse users.
+**Action:** Always include 'aria-label' for icon buttons and apply 'focus-visible' ring styles to all interactive elements to ensure clear keyboard navigation.

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -106,8 +106,9 @@ export function AccountCard({ account, index, onDelete }: AccountCardProps) {
           </span>
           <button
             onClick={handleDelete}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-red-500 transition-colors rounded-md hover:bg-red-50 dark:hover:bg-red-900/20"
+            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-red-500 transition-colors rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none"
             title={t("deleteAccount")}
+            aria-label={t("deleteAccount")}
           >
             <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -36,7 +36,8 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
             onClick={onRefresh}
             disabled={refreshing}
             title={t("refresh")}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label={t("refresh")}
+            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none"
           >
             <svg
               class={`size-[18px] ${refreshing ? "animate-spin" : ""}`}

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -50,7 +50,7 @@ export function CopyButton({ getText, class: className, titleKey, variant = "ico
     return (
       <button
         onClick={handleCopy}
-        class={`flex items-center gap-1.5 px-3 py-1.5 ${bgClass} text-white rounded text-xs font-medium transition-colors ${className || ""}`}
+        class={`flex items-center gap-1.5 px-3 py-1.5 ${bgClass} text-white rounded text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none ${className || ""}`}
       >
         <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
           <rect x="9" y="9" width="13" height="13" rx="2" />
@@ -66,7 +66,7 @@ export function CopyButton({ getText, class: className, titleKey, variant = "ico
   return (
     <button
       onClick={handleCopy}
-      class={`p-1.5 transition-colors rounded-md hover:bg-slate-100 dark:hover:bg-border-dark ${
+      class={`p-1.5 transition-colors rounded-md hover:bg-slate-100 dark:hover:bg-border-dark focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none ${
         state === "ok"
           ? "text-primary"
           : state === "fail"
@@ -74,6 +74,7 @@ export function CopyButton({ getText, class: className, titleKey, variant = "ico
             : "text-slate-400 dark:text-text-dim hover:text-primary"
       } ${className || ""}`}
       title={titleKey ? t(titleKey as TranslationKey) : undefined}
+      aria-label={titleKey ? t(titleKey as TranslationKey) : t("copy")}
     >
       {state === "ok" ? SVG_CHECK : state === "fail" ? SVG_FAIL : SVG_COPY}
     </button>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -49,23 +49,25 @@ export function Header({ onAddAccount }: HeaderProps) {
             {/* Language Toggle */}
             <button
               onClick={toggleLang}
-              class="p-2 rounded-lg text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
+              class="p-2 rounded-lg text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none"
               title="\u4e2d/EN"
+              aria-label={t("switchLanguage")}
             >
               <span class="text-xs font-bold inline-flex items-center justify-center w-5">{lang === "en" ? "EN" : "\u4e2d"}</span>
             </button>
             {/* Theme Toggle */}
             <button
               onClick={toggleTheme}
-              class="p-2 rounded-lg text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
+              class="p-2 rounded-lg text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none"
               title={t("toggleTheme")}
+              aria-label={t("toggleTheme")}
             >
               {isDark ? SVG_SUN : SVG_MOON}
             </button>
             {/* Add Account */}
             <button
               onClick={onAddAccount}
-              class="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-hover text-white text-xs font-semibold rounded-lg transition-colors shadow-sm active:scale-95"
+              class="flex items-center gap-2 px-4 py-2 bg-primary hover:bg-primary-hover text-white text-xs font-semibold rounded-lg transition-colors shadow-sm active:scale-95 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none"
             >
               <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />

--- a/web/src/i18n/translations.ts
+++ b/web/src/i18n/translations.ts
@@ -58,6 +58,7 @@ export const translations = {
     copyFailed: "Failed",
     refresh: "Refresh",
     updatedAt: "Updated at",
+    switchLanguage: "Switch language",
     footer: "\u00a9 2025 Codex Proxy. All rights reserved.",
   },
   zh: {
@@ -121,6 +122,7 @@ export const translations = {
     copyFailed: "\u5931\u8d25",
     refresh: "\u5237\u65b0",
     updatedAt: "\u66f4\u65b0\u4e8e",
+    switchLanguage: "\u5207\u6362\u8bed\u8a00",
     footer:
       "\u00a9 2025 Codex Proxy\u3002\u4fdd\u7559\u6240\u6709\u6743\u5229\u3002",
   },


### PR DESCRIPTION
This PR implements several micro-UX improvements focused on accessibility and keyboard navigation. 

### 💡 What
- Added descriptive `aria-label` attributes to icon-only buttons across the application.
- Implemented `focus-visible` ring styles to ensure interactive elements have a clear, visible focus state when navigated via the keyboard.
- Added a new translation key `switchLanguage` to `web/src/i18n/translations.ts`.

### 🎯 Why
Icon-only buttons are often inaccessible to screen reader users as they lack text content. Additionally, default browser focus outlines are sometimes suppressed or inconsistent; explicitly defining `focus-visible` styles ensures a consistent and accessible experience for keyboard-only users without cluttering the UI for mouse users.

### ♿ Accessibility
- All icon buttons now have localized accessible names.
- Keyboard navigation is visually clear with the addition of primary-colored focus rings.
- Used `focus-visible` to prevent focus rings from appearing on mouse clicks.

---
*PR created automatically by Jules for task [9889545588715147060](https://jules.google.com/task/9889545588715147060) started by @icebear0828*