### PR TITLE
test: verify Docker image builds and starts successfully

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,49 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Test Default Port (8080)
+        run: |
+          # Start container
+          docker run -d --name test-container-default -p 8080:8080 codex-proxy-test
+
+          # Wait for healthcheck to pass (up to 30s)
+          timeout 30 bash -c 'until docker inspect --format="{{.State.Health.Status}}" test-container-default | grep -q "healthy"; do sleep 2; done'
+
+          # Verify health endpoint
+          curl -f http://localhost:8080/health
+
+          # Cleanup
+          docker stop test-container-default
+          docker rm test-container-default
+
+      - name: Test Custom Port (8090)
+        run: |
+          # Create custom config
+          mkdir -p config
+          echo -e "server:\n  port: 8090" > config/default.yaml
+
+          # Start container with custom config mapped
+          docker run -d --name test-container-custom -p 8090:8090 -v $(pwd)/config/default.yaml:/app/config/default.yaml codex-proxy-test
+
+          # Wait for healthcheck to pass (up to 30s)
+          timeout 30 bash -c 'until docker inspect --format="{{.State.Health.Status}}" test-container-custom | grep -q "healthy"; do sleep 2; done'
+
+          # Verify health endpoint
+          curl -f http://localhost:8090/health
+
+          # Cleanup
+          docker stop test-container-custom
+          docker rm test-container-custom

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.67",
+  "version": "1.0.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "1.0.67",
+      "version": "1.0.73",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -7364,7 +7364,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "1.0.67",
+      "version": "1.0.73",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },


### PR DESCRIPTION
This PR adds a CI workflow named `Docker Smoke Test` to verify the Dockerfile and container runtime environment.
It runs on `push` to `master` and `pull_request`.

Key testing steps:
- Builds `codex-proxy-test` from the repo root Dockerfile.
- Runs the container with the default port 8080.
- Waits for up to 30s for the healthcheck to pass using `docker inspect` for the `healthy` status.
- Verifies the `http://localhost:8080/health` endpoint.
- Cleans up and repeats the test with a custom `config/default.yaml` mapping the port to 8090.
- Verifies the healthcheck and endpoint correctly reflect the new port 8090.

Fixes #120

---
*PR created automatically by Jules for task [2564536036965797434](https://jules.google.com/task/2564536036965797434) started by @icebear0828*