### PR TITLE
fix: preserve model name suffixes in API responses

### DIFF
--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -195,7 +195,7 @@ export interface ParsedModelName {
 }
 
 const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
-const EFFORT_SUFFIXES = new Set(["minimal", "low", "medium", "high", "xhigh"]);
+const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 
 /**
  * Parse a model name that may contain embedded suffixes for service_tier and reasoning_effort.
@@ -241,6 +241,14 @@ export function parseModelName(input: string): ParsedModelName {
   // 3. Resolve remaining as model
   const modelId = resolveModelId(remaining);
   return { modelId, serviceTier, reasoningEffort };
+}
+
+/** Reconstruct display model name: resolved modelId + any parsed suffixes. */
+export function buildDisplayModelName(parsed: ParsedModelName): string {
+  let name = parsed.modelId;
+  if (parsed.reasoningEffort) name += `-${parsed.reasoningEffort}`;
+  if (parsed.serviceTier) name += `-${parsed.serviceTier}`;
+  return name;
 }
 
 // ── Getters ────────────────────────────────────────────────────────

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -9,6 +9,7 @@ import {
   collectCodexResponse,
 } from "../translation/codex-to-openai.js";
 import { getConfig } from "../config.js";
+import { parseModelName, buildDisplayModelName } from "../models/model-store.js";
 import {
   handleProxyRequest,
   type FormatAdapter,
@@ -122,6 +123,7 @@ export function createChatRoutes(
     const req = parsed.data;
 
     const codexRequest = translateToCodexRequest(req);
+    const displayModel = buildDisplayModelName(parseModelName(req.model));
     const wantReasoning = !!req.reasoning_effort;
 
     return handleProxyRequest(
@@ -130,7 +132,7 @@ export function createChatRoutes(
       cookieJar,
       {
         codexRequest,
-        model: codexRequest.model,
+        model: displayModel,
         isStreaming: req.stream,
       },
       makeOpenAIFormat(wantReasoning),

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -16,6 +16,7 @@ import {
   collectCodexToAnthropicResponse,
 } from "../translation/codex-to-anthropic.js";
 import { getConfig } from "../config.js";
+import { parseModelName, buildDisplayModelName } from "../models/model-store.js";
 import {
   handleProxyRequest,
   type FormatAdapter,
@@ -104,7 +105,7 @@ export function createMessagesRoutes(
       cookieJar,
       {
         codexRequest,
-        model: req.model,
+        model: buildDisplayModelName(parseModelName(req.model)),
         isStreaming: req.stream,
       },
       makeAnthropicFormat(wantThinking),

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -12,7 +12,7 @@ import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import type { CodexResponsesRequest, CodexInputItem, CodexApi } from "../proxy/codex-api.js";
 import { getConfig } from "../config.js";
-import { parseModelName, resolveModelId, getModelInfo } from "../models/model-store.js";
+import { parseModelName, resolveModelId, getModelInfo, buildDisplayModelName } from "../models/model-store.js";
 import { EmptyResponseError } from "../translation/codex-event-extractor.js";
 import {
   handleProxyRequest,
@@ -215,6 +215,7 @@ export function createResponsesRoutes(
     const rawModel = typeof body.model === "string" ? body.model : "codex";
     const parsed = parseModelName(rawModel);
     const modelId = resolveModelId(parsed.modelId);
+    const displayModel = buildDisplayModelName(parsed);
     const modelInfo = getModelInfo(modelId);
 
     // Build CodexResponsesRequest
@@ -269,7 +270,7 @@ export function createResponsesRoutes(
       cookieJar,
       {
         codexRequest,
-        model: modelId,
+        model: displayModel,
         isStreaming: clientWantsStream,
       },
       PASSTHROUGH_FORMAT,


### PR DESCRIPTION
## Summary
- Response model name was losing suffixes (`-fast`, `-high`, `-low`, etc.) because it used the stripped base model ID from `parseModelName()` instead of the original requested model name
- Added `buildDisplayModelName()` helper that reconstructs the display model: resolved `modelId` + reasoning effort suffix + service tier suffix
- Added `none` to `EFFORT_SUFFIXES` (gpt-5.4 supports `none` reasoning effort, was missing)
- Applied fix to all 3 API routes: `/v1/chat/completions`, `/v1/messages`, `/v1/responses`

## Examples
| Request model | Before | After |
|---|---|---|
| `gpt-5.4-fast` | `gpt-5.4` | `gpt-5.4-fast` |
| `gpt-5.4-high` | `gpt-5.4` | `gpt-5.4-high` |
| `gpt-5.4-high-fast` | `gpt-5.4` | `gpt-5.4-high-fast` |
| `codex-fast` | `gpt-5.4` | `gpt-5.4-fast` |
| `gpt-5.4-none` | (fell to default) | `gpt-5.4-none` |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 43 unit tests pass
- [ ] Manual test: `curl` with `-fast` suffix → response model includes `-fast`
- [ ] Manual test: `curl` with `-high` suffix → response model includes `-high`
- [ ] Manual test: `curl` with compound `-high-fast` → response preserves both

🤖 Generated with [Claude Code](https://claude.com/claude-code)