### PR TITLE
fix: macOS Electron login error -86 (EBADARCH) (#96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,12 @@ jobs:
             artifact: windows
           - os: macos-latest
             platform: mac
-            artifact: macos
+            arch: arm64
+            artifact: macos-arm64
+          - os: macos-latest
+            platform: mac
+            arch: x64
+            artifact: macos-x64
           - os: ubuntu-latest
             platform: linux
             artifact: linux
@@ -48,7 +53,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Setup curl-impersonate
-        run: npx tsx scripts/setup-curl.ts
+        run: npx tsx scripts/setup-curl.ts ${{ matrix.arch && format('--arch {0}', matrix.arch) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,8 +66,8 @@ jobs:
       - name: Build app
         run: npm run app:build
 
-      - name: Pack (${{ matrix.platform }})
-        run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} --publish never
+      - name: Pack (${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }})
+        run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} ${{ matrix.arch && format('--{0}', matrix.arch) || '' }} --publish never
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- macOS Electron 桌面版登录报 `spawn Unknown system error -86`：CI 在 arm64 runner 上同时构建 arm64/x64 DMG，但只下载 arm64 的 curl-impersonate，导致 Intel Mac 用户 spawn 失败（EBADARCH）；拆分为 per-arch 构建 + `setup-curl.ts` 支持 `--arch` 交叉下载；错误提示改为明确的架构不匹配诊断 (#96)
 - 默认关闭 desktop context 注入：之前每次请求注入 ~1500 token 的 Codex Desktop 系统提示，导致 prompt_tokens 虚高；新增 `model.inject_desktop_context` 配置项（默认 `false`），需要时可手动开启 (#95)
 
 ### Added

--- a/scripts/setup-curl.ts
+++ b/scripts/setup-curl.ts
@@ -27,9 +27,18 @@ interface PlatformInfo {
   destName: string;
 }
 
+/** Parse --arch flag from CLI args to override process.arch (for cross-compilation). */
+function getTargetArch(): string {
+  const idx = process.argv.indexOf("--arch");
+  if (idx !== -1 && process.argv[idx + 1]) {
+    return process.argv[idx + 1];
+  }
+  return process.arch;
+}
+
 function getPlatformInfo(version: string): PlatformInfo {
   const platform = process.platform;
-  const arch = process.arch;
+  const arch = getTargetArch();
 
   if (platform === "linux") {
     const archStr = arch === "arm64" ? "aarch64-linux-gnu" : "x86_64-linux-gnu";
@@ -227,7 +236,8 @@ async function main() {
   // Resolve latest version from GitHub
   const version = await getLatestVersion();
   console.log(`[setup] curl-impersonate setup (${version})`);
-  console.log(`[setup] Platform: ${process.platform}-${process.arch}`);
+  const targetArch = getTargetArch();
+  console.log(`[setup] Platform: ${process.platform}-${targetArch}${targetArch !== process.arch ? ` (cross: host=${process.arch})` : ""}`);
 
   const info = getPlatformInfo(version);
   const isWindowsDll = process.platform === "win32";

--- a/src/tls/__tests__/curl-cli-transport.test.ts
+++ b/src/tls/__tests__/curl-cli-transport.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../curl-binary.js", () => ({
+  resolveCurlBinary: () => "/mock/bin/curl-impersonate",
+  getChromeTlsArgs: () => [],
+  getProxyArgs: () => [],
+  isImpersonate: () => true,
+}));
+
+import { formatSpawnError } from "../curl-cli-transport.js";
+
+describe("formatSpawnError", () => {
+  it("returns architecture mismatch hint for errno -86 (EBADARCH)", () => {
+    const err = Object.assign(new Error("spawn Unknown system error -86"), { errno: -86 });
+    const msg = formatSpawnError(err);
+    expect(msg).toContain("wrong CPU architecture");
+    expect(msg).toContain(process.arch);
+    expect(msg).toContain("npm run setup");
+    expect(msg).toContain("/mock/bin/curl-impersonate");
+  });
+
+  it("detects -86 from error message when errno is not set", () => {
+    const err = new Error("spawn Unknown system error -86");
+    const msg = formatSpawnError(err);
+    expect(msg).toContain("wrong CPU architecture");
+  });
+
+  it("returns generic message for other spawn errors", () => {
+    const err = new Error("spawn ENOENT");
+    const msg = formatSpawnError(err);
+    expect(msg).toBe("curl spawn error: spawn ENOENT");
+    expect(msg).not.toContain("architecture");
+  });
+});

--- a/src/tls/__tests__/setup-curl-arch.test.ts
+++ b/src/tls/__tests__/setup-curl-arch.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import { resolve } from "path";
+
+const SETUP_SCRIPT = resolve(__dirname, "../../../scripts/setup-curl.ts");
+
+describe("setup-curl --arch flag", () => {
+  it("uses --arch override in platform line", () => {
+    const output = execFileSync(
+      "npx",
+      ["tsx", SETUP_SCRIPT, "--check", "--arch", "x64"],
+      { encoding: "utf-8", timeout: 30_000 },
+    );
+    // Should report x64 as target, with cross-compilation note if host differs
+    expect(output).toContain(`${process.platform}-x64`);
+    if (process.arch !== "x64") {
+      expect(output).toContain(`cross: host=${process.arch}`);
+    }
+  });
+
+  it("defaults to host arch without --arch flag", () => {
+    const output = execFileSync(
+      "npx",
+      ["tsx", SETUP_SCRIPT, "--check"],
+      { encoding: "utf-8", timeout: 30_000 },
+    );
+    expect(output).toContain(`${process.platform}-${process.arch}`);
+    expect(output).not.toContain("cross:");
+  });
+});

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -160,7 +160,7 @@ export class CurlCliTransport implements TlsTransport {
         if (signal) {
           signal.removeEventListener("abort", onAbort);
         }
-        reject(new Error(`curl spawn error: ${err.message}`));
+        reject(new Error(formatSpawnError(err)));
       });
     });
   }
@@ -228,6 +228,24 @@ export class CurlCliTransport implements TlsTransport {
   }
 }
 
+/**
+ * Format a spawn error with architecture hint for EBADARCH (-86) on macOS.
+ * This commonly happens when curl-impersonate binary doesn't match the CPU arch.
+ */
+export function formatSpawnError(err: Error & { errno?: number; code?: string }): string {
+  // errno -86 = EBADARCH (Bad CPU type in executable) on macOS
+  if (err.errno === -86 || err.message.includes("-86")) {
+    const binary = resolveCurlBinary();
+    return (
+      `curl-impersonate binary has wrong CPU architecture for this system. ` +
+      `Binary: ${binary}, Host arch: ${process.arch}. ` +
+      `Fix: run "npm run setup -- --force" to download the correct binary, ` +
+      `or delete bin/curl-impersonate to fall back to system curl.`
+    );
+  }
+  return `curl spawn error: ${err.message}`;
+}
+
 /** Execute curl via execFile and parse the status code from the output. */
 function execCurl(args: string[]): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
@@ -237,7 +255,13 @@ function execCurl(args: string[]): Promise<{ status: number; body: string }> {
       { maxBuffer: 2 * 1024 * 1024 },
       (err, stdout, stderr) => {
         if (err) {
-          reject(new Error(`curl failed: ${err.message} ${stderr}`));
+          const castErr = err as Error & { errno?: number };
+          // Check for EBADARCH first (architecture mismatch)
+          if (castErr.errno === -86 || err.message.includes("-86")) {
+            reject(new Error(formatSpawnError(castErr)));
+          } else {
+            reject(new Error(`curl failed: ${err.message} ${stderr}`));
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
- CI 在单个 arm64 runner 上同时构建 arm64/x64 DMG，但只下载 arm64 的 curl-impersonate，导致 Intel Mac 用户登录时 spawn 失败（EBADARCH -86）
- 拆分 macOS CI 为 per-arch job，`setup-curl.ts` 新增 `--arch` flag 支持交叉下载
- spawn 错误提示改为明确的架构不匹配诊断 + 修复建议

Closes #96

## Test plan
- [x] 5 new tests (formatSpawnError + setup-curl --arch) pass
- [x] Full suite 790/790 pass
- [ ] Verify next Electron release produces working x64 + arm64 DMGs