### PR TITLE
test: verify Electron app packages and launches

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -1,0 +1,56 @@
+name: Build and Test Electron App
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test-electron:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install all workspace dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Setup curl-impersonate
+        run: npx tsx scripts/setup-curl.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install web frontend dependencies
+        run: cd web && npm ci
+
+      - name: Install desktop frontend dependencies
+        run: cd packages/electron/desktop && npm ci
+
+      - name: Build core (web + tsc)
+        run: npm run build
+
+      - name: Build desktop frontend
+        run: cd packages/electron/desktop && npx vite build
+
+      - name: Bundle Electron (esbuild)
+        working-directory: packages/electron
+        run: npm run build
+
+      - name: Prepare pack (copy root resources)
+        working-directory: packages/electron
+        run: node electron/prepare-pack.mjs
+
+      - name: Pack Electron (linux)
+        working-directory: packages/electron
+        run: npx electron-builder --config electron-builder.yml --linux --publish never
+
+      - name: Run E2E Launch Test
+        run: xvfb-run npx vitest run packages/electron/__tests__/launch.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ stitch-designs/
 stitch-screens/
 CLAUDE.md
 *.tar.gz
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.67",
+  "version": "1.0.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "1.0.67",
+      "version": "1.0.83",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@electron/asar": "^3.2.0",
+        "@playwright/test": "^1.58.2",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
@@ -1222,6 +1223,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5622,6 +5639,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7364,14 +7428,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "1.0.67",
+      "version": "1.0.83",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.58.2"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@electron/asar": "^3.2.0",
+    "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",

--- a/packages/electron/__tests__/launch.test.ts
+++ b/packages/electron/__tests__/launch.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from 'vitest';
+import { _electron as electron } from 'playwright';
+import { resolve } from 'path';
+import { readdirSync } from 'fs';
+
+test('launch packaged app', async () => {
+  const unpackedPath = resolve(__dirname, '../release/linux-unpacked');
+
+  // Find the executable in the unpacked path
+  const files = readdirSync(unpackedPath);
+  let executable = files.find(f => f.startsWith('@codex-proxyelectron'));
+
+  if (!executable) {
+    throw new Error('Executable not found in linux-unpacked');
+  }
+
+  const executablePath = resolve(unpackedPath, executable);
+
+  const electronApp = await electron.launch({
+    executablePath,
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+
+  const isAppReady = await electronApp.evaluate(async ({ app }) => {
+    return app.isReady();
+  });
+  expect(isAppReady).toBeTruthy();
+
+  const window = await electronApp.firstWindow();
+  expect(window).toBeTruthy();
+
+  await electronApp.close();
+}, 30000);

--- a/packages/electron/desktop/package-lock.json
+++ b/packages/electron/desktop/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "desktop",
+  "name": "@codex-proxy/desktop",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "desktop",
+      "name": "@codex-proxy/desktop",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.58.2"
   }
 }


### PR DESCRIPTION
Fixes #121 

Added an end-to-end launch test for the packaged Electron app using Playwright and Vitest to test that it successfully opens and exits. Also added a GitHub Actions CI workflow to verify that the app can be packaged by `electron-builder` and launched without crashing.

---
*PR created automatically by Jules for task [92036619833501732](https://jules.google.com/task/92036619833501732) started by @icebear0828*