### PR TITLE
fix: clear quota warnings when account is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- 删除账号后额度预警横幅未清除：`DELETE /auth/accounts/:id` 漏调 `clearWarnings()`，导致已删除账号的 quota warning 残留在前端 (#100)
 - macOS Electron 桌面版登录报 `spawn Unknown system error -86`：CI 在 arm64 runner 上同时构建 arm64/x64 DMG，但只下载 arm64 的 curl-impersonate，导致 Intel Mac 用户 spawn 失败（EBADARCH）；拆分为 per-arch 构建 + `setup-curl.ts` 支持 `--arch` 交叉下载；错误提示改为明确的架构不匹配诊断 (#96)
 - 默认关闭 desktop context 注入：之前每次请求注入 ~1500 token 的 Codex Desktop 系统提示，导致 prompt_tokens 虚高；新增 `model.inject_desktop_context` 配置项（默认 `false`），需要时可手动开启 (#95)
 

--- a/src/routes/__tests__/accounts-delete-warnings.test.ts
+++ b/src/routes/__tests__/accounts-delete-warnings.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests that deleting an account also clears its quota warnings.
+ * Regression test for issue #100.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock fs before importing anything
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("../../paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-data"),
+  getConfigDir: vi.fn(() => "/tmp/test-config"),
+}));
+
+vi.mock("../../config.js", () => ({
+  getConfig: vi.fn(() => ({
+    auth: {
+      jwt_token: null,
+      rotation_strategy: "least_used",
+      rate_limit_backoff_seconds: 60,
+    },
+    server: { proxy_api_key: null },
+  })),
+}));
+
+const mockIsTokenExpired = vi.hoisted(() => vi.fn(() => false));
+vi.mock("../../auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token.slice(0, 8)}`),
+  extractUserProfile: vi.fn((token: string) => ({
+    email: `${token.slice(0, 4)}@test.com`,
+    chatgpt_plan_type: "free",
+  })),
+  isTokenExpired: mockIsTokenExpired,
+}));
+
+vi.mock("../../utils/jitter.js", () => ({
+  jitter: vi.fn((val: number) => val),
+}));
+
+vi.mock("../../models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+}));
+
+import { Hono } from "hono";
+import { AccountPool } from "../../auth/account-pool.js";
+import { createAccountRoutes } from "../../routes/accounts.js";
+import { updateWarnings, getActiveWarnings, clearWarnings } from "../../auth/quota-warnings.js";
+
+const mockScheduler = {
+  scheduleOne: vi.fn(),
+  clearOne: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+};
+
+describe("DELETE /auth/accounts/:id clears quota warnings", () => {
+  let pool: AccountPool;
+  let app: Hono;
+
+  beforeEach(() => {
+    mockIsTokenExpired.mockReturnValue(false);
+    pool = new AccountPool();
+    const routes = createAccountRoutes(pool, mockScheduler as never);
+    app = new Hono();
+    app.route("/", routes);
+
+    // Clean up warnings state between tests
+    for (const w of getActiveWarnings()) {
+      clearWarnings(w.accountId);
+    }
+  });
+
+  it("should clear quota warnings when an account is deleted", async () => {
+    // Add an account
+    const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-delete-warnings";
+    const addResp = await app.request("/auth/accounts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(addResp.status).toBe(200);
+    const { account } = await addResp.json();
+    const accountId = account.id;
+
+    // Simulate quota warnings for this account
+    updateWarnings(accountId, [
+      {
+        accountId,
+        email: "test@test.com",
+        window: "primary",
+        level: "critical",
+        usedPercent: 95,
+        resetAt: null,
+      },
+    ]);
+    expect(getActiveWarnings().some((w) => w.accountId === accountId)).toBe(true);
+
+    // Delete the account
+    const delResp = await app.request(`/auth/accounts/${encodeURIComponent(accountId)}`, {
+      method: "DELETE",
+    });
+    expect(delResp.status).toBe(200);
+
+    // Warnings should be cleared
+    expect(getActiveWarnings().some((w) => w.accountId === accountId)).toBe(false);
+  });
+
+  it("should not fail when deleting account with no warnings", async () => {
+    const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-no-warnings";
+    const addResp = await app.request("/auth/accounts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    const { account } = await addResp.json();
+
+    // No warnings set — delete should still succeed
+    const delResp = await app.request(`/auth/accounts/${encodeURIComponent(account.id)}`, {
+      method: "DELETE",
+    });
+    expect(delResp.status).toBe(200);
+    const body = await delResp.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -26,7 +26,7 @@ import type { CodexQuota, AccountInfo } from "../auth/types.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { toQuota } from "../auth/quota-utils.js";
-import { getActiveWarnings, getWarningsLastUpdated } from "../auth/quota-warnings.js";
+import { clearWarnings, getActiveWarnings, getWarningsLastUpdated } from "../auth/quota-warnings.js";
 
 const BulkImportSchema = z.object({
   accounts: z.array(z.object({
@@ -216,6 +216,7 @@ export function createAccountRoutes(
       return c.json({ error: "Account not found" });
     }
     cookieJar?.clear(id);
+    clearWarnings(id);
     return c.json({ success: true });
   });
 


### PR DESCRIPTION
## Summary

- `DELETE /auth/accounts/:id` 漏调 `clearWarnings(id)`，导致已删除账号的 quota warning 横幅残留在 Dashboard
- 添加 `clearWarnings(id)` 到删除流程中，紧随 `cookieJar?.clear(id)` 之后

Closes #100

## Test plan

- [x] 新增 `accounts-delete-warnings.test.ts`：验证删除账号后 `getActiveWarnings()` 不再包含该账号
- [x] 验证无 warning 的账号删除不会报错
- [x] 全量测试通过