### PR TITLE
fix: 429 real reset duration + auto-fallback + scheduling tiebreaker

### DIFF
--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -132,10 +132,14 @@ export class AccountPool {
       this.roundRobinIndex++;
       return selected;
     }
-    // least_used: sort by request_count asc, then by last_used asc (LRU)
+    // least_used: sort by request_count asc → window_reset_at asc → last_used asc (LRU)
     candidates.sort((a, b) => {
       const diff = a.usage.request_count - b.usage.request_count;
       if (diff !== 0) return diff;
+      // Prefer accounts whose quota window resets sooner (more fresh capacity)
+      const aReset = a.usage.window_reset_at ?? Infinity;
+      const bReset = b.usage.window_reset_at ?? Infinity;
+      if (aReset !== bReset) return aReset - bReset;
       const aTime = a.usage.last_used ? new Date(a.usage.last_used).getTime() : 0;
       const bTime = b.usage.last_used ? new Date(b.usage.last_used).getTime() : 0;
       return aTime - bTime;

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -59,6 +59,23 @@ function toErrorStatus(status: number): StatusCode {
   return (status >= 400 && status < 600 ? status : 502) as StatusCode;
 }
 
+/** Extract the rate-limit reset duration from a 429 error body, if available. */
+function extractRetryAfterSec(body: string): number | undefined {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    const error = parsed.error as Record<string, unknown> | undefined;
+    if (!error) return undefined;
+    if (typeof error.resets_in_seconds === "number" && error.resets_in_seconds > 0) {
+      return error.resets_in_seconds;
+    }
+    if (typeof error.resets_at === "number" && error.resets_at > 0) {
+      const diff = error.resets_at - Date.now() / 1000;
+      return diff > 0 ? diff : undefined;
+    }
+  } catch { /* use default backoff */ }
+  return undefined;
+}
+
 /** Check if a CodexApiError indicates the model is not supported on the account's plan. */
 function isModelNotSupportedError(err: CodexApiError): boolean {
   // Only 4xx client errors (exclude 429 rate-limit)
@@ -256,8 +273,29 @@ export async function handleProxyRequest(
           err.message,
         );
         if (err.status === 429) {
-          // P1-6: Count 429s as requests via encapsulated API (no direct entry mutation)
-          accountPool.markRateLimited(activeEntryId, { countRequest: true });
+          const retryAfterSec = extractRetryAfterSec(err.body);
+          accountPool.markRateLimited(activeEntryId, { retryAfterSec, countRequest: true });
+
+          const failedEmail = accountPool.getEntry(activeEntryId)?.email ?? "?";
+          console.warn(
+            `[${fmt.tag}] Account ${activeEntryId} (${failedEmail}) | 429 rate limited` +
+            (retryAfterSec != null ? ` (resets in ${Math.round(retryAfterSec)}s)` : "") +
+            `, trying different account...`,
+          );
+
+          const retry = accountPool.acquire({
+            model: req.codexRequest.model,
+            excludeIds: triedEntryIds,
+          });
+          if (retry) {
+            activeEntryId = retry.entryId;
+            triedEntryIds.push(retry.entryId);
+            const retryProxyUrl = proxyPool?.resolveProxyUrl(retry.entryId);
+            codexApi = new CodexApi(retry.token, retry.accountId, cookieJar, retry.entryId, retryProxyUrl);
+            console.log(`[${fmt.tag}] 429 fallback → account ${retry.entryId}`);
+            continue;
+          }
+
           c.status(429);
           return c.json(fmt.format429(err.message));
         }

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -300,9 +300,7 @@ export async function handleProxyRequest(
           return c.json(fmt.format429(err.message));
         }
         accountPool.release(activeEntryId);
-        const code = (
-          err.status >= 400 && err.status < 600 ? err.status : 502
-        ) as StatusCode;
+        const code = toErrorStatus(err.status);
         c.status(code);
         return c.json(fmt.formatError(code, err.message));
       }


### PR DESCRIPTION
## Summary

Fixes #65 — 429 rate-limited accounts were recovering after 60s (hardcoded config default) instead of respecting the actual cooldown from the backend (e.g. 5.5 days for free plans), causing repeated failed requests.

- **Parse real reset time from 429 body**: Extract `resets_in_seconds` (or `resets_at` fallback) from the Codex API 429 error response and pass to `markRateLimited({ retryAfterSec })`. The infrastructure was already there — just needed the value.
- **Auto-fallback to next account on 429**: Instead of immediately returning 429 to the client, try `acquire()` with the next available account (same pattern as model-not-supported retry). Loop until success or all accounts exhausted.
- **Scheduling tiebreaker**: `selectByStrategy()` now sorts by `request_count` → `window_reset_at` (prefer sooner reset) → `last_used` (LRU). Accounts with sooner quota resets get priority.

## Test plan

- [x] 429 with `resets_in_seconds` in body → `markRateLimited` receives correct `retryAfterSec`
- [x] 429 with `resets_at` fallback → correctly computes seconds until reset
- [x] 429 with plain body → falls back to config default (undefined retryAfterSec)
- [x] 429 fallback succeeds with second account → returns 200
- [x] 429 exhausts all accounts → returns 429 to client
- [x] `window_reset_at` tiebreaker → sooner reset preferred
- [x] `window_reset_at` null → ranked after known values
- [x] Full regression: 666/666 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)