### PR TITLE
test: add CI smoke tests for Docker, Electron, and Web frontend

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,65 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Test default port (8080)
+        run: |
+          docker run -d --name proxy-default -p 8080:8080 codex-proxy-test
+
+          # Wait for healthcheck to pass (up to 30s)
+          echo "Waiting for container to be healthy..."
+          for i in {1..30}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health | grep 200 > /dev/null; then
+              echo "Healthcheck passed!"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Healthcheck failed."
+          docker logs proxy-default
+          exit 1
+
+      - name: Cleanup default container
+        run: |
+          docker stop proxy-default
+          docker rm proxy-default
+
+      - name: Test custom port (8090)
+        run: |
+          # Create custom config
+          sed 's/port: 8080/port: 8090/' config/default.yaml > custom.yaml
+
+          # Run container mapping custom.yaml to config/default.yaml
+          docker run -d --name proxy-custom -p 8090:8090 \
+            -v $(pwd)/custom.yaml:/app/config/default.yaml \
+            codex-proxy-test
+
+          echo "Waiting for custom container to be healthy..."
+          for i in {1..30}; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/health | grep 200 > /dev/null; then
+              echo "Healthcheck passed on 8090!"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Healthcheck failed on 8090."
+          docker logs proxy-custom
+          exit 1
+
+      - name: Cleanup custom container
+        if: always()
+        run: |
+          docker stop proxy-custom || true
+          docker rm proxy-custom || true

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,45 @@
+name: Electron Smoke Test
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "packages/electron/**"
+  pull_request:
+    paths:
+      - "packages/electron/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build root
+        run: npm run build
+
+      - name: Build electron
+        run: |
+          cd packages/electron
+          npm run build
+          node electron/prepare-pack.mjs
+
+      - name: Package electron
+        run: |
+          cd packages/electron
+          npx electron-builder --linux --dir
+
+      - name: Install Playwright deps
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Electron Launch Smoke Test
+        run: |
+          xvfb-run npx vitest run packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,26 @@
+name: Web Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web + backend
+        run: npm run build
+
+      - name: Run Web Smoke Test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "vitest";
+import { _electron as electron } from "playwright";
+import fs from "fs";
+import path from "path";
+
+test("Smoke Test: Electron app packages and launches", async () => {
+  // Find the built binary dynamically
+  const unpackedDir = path.join(import.meta.dirname, "../../release/linux-unpacked");
+
+  // The executable is the one with no extension or just find @codex-proxyelectron
+  // `electron-builder` might output different names, so we can check for specific names or permissions
+  const files = fs.readdirSync(unpackedDir);
+
+  // Known executable names that electron-builder might output
+  const possibleNames = ["@codex-proxyelectron", "codex-proxy", "Codex Proxy"];
+
+  let executableName = files.find(f => possibleNames.includes(f));
+
+  if (!executableName) {
+    // Fallback: finding a file without extension that is likely the binary
+    executableName = files.find(f => !f.includes(".") && !f.includes("chrome"));
+  }
+
+  if (!executableName) {
+    throw new Error("Could not find electron executable in " + unpackedDir);
+  }
+
+  const executablePath = path.join(unpackedDir, executableName);
+
+  const app = await electron.launch({
+    executablePath,
+    args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"], // Useful for CI/headless
+  });
+
+  const window = await app.firstWindow();
+
+  // Verify window opens
+  expect(window).toBeDefined();
+
+  // Assert window count
+  const windows = app.windows();
+  expect(windows.length).toBe(1);
+
+  // Close app cleanly
+  await app.close();
+});

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.58.2"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,51 @@
+import { test, expect, afterAll } from "vitest";
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs";
+import path from "path";
+
+let serverProcess: ChildProcess;
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+test("Smoke Test: Web frontend builds and serves", async () => {
+  // 1. Verify CSS assets contain theme rules
+  const assetsDir = path.join(import.meta.dirname, "../../public/assets");
+  const files = fs.readdirSync(assetsDir);
+  const cssFile = files.find((f) => f.endsWith(".css"));
+  expect(cssFile).toBeDefined();
+
+  const cssContent = fs.readFileSync(path.join(assetsDir, cssFile!), "utf8");
+  expect(cssContent).toContain("dark:"); // Contains dark theme rule
+
+  // verify it's a non-empty CSS file
+  expect(cssContent.length).toBeGreaterThan(0);
+
+  // 2. Start server
+  // process.env.PORT is supported according to src/config.ts applyEnvOverrides
+  serverProcess = spawn("node", ["dist/index.js"], {
+    env: { ...process.env, PORT: "8081" },
+  });
+
+  // Wait for server to be ready with a retry loop
+  let isReady = false;
+  for (let i = 0; i < 30; i++) {
+    try {
+      const res = await fetch("http://localhost:8081/");
+      if (res.ok) {
+        isReady = true;
+        const html = await res.text();
+        expect(html).toContain('<div id="app"></div>');
+        break;
+      }
+    } catch (err) {
+      // Ignore connection refused errors during startup
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  expect(isReady).toBe(true);
+}, 35000);


### PR DESCRIPTION
This pull request introduces three new CI smoke tests to verify the core components of Codex Proxy without modifying existing production dependencies or constraints:
1. Docker build and healthcheck workflow (.github/workflows/docker-smoke-test.yml).
2. Electron package and Playwright launch test (.github/workflows/electron-smoke-test.yml and packages/electron/__tests__/launch/smoke.test.ts).
3. Web frontend Vite build and Hono server integration test (.github/workflows/web-smoke-test.yml and src/__tests__/web-smoke.test.ts).

---
*PR created automatically by Jules for task [8020308830989222987](https://jules.google.com/task/8020308830989222987) started by @icebear0828*