### PR TITLE
fix: add missing userId field to test fixtures

### DIFF
--- a/src/auth/__tests__/account-persistence.test.ts
+++ b/src/auth/__tests__/account-persistence.test.ts
@@ -31,6 +31,7 @@ function makeEntry(id: string): AccountEntry {
     refreshToken: null,
     email: `${id}@test.com`,
     accountId: `acct-${id}`,
+    userId: `user-${id}`,
     planType: "free",
     proxyApiKey: `key-${id}`,
     status: "active",

--- a/src/auth/__tests__/rotation-strategy.test.ts
+++ b/src/auth/__tests__/rotation-strategy.test.ts
@@ -10,6 +10,7 @@ function makeEntry(id: string, overrides?: Partial<AccountEntry["usage"]>): Acco
     refreshToken: null,
     email: `${id}@test.com`,
     accountId: `acct-${id}`,
+    userId: `user-${id}`,
     planType: "free",
     proxyApiKey: `key-${id}`,
     status: "active",


### PR DESCRIPTION
## Summary

Two test helper `makeEntry()` functions were missing the `userId` field added in #127, causing `npm run build` (tsc) to fail.

## Test plan

- [x] `npm run build` passes
- [x] 17/17 affected tests pass