### PR TITLE
fix: disable desktop context injection by default (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 默认关闭 desktop context 注入：之前每次请求注入 ~1500 token 的 Codex Desktop 系统提示，导致 prompt_tokens 虚高；新增 `model.inject_desktop_context` 配置项（默认 `false`），需要时可手动开启 (#95)
+
 ### Added
 
 - 额度自动刷新 + 分层预警：后台每 5 分钟（可配置）定时拉取所有账号的官方额度，缓存到 AccountEntry 供 Dashboard 即时读取；额度达到阈值（默认 80%/90%，可自定义）时显示 warning/critical 横幅；额度耗尽的账号自动标记为 rate_limited 跳过分配，到期自动恢复 (#92)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,8 +3,8 @@ api:
   timeout_seconds: 60
 client:
   originator: Codex Desktop
-  app_version: 26.313.41514
-  build_number: "1043"
+  app_version: 26.311.21342
+  build_number: "993"
   platform: darwin
   arch: arm64
   chromium_version: "144"
@@ -39,10 +39,6 @@ tls:
 quota:
   refresh_interval_minutes: 5
   warning_thresholds:
-    primary:
-      - 80
-      - 90
-    secondary:
-      - 80
-      - 90
+    primary: [80, 90]
+    secondary: [80, 90]
   skip_exhausted: true

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,8 +3,8 @@ api:
   timeout_seconds: 60
 client:
   originator: Codex Desktop
-  app_version: 26.311.21342
-  build_number: "993"
+  app_version: 26.313.41514
+  build_number: "1043"
   platform: darwin
   arch: arm64
   chromium_version: "144"
@@ -12,6 +12,7 @@ model:
   default: gpt-5.2-codex
   default_reasoning_effort: medium
   default_service_tier: null
+  inject_desktop_context: false
   suppress_desktop_directives: true
 auth:
   jwt_token: null
@@ -38,6 +39,10 @@ tls:
 quota:
   refresh_interval_minutes: 5
   warning_thresholds:
-    primary: [80, 90]
-    secondary: [80, 90]
+    primary:
+      - 80
+      - 90
+    secondary:
+      - 80
+      - 90
   skip_exhausted: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ const ConfigSchema = z.object({
     default: z.string().default("gpt-5.2-codex"),
     default_reasoning_effort: z.string().default("medium"),
     default_service_tier: z.string().nullable().default(null),
+    inject_desktop_context: z.boolean().default(false),
     suppress_desktop_directives: z.boolean().default(true),
   }),
   auth: z.object({

--- a/src/translation/shared-utils.ts
+++ b/src/translation/shared-utils.ts
@@ -43,6 +43,7 @@ const SUPPRESS_PROMPT =
  * to override desktop-specific behaviors.
  */
 export function buildInstructions(userInstructions: string): string {
+  if (!getConfig().model.inject_desktop_context) return userInstructions;
   const ctx = getDesktopContext();
   if (!ctx) return userInstructions;
   if (getConfig().model.suppress_desktop_directives) {


### PR DESCRIPTION
## Summary

- 之前每次请求都注入 ~1500 token 的 Codex Desktop 系统提示（`desktop-context.md`），导致 `prompt_tokens` 从 ~17 虚高到 ~1587
- 新增 `model.inject_desktop_context` 配置项（默认 `false`），不再默认注入
- 需要 desktop context 的用户可在 `config/default.yaml` 设置 `inject_desktop_context: true`

Closes #95

## Test plan

- [x] 单元测试验证 `inject_desktop_context: false` 时 `buildInstructions()` 只返回用户指令
- [x] 单元测试验证 `inject_desktop_context: true` 时正常注入 desktop context
- [x] 实测 `prompt_tokens` 从 1587 降至 17
- [x] 全量 788 tests 通过