### PR TITLE
🎨 Palette: Add spinner and focus states to AddAccount form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Improving Async Feedback and Keyboard Navigation in Forms
+**Learning:** Adding a visual spinner and explicit focus rings significantly improves the usability of critical actions like account connection, especially for keyboard-only users.
+**Action:** Always include `focus-visible` ring styles and loading states for any async operation button to provide immediate, accessible feedback.

--- a/web/src/components/AddAccount.tsx
+++ b/web/src/components/AddAccount.tsx
@@ -9,6 +9,13 @@ interface AddAccountProps {
   addError: string;
 }
 
+const SVG_SPINNER = (
+  <svg class="animate-spin size-3.5" viewBox="0 0 24 24" fill="none">
+    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" />
+    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+  </svg>
+);
+
 export function AddAccount({ visible, onSubmitRelay, addInfo, addError }: AddAccountProps) {
   const t = useT();
   const [input, setInput] = useState("");
@@ -44,14 +51,16 @@ export function AddAccount({ visible, onSubmitRelay, addInfo, addError }: AddAcc
               value={input}
               onInput={(e) => setInput((e.target as HTMLInputElement).value)}
               placeholder={t("pasteCallback")}
-              class="flex-1 px-3 py-2.5 bg-slate-50 dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-sm font-mono text-slate-600 dark:text-text-main focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-colors"
+              class="flex-1 px-3 py-2.5 bg-slate-50 dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-sm font-mono text-slate-600 dark:text-text-main focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-bg-dark outline-none transition-colors"
             />
             <button
               onClick={handleSubmit}
               disabled={submitting}
-              class="px-4 py-2.5 bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-lg text-sm font-medium text-slate-700 dark:text-text-main hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
+              aria-label={submitting ? t("submitting") : t("submit")}
+              class="flex items-center gap-2 px-4 py-2.5 bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-lg text-sm font-medium text-slate-700 dark:text-text-main hover:bg-slate-50 dark:hover:bg-border-dark focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-bg-dark outline-none transition-colors"
             >
-              {submitting ? t("submitting") : t("submit")}
+              {submitting && SVG_SPINNER}
+              <span>{submitting ? t("submitting") : t("submit")}</span>
             </button>
           </div>
         </section>


### PR DESCRIPTION
🎨 Palette: Micro-UX improvement for the AddAccount component.

💡 What:
- Added a loading spinner to the "Submit" button when the account connection is in progress.
- Enhanced the input field and submit button with visible focus-ring styles when navigated via keyboard.
- Added a dynamic ARIA label to the button to reflect the current state for screen readers.

🎯 Why:
- Provides immediate visual feedback to the user when they click "Submit", preventing repeated clicks and uncertainty.
- Improves keyboard accessibility by making it clear which form element is currently focused.

♿ Accessibility:
- Implemented `focus-visible:ring-2` utility classes for accessible focus states.
- Added a dynamic `aria-label` to the button.


---
*PR created automatically by Jules for task [9257568815583950883](https://jules.google.com/task/9257568815583950883) started by @icebear0828*