### PR TITLE
fix: add Cache-Control headers to prevent stale frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - 模型列表自动同步：后端动态 fetch 成功后自动回写 `config/models.yaml`，静态配置不再滞后；前端每 60s 轮询模型列表，新模型无需刷新页面即可选择
 - Tuple Schema 支持：`prefixItems`（JSON Schema 2020-12 tuple）自动转换为等价 object schema 发给上游，响应侧还原为数组；OpenAI / Gemini / Responses 三端点统一支持
 
+### Fixed
+
+- 前端缓存问题：`index.html` 设置 `Cache-Control: no-cache` 防止浏览器缓存旧页面，`/assets/*` 设置 immutable 长缓存（Vite content hash）
+
 ### Changed
 
 - Light mode 背景色从 `#f6f8f6` 改为纯白 `#ffffff`，增大亮/暗主题视觉差异

--- a/src/routes/web.ts
+++ b/src/routes/web.ts
@@ -28,12 +28,16 @@ export function createWebRoutes(accountPool: AccountPool): Hono {
   console.log(`[Web] publicDir: ${publicDir} (exists: ${hasWebUI})`);
   console.log(`[Web] desktopPublicDir: ${desktopPublicDir} (exists: ${hasDesktopUI})`);
 
-  // Serve Vite build assets (web)
-  app.use("/assets/*", serveStatic({ root: publicDir }));
+  // Serve Vite build assets (web) — immutable cache (filenames contain content hash)
+  app.use("/assets/*", async (c, next) => {
+    c.header("Cache-Control", "public, max-age=31536000, immutable");
+    await next();
+  }, serveStatic({ root: publicDir }));
 
   app.get("/", (c) => {
     try {
       const html = readFileSync(webIndexPath, "utf-8");
+      c.header("Cache-Control", "no-cache");
       return c.html(html);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -44,13 +48,17 @@ export function createWebRoutes(accountPool: AccountPool): Hono {
 
   // Desktop UI — served at /desktop for Electron
   if (hasDesktopUI) {
-    app.use("/desktop/assets/*", serveStatic({
+    app.use("/desktop/assets/*", async (c, next) => {
+      c.header("Cache-Control", "public, max-age=31536000, immutable");
+      await next();
+    }, serveStatic({
       root: desktopPublicDir,
       rewriteRequestPath: (path) => path.replace(/^\/desktop/, ""),
     }));
 
     app.get("/desktop", (c) => {
       const html = readFileSync(desktopIndexPath, "utf-8");
+      c.header("Cache-Control", "no-cache");
       return c.html(html);
     });
   } else {


### PR DESCRIPTION
## Summary
- `index.html`（`/` 和 `/desktop`）设置 `Cache-Control: no-cache`，浏览器每次请求都会验证是否有新版本
- `/assets/*` 和 `/desktop/assets/*` 设置 `Cache-Control: public, max-age=31536000, immutable`，Vite content hash 保证文件名唯一

## 问题
更新后浏览器可能缓存旧的 `index.html`，导致加载旧 JS bundle，前端模型列表不更新（#78）

## Test plan
- [x] TypeScript 编译通过
- [x] 711 tests passed（8 个 pre-existing theme failure）
- [x] 新增 4 个 cache header 验证测试