### PR TITLE
fix: allow multiple team accounts sharing same chatgpt_account_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Fixed
 
+- 同一 Team 的多个账号因共享 `chatgpt_account_id` 只能添加一个的问题（#126）
+  - 去重逻辑改为 `accountId + userId` 组合键，Team 成员各自保留独立条目
+  - `AccountEntry` 新增 `userId` 字段，持久化层自动回填
 - 额度耗尽账号仍显示「活跃」并接收请求的问题（#115）
   - `markQuotaExhausted()` 现在可以覆盖 `rate_limited` 状态（仅延长，不缩短 reset 时间）
   - 后台额度刷新现在同时检查 `rate_limited` 账号，防止因 429 短暂 backoff 导致漏检

--- a/src/auth/__tests__/account-pool-team-dedup.test.ts
+++ b/src/auth/__tests__/account-pool-team-dedup.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for team account deduplication.
+ *
+ * Team accounts share the same chatgpt_account_id but have distinct
+ * chatgpt_user_id values. They should be treated as separate accounts.
+ * See: https://github.com/icebear0828/codex-proxy/issues/126
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+}));
+
+vi.mock("../../config.js", () => ({
+  getConfig: vi.fn(() => ({
+    server: { proxy_api_key: null },
+    auth: { jwt_token: "", rotation_strategy: "least_used", rate_limit_backoff_seconds: 60 },
+  })),
+}));
+
+// Team members share the same accountId but have distinct user IDs
+const TEAM_ACCOUNT_ID = "acct-team-abc123";
+
+let profileForToken: Record<string, { chatgpt_plan_type: string; email: string; chatgpt_user_id?: string }> = {};
+
+vi.mock("../../auth/jwt-utils.js", () => ({
+  isTokenExpired: vi.fn(() => false),
+  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+  extractChatGptAccountId: vi.fn((token: string) => {
+    // All "team-*" tokens share the same account ID
+    if (token.startsWith("team-")) return TEAM_ACCOUNT_ID;
+    return `acct-${token}`;
+  }),
+  extractUserProfile: vi.fn((token: string) => profileForToken[token] ?? null),
+}));
+
+vi.mock("../../utils/jitter.js", () => ({
+  jitter: vi.fn((val: number) => val),
+}));
+
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(() => JSON.stringify({ accounts: [] })),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+import { AccountPool } from "../account-pool.js";
+
+describe("team account dedup (issue #126)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profileForToken = {};
+  });
+
+  it("allows multiple team members with same accountId but different userId", () => {
+    profileForToken = {
+      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
+      "team-bob": { chatgpt_plan_type: "team", email: "bob@corp.com", chatgpt_user_id: "user-bob" },
+    };
+
+    const pool = new AccountPool();
+    const idAlice = pool.addAccount("team-alice");
+    const idBob = pool.addAccount("team-bob");
+
+    // Both should exist as separate entries
+    expect(idAlice).not.toBe(idBob);
+    expect(pool.getAccounts()).toHaveLength(2);
+
+    const accounts = pool.getAccounts();
+    expect(accounts.map((a) => a.email).sort()).toEqual(["alice@corp.com", "bob@corp.com"]);
+    expect(accounts.map((a) => a.userId).sort()).toEqual(["user-alice", "user-bob"]);
+    // Both share the same accountId
+    expect(accounts[0].accountId).toBe(TEAM_ACCOUNT_ID);
+    expect(accounts[1].accountId).toBe(TEAM_ACCOUNT_ID);
+  });
+
+  it("still deduplicates when same user re-adds their token", () => {
+    profileForToken = {
+      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
+      "team-alice-refreshed": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
+    };
+
+    const pool = new AccountPool();
+    const id1 = pool.addAccount("team-alice");
+    const id2 = pool.addAccount("team-alice-refreshed");
+
+    // Same user → should update, not duplicate
+    expect(id1).toBe(id2);
+    expect(pool.getAccounts()).toHaveLength(1);
+  });
+
+  it("third team member adds without overwriting existing members", () => {
+    profileForToken = {
+      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
+      "team-bob": { chatgpt_plan_type: "team", email: "bob@corp.com", chatgpt_user_id: "user-bob" },
+      "team-carol": { chatgpt_plan_type: "team", email: "carol@corp.com", chatgpt_user_id: "user-carol" },
+    };
+
+    const pool = new AccountPool();
+    pool.addAccount("team-alice");
+    pool.addAccount("team-bob");
+    pool.addAccount("team-carol");
+
+    expect(pool.getAccounts()).toHaveLength(3);
+    const emails = pool.getAccounts().map((a) => a.email).sort();
+    expect(emails).toEqual(["alice@corp.com", "bob@corp.com", "carol@corp.com"]);
+  });
+
+  it("userId is included in AccountInfo", () => {
+    profileForToken = {
+      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
+    };
+
+    const pool = new AccountPool();
+    pool.addAccount("team-alice");
+
+    const info = pool.getAccounts()[0];
+    expect(info.userId).toBe("user-alice");
+  });
+
+  it("accounts without userId still dedup by accountId alone", () => {
+    // Legacy tokens without chatgpt_user_id
+    profileForToken = {
+      "solo-token1": { chatgpt_plan_type: "free", email: "user@test.com" },
+      "solo-token2": { chatgpt_plan_type: "free", email: "user@test.com" },
+    };
+
+    // Both map to the same accountId (acct-solo-token1 vs acct-solo-token2 — different!)
+    // but if they had the same accountId, they'd dedup since both userId are null
+    const pool = new AccountPool();
+    pool.addAccount("solo-token1");
+    pool.addAccount("solo-token2");
+
+    // Different accountId → separate entries
+    expect(pool.getAccounts()).toHaveLength(2);
+  });
+});

--- a/src/auth/account-persistence.ts
+++ b/src/auth/account-persistence.ts
@@ -92,6 +92,7 @@ function migrateFromLegacy(): AccountEntry[] {
       refreshToken: null,
       email: data.userInfo?.email ?? null,
       accountId: accountId,
+      userId: extractUserProfile(data.token)?.chatgpt_user_id ?? null,
       planType: data.userInfo?.planType ?? null,
       proxyApiKey: data.proxyApiKey ?? "codex-proxy-" + randomBytes(24).toString("hex"),
       status: isTokenExpired(data.token) ? "expired" : "active",
@@ -144,7 +145,7 @@ function loadPersisted(): { entries: AccountEntry[]; needsPersist: boolean } {
       if (!entry.id || !entry.token) continue;
 
       // Backfill missing fields from JWT
-      if (!entry.planType || !entry.email || !entry.accountId) {
+      if (!entry.planType || !entry.email || !entry.accountId || !entry.userId) {
         const profile = extractUserProfile(entry.token);
         const accountId = extractChatGptAccountId(entry.token);
         if (!entry.planType && profile?.chatgpt_plan_type) {
@@ -159,6 +160,15 @@ function loadPersisted(): { entries: AccountEntry[]; needsPersist: boolean } {
           entry.accountId = accountId;
           needsPersist = true;
         }
+        if (!entry.userId && profile?.chatgpt_user_id) {
+          entry.userId = profile.chatgpt_user_id;
+          needsPersist = true;
+        }
+      }
+      // Backfill userId for entries missing it (pre-v1.0.68)
+      if (entry.userId === undefined) {
+        entry.userId = null;
+        needsPersist = true;
       }
       // Backfill empty_response_count
       if (entry.usage.empty_response_count == null) {

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -240,11 +240,15 @@ export class AccountPool {
   addAccount(token: string, refreshToken?: string | null): string {
     const accountId = extractChatGptAccountId(token);
     const profile = extractUserProfile(token);
+    const userId = profile?.chatgpt_user_id ?? null;
 
-    // Deduplicate by accountId
+    // Deduplicate by accountId + userId (team members share accountId but have distinct userId)
     if (accountId) {
       for (const existing of this.accounts.values()) {
-        if (existing.accountId === accountId) {
+        if (
+          existing.accountId === accountId &&
+          existing.userId === userId
+        ) {
           // Update the existing entry's token
           existing.token = token;
           if (refreshToken !== undefined) {
@@ -266,6 +270,7 @@ export class AccountPool {
       refreshToken: refreshToken ?? null,
       email: profile?.email ?? null,
       accountId,
+      userId,
       planType: profile?.chatgpt_plan_type ?? null,
       proxyApiKey: "codex-proxy-" + randomBytes(24).toString("hex"),
       status: isTokenExpired(token) ? "expired" : "active",
@@ -362,6 +367,7 @@ export class AccountPool {
     entry.email = profile?.email ?? entry.email;
     entry.planType = profile?.chatgpt_plan_type ?? entry.planType;
     entry.accountId = extractChatGptAccountId(newToken) ?? entry.accountId;
+    entry.userId = profile?.chatgpt_user_id ?? entry.userId;
     entry.status = "active";
     this.persistNow(); // Critical data — persist immediately
   }
@@ -568,6 +574,7 @@ export class AccountPool {
       id: entry.id,
       email: entry.email,
       accountId: entry.accountId,
+      userId: entry.userId,
       planType: entry.planType,
       status: entry.status,
       usage: { ...entry.usage },

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -36,6 +36,8 @@ export interface AccountEntry {
   refreshToken: string | null;
   email: string | null;
   accountId: string | null;
+  /** Per-user unique ID (chatgpt_user_id). Team members share accountId but have distinct userId. */
+  userId: string | null;
   planType: string | null;
   proxyApiKey: string;
   status: AccountStatus;
@@ -52,6 +54,7 @@ export interface AccountInfo {
   id: string;
   email: string | null;
   accountId: string | null;
+  userId: string | null;
   planType: string | null;
   status: AccountStatus;
   usage: AccountUsage;


### PR DESCRIPTION
## Summary

Closes #126

- Team members share the same `chatgpt_account_id` in their JWT tokens, but each has a unique `chatgpt_user_id`
- The previous dedup logic only checked `accountId`, causing the second team member's token to overwrite the first
- Changed dedup key to `(accountId, userId)` composite — same team, different users → separate entries; same user re-adding → update existing entry

## Changes

- `AccountEntry` / `AccountInfo`: add `userId: string | null` field
- `addAccount()`: dedup by `accountId + userId` instead of `accountId` alone
- `updateToken()`: sync `userId` from refreshed JWT
- `account-persistence.ts`: backfill `userId` from JWT on load (migration for existing data)
- 5 new tests covering team dedup scenarios

## Test plan

- [x] 960 tests pass (75 files, including 5 new team dedup tests)
- [ ] Manual: add two tokens from the same Team → both should appear as separate accounts