### PR TITLE
fix: let curl auto-negotiate Accept-Encoding for OAuth

### DIFF
--- a/src/tls/curl-fetch.ts
+++ b/src/tls/curl-fetch.ts
@@ -31,9 +31,9 @@ export async function curlFetchGet(
 ): Promise<CurlFetchResponse> {
   const transport = getTransport();
   const headers = buildAnonymousHeaders();
-  if (!transport.isImpersonate()) {
-    headers["Accept-Encoding"] = "gzip, deflate";
-  }
+  // Let --compressed auto-negotiate Accept-Encoding based on curl's actual
+  // decompression capabilities, avoiding error 61 on builds lacking br/zstd.
+  delete headers["Accept-Encoding"];
 
   const result = await transport.get(url, headers, 30, options?.proxyUrl);
   return {
@@ -54,9 +54,9 @@ export async function curlFetchPost(
 ): Promise<CurlFetchResponse> {
   const transport = getTransport();
   const headers = buildAnonymousHeaders();
-  if (!transport.isImpersonate()) {
-    headers["Accept-Encoding"] = "gzip, deflate";
-  }
+  // Let --compressed auto-negotiate Accept-Encoding based on curl's actual
+  // decompression capabilities, avoiding error 61 on builds lacking br/zstd.
+  delete headers["Accept-Encoding"];
   headers["Content-Type"] = contentType;
 
   const result = await transport.simplePost(url, headers, body, 30, options?.proxyUrl);


### PR DESCRIPTION
## Summary
- Remove explicit `Accept-Encoding: gzip, deflate, br, zstd` header from OAuth/appcast requests in `curl-fetch.ts`
- Let `--compressed` flag auto-negotiate encoding based on curl's actual decompression capabilities
- Fixes curl error 61 ("Unrecognized content encoding type") on builds where curl lacks brotli/zstd support

## Root Cause
The previous fix (abe58f1) only downgraded `Accept-Encoding` for system curl (`!isImpersonate()`), but curl-impersonate builds can also lack br/zstd libs. By deleting the header entirely and relying on `--compressed`, curl will only request encodings it can actually decompress — regardless of version or build config.

## Scope
- Only affects `curlFetchGet()` and `curlFetchPost()` in `src/tls/curl-fetch.ts`
- These are only used by OAuth (4 call sites) and appcast (1 call site)
- Codex API requests (`codex-api.ts`) are **not affected** — they have their own header handling

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] OAuth login works on macOS with curl-impersonate
- [ ] OAuth login works on devices with old/limited system curl
- [ ] Codex API requests still send full `Accept-Encoding: gzip, deflate, br, zstd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)