### PR TITLE
fix: trust backend model list and add x-codex-beta-features header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- 新模型（如 `gpt-5.4-mini`）无法被动态发现的问题
+  - 移除 `isCodexCompatibleId()` 白名单过滤，信任后端 `/codex/models` 返回
 - 同一 Team 的多个账号因共享 `chatgpt_account_id` 只能添加一个的问题（#126）
   - 去重逻辑改为 `accountId + userId` 组合键，Team 成员各自保留独立条目
   - `AccountEntry` 新增 `userId` 字段，持久化层自动回填

--- a/src/models/__tests__/plan-routing.test.ts
+++ b/src/models/__tests__/plan-routing.test.ts
@@ -118,18 +118,18 @@ describe("plan-based model routing", () => {
     expect(getModelPlanTypes("nonexistent-model")).toEqual([]);
   });
 
-  it("non-Codex model slugs are filtered out", () => {
+  it("all backend model slugs are admitted (no client-side filtering)", () => {
     applyBackendModelsForPlan("free", [
       makeModel("gpt-5.2-codex"),
-      makeModel("research"),           // not Codex-compatible
-      makeModel("gpt-5-2"),            // hyphen instead of dot
-      makeModel("some-internal-slug"), // not Codex-compatible
+      makeModel("research"),
+      makeModel("gpt-5-2"),
+      makeModel("some-internal-slug"),
     ]);
 
     expect(getModelPlanTypes("gpt-5.2-codex")).toContain("free");
-    expect(getModelPlanTypes("research")).toEqual([]);
-    expect(getModelPlanTypes("gpt-5-2")).toEqual([]);
-    expect(getModelPlanTypes("some-internal-slug")).toEqual([]);
+    expect(getModelPlanTypes("research")).toContain("free");
+    expect(getModelPlanTypes("gpt-5-2")).toContain("free");
+    expect(getModelPlanTypes("some-internal-slug")).toContain("free");
   });
 
   it("gpt-oss-* models are admitted", () => {

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -140,33 +140,19 @@ function normalizeBackendModel(raw: BackendModelEntry): NormalizedModelWithMeta 
   };
 }
 
-/** Check if a model ID is Codex-compatible (gpt-X.Y-codex-*, bare gpt-X.Y, or gpt-oss-*). */
-function isCodexCompatibleId(id: string): boolean {
-  if (/^gpt-\d+(\.\d+)?-codex/.test(id)) return true;
-  if (/^gpt-\d+(\.\d+)?$/.test(id)) return true;
-  if (/^gpt-oss-/.test(id)) return true;
-  return false;
-}
-
 /**
  * Merge backend models into the catalog.
  *
  * Strategy:
+ *   - Trust backend: all models returned by the backend are accepted
+ *     (primary endpoint /codex/models only returns Codex-compatible models)
  *   - Backend models overwrite static models with the same ID
  *     (but YAML fields fill in missing backend fields)
  *   - Static-only models are preserved (YAML may know about models the backend doesn't list)
- *   - New Codex models from backend are auto-admitted (prevents missing new releases)
  *   - Aliases are never touched (always from YAML)
  */
 export function applyBackendModels(backendModels: BackendModelEntry[]): void {
-  // Keep models that either exist in static catalog OR are Codex models.
-  // This prevents ChatGPT-only slugs (gpt-5-2, research, etc.) from
-  // entering the catalog, while auto-admitting new Codex releases.
-  const staticIds = new Set(_catalog.map((m) => m.id));
-  const filtered = backendModels.filter((raw) => {
-    const id = raw.slug ?? raw.id ?? raw.name ?? "";
-    return staticIds.has(id) || isCodexCompatibleId(id);
-  });
+  const filtered = backendModels;
 
   const staticMap = new Map(_catalog.map((m) => [m.id, m]));
   const merged: CodexModelInfo[] = [];
@@ -206,9 +192,8 @@ export function applyBackendModels(backendModels: BackendModelEntry[]): void {
 
   _catalog = merged;
   _lastFetchTime = new Date().toISOString();
-  const skipped = backendModels.length - filtered.length;
   console.log(
-    `[ModelStore] Merged ${filtered.length} backend (${skipped} non-codex skipped) + ${merged.length - filtered.length} static-only = ${merged.length} total models`,
+    `[ModelStore] Merged ${filtered.length} backend + ${merged.length - filtered.length} static-only = ${merged.length} total models`,
   );
 
   // Auto-sync merged catalog back to models.yaml
@@ -261,12 +246,9 @@ export function applyBackendModelsForPlan(planType: string, backendModels: Backe
 
   // Build new model set for this plan and replace atomically
   const admittedIds = new Set<string>();
-  const catalogIds = new Set(_catalog.map((m) => m.id));
   for (const raw of backendModels) {
     const id = raw.slug ?? raw.id ?? raw.name ?? "";
-    if (catalogIds.has(id) || isCodexCompatibleId(id)) {
-      admittedIds.add(id);
-    }
+    if (id) admittedIds.add(id);
   }
   _planModelMap.set(planType, admittedIds);
 


### PR DESCRIPTION
## Summary

New models like `gpt-5.4-mini` were not appearing in the proxy's model list because `isCodexCompatibleId()` regex whitelist filtered out model IDs that didn't match hardcoded patterns (`gpt-X.Y-codex*`, bare `gpt-X.Y`, `gpt-oss-*`).

The `/codex/models` endpoint only returns Codex-compatible models — client-side filtering is unnecessary and breaks whenever OpenAI changes naming conventions.

## Changes

- Remove `isCodexCompatibleId()` filter — accept all backend models
- Update tests to reflect no-filter behavior

## Test plan

- [x] 961 tests pass
- [x] E2E: `gpt-5.4-mini` appears in `/v1/models` after model refresh
- [x] E2E: 3/3 requests to `gpt-5.4-mini` return HTTP 200