### PR TITLE
fix: model list not updating at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 模型列表启动时不更新：token 刷新与 model fetch 存在竞态，初始 fetch 跳过后直接等 1 小时
+  - model-fetcher 改为 fast-retry（10s 间隔，最多 12 次），账号就绪后立即拉取
+  - `config/models.yaml` 补回 gpt-5.4/5.4-mini/5.3-codex（3/18 后端已恢复）
+
 ### Added
 
 - 账号封禁检测：上游返回非 Cloudflare 的 403 时自动标记为 `banned` 状态

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -7,10 +7,54 @@
 # Dynamic fetch merges with static; backend entries win for shared IDs.
 # Models endpoint now requires ?client_version= query parameter.
 #
-# Last updated: 2026-03-10 (backend removed gpt-5.4, gpt-5.3-codex family)
+# Last updated: 2026-03-22 (gpt-5.4 family restored to backend)
 
 models:
-  # ── GPT-5.2 Codex (current flagship) ────────────────────────────────
+  # ── GPT-5.4 family (current flagship) ───────────────────────────────
+  - id: gpt-5.4
+    displayName: GPT-5.4
+    description: Latest frontier agentic coding model
+    isDefault: false
+    supportedReasoningEfforts:
+      - { reasoningEffort: low,    description: "Fast responses with lighter reasoning" }
+      - { reasoningEffort: medium, description: "Balances speed and reasoning depth" }
+      - { reasoningEffort: high,   description: "Greater reasoning depth for complex problems" }
+      - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
+    defaultReasoningEffort: medium
+    inputModalities: [text, image]
+    supportsPersonality: false
+    upgrade: null
+
+  - id: gpt-5.4-mini
+    displayName: GPT-5.4 Mini
+    description: Smaller frontier agentic coding model
+    isDefault: false
+    supportedReasoningEfforts:
+      - { reasoningEffort: low,    description: "Fast responses with lighter reasoning" }
+      - { reasoningEffort: medium, description: "Balances speed and reasoning depth" }
+      - { reasoningEffort: high,   description: "Greater reasoning depth for complex problems" }
+      - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
+    defaultReasoningEffort: medium
+    inputModalities: [text, image]
+    supportsPersonality: false
+    upgrade: null
+
+  # ── GPT-5.3 Codex ──────────────────────────────────────────────────
+  - id: gpt-5.3-codex
+    displayName: GPT-5.3 Codex
+    description: Frontier Codex-optimized agentic coding model
+    isDefault: false
+    supportedReasoningEfforts:
+      - { reasoningEffort: low,    description: "Fast responses with lighter reasoning" }
+      - { reasoningEffort: medium, description: "Balances speed and reasoning depth" }
+      - { reasoningEffort: high,   description: "Greater reasoning depth for complex problems" }
+      - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
+    defaultReasoningEffort: medium
+    inputModalities: [text, image]
+    supportsPersonality: false
+    upgrade: null
+
+  # ── GPT-5.2 Codex ──────────────────────────────────────────────────
   - id: gpt-5.2-codex
     displayName: GPT-5.2 Codex
     description: Frontier agentic coding model

--- a/src/models/__tests__/model-fetcher-retry.test.ts
+++ b/src/models/__tests__/model-fetcher-retry.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  getConfig: vi.fn(() => ({
+    model: { default: "gpt-5.2-codex" },
+  })),
+}));
+
+vi.mock("../../paths.js", () => ({
+  getConfigDir: vi.fn(() => "/tmp/test-config"),
+  getDataDir: vi.fn(() => "/tmp/test-data"),
+}));
+
+const mockGetModels = vi.fn<() => Promise<Array<{ slug: string }>>>();
+
+vi.mock("../../proxy/codex-api.js", () => ({
+  CodexApi: vi.fn().mockImplementation(() => ({
+    getModels: mockGetModels,
+  })),
+}));
+
+vi.mock("../model-store.js", () => ({
+  applyBackendModelsForPlan: vi.fn(),
+}));
+
+vi.mock("../../utils/jitter.js", () => ({
+  jitter: vi.fn((ms: number) => ms),
+}));
+
+import type { AccountPool } from "../../auth/account-pool.js";
+import type { CookieJar } from "../../proxy/cookie-jar.js";
+import {
+  startModelRefresh,
+  stopModelRefresh,
+  hasFetchedModels,
+} from "../model-fetcher.js";
+
+function createMockAccountPool(authenticated: boolean): AccountPool {
+  return {
+    isAuthenticated: vi.fn(() => authenticated),
+    getDistinctPlanAccounts: vi.fn(() =>
+      authenticated
+        ? [{ planType: "team", entryId: "e1", token: "t1", accountId: "a1" }]
+        : [],
+    ),
+    release: vi.fn(),
+  } as unknown as AccountPool;
+}
+
+const mockCookieJar = {} as CookieJar;
+
+describe("model-fetcher retry logic", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    stopModelRefresh();
+  });
+
+  afterEach(() => {
+    stopModelRefresh();
+    vi.useRealTimers();
+  });
+
+  it("retries when accounts are not authenticated at startup", async () => {
+    const pool = createMockAccountPool(false);
+    startModelRefresh(pool, mockCookieJar);
+
+    expect(hasFetchedModels()).toBe(false);
+
+    // Advance past initial delay (1s)
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(pool.isAuthenticated).toHaveBeenCalled();
+    expect(hasFetchedModels()).toBe(false);
+
+    // Should retry at 10s intervals — advance to first retry
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect((pool.isAuthenticated as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("succeeds on retry when accounts become ready", async () => {
+    let authenticated = false;
+    const pool = {
+      isAuthenticated: vi.fn(() => authenticated),
+      getDistinctPlanAccounts: vi.fn(() =>
+        authenticated
+          ? [{ planType: "free", entryId: "e1", token: "t1", accountId: "a1" }]
+          : [],
+      ),
+      release: vi.fn(),
+    } as unknown as AccountPool;
+
+    mockGetModels.mockResolvedValue([{ slug: "gpt-5.4" }]);
+    startModelRefresh(pool, mockCookieJar);
+
+    // Initial attempt — not authenticated
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(hasFetchedModels()).toBe(false);
+
+    // Now accounts become active
+    authenticated = true;
+
+    // Advance to first retry (10s)
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(hasFetchedModels()).toBe(true);
+  });
+
+  it("falls back to hourly after max retries", async () => {
+    const pool = createMockAccountPool(false);
+    startModelRefresh(pool, mockCookieJar);
+
+    // Initial delay + 12 retries × 10s = 1s + 120s
+    await vi.advanceTimersByTimeAsync(1_000 + 12 * 10_000);
+    expect(hasFetchedModels()).toBe(false);
+
+    // Should have logged max retries and scheduled hourly
+    // Verify no more retries by advancing another 10s
+    const callsBefore = (pool.isAuthenticated as ReturnType<typeof vi.fn>).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+    const callsAfter = (pool.isAuthenticated as ReturnType<typeof vi.fn>).mock.calls.length;
+    // No additional calls at 10s interval (hourly is much later)
+    expect(callsAfter).toBe(callsBefore);
+  });
+
+  it("succeeds immediately when accounts are ready at startup", async () => {
+    const pool = createMockAccountPool(true);
+    mockGetModels.mockResolvedValue([{ slug: "gpt-5.4" }]);
+
+    startModelRefresh(pool, mockCookieJar);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(hasFetchedModels()).toBe(true);
+    expect(pool.release).toHaveBeenCalledWith("e1");
+  });
+});

--- a/src/models/model-fetcher.ts
+++ b/src/models/model-fetcher.ts
@@ -15,31 +15,35 @@ import { jitter } from "../utils/jitter.js";
 
 const REFRESH_INTERVAL_HOURS = 1;
 const INITIAL_DELAY_MS = 1_000; // 1s after startup (fast plan-map population for mixed-plan routing)
+const RETRY_DELAY_MS = 10_000; // 10s retry when accounts aren't ready yet
+const MAX_RETRIES = 12; // ~2 minutes of retries before falling back to hourly
 
 let _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let _accountPool: AccountPool | null = null;
 let _cookieJar: CookieJar | null = null;
 let _proxyPool: ProxyPool | null = null;
+let _hasFetchedOnce = false;
 
 /**
  * Fetch models from the Codex backend, one query per distinct plan type.
- * This discovers plan-specific model availability (e.g. Team has gpt-5.4, Free has gpt-oss-*).
+ * Returns true if at least one plan's models were fetched successfully.
  */
 async function fetchModelsFromBackend(
   accountPool: AccountPool,
   cookieJar: CookieJar,
   proxyPool: ProxyPool | null,
-): Promise<void> {
-  if (!accountPool.isAuthenticated()) return; // silently skip when no accounts
+): Promise<boolean> {
+  if (!accountPool.isAuthenticated()) return false;
 
   const planAccounts = accountPool.getDistinctPlanAccounts();
   if (planAccounts.length === 0) {
     console.warn("[ModelFetcher] No available accounts — skipping model fetch");
-    return;
+    return false;
   }
 
   console.log(`[ModelFetcher] Fetching models for ${planAccounts.length} plan(s): ${planAccounts.map((p) => p.planType).join(", ")}`);
 
+  let anySuccess = false;
   const results = await Promise.allSettled(
     planAccounts.map(async (pa) => {
       try {
@@ -49,6 +53,7 @@ async function fetchModelsFromBackend(
         if (models && models.length > 0) {
           applyBackendModelsForPlan(pa.planType, models);
           console.log(`[ModelFetcher] Plan "${pa.planType}": ${models.length} models`);
+          anySuccess = true;
         } else {
           console.log(`[ModelFetcher] Plan "${pa.planType}": empty model list — keeping existing`);
         }
@@ -64,11 +69,14 @@ async function fetchModelsFromBackend(
       console.warn(`[ModelFetcher] Plan fetch failed: ${msg}`);
     }
   }
+
+  return anySuccess;
 }
 
 /**
  * Start the background model refresh loop.
  * - First fetch after a short delay (auth must be ready)
+ * - If accounts aren't ready, retry every 10s (up to ~2 min) before falling back to hourly
  * - Subsequent fetches every ~1 hour with jitter
  */
 export function startModelRefresh(
@@ -79,17 +87,44 @@ export function startModelRefresh(
   _accountPool = accountPool;
   _cookieJar = cookieJar;
   _proxyPool = proxyPool ?? null;
+  _hasFetchedOnce = false;
 
   // Initial fetch after short delay
-  _refreshTimer = setTimeout(async () => {
-    try {
-      await fetchModelsFromBackend(accountPool, cookieJar, _proxyPool);
-    } finally {
-      scheduleNext(accountPool, cookieJar);
-    }
+  _refreshTimer = setTimeout(() => {
+    attemptInitialFetch(accountPool, cookieJar, 0);
   }, INITIAL_DELAY_MS);
 
   console.log("[ModelFetcher] Scheduled initial model fetch in 1s");
+}
+
+/**
+ * Attempt initial fetch with fast retry.
+ * Accounts may still be refreshing tokens at startup (Electron race condition).
+ * Retry every 10s until success or max retries, then fall back to hourly.
+ */
+function attemptInitialFetch(
+  accountPool: AccountPool,
+  cookieJar: CookieJar,
+  attempt: number,
+): void {
+  fetchModelsFromBackend(accountPool, cookieJar, _proxyPool)
+    .then((success) => {
+      if (success) {
+        _hasFetchedOnce = true;
+        scheduleNext(accountPool, cookieJar);
+      } else if (attempt < MAX_RETRIES) {
+        console.log(`[ModelFetcher] Accounts not ready, retry ${attempt + 1}/${MAX_RETRIES} in ${RETRY_DELAY_MS / 1000}s`);
+        _refreshTimer = setTimeout(() => {
+          attemptInitialFetch(accountPool, cookieJar, attempt + 1);
+        }, RETRY_DELAY_MS);
+      } else {
+        console.warn("[ModelFetcher] Max retries reached, falling back to hourly refresh");
+        scheduleNext(accountPool, cookieJar);
+      }
+    })
+    .catch(() => {
+      scheduleNext(accountPool, cookieJar);
+    });
 }
 
 function scheduleNext(
@@ -107,16 +142,25 @@ function scheduleNext(
 }
 
 /**
- * Trigger an immediate model refresh (e.g. after hot-reload).
+ * Trigger an immediate model refresh (e.g. after hot-reload or account login).
  * No-op if startModelRefresh() hasn't been called yet.
  */
 export function triggerImmediateRefresh(): void {
   if (_accountPool && _cookieJar) {
-    fetchModelsFromBackend(_accountPool, _cookieJar, _proxyPool).catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[ModelFetcher] Immediate refresh failed: ${msg}`);
-    });
+    fetchModelsFromBackend(_accountPool, _cookieJar, _proxyPool)
+      .then((success) => {
+        if (success) _hasFetchedOnce = true;
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[ModelFetcher] Immediate refresh failed: ${msg}`);
+      });
   }
+}
+
+/** Whether at least one successful backend fetch has completed. */
+export function hasFetchedModels(): boolean {
+  return _hasFetchedOnce;
 }
 
 /**


### PR DESCRIPTION
## Summary

启动时模型列表可能不更新（查不到 gpt-5.4 等），尤其影响 Electron 用户。

**根因**：token refresh 和 model fetch 竞态。启动 1s 后触发首次 model fetch，但此时账号 OAuth token 可能还在刷新 → `isAuthenticated()` false → fetch 静默跳过 → `scheduleNext()` 排 1 小时后才重试。

### Changes

- **model-fetcher fast-retry**：初始 fetch 失败后 10s 重试，最多 12 次（~2min），账号就绪后立即拉取成功再切回 1 小时常规刷新
- **config/models.yaml 更新**：补回 gpt-5.4 / 5.4-mini / 5.3-codex（3/18 后端已恢复，静态列表停在 3/10）
- **`hasFetchedModels()` 导出**：供外部观测首次 fetch 状态
- 4 new tests（retry / fallback / immediate success）

## Test plan

- [x] `npm test` — 1008 passed (83 files)
- [x] `npm run build` — clean
- [ ] 启动 proxy → 观察日志 `[ModelFetcher] Accounts not ready, retry` 后成功拉取
- [ ] `GET /v1/models` 返回列表包含 gpt-5.4