### PR TITLE
fix: strip service_tier from body + OpenAI-Beta header + gpt-5.4 efforts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - README Docker 快速开始补充 `cp .env.example .env` 步骤，修复新用户因缺少 `.env` 文件导致 `docker compose up -d` 启动失败的问题 (#38)
 - 识别 `response.output_item.done`、`response.incomplete`、`response.queued` Codex SSE 事件，消除 "Unknown event" 日志噪音
+- 剥离 `service_tier` 字段：Codex 后端不接受请求体中的 `service_tier`，现在 proxy 在发送前自动移除，修复 `-fast` 后缀导致 "Unsupported service_tier" 报错
+- 更新 gpt-5.4 推理等级：`minimal` → `none`，新增 `xhigh`（与后端实际支持的值对齐）
+- 添加 `OpenAI-Beta` 请求头：与 Codex Desktop 保持一致（`responses_websockets=2026-02-06`）
 - 流式 SSE 请求不再设置 `--max-time` 墙钟超时，修复思考链（reasoning/thinking）在 60 秒处中断的问题；连接保护由 header 超时 + AbortSignal 提供，非流式请求（models、usage）超时不受影响
 
 ### Added
@@ -17,7 +20,7 @@
 - `/v1/responses` 端点：Codex Responses API 直通，无格式转换，支持原始 SSE 事件流和多账号负载均衡
 
 - 模型名后缀系统：通过模型名嵌入推理等级和速度模式（如 `gpt-5.4-high-fast`），CLI 工具（Claude Code、opencode 等）无需额外参数即可控制推理强度和 Fast 模式
-- `service_tier` 支持：接受 API 请求体中的 `service_tier` 字段（"fast" / "flex"），或通过 `-fast` 模型名后缀自动设置
+- `service_tier` 后缀解析：通过 `-fast`/`-flex` 模型名后缀解析，保留在 proxy 层元数据中（Codex 后端不接受 `service_tier` 请求体字段，Desktop 在 app-server 层处理）
 - Dashboard Speed 切换：模型选择器下方新增 Standard / Fast 速度切换按钮
 
 - 代理分配管理页面（`#/proxy-settings`）：双栏矩阵式布局，批量管理数百账号的代理分配

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -13,10 +13,11 @@ models:
     description: Latest Codex flagship model
     isDefault: true
     supportedReasoningEfforts:
-      - { reasoningEffort: minimal, description: "Minimal reasoning" }
-      - { reasoningEffort: low,     description: "Fastest responses" }
-      - { reasoningEffort: medium,  description: "Balanced speed and quality" }
-      - { reasoningEffort: high,    description: "Deepest reasoning" }
+      - { reasoningEffort: none,   description: "No reasoning" }
+      - { reasoningEffort: low,    description: "Fastest responses" }
+      - { reasoningEffort: medium, description: "Balanced speed and quality" }
+      - { reasoningEffort: high,   description: "Deepest reasoning" }
+      - { reasoningEffort: xhigh,  description: "Extended deep reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
     supportsPersonality: true

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -248,11 +248,18 @@ export class CodexApi {
       buildHeadersWithContentType(this.token, this.accountId),
     );
     headers["Accept"] = "text/event-stream";
+    // Codex Desktop sends this beta header to enable newer API features
+    headers["OpenAI-Beta"] = "responses_websockets=2026-02-06";
+
+    // Strip service_tier from body — Codex backend doesn't accept it as a body field.
+    // Desktop app handles Fast mode internally (lighter reasoning), not via the API.
+    const { service_tier: _st, ...bodyWithoutServiceTier } = request;
+    const body = JSON.stringify(bodyWithoutServiceTier);
 
     // No wall-clock timeout for streaming SSE — header timeout + AbortSignal provide protection
     let transportRes;
     try {
-      transportRes = await transport.post(url, headers, JSON.stringify(request), signal, undefined, this.proxyUrl);
+      transportRes = await transport.post(url, headers, body, signal, undefined, this.proxyUrl);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new CodexApiError(0, msg);


### PR DESCRIPTION
## Summary
- **Strip `service_tier` from request body**: Codex backend rejects `service_tier` in the POST body (`"Unsupported service_tier: fast"`). Desktop app handles Fast mode at the app-server level (Rust binary), not via the HTTP API. Proxy now auto-removes `service_tier` before sending.
- **Add `OpenAI-Beta` header**: Desktop binary sends `OpenAI-Beta: responses_websockets=2026-02-06` — discovered via `strings` analysis of the native codex binary on device C.
- **Update gpt-5.4 reasoning efforts**: `minimal` → `none`, added `xhigh` (matching backend's actual supported values: none/low/medium/high/xhigh).

## Root cause
The Codex Desktop's `ResponseCreate` struct (in `codex-rs/codex-api/src/endpoint/responses.rs`) does NOT include `service_tier` as a field. The Desktop passes `serviceTier` via IPC to the app-server binary, which handles it internally (lighter reasoning) without forwarding to the backend API.

## Test plan
- [x] `gpt-5.4-fast` via `/v1/chat/completions` — succeeds (was: "Unsupported service_tier")
- [x] `gpt-5.4` with `reasoning_effort: "xhigh"` — succeeds
- [x] `/v1/responses` with `-fast` suffix — succeeds
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)