### PR TITLE
fix: strip Accept-Encoding in curl-cli transport (error 61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- curl error 61：fingerprint 的 `Accept-Encoding: br, zstd` 覆盖了 `--compressed` 自动协商，系统 curl 不支持 br/zstd 时解压失败
+  - curl-cli-transport 统一跳过 `Accept-Encoding` header，由 `--compressed` 按 curl 实际能力协商
 - 模型列表启动时不更新：token 刷新与 model fetch 存在竞态，初始 fetch 跳过后直接等 1 小时
   - model-fetcher 改为 fast-retry（10s 间隔，最多 12 次），账号就绪后立即拉取
   - `config/models.yaml` 补回 gpt-5.4/5.4-mini/5.3-codex（3/18 后端已恢复）

--- a/src/tls/__tests__/curl-cli-transport.test.ts
+++ b/src/tls/__tests__/curl-cli-transport.test.ts
@@ -7,7 +7,7 @@ vi.mock("../curl-binary.js", () => ({
   isImpersonate: () => true,
 }));
 
-import { formatSpawnError } from "../curl-cli-transport.js";
+import { formatSpawnError, pushHeaderArgs } from "../curl-cli-transport.js";
 
 describe("formatSpawnError", () => {
   it("returns architecture mismatch hint for errno -86 (EBADARCH)", () => {
@@ -30,5 +30,26 @@ describe("formatSpawnError", () => {
     const msg = formatSpawnError(err);
     expect(msg).toBe("curl spawn error: spawn ENOENT");
     expect(msg).not.toContain("architecture");
+  });
+});
+
+describe("pushHeaderArgs", () => {
+  it("strips Accept-Encoding so --compressed auto-negotiates", () => {
+    const args: string[] = [];
+    pushHeaderArgs(args, {
+      Authorization: "Bearer tok",
+      "Accept-Encoding": "gzip, deflate, br, zstd",
+      "User-Agent": "test/1.0",
+    });
+    expect(args).toEqual([
+      "-H", "Authorization: Bearer tok",
+      "-H", "User-Agent: test/1.0",
+    ]);
+  });
+
+  it("strips accept-encoding case-insensitively", () => {
+    const args: string[] = [];
+    pushHeaderArgs(args, { "accept-encoding": "gzip" });
+    expect(args).toEqual([]);
   });
 });

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -14,6 +14,14 @@ import type { TlsTransport, TlsTransportResponse } from "./transport.js";
 const STATUS_SEPARATOR = "\n__CURL_HTTP_STATUS__";
 const HEADER_TIMEOUT_MS = 30_000;
 
+/** Push header args to curl, skipping Accept-Encoding so --compressed can auto-negotiate. */
+export function pushHeaderArgs(args: string[], headers: Record<string, string>): void {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "accept-encoding") continue;
+    args.push("-H", `${key}: ${value}`);
+  }
+}
+
 export class CurlCliTransport implements TlsTransport {
   /**
    * Streaming POST — spawns curl with -i to capture headers + stream body.
@@ -43,9 +51,7 @@ export class CurlCliTransport implements TlsTransport {
         args.push("--max-time", String(timeoutSec));
       }
 
-      for (const [key, value] of Object.entries(headers)) {
-        args.push("-H", `${key}: ${value}`);
-      }
+      pushHeaderArgs(args, headers);
       // Suppress curl's auto Expect: 100-continue (Chromium never sends it)
       args.push("-H", "Expect:");
       args.push(url);
@@ -188,9 +194,7 @@ export class CurlCliTransport implements TlsTransport {
       "--max-time", String(timeoutSec),
     ];
 
-    for (const [key, value] of Object.entries(headers)) {
-      args.push("-H", `${key}: ${value}`);
-    }
+    pushHeaderArgs(args, headers);
     args.push("-H", "Expect:");
     args.push("-w", STATUS_SEPARATOR + "%{http_code}");
     args.push(url);
@@ -218,9 +222,7 @@ export class CurlCliTransport implements TlsTransport {
       "-X", "POST",
     ];
 
-    for (const [key, value] of Object.entries(headers)) {
-      args.push("-H", `${key}: ${value}`);
-    }
+    pushHeaderArgs(args, headers);
     args.push("-H", "Expect:");
     args.push("-d", body);
     args.push("-w", STATUS_SEPARATOR + "%{http_code}");


### PR DESCRIPTION
## Summary

- curl-cli-transport 显式传递 `Accept-Encoding: gzip, deflate, br, zstd`（来自 fingerprint config），覆盖了 `--compressed` 的自动协商
- 系统 curl 不支持 br/zstd 时，上游用这些编码响应 → curl error 61
- 新增 `pushHeaderArgs()` 统一过滤 `Accept-Encoding`，让 `--compressed` 按 curl 实际能力协商
- FFI 路径和 curl-fetch 已有类似处理，只有 curl-cli-transport 的三个调用点遗漏

## Test plan

- [x] `pushHeaderArgs` 单元测试（过滤 + 大小写不敏感）
- [ ] koffi 未安装环境下 E2E 验证请求正常