### PR TITLE
fix: pass through cached_tokens from Codex API

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -35,7 +35,7 @@ export interface FormatAdapter {
     api: CodexApi,
     response: Response,
     model: string,
-    onUsage: (u: { input_tokens: number; output_tokens: number }) => void,
+    onUsage: (u: { input_tokens: number; output_tokens: number; cached_tokens?: number; reasoning_tokens?: number }) => void,
     onResponseId: (id: string) => void,
   ) => AsyncGenerator<string>;
   collectTranslator: (
@@ -44,7 +44,7 @@ export interface FormatAdapter {
     model: string,
   ) => Promise<{
     response: unknown;
-    usage: { input_tokens: number; output_tokens: number };
+    usage: { input_tokens: number; output_tokens: number; cached_tokens?: number; reasoning_tokens?: number };
     responseId: string | null;
   }>;
 }
@@ -94,7 +94,7 @@ export async function handleProxyRequest(
     JSON.stringify(req.codexRequest).slice(0, 300),
   );
 
-  let usageInfo: { input_tokens: number; output_tokens: number } | undefined;
+  let usageInfo: { input_tokens: number; output_tokens: number; cached_tokens?: number; reasoning_tokens?: number } | undefined;
 
   // P0-2: AbortController to kill curl when client disconnects
   const abortController = new AbortController();

--- a/src/translation/codex-event-extractor.ts
+++ b/src/translation/codex-event-extractor.ts
@@ -14,6 +14,8 @@ import {
 export interface UsageInfo {
   input_tokens: number;
   output_tokens: number;
+  cached_tokens?: number;
+  reasoning_tokens?: number;
 }
 
 export interface FunctionCallStart {

--- a/src/translation/codex-to-anthropic.ts
+++ b/src/translation/codex-to-anthropic.ts
@@ -22,6 +22,7 @@ import { iterateCodexEvents, EmptyResponseError } from "./codex-event-extractor.
 export interface AnthropicUsageInfo {
   input_tokens: number;
   output_tokens: number;
+  cached_tokens?: number;
 }
 
 /** Format an Anthropic SSE event with named event type */
@@ -47,6 +48,7 @@ export async function* streamCodexToAnthropic(
   const msgId = `msg_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
   let outputTokens = 0;
   let inputTokens = 0;
+  let cachedTokens: number | undefined;
   let hasToolCalls = false;
   let hasContent = false;
   let contentIndex = 0;
@@ -218,7 +220,8 @@ export async function* streamCodexToAnthropic(
         if (evt.usage) {
           inputTokens = evt.usage.input_tokens;
           outputTokens = evt.usage.output_tokens;
-          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens });
+          cachedTokens = evt.usage.cached_tokens;
+          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens });
         }
         // Inject error text if stream completed with no content
         if (!hasContent) {
@@ -242,7 +245,11 @@ export async function* streamCodexToAnthropic(
   yield formatSSE("message_delta", {
     type: "message_delta",
     delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn" },
-    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+    usage: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      ...(cachedTokens != null ? { cache_read_input_tokens: cachedTokens } : {}),
+    },
   });
 
   // 5. message_stop
@@ -270,6 +277,7 @@ export async function collectCodexToAnthropicResponse(
   let fullReasoning = "";
   let inputTokens = 0;
   let outputTokens = 0;
+  let cachedTokens: number | undefined;
   let responseId: string | null = null;
 
   // Collect tool calls
@@ -285,6 +293,7 @@ export async function collectCodexToAnthropicResponse(
     if (evt.usage) {
       inputTokens = evt.usage.input_tokens;
       outputTokens = evt.usage.output_tokens;
+      cachedTokens = evt.usage.cached_tokens;
     }
     if (evt.functionCallDone) {
       let parsedInput: Record<string, unknown> = {};
@@ -323,6 +332,7 @@ export async function collectCodexToAnthropicResponse(
   const usage: AnthropicUsage = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
+    ...(cachedTokens != null ? { cache_read_input_tokens: cachedTokens } : {}),
   };
 
   return {

--- a/src/translation/codex-to-anthropic.ts
+++ b/src/translation/codex-to-anthropic.ts
@@ -23,6 +23,7 @@ export interface AnthropicUsageInfo {
   input_tokens: number;
   output_tokens: number;
   cached_tokens?: number;
+  reasoning_tokens?: number;
 }
 
 /** Format an Anthropic SSE event with named event type */
@@ -221,7 +222,7 @@ export async function* streamCodexToAnthropic(
           inputTokens = evt.usage.input_tokens;
           outputTokens = evt.usage.output_tokens;
           cachedTokens = evt.usage.cached_tokens;
-          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens });
+          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens, reasoning_tokens: evt.usage.reasoning_tokens });
         }
         // Inject error text if stream completed with no content
         if (!hasContent) {

--- a/src/translation/codex-to-gemini.ts
+++ b/src/translation/codex-to-gemini.ts
@@ -20,6 +20,7 @@ import { iterateCodexEvents, EmptyResponseError } from "./codex-event-extractor.
 export interface GeminiUsageInfo {
   input_tokens: number;
   output_tokens: number;
+  cached_tokens?: number;
 }
 
 /**
@@ -35,6 +36,7 @@ export async function* streamCodexToGemini(
 ): AsyncGenerator<string> {
   let inputTokens = 0;
   let outputTokens = 0;
+  let cachedTokens: number | undefined;
   let hasContent = false;
 
   for await (const evt of iterateCodexEvents(codexApi, rawResponse)) {
@@ -112,7 +114,8 @@ export async function* streamCodexToGemini(
         if (evt.usage) {
           inputTokens = evt.usage.input_tokens;
           outputTokens = evt.usage.output_tokens;
-          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens });
+          cachedTokens = evt.usage.cached_tokens;
+          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens });
         }
 
         // Inject error text if stream completed with no content
@@ -148,6 +151,7 @@ export async function* streamCodexToGemini(
             promptTokenCount: inputTokens,
             candidatesTokenCount: outputTokens,
             totalTokenCount: inputTokens + outputTokens,
+            ...(cachedTokens != null ? { cachedContentTokenCount: cachedTokens } : {}),
           },
           modelVersion: model,
         };
@@ -174,6 +178,7 @@ export async function collectCodexToGeminiResponse(
   let fullText = "";
   let inputTokens = 0;
   let outputTokens = 0;
+  let cachedTokens: number | undefined;
   let responseId: string | null = null;
   const functionCallParts: GeminiPart[] = [];
 
@@ -186,6 +191,7 @@ export async function collectCodexToGeminiResponse(
     if (evt.usage) {
       inputTokens = evt.usage.input_tokens;
       outputTokens = evt.usage.output_tokens;
+      cachedTokens = evt.usage.cached_tokens;
     }
     if (evt.functionCallDone) {
       let args: Record<string, unknown> = {};
@@ -201,12 +207,14 @@ export async function collectCodexToGeminiResponse(
   const usage: GeminiUsageInfo = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
+    cached_tokens: cachedTokens,
   };
 
   const usageMetadata: GeminiUsageMetadata = {
     promptTokenCount: inputTokens,
     candidatesTokenCount: outputTokens,
     totalTokenCount: inputTokens + outputTokens,
+    ...(cachedTokens != null ? { cachedContentTokenCount: cachedTokens } : {}),
   };
 
   // Detect empty response (HTTP 200 but no content)

--- a/src/translation/codex-to-gemini.ts
+++ b/src/translation/codex-to-gemini.ts
@@ -21,6 +21,7 @@ export interface GeminiUsageInfo {
   input_tokens: number;
   output_tokens: number;
   cached_tokens?: number;
+  reasoning_tokens?: number;
 }
 
 /**
@@ -115,7 +116,7 @@ export async function* streamCodexToGemini(
           inputTokens = evt.usage.input_tokens;
           outputTokens = evt.usage.output_tokens;
           cachedTokens = evt.usage.cached_tokens;
-          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens });
+          onUsage?.({ input_tokens: inputTokens, output_tokens: outputTokens, cached_tokens: cachedTokens, reasoning_tokens: evt.usage.reasoning_tokens });
         }
 
         // Inject error text if stream completed with no content
@@ -207,7 +208,7 @@ export async function collectCodexToGeminiResponse(
   const usage: GeminiUsageInfo = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
-    cached_tokens: cachedTokens,
+    ...(cachedTokens != null ? { cached_tokens: cachedTokens } : {}),
   };
 
   const usageMetadata: GeminiUsageMetadata = {

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -240,6 +240,20 @@ export async function* streamCodexToOpenAI(
             ],
           });
         }
+        // Build usage object for final chunk (OpenAI includes usage in last streaming chunk)
+        const chunkUsage: ChatCompletionChunk["usage"] = evt.usage
+          ? {
+              prompt_tokens: evt.usage.input_tokens,
+              completion_tokens: evt.usage.output_tokens,
+              total_tokens: evt.usage.input_tokens + evt.usage.output_tokens,
+              ...(evt.usage.cached_tokens != null
+                ? { prompt_tokens_details: { cached_tokens: evt.usage.cached_tokens } }
+                : {}),
+              ...(evt.usage.reasoning_tokens != null
+                ? { completion_tokens_details: { reasoning_tokens: evt.usage.reasoning_tokens } }
+                : {}),
+            }
+          : null;
         yield formatSSE({
           id: chunkId,
           object: "chat.completion.chunk",
@@ -252,6 +266,7 @@ export async function* streamCodexToOpenAI(
               finish_reason: hasToolCalls ? "tool_calls" : "stop",
             },
           ],
+          usage: chunkUsage,
         });
         break;
       }
@@ -278,6 +293,8 @@ export async function collectCodexResponse(
   let fullReasoning = "";
   let promptTokens = 0;
   let completionTokens = 0;
+  let cachedTokens: number | undefined;
+  let reasoningTokens: number | undefined;
   let responseId: string | null = null;
 
   // Collect tool calls
@@ -293,6 +310,8 @@ export async function collectCodexResponse(
     if (evt.usage) {
       promptTokens = evt.usage.input_tokens;
       completionTokens = evt.usage.output_tokens;
+      cachedTokens = evt.usage.cached_tokens;
+      reasoningTokens = evt.usage.reasoning_tokens;
     }
     if (evt.functionCallDone) {
       toolCalls.push({
@@ -340,11 +359,19 @@ export async function collectCodexResponse(
         prompt_tokens: promptTokens,
         completion_tokens: completionTokens,
         total_tokens: promptTokens + completionTokens,
+        ...(cachedTokens != null
+          ? { prompt_tokens_details: { cached_tokens: cachedTokens } }
+          : {}),
+        ...(reasoningTokens != null
+          ? { completion_tokens_details: { reasoning_tokens: reasoningTokens } }
+          : {}),
       },
     },
     usage: {
       input_tokens: promptTokens,
       output_tokens: completionTokens,
+      cached_tokens: cachedTokens,
+      reasoning_tokens: reasoningTokens,
     },
     responseId,
   };

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -133,6 +133,8 @@ export interface AnthropicContentBlock {
 export interface AnthropicUsage {
   input_tokens: number;
   output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
 }
 
 export interface AnthropicMessagesResponse {

--- a/src/types/codex-events.ts
+++ b/src/types/codex-events.ts
@@ -14,6 +14,8 @@ export interface CodexResponseData {
   usage?: {
     input_tokens: number;
     output_tokens: number;
+    cached_tokens?: number;
+    reasoning_tokens?: number;
   };
   [key: string]: unknown;
 }
@@ -156,6 +158,16 @@ function parseResponseData(data: unknown): CodexResponseData | undefined {
       input_tokens: typeof resp.usage.input_tokens === "number" ? resp.usage.input_tokens : 0,
       output_tokens: typeof resp.usage.output_tokens === "number" ? resp.usage.output_tokens : 0,
     };
+    // Extract cached_tokens from input_tokens_details
+    const inputDetails = isRecord(resp.usage.input_tokens_details) ? resp.usage.input_tokens_details : undefined;
+    if (inputDetails && typeof inputDetails.cached_tokens === "number") {
+      result.usage.cached_tokens = inputDetails.cached_tokens;
+    }
+    // Extract reasoning_tokens from output_tokens_details
+    const outputDetails = isRecord(resp.usage.output_tokens_details) ? resp.usage.output_tokens_details : undefined;
+    if (outputDetails && typeof outputDetails.reasoning_tokens === "number") {
+      result.usage.reasoning_tokens = outputDetails.reasoning_tokens;
+    }
   }
   return result;
 }

--- a/src/types/gemini.ts
+++ b/src/types/gemini.ts
@@ -105,6 +105,7 @@ export interface GeminiUsageMetadata {
   promptTokenCount: number;
   candidatesTokenCount: number;
   totalTokenCount: number;
+  cachedContentTokenCount?: number;
 }
 
 export interface GeminiGenerateContentResponse {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -101,6 +101,12 @@ export interface ChatCompletionUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  prompt_tokens_details?: {
+    cached_tokens?: number;
+  };
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
+  };
 }
 
 export interface ChatCompletionResponse {
@@ -143,6 +149,7 @@ export interface ChatCompletionChunk {
   created: number;
   model: string;
   choices: ChatCompletionChunkChoice[];
+  usage?: ChatCompletionUsage | null;
 }
 
 // --- Error ---


### PR DESCRIPTION
## Summary
- Extract `cached_tokens` from `input_tokens_details` and `reasoning_tokens` from `output_tokens_details` in Codex API responses
- Pass through to all three output formats: OpenAI (`prompt_tokens_details.cached_tokens`), Anthropic (`cache_read_input_tokens`), Gemini (`cachedContentTokenCount`)
- Covers both streaming and non-streaming modes across the full translation pipeline

## Changed files (9)
| Layer | File | Change |
|-------|------|--------|
| Parsing | `src/types/codex-events.ts` | Extract `cached_tokens` / `reasoning_tokens` from nested details |
| Core | `src/translation/codex-event-extractor.ts` | Expand `UsageInfo` interface |
| OpenAI | `src/types/openai.ts` | Add `prompt_tokens_details` / `completion_tokens_details` |
| OpenAI | `src/translation/codex-to-openai.ts` | Emit usage with details in streaming final chunk + non-streaming |
| Anthropic | `src/types/anthropic.ts` | Add `cache_read_input_tokens` |
| Anthropic | `src/translation/codex-to-anthropic.ts` | Include cache fields in usage |
| Gemini | `src/types/gemini.ts` | Add `cachedContentTokenCount` |
| Gemini | `src/translation/codex-to-gemini.ts` | Include cache fields in usage |
| Shared | `src/routes/shared/proxy-handler.ts` | Widen `FormatAdapter` types |

## Test plan
- [ ] Send a multi-turn conversation and verify `prompt_tokens_details.cached_tokens` is non-zero in the OpenAI response
- [ ] Verify Anthropic `/v1/messages` response includes `cache_read_input_tokens` in usage
- [ ] Verify streaming mode includes `usage` in the final chunk

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)