### PR TITLE
fix: prevent quota-exhausted accounts from cycling back to active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- 额度耗尽账号仍显示「活跃」并接收请求的问题（#115）
+  - `markQuotaExhausted()` 现在可以覆盖 `rate_limited` 状态（仅延长，不缩短 reset 时间）
+  - 后台额度刷新现在同时检查 `rate_limited` 账号，防止因 429 短暂 backoff 导致漏检
 - `/v1/responses` 不再强制要求 `instructions` 字段，未传时默认空字符串（#71）
   - 修复 Cherry 等第三方客户端不传 `instructions` 时返回 400 的兼容性问题
 - CI 构建修复：WebSocket 传输 `instructions` 类型不匹配（TS2322）导致 Electron/Docker 编译失败

--- a/README.md
+++ b/README.md
@@ -481,6 +481,10 @@ server:
 - 模型响应中自动过滤 Codex Desktop 指令
 <!-- CHANGELOG:END -->
 
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=icebear0828/codex-proxy&type=Date)](https://star-history.com/#icebear0828/codex-proxy&Date)
+
 ## 📄 许可协议 (License)
 
 本项目采用 **非商业许可 (Non-Commercial)**：

--- a/config/prompts/automation-response.md
+++ b/config/prompts/automation-response.md
@@ -11,19 +11,16 @@ Response MUST end with a remark-directive block.
 - REQUIRED: End with a valid remark-directive block on its own line (not inline).
   - Always include an inbox item directive:
     \`::inbox-item{title="Sample title" summary="Place description here"}\`
-- If you want to close the thread, add an archive directive on its own line after the inbox item:
-  \`::archive-thread\`
 
 ## Choosing return value
 
 - For recurring/bg threads (e.g., "pull datadog logs and fix any new bugs", "address the PR comments"):
   - Always return \`::inbox-item{...}\` with the title/summary the user should see.
-  - Only add \`::archive-thread\` when there is nothing actionable or new to show. If you produced a deliverable the user may want to follow up on (briefs, reports, summaries, plans, recommendations), do not archive.
 
 ## Guidelines
 
 - Directives MUST be on their own line.
-- Output exactly ONE inbox-item directive. Archive-thread is optional.
+- Output exactly ONE inbox-item directive.
 - Do NOT use invalid remark-directive formatting.
 - DO NOT place commas between arguments.
   - Valid: \`::inbox-item{title="Sample title" summary="Place description here"}\`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.59",
+  "version": "1.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "1.0.59",
+      "version": "1.0.67",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -7364,7 +7364,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "1.0.58",
+      "version": "1.0.67",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/src/auth/__tests__/account-pool-quota.test.ts
+++ b/src/auth/__tests__/account-pool-quota.test.ts
@@ -123,7 +123,7 @@ describe("AccountPool quota methods", () => {
       expect(entry?.usage.rate_limit_until).toBeTruthy();
     });
 
-    it("does not override non-active status", () => {
+    it("does not override disabled status", () => {
       const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd");
       pool.markStatus(id, "disabled");
 
@@ -131,6 +131,51 @@ describe("AccountPool quota methods", () => {
 
       const entry = pool.getEntry(id);
       expect(entry?.status).toBe("disabled"); // unchanged
+    });
+
+    it("does not override expired status", () => {
+      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd2");
+      pool.markStatus(id, "expired");
+
+      pool.markQuotaExhausted(id, Math.floor(Date.now() / 1000) + 3600);
+
+      const entry = pool.getEntry(id);
+      expect(entry?.status).toBe("expired"); // unchanged
+    });
+
+    it("extends rate_limit_until on already rate_limited account", () => {
+      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd3");
+      // Simulate 429 backoff (short)
+      pool.markRateLimited(id, { retryAfterSec: 60 });
+      const entryBefore = pool.getEntry(id);
+      expect(entryBefore?.status).toBe("rate_limited");
+      const shortUntil = new Date(entryBefore!.usage.rate_limit_until!).getTime();
+
+      // Quota refresh discovers exhaustion — much longer reset
+      const resetAt = Math.floor(Date.now() / 1000) + 7200; // 2 hours
+      pool.markQuotaExhausted(id, resetAt);
+
+      const entryAfter = pool.getEntry(id);
+      expect(entryAfter?.status).toBe("rate_limited");
+      const longUntil = new Date(entryAfter!.usage.rate_limit_until!).getTime();
+      expect(longUntil).toBeGreaterThan(shortUntil);
+    });
+
+    it("does not shorten existing rate_limit_until", () => {
+      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd4");
+      // Mark with long reset (e.g. 7-day quota)
+      const longResetAt = Math.floor(Date.now() / 1000) + 86400; // 24 hours
+      pool.markQuotaExhausted(id, longResetAt);
+
+      const entryBefore = pool.getEntry(id);
+      const originalUntil = entryBefore!.usage.rate_limit_until;
+
+      // Try to mark with shorter reset (e.g. 5-hour quota)
+      const shortResetAt = Math.floor(Date.now() / 1000) + 3600; // 1 hour
+      pool.markQuotaExhausted(id, shortResetAt);
+
+      const entryAfter = pool.getEntry(id);
+      expect(entryAfter!.usage.rate_limit_until).toBe(originalUntil); // unchanged
     });
   });
 

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -320,12 +320,20 @@ export class AccountPool {
   markQuotaExhausted(entryId: string, resetAtUnix: number | null): void {
     const entry = this.accounts.get(entryId);
     if (!entry) return;
-    // Only mark if currently active — don't override other states
-    if (entry.status !== "active") return;
+    // Don't override disabled or expired states
+    if (entry.status === "disabled" || entry.status === "expired") return;
 
     const until = resetAtUnix
       ? new Date(resetAtUnix * 1000).toISOString()
       : new Date(Date.now() + 300_000).toISOString(); // fallback 5 min
+
+    // Only extend rate_limit_until, never shorten it
+    if (entry.status === "rate_limited" && entry.usage.rate_limit_until) {
+      const existing = new Date(entry.usage.rate_limit_until).getTime();
+      const proposed = new Date(until).getTime();
+      if (proposed <= existing) return;
+    }
+
     entry.status = "rate_limited";
     entry.usage.rate_limit_until = until;
     this.acquireLocks.delete(entryId);

--- a/src/auth/usage-refresher.ts
+++ b/src/auth/usage-refresher.ts
@@ -35,13 +35,13 @@ async function fetchQuotaForAllAccounts(
 ): Promise<void> {
   if (!pool.isAuthenticated()) return;
 
-  const entries = pool.getAllEntries().filter((e) => e.status === "active");
+  const entries = pool.getAllEntries().filter((e) => e.status === "active" || e.status === "rate_limited");
   if (entries.length === 0) return;
 
   const config = getConfig();
   const thresholds = config.quota.warning_thresholds;
 
-  console.log(`[QuotaRefresh] Refreshing quota for ${entries.length} active account(s)`);
+  console.log(`[QuotaRefresh] Refreshing quota for ${entries.length} active/rate-limited account(s)`);
 
   const results = await Promise.allSettled(
     entries.map(async (entry) => {


### PR DESCRIPTION
## Summary

Fixes #115 — accounts that have exhausted their quota were still showing as "active" and receiving requests.

- **Root cause**: 429 backoff (60s) recovered accounts to `active` before the 5-min quota refresher could mark them as truly exhausted. `markQuotaExhausted()` only worked on `active` accounts, and the quota refresher only checked `active` accounts — creating a timing dead zone where neither could break the cycle.
- `markQuotaExhausted()` now works on `rate_limited` accounts (only extends `rate_limit_until`, never shortens)
- Quota refresher now includes `rate_limited` accounts in its fetch cycle
- Also includes README star-history update and automation-response prompt cleanup

## Test plan

- [x] 4 new tests in `account-pool-quota.test.ts` (extends rate_limit, no-shorten, skip disabled, skip expired)
- [x] All 958 tests pass
- [ ] Manual: exhaust an account's quota, verify it stays `rate_limited` until real reset time