### PR TITLE
docs: add .env setup step to Docker quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ cd codex-proxy
 ### Docker（推荐，所有平台通用）
 
 ```bash
+# macOS / Linux
+cp .env.example .env
+
+# Windows (PowerShell)
+# copy .env.example .env
+
 docker compose up -d
 # 打开 http://localhost:8080 登录
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,6 +58,12 @@ cd codex-proxy
 #### Docker (Recommended)
 
 ```bash
+# macOS / Linux
+cp .env.example .env
+
+# Windows (PowerShell)
+# copy .env.example .env
+
 docker compose up -d
 # Open http://localhost:8080 to log in
 ```


### PR DESCRIPTION
## Summary

- Add `cp .env.example .env` step before `docker compose up -d` in both `README.md` and `README_EN.md`
- Include Windows PowerShell equivalent (`copy .env.example .env`) as a comment
- Prevents first-run failure when `.env` file is missing

## Problem

Docker Compose requires a `.env` file referenced in `docker-compose.yml`. Without copying `.env.example` first, the container fails immediately with:

**Windows:**
env file D:\\...\codex-proxy.env not found: CreateFile  The system cannot find the file specified.



**macOS / Linux:**
env file /path/to/codex-proxy/.env not found: no such file or directory



## Changes

Updated Docker quick start flow in both `README.md` (zh) and `README_EN.md` (en):

```bash
git clone https://github.com/icebear0828/codex-proxy.git
cd codex-proxy

# macOS / Linux
cp .env.example .env
# Windows (PowerShell)
# copy .env.example .env

docker compose up -d