### PR TITLE
fix: recursive additionalProperties injection + upstream error status propagation

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -12,6 +12,7 @@ import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import type { CodexResponsesRequest, CodexInputItem, CodexApi } from "../proxy/codex-api.js";
 import { getConfig } from "../config.js";
+import { injectAdditionalProperties } from "../translation/shared-utils.js";
 import { parseModelName, resolveModelId, getModelInfo, buildDisplayModelName } from "../models/model-store.js";
 import { EmptyResponseError } from "../translation/codex-event-extractor.js";
 import {
@@ -274,7 +275,7 @@ export function createResponsesRoutes(
             ? { name: body.text.format.name }
             : {}),
           ...(isRecord(body.text.format.schema)
-            ? { schema: body.text.format.schema as Record<string, unknown> }
+            ? { schema: injectAdditionalProperties(body.text.format.schema as Record<string, unknown>) }
             : {}),
           ...(typeof body.text.format.strict === "boolean"
             ? { strict: body.text.format.strict }

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -207,8 +207,12 @@ export async function handleProxyRequest(
               return c.json(fmt.formatError(502, "Codex returned empty responses across all available accounts"));
             }
             const msg = collectErr instanceof Error ? collectErr.message : "Unknown error";
-            c.status(502);
-            return c.json(fmt.formatError(502, msg));
+            // Extract upstream status from error message (e.g. "HTTP/1.1 400 Bad Request")
+            const statusMatch = msg.match(/HTTP\/[\d.]+ (\d{3})/);
+            const upstreamStatus = statusMatch ? parseInt(statusMatch[1], 10) : 0;
+            const code = (upstreamStatus >= 400 && upstreamStatus < 600 ? upstreamStatus : 502) as StatusCode;
+            c.status(code);
+            return c.json(fmt.formatError(code, msg));
           }
         }
       }

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -101,30 +101,42 @@ export class CurlCliTransport implements TlsTransport {
 
         // Accumulate until we find \r\n\r\n header separator
         headerBuf = Buffer.concat([headerBuf, chunk]);
-        const separatorIdx = headerBuf.indexOf("\r\n\r\n");
-        if (separatorIdx === -1) return;
 
-        headersParsed = true;
-        clearTimeout(headerTimer);
-        const headerBlock = headerBuf.subarray(0, separatorIdx).toString("utf-8");
-        const remaining = headerBuf.subarray(separatorIdx + 4);
+        // Loop to skip intermediate header blocks (CONNECT tunnel 200, 100 Continue, etc.)
+        while (!headersParsed) {
+          const separatorIdx = headerBuf.indexOf("\r\n\r\n");
+          if (separatorIdx === -1) return; // wait for more data
 
-        const { status, headers: parsedHeaders, setCookieHeaders } = parseHeaderDump(headerBlock);
+          const headerBlock = headerBuf.subarray(0, separatorIdx).toString("utf-8");
+          const remainder = headerBuf.subarray(separatorIdx + 4);
 
-        if (remaining.length > 0) {
-          bodyController?.enqueue(new Uint8Array(remaining));
+          const parsed = parseHeaderDump(headerBlock);
+
+          // Skip intermediate responses: CONNECT tunnel, 1xx informational
+          if (parsed.status < 200 || isConnectResponse(headerBlock)) {
+            headerBuf = remainder;
+            continue;
+          }
+
+          // Real response found
+          headersParsed = true;
+          clearTimeout(headerTimer);
+
+          if (remainder.length > 0) {
+            bodyController?.enqueue(new Uint8Array(remainder));
+          }
+
+          if (signal) {
+            signal.removeEventListener("abort", onAbort);
+          }
+
+          resolve({
+            status: parsed.status,
+            headers: parsed.headers,
+            body: bodyStream,
+            setCookieHeaders: parsed.setCookieHeaders,
+          });
         }
-
-        if (signal) {
-          signal.removeEventListener("abort", onAbort);
-        }
-
-        resolve({
-          status,
-          headers: parsedHeaders,
-          body: bodyStream,
-          setCookieHeaders,
-        });
       });
 
       let stderrBuf = "";
@@ -283,4 +295,10 @@ function parseHeaderDump(headerBlock: string): {
   }
 
   return { status, headers, setCookieHeaders };
+}
+
+/** Detect CONNECT tunnel responses (e.g. "HTTP/1.1 200 Connection established"). */
+function isConnectResponse(headerBlock: string): boolean {
+  const firstLine = headerBlock.split("\r\n")[0] ?? "";
+  return /connection\s+established/i.test(firstLine);
 }

--- a/src/translation/gemini-to-codex.ts
+++ b/src/translation/gemini-to-codex.ts
@@ -14,7 +14,7 @@ import type {
 } from "../proxy/codex-api.js";
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
-import { buildInstructions, budgetToEffort } from "./shared-utils.js";
+import { buildInstructions, budgetToEffort, injectAdditionalProperties } from "./shared-utils.js";
 import { geminiToolsToCodex, geminiToolConfigToCodex } from "./tool-format.js";
 
 /**
@@ -237,8 +237,8 @@ export function translateGeminiToCodexRequest(
   if (mimeType === "application/json") {
     const schema = req.generationConfig?.responseSchema;
     if (schema && Object.keys(schema).length > 0) {
-      // Codex strict mode requires additionalProperties: false at root level
-      const strictSchema = { additionalProperties: false, ...schema };
+      // Codex strict mode requires additionalProperties: false on every object
+      const strictSchema = injectAdditionalProperties(schema as Record<string, unknown>);
       request.text = {
         format: {
           type: "json_schema",

--- a/src/translation/openai-to-codex.ts
+++ b/src/translation/openai-to-codex.ts
@@ -10,7 +10,7 @@ import type {
 } from "../proxy/codex-api.js";
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
-import { buildInstructions } from "./shared-utils.js";
+import { buildInstructions, injectAdditionalProperties } from "./shared-utils.js";
 import {
   openAIToolsToCodex,
   openAIToolChoiceToCodex,
@@ -204,7 +204,9 @@ export function translateToCodexRequest(
         format: {
           type: "json_schema",
           name: req.response_format.json_schema.name,
-          schema: req.response_format.json_schema.schema,
+          schema: injectAdditionalProperties(
+            req.response_format.json_schema.schema as Record<string, unknown>,
+          ),
           ...(req.response_format.json_schema.strict !== undefined
             ? { strict: req.response_format.json_schema.strict }
             : {}),

--- a/src/translation/shared-utils.ts
+++ b/src/translation/shared-utils.ts
@@ -61,3 +61,77 @@ export function budgetToEffort(budget: number | undefined): string | undefined {
   if (budget < 20000) return "high";
   return "xhigh";
 }
+
+/**
+ * Recursively inject `additionalProperties: false` into every object-type node
+ * of a JSON Schema. Deep-clones input to avoid mutation.
+ *
+ * Codex API requires explicit `additionalProperties: false` on every object in
+ * strict mode; OpenAI's native API auto-injects this but our proxy must do it.
+ */
+export function injectAdditionalProperties(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  return walkSchema(structuredClone(schema));
+}
+
+function walkSchema(node: Record<string, unknown>): Record<string, unknown> {
+  // Inject on object types that don't already specify additionalProperties
+  if (node.type === "object" && node.additionalProperties === undefined) {
+    node.additionalProperties = false;
+  }
+
+  // Traverse properties
+  if (isRecord(node.properties)) {
+    for (const key of Object.keys(node.properties)) {
+      const prop = node.properties[key];
+      if (isRecord(prop)) {
+        node.properties[key] = walkSchema(prop);
+      }
+    }
+  }
+
+  // Traverse $defs / definitions
+  for (const defsKey of ["$defs", "definitions"] as const) {
+    if (isRecord(node[defsKey])) {
+      const defs = node[defsKey] as Record<string, unknown>;
+      for (const key of Object.keys(defs)) {
+        if (isRecord(defs[key])) {
+          defs[key] = walkSchema(defs[key] as Record<string, unknown>);
+        }
+      }
+    }
+  }
+
+  // Traverse items (array items)
+  if (isRecord(node.items)) {
+    node.items = walkSchema(node.items as Record<string, unknown>);
+  }
+
+  // Traverse prefixItems
+  if (Array.isArray(node.prefixItems)) {
+    node.prefixItems = node.prefixItems.map((item: unknown) =>
+      isRecord(item) ? walkSchema(item) : item,
+    );
+  }
+
+  // Traverse combinators: oneOf, anyOf, allOf
+  for (const combiner of ["oneOf", "anyOf", "allOf"] as const) {
+    if (Array.isArray(node[combiner])) {
+      node[combiner] = (node[combiner] as unknown[]).map((entry: unknown) =>
+        isRecord(entry) ? walkSchema(entry) : entry,
+      );
+    }
+  }
+
+  // Traverse not
+  if (isRecord(node.not)) {
+    node.not = walkSchema(node.not as Record<string, unknown>);
+  }
+
+  return node;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}


### PR DESCRIPTION
## Summary
- **Fix 1**: Add `injectAdditionalProperties()` — recursively injects `additionalProperties: false` on every object-type node in JSON schemas. Codex API requires this explicitly but OpenAI auto-injects it when `strict: true`. Applied to all 3 endpoints (OpenAI, Gemini, Responses passthrough).
- **Fix 2**: Fix CONNECT tunnel header parsing in `curl-cli-transport` — loop to skip intermediate header blocks (CONNECT 200, 100 Continue) before parsing actual response headers. Previously the tunnel's `HTTP/1.1 200` was parsed as the real status, masking upstream 4xx errors as 502.
- **Fix 3**: Extract upstream HTTP status from error messages in non-streaming collect path instead of hardcoding 502.

## Test plan
- [x] `npx vitest run` — 660/660 tests pass (41 files)
- [ ] Manual test on device C with `json_schema` response_format request
- [ ] Verify 400 errors from Codex are returned as 400 (not 502) when behind proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)