### PR TITLE
fix: graceful fallback when system curl lacks --compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - curl error 61：fingerprint 的 `Accept-Encoding: br, zstd` 覆盖了 `--compressed` 自动协商，系统 curl 不支持 br/zstd 时解压失败
   - curl-cli-transport 统一跳过 `Accept-Encoding` header，由 `--compressed` 按 curl 实际能力协商
+- 系统 curl 不支持 `--compressed` 时启动报错
+  - 启动时探测支持情况，不支持则跳过该 flag 并提示安装 curl-impersonate
 - 模型列表启动时不更新：token 刷新与 model fetch 存在竞态，初始 fetch 跳过后直接等 1 小时
   - model-fetcher 改为 fast-retry（10s 间隔，最多 12 次），账号就绪后立即拉取
   - `config/models.yaml` 补回 gpt-5.4/5.4-mini/5.3-codex（3/18 后端已恢复）

--- a/src/tls/__tests__/supports-compressed.test.ts
+++ b/src/tls/__tests__/supports-compressed.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execFileSync } from "child_process";
+
+vi.mock("child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: () => false, // force system curl fallback
+}));
+
+vi.mock("../../config.js", () => ({
+  getConfig: () => ({
+    tls: { curl_binary: "auto", proxy_url: null, force_http11: false },
+  }),
+}));
+
+vi.mock("../../paths.js", () => ({
+  getBinDir: () => "/nonexistent",
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+describe("supportsCompressed", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns true when system curl supports --compressed", async () => {
+    mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+    const { supportsCompressed, resetCurlBinaryCache } = await import("../curl-binary.js");
+    resetCurlBinaryCache();
+    expect(supportsCompressed()).toBe(true);
+  });
+
+  it("returns false when system curl probe throws", async () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error("curl: option --compressed: the installed libcurl has no support for this");
+    });
+    const { supportsCompressed, resetCurlBinaryCache } = await import("../curl-binary.js");
+    resetCurlBinaryCache();
+    expect(supportsCompressed()).toBe(false);
+  });
+
+  it("resetCurlBinaryCache resets supportsCompressed to true", async () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error("no support");
+    });
+    const { supportsCompressed, resetCurlBinaryCache } = await import("../curl-binary.js");
+    resetCurlBinaryCache();
+    // After reset + re-resolve with failing probe → false
+    expect(supportsCompressed()).toBe(false);
+    // Reset should restore default
+    resetCurlBinaryCache();
+    // Now make probe succeed
+    mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+    expect(supportsCompressed()).toBe(true);
+  });
+});

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -293,10 +293,6 @@ export function getResolvedProfile(): string {
 }
 
 /**
- * Get the detected proxy URL (or null if no proxy).
- * Used by LibcurlFfiTransport which needs the URL directly (not CLI args).
- */
-/**
  * Whether the resolved curl binary supports --compressed.
  * Always true for curl-impersonate; probed at startup for system curl.
  */
@@ -305,6 +301,10 @@ export function supportsCompressed(): boolean {
   return _supportsCompressed;
 }
 
+/**
+ * Get the detected proxy URL (or null if no proxy).
+ * Used by LibcurlFfiTransport which needs the URL directly (not CLI args).
+ */
 export function getProxyUrl(): string | null {
   return _proxyUrl ?? null;
 }
@@ -332,6 +332,7 @@ export function getCurlDiagnostics(): {
 export function resetCurlBinaryCache(): void {
   _resolved = null;
   _isImpersonate = false;
+  _supportsCompressed = true;
   _tlsArgs = null;
   _resolvedProfile = "chrome136";
 }

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -69,6 +69,7 @@ const CHROME_TLS_ARGS: string[] = [
 
 let _resolved: string | null = null;
 let _isImpersonate = false;
+let _supportsCompressed = true;
 let _tlsArgs: string[] | null = null;
 let _resolvedProfile = "chrome136";
 
@@ -100,6 +101,18 @@ export function resolveCurlBinary(): string {
   // Fallback to system curl
   _resolved = "curl";
   _isImpersonate = false;
+
+  // Probe --compressed support (some minimal curl builds lack libz)
+  try {
+    execFileSync("curl", ["--compressed", "-s", "-o", "/dev/null", "data:,"], {
+      timeout: 3000,
+      stdio: "pipe",
+    });
+  } catch {
+    _supportsCompressed = false;
+    console.warn("[TLS] System curl lacks --compressed support. Consider running \"npm run setup\" to install curl-impersonate.");
+  }
+
   console.warn(
     `[TLS] curl-impersonate not found at ${binPath}. ` +
     `Falling back to system curl. Run "npm/pnpm/bun run setup" to install curl-impersonate.`,
@@ -283,6 +296,15 @@ export function getResolvedProfile(): string {
  * Get the detected proxy URL (or null if no proxy).
  * Used by LibcurlFfiTransport which needs the URL directly (not CLI args).
  */
+/**
+ * Whether the resolved curl binary supports --compressed.
+ * Always true for curl-impersonate; probed at startup for system curl.
+ */
+export function supportsCompressed(): boolean {
+  resolveCurlBinary(); // ensure detection has run
+  return _supportsCompressed;
+}
+
 export function getProxyUrl(): string | null {
   return _proxyUrl ?? null;
 }

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawn, execFile } from "child_process";
-import { resolveCurlBinary, getChromeTlsArgs, getProxyArgs, isImpersonate as curlIsImpersonate } from "./curl-binary.js";
+import { resolveCurlBinary, getChromeTlsArgs, getProxyArgs, isImpersonate as curlIsImpersonate, supportsCompressed } from "./curl-binary.js";
 import type { TlsTransport, TlsTransportResponse } from "./transport.js";
 
 const STATUS_SEPARATOR = "\n__CURL_HTTP_STATUS__";
@@ -40,7 +40,7 @@ export class CurlCliTransport implements TlsTransport {
         ...getChromeTlsArgs(),
         ...resolveProxyArgs(proxyUrl),
         "-s", "-S",
-        "--compressed",
+        ...(supportsCompressed() ? ["--compressed"] : []),
         "-N",            // no output buffering (SSE)
         "-i",            // include response headers in stdout
         "-X", "POST",
@@ -190,7 +190,7 @@ export class CurlCliTransport implements TlsTransport {
       ...getChromeTlsArgs(),
       ...resolveProxyArgs(proxyUrl),
       "-s", "-S",
-      "--compressed",
+      ...(supportsCompressed() ? ["--compressed"] : []),
       "--max-time", String(timeoutSec),
     ];
 
@@ -217,7 +217,7 @@ export class CurlCliTransport implements TlsTransport {
       ...getChromeTlsArgs(),
       ...resolveProxyArgs(proxyUrl),
       "-s", "-S",
-      "--compressed",
+      ...(supportsCompressed() ? ["--compressed"] : []),
       "--max-time", String(timeoutSec),
       "-X", "POST",
     ];


### PR DESCRIPTION
## Summary

- 系统 curl 精简构建可能不支持 `--compressed`（缺 libz），导致所有请求直接报错
- 启动时探测 `--compressed` 支持情况，不支持则跳过该 flag
- 日志提示用户安装 curl-impersonate
- 不支持时功能正常，仅传输未压缩（体积稍大）

承接 #152（Accept-Encoding 修复）

## Test plan

- [x] 现有 TLS 测试全部通过
- [ ] 精简 curl 环境 E2E 验证