### PR TITLE
fix: exclude test files from tsc build to unbreak Docker CI

### DIFF
--- a/src/__tests__/update-checker.test.ts
+++ b/src/__tests__/update-checker.test.ts
@@ -68,7 +68,6 @@ describe("update-checker writes to data/, not config/", () => {
       ok: true,
       status: 200,
       body: APPCAST_XML,
-      headers: {},
     });
 
     // Dynamic import to get fresh module state
@@ -97,7 +96,6 @@ describe("update-checker writes to data/, not config/", () => {
       ok: true,
       status: 200,
       body: APPCAST_XML,
-      headers: {},
     });
 
     const { checkForUpdate } = await import("../update-checker.js");
@@ -115,7 +113,6 @@ describe("update-checker writes to data/, not config/", () => {
       ok: true,
       status: 200,
       body: APPCAST_XML,
-      headers: {},
     });
 
     const { checkForUpdate } = await import("../update-checker.js");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- `tsconfig.json` included `src/**/__tests__/**` and `*.test.ts` in compilation. When test fixtures drifted from changed interfaces, `npx tsc` in Dockerfile failed — even though Vitest passed fine.
- Exclude test globs from tsconfig `exclude` array so Docker build only compiles production code.
- Fix stale `headers` property in `update-checker.test.ts` mocks (`CurlFetchResponse` has no `headers` field).

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm test` — 978/979 passed (1 pre-existing flaky E2E timeout, unrelated)
- [ ] Docker CI should pass on this PR