### PR TITLE
test: add smoke tests for docker, electron, and web

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,36 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Test default port (8080)
+        run: |
+          docker run -d --name test-container -p 8080:8080 codex-proxy-test
+          echo "Waiting for healthcheck to pass..."
+          timeout 30s bash -c 'while ! curl -s http://localhost:8080/health > /dev/null; do sleep 1; done'
+          curl -f http://localhost:8080/health
+          docker rm -f test-container
+
+      - name: Test custom port (8090)
+        run: |
+          mkdir -p config
+          echo "server:" > config/custom.yaml
+          echo "  port: 8090" >> config/custom.yaml
+          docker run -d --name test-container-custom -v $PWD/config/custom.yaml:/app/config/default.yaml -p 8090:8090 codex-proxy-test
+          echo "Waiting for healthcheck to pass..."
+          timeout 30s bash -c 'while ! curl -s http://localhost:8090/health > /dev/null; do sleep 1; done'
+          curl -f http://localhost:8090/health
+          docker rm -f test-container-custom

--- a/.github/workflows/electron-smoke.yml
+++ b/.github/workflows/electron-smoke.yml
@@ -1,0 +1,32 @@
+name: Electron Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Electron App
+        run: |
+          cd packages/electron
+          npm run build

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -1,0 +1,44 @@
+name: Web Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Web Frontend
+        run: npm run build:web
+
+      - name: Verify Web Output
+        run: |
+          if [ ! -d "public" ]; then
+            echo "Error: public/ output directory not found!"
+            exit 1
+          fi
+
+          if [ ! -f "public/index.html" ]; then
+            echo "Error: public/index.html not found!"
+            exit 1
+          fi
+
+          echo "Web build successfully verified!"


### PR DESCRIPTION
Adds three new GitHub Actions workflows:
- `.github/workflows/docker-smoke.yml` to build and run the Docker image.
- `.github/workflows/electron-smoke.yml` to verify the Electron build.
- `.github/workflows/web-smoke.yml` to verify the Web frontend build output.

---
*PR created automatically by Jules for task [7732596510298458058](https://jules.google.com/task/7732596510298458058) started by @icebear0828*