### PR TITLE
feat: 添加 force_http11 配置选项，支持不支持 HTTP/2 的代理

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,23 @@ for await (const chunk of stream) {
 | `client` | `app_version`, `build_number`, `chromium_version` | 模拟的 Codex Desktop 版本与 Chromium 版本 |
 | `model` | `default`, `default_reasoning_effort`, `default_service_tier` | 默认模型、推理强度与速度模式 |
 | `auth` | `rotation_strategy`, `rate_limit_backoff_seconds` | 轮换策略与限流退避 |
-| `tls` | `curl_binary`, `impersonate_profile`, `proxy_url` | TLS 伪装与代理配置 |
+| `tls` | `curl_binary`, `impersonate_profile`, `proxy_url`, `force_http11` | TLS 伪装与代理配置 |
+
+#### TLS 配置选项
+
+```yaml
+tls:
+  curl_binary: auto                # curl 二进制路径（auto 自动检测）
+  impersonate_profile: chrome136   # Chrome 伪装版本
+  proxy_url: null                  # 代理地址（null 自动检测本地代理）
+  force_http11: false              # 强制使用 HTTP/1.1（解决代理不支持 HTTP/2 的问题）
+```
+
+**`force_http11`**：当你的代理（如 Clash/mihomo）出现以下错误时启用：
+```
+curl: (16) Remote peer returned unexpected data while we expected SETTINGS frame.
+Perhaps, peer does not support HTTP/2 properly.
+```
 
 ### API 密钥 (proxy_api_key)
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -34,3 +34,5 @@ tls:
   curl_binary: auto
   impersonate_profile: chrome144
   proxy_url: null
+  # 当代理不支持 HTTP/2 时启用此选项（如遇到 SETTINGS frame 错误）
+  force_http11: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ const ConfigSchema = z.object({
     impersonate_profile: z.string().default("chrome136"),
     proxy_url: z.string().nullable().default(null),
     transport: z.enum(["auto", "curl-cli", "libcurl-ffi"]).default("auto"),
+    force_http11: z.boolean().default(false),
   }).default({}),
 });
 

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -165,6 +165,7 @@ function detectImpersonateSupport(binary: string): string[] {
  * Get Chrome TLS profile args to prepend to curl commands.
  * Returns empty array when using system curl (args are curl-impersonate specific).
  * Uses --impersonate flag when available, otherwise falls back to manual CHROME_TLS_ARGS.
+ * When force_http11 is enabled, adds --http1.1 to force HTTP/1.1 protocol.
  */
 export function getChromeTlsArgs(): string[] {
   // Ensure binary is resolved first
@@ -173,7 +174,13 @@ export function getChromeTlsArgs(): string[] {
   if (!_tlsArgs) {
     _tlsArgs = detectImpersonateSupport(_resolved!);
   }
-  return [..._tlsArgs];
+  const args = [..._tlsArgs];
+  // Force HTTP/1.1 when configured (for proxies that don't support HTTP/2)
+  const config = getConfig();
+  if (config.tls.force_http11) {
+    args.push("--http1.1");
+  }
+  return args;
 }
 
 /**

--- a/src/tls/libcurl-ffi-transport.ts
+++ b/src/tls/libcurl-ffi-transport.ts
@@ -14,6 +14,7 @@ import type { IKoffiLib, IKoffiCType, IKoffiRegisteredCallback, KoffiFunction } 
 import type { TlsTransport, TlsTransportResponse } from "./transport.js";
 import { getProxyUrl, getResolvedProfile } from "./curl-binary.js";
 import { getBinDir } from "../paths.js";
+import { getConfig } from "../config.js";
 
 // ── libcurl constants ──────────────────────────────────────────────
 
@@ -30,6 +31,7 @@ const CURLOPT_PROXY = 10004;
 const CURLOPT_CAINFO = 10065;
 const CURLOPT_ACCEPT_ENCODING = 10102;
 const CURLOPT_HTTP_VERSION = 84;
+const CURL_HTTP_VERSION_1_1 = 2;
 const CURL_HTTP_VERSION_2_0 = 3;
 const CURLINFO_RESPONSE_CODE = 0x200002;
 const CURLM_OK = 0;
@@ -462,7 +464,11 @@ export class LibcurlFfiTransport implements TlsTransport {
 
     b.curl_easy_setopt_str(easy, CURLOPT_URL, url);
     b.curl_easy_setopt_long(easy, CURLOPT_NOSIGNAL, 1);
-    b.curl_easy_setopt_long(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+
+    // HTTP version: use HTTP/1.1 when force_http11 is enabled (for proxies that don't support HTTP/2)
+    const config = getConfig();
+    const httpVersion = config.tls.force_http11 ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_2_0;
+    b.curl_easy_setopt_long(easy, CURLOPT_HTTP_VERSION, httpVersion);
 
     // Accept-Encoding — let libcurl handle decompression
     b.curl_easy_setopt_str(easy, CURLOPT_ACCEPT_ENCODING, "");


### PR DESCRIPTION
## 概述

添加 `force_http11` 配置选项，解决代理不支持 HTTP/2 导致的连接问题。

## 问题背景

当使用 Clash/mihomo 等不支持 HTTP/2 的代理时，会遇到以下错误：
```
curl: (16) Remote peer returned unexpected data while we expected SETTINGS frame.
Perhaps, peer does not support HTTP/2 properly.
```

## 解决方案

在 TLS 配置中新增 `force_http11` 选项，强制使用 HTTP/1.1 协议：

```yaml
tls:
  force_http11: true  # 强制使用 HTTP/1.1
```

## 修改内容

- `src/config.ts`: 添加 `force_http11` 配置项（默认 `false`）
- `src/tls/curl-binary.ts`: curl CLI 传输添加 `--http1.1` 参数支持
- `src/tls/libcurl-ffi-transport.ts`: FFI 传输添加 `CURL_HTTP_VERSION_1_1` 支持
- `config/default.yaml`: 默认启用该选项（`true`）
- `README.md`: 添加配置说明文档

## 测试计划

- [ ] 使用支持 HTTP/2 的代理时，`force_http11: false` 正常工作
- [ ] 使用不支持 HTTP/2 的代理时，`force_http11: true` 解决 SETTINGS frame 错误
- [ ] curl CLI 和 FFI 两种传输模式都能正确应用该配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)