### PR TITLE
fix: Docker HEALTHCHECK reads port from config (#118)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,11 @@ EXPOSE 8080
 RUN mkdir -p /app/data
 
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
+COPY docker-healthcheck.sh /
+RUN chmod +x /docker-entrypoint.sh /docker-healthcheck.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -fs http://localhost:8080/health || exit 1
+  CMD /docker-healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Read server port from config, fallback to 8080
+PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+exec curl -fs "http://localhost:${PORT:-8080}/health" || exit 1

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Read server port from config, fallback to 8080
 PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
-exec curl -fs "http://localhost:${PORT:-8080}/health" || exit 1
+curl -fs "http://localhost:${PORT:-8080}/health" || exit 1


### PR DESCRIPTION
## Summary
- HEALTHCHECK was hardcoded to `localhost:8080`, causing infinite restart loops when users configured a different `server.port` (e.g. 8090)
- Add `docker-healthcheck.sh` that reads the port from `config/default.yaml`, falling back to 8080

Closes #118

## Test plan
- [ ] Build image, set `server.port: 8090` in config, verify container stays healthy
- [ ] Verify default port (8080) still works without config override