### PR TITLE
fix(auth): add direct-connection fallback for OAuth behind proxy

### DIFF
--- a/src/auth/oauth-pkce.ts
+++ b/src/auth/oauth-pkce.ts
@@ -9,7 +9,8 @@ import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import { homedir } from "os";
 import { getConfig } from "../config.js";
-import { curlFetchPost } from "../tls/curl-fetch.js";
+import { curlFetchPost, type CurlFetchResponse } from "../tls/curl-fetch.js";
+import { withDirectFallback, isCloudflareChallengeResponse } from "../tls/direct-fallback.js";
 
 export interface PKCEChallenge {
   codeVerifier: string;
@@ -40,6 +41,8 @@ interface PendingSession {
   source: "login" | "dashboard";
   createdAt: number;
 }
+
+const isCfResponse = (r: CurlFetchResponse) => isCloudflareChallengeResponse(r.status, r.body);
 
 /** In-memory store for pending OAuth sessions, keyed by `state`. */
 const pendingSessions = new Map<string, PendingSession>();
@@ -121,10 +124,14 @@ export async function exchangeCode(
     code_verifier: codeVerifier,
   });
 
-  const resp = await curlFetchPost(
-    config.auth.oauth_token_endpoint,
-    "application/x-www-form-urlencoded",
-    body.toString(),
+  const resp = await withDirectFallback(
+    (proxyUrl) => curlFetchPost(
+      config.auth.oauth_token_endpoint,
+      "application/x-www-form-urlencoded",
+      body.toString(),
+      { proxyUrl },
+    ),
+    { tag: "OAuth/exchangeCode", shouldFallback: isCfResponse },
   );
 
   if (!resp.ok) {
@@ -148,10 +155,14 @@ export async function refreshAccessToken(
     refresh_token: refreshToken,
   });
 
-  const resp = await curlFetchPost(
-    config.auth.oauth_token_endpoint,
-    "application/x-www-form-urlencoded",
-    body.toString(),
+  const resp = await withDirectFallback(
+    (proxyUrl) => curlFetchPost(
+      config.auth.oauth_token_endpoint,
+      "application/x-www-form-urlencoded",
+      body.toString(),
+      { proxyUrl },
+    ),
+    { tag: "OAuth/refresh", shouldFallback: isCfResponse },
   );
 
   if (!resp.ok) {
@@ -342,10 +353,14 @@ export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
     scope: "openid profile email offline_access",
   });
 
-  const resp = await curlFetchPost(
-    "https://auth.openai.com/oauth/device/code",
-    "application/x-www-form-urlencoded",
-    body.toString(),
+  const resp = await withDirectFallback(
+    (proxyUrl) => curlFetchPost(
+      "https://auth.openai.com/oauth/device/code",
+      "application/x-www-form-urlencoded",
+      body.toString(),
+      { proxyUrl },
+    ),
+    { tag: "OAuth/deviceCode", shouldFallback: isCfResponse },
   );
 
   if (!resp.ok) {
@@ -368,10 +383,14 @@ export async function pollDeviceToken(deviceCode: string): Promise<TokenResponse
     client_id: config.auth.oauth_client_id,
   });
 
-  const resp = await curlFetchPost(
-    config.auth.oauth_token_endpoint,
-    "application/x-www-form-urlencoded",
-    body.toString(),
+  const resp = await withDirectFallback(
+    (proxyUrl) => curlFetchPost(
+      config.auth.oauth_token_endpoint,
+      "application/x-www-form-urlencoded",
+      body.toString(),
+      { proxyUrl },
+    ),
+    { tag: "OAuth/pollDevice", shouldFallback: isCfResponse },
   );
 
   if (!resp.ok) {

--- a/src/tls/curl-fetch.ts
+++ b/src/tls/curl-fetch.ts
@@ -17,14 +17,25 @@ export interface CurlFetchResponse {
   ok: boolean;
 }
 
+export interface CurlFetchOptions {
+  /** Proxy override: undefined = global default, null = direct, string = specific. */
+  proxyUrl?: string | null;
+}
+
 /**
  * Perform a GET request via the TLS transport.
  */
-export async function curlFetchGet(url: string): Promise<CurlFetchResponse> {
+export async function curlFetchGet(
+  url: string,
+  options?: CurlFetchOptions,
+): Promise<CurlFetchResponse> {
   const transport = getTransport();
   const headers = buildAnonymousHeaders();
+  if (!transport.isImpersonate()) {
+    headers["Accept-Encoding"] = "gzip, deflate";
+  }
 
-  const result = await transport.get(url, headers, 30);
+  const result = await transport.get(url, headers, 30, options?.proxyUrl);
   return {
     status: result.status,
     body: result.body,
@@ -39,12 +50,16 @@ export async function curlFetchPost(
   url: string,
   contentType: string,
   body: string,
+  options?: CurlFetchOptions,
 ): Promise<CurlFetchResponse> {
   const transport = getTransport();
   const headers = buildAnonymousHeaders();
+  if (!transport.isImpersonate()) {
+    headers["Accept-Encoding"] = "gzip, deflate";
+  }
   headers["Content-Type"] = contentType;
 
-  const result = await transport.simplePost(url, headers, body, 30);
+  const result = await transport.simplePost(url, headers, body, 30, options?.proxyUrl);
   return {
     status: result.status,
     body: result.body,

--- a/src/tls/direct-fallback.ts
+++ b/src/tls/direct-fallback.ts
@@ -1,0 +1,78 @@
+/**
+ * Direct-connection fallback for proxied requests.
+ *
+ * When a global proxy is configured, some endpoints (e.g. auth.openai.com)
+ * may reject the proxy IP via Cloudflare challenge or cause TLS errors.
+ * This module provides a generic wrapper that retries with a direct connection.
+ */
+
+import { getProxyUrl } from "./curl-binary.js";
+
+/** Detect if an HTTP response is a Cloudflare challenge page. */
+export function isCloudflareChallengeResponse(status: number, body: string): boolean {
+  if (status !== 403) return false;
+  const lower = body.toLowerCase();
+  return (
+    lower.includes("cf-mitigated") ||
+    lower.includes("cf-chl-bypass") ||
+    lower.includes("_cf_chl") ||
+    lower.includes("attention required") ||
+    lower.includes("just a moment")
+  );
+}
+
+/** Detect if an error is a proxy/TLS network failure worth retrying direct. */
+export function isProxyNetworkError(error: unknown): boolean {
+  const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return (
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("ssl_error_syscall") ||
+    msg.includes("schannel") ||
+    msg.includes("connection reset by peer") ||
+    msg.includes("socket hang up") ||
+    msg.includes("curl exited with code 35") ||  // TLS handshake failure
+    msg.includes("curl exited with code 56")     // network receive error
+  );
+}
+
+export interface DirectFallbackOptions<T> {
+  /** Label for log messages. */
+  tag?: string;
+  /** Check if a successful (non-thrown) result should trigger fallback (e.g. CF 403). */
+  shouldFallback?: (result: T) => boolean;
+}
+
+/**
+ * Execute an async operation with automatic direct-connection fallback.
+ *
+ * The callback receives `proxyUrl`:
+ * - First call: `undefined` (use global proxy default)
+ * - Fallback call: `null` (force direct, bypass proxy)
+ *
+ * If no global proxy is configured, runs once with no fallback.
+ */
+export async function withDirectFallback<T>(
+  fn: (proxyUrl: string | null | undefined) => Promise<T>,
+  options?: DirectFallbackOptions<T>,
+): Promise<T> {
+  const label = options?.tag ?? "DirectFallback";
+  const hasProxy = getProxyUrl() !== null;
+
+  try {
+    const result = await fn(undefined);
+
+    if (hasProxy && options?.shouldFallback?.(result)) {
+      console.warn(`[${label}] Cloudflare challenge via proxy, retrying direct`);
+      return await fn(null);
+    }
+
+    return result;
+  } catch (err) {
+    if (hasProxy && isProxyNetworkError(err)) {
+      console.warn(`[${label}] Network/TLS error via proxy, retrying direct`);
+      return await fn(null);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

- Add generic `withDirectFallback()` wrapper (`src/tls/direct-fallback.ts`) that detects Cloudflare challenges (403) and TLS/network errors, then retries with direct connection
- Add `proxyUrl` pass-through option to `curlFetchGet`/`curlFetchPost`
- Fix `Accept-Encoding` for system curl in `curl-fetch.ts` (strip `br, zstd` when not impersonate — matches existing pattern in `codex-api.ts`)
- Wrap all 4 OAuth functions (`exchangeCode`, `refreshAccessToken`, `requestDeviceCode`, `pollDeviceToken`) with direct-connection fallback

Inspired by #49 — same problem, cleaner implementation (no duplicate code, no redundant types, no unrelated deps).

## Test plan

- [ ] `npm run build` passes
- [ ] OAuth login works without proxy (no fallback triggered, zero overhead)
- [ ] OAuth login works with proxy that triggers CF challenge (fallback to direct logged)
- [ ] Token refresh works through proxy / direct fallback
- [ ] Device code flow works through proxy / direct fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)