### PR TITLE
fix: skip proxy update checker in Electron mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { ProxyPool } from "./proxy/proxy-pool.js";
 import { createProxyRoutes } from "./routes/proxies.js";
 import { createResponsesRoutes } from "./routes/responses.js";
 import { startUpdateChecker, stopUpdateChecker } from "./update-checker.js";
-import { startProxyUpdateChecker, stopProxyUpdateChecker, setCloseHandler } from "./self-update.js";
+import { startProxyUpdateChecker, stopProxyUpdateChecker, setCloseHandler, getDeployMode } from "./self-update.js";
 import { initProxy } from "./tls/curl-binary.js";
 import { initTransport } from "./tls/transport.js";
 import { loadStaticModels } from "./models/model-store.js";
@@ -116,9 +116,12 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   }
   console.log();
 
-  // Start background update checker
+  // Start background update checkers
+  // (Electron has its own native auto-updater — skip proxy update checker)
   startUpdateChecker();
-  startProxyUpdateChecker();
+  if (getDeployMode() !== "electron") {
+    startProxyUpdateChecker();
+  }
 
   // Start background model refresh (requires auth to be ready)
   startModelRefresh(accountPool, cookieJar, proxyPool);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,12 +75,13 @@ function Dashboard() {
   const prevUpdateAvailable = useRef(false);
 
   // Auto-open modal when update becomes available after a check
+  // (Electron has its own native auto-updater — don't show web modal)
   useEffect(() => {
-    if (update.hasUpdate && !prevUpdateAvailable.current) {
+    if (update.hasUpdate && !prevUpdateAvailable.current && update.proxyUpdateInfo?.mode !== "electron") {
       setShowModal(true);
     }
     prevUpdateAvailable.current = update.hasUpdate;
-  }, [update.hasUpdate]);
+  }, [update.hasUpdate, update.proxyUpdateInfo?.mode]);
 
   const handleProxyChange = async (accountId: string, proxyId: string) => {
     accounts.patchLocal(accountId, { proxyId });


### PR DESCRIPTION
## Summary
- Electron has its own native auto-updater (`electron-updater`) — the backend's `startProxyUpdateChecker()` was also running, causing the web UI UpdateModal to conflict with the native updater
- Skip `startProxyUpdateChecker()` when deploy mode is `"electron"`
- Don't auto-open `UpdateModal` in Electron mode

## Test plan
- [ ] Electron desktop: no web UpdateModal popup, native auto-updater works as before
- [ ] CLI (git mode): proxy update checker + web modal still works normally