### PR TITLE
fix: stream disconnection handling in curl transport + proxy handler

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -153,7 +153,13 @@ export async function handleProxyRequest(
               () => {},
               req.tupleSchema,
             )) {
-              await s.write(chunk);
+              try {
+                await s.write(chunk);
+              } catch {
+                // Client disconnected mid-stream — stop reading upstream
+                abortController.abort();
+                return;
+              }
             }
           } catch (err) {
             // P2-8: Send error SSE event to client before closing
@@ -161,7 +167,6 @@ export async function handleProxyRequest(
               const errMsg = err instanceof Error ? err.message : "Stream interrupted";
               await s.write(`data: ${JSON.stringify({ error: { message: errMsg, type: "stream_error" } })}\n\n`);
             } catch { /* client already gone */ }
-            throw err;
           } finally {
             // P0-2: Kill curl subprocess if still running
             abortController.abort();

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -151,8 +151,14 @@ export class CurlCliTransport implements TlsTransport {
         }
         if (!headersParsed) {
           reject(new Error(`curl exited with code ${code}: ${stderrBuf}`));
+        } else if (code !== 0 && code !== null) {
+          // curl died mid-stream (e.g. connection reset, SIGPIPE) — signal error to reader
+          try {
+            bodyController?.error(new Error(`curl exited with code ${code} mid-stream: ${stderrBuf.trim() || "connection lost"}`));
+          } catch { /* stream already closed */ }
+        } else {
+          bodyController?.close();
         }
-        bodyController?.close();
       });
 
       child.on("error", (err) => {


### PR DESCRIPTION
## Summary
- curl 进程中途异常退出（connection reset、SIGPIPE）时，改用 `bodyController.error()` 传播错误，而非 `close()` 静默截断 stream
- proxy-handler 的 `s.write(chunk)` 加 try/catch，客户端断开时主动 abort 上游 curl 进程并停止 stream
- 移除 catch block 里的 `throw err`，避免 stream 关闭后 unhandled rejection

## Root cause
用户报告 Codex CLI 出现 "stream disconnected before completion"。排查发现 curl 进程非零退出时 `bodyController.close()` 让 stream 看起来正常结束，客户端收到不完整内容但没有错误信号。

## Test plan
- [x] `npm test` — 相关测试通过
- [x] Codex CLI 长 stream 测试（1464 tokens essay）完整完成无断流
- [x] curl 短 stream + 长 stream 手动验证