### PR TITLE
fix: recover rate_limited accounts when quota no longer exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- 额度恢复后账号仍显示"已限速"（#162）
+  - usage-refresher 发现 `limit_reached: false` 时主动调用 `clearRateLimit()` 恢复 active 并清除 `rate_limit_until`
 - Anthropic `/v1/messages` 截图场景 400 报错：`tool_result.content` 不支持 image block
   - Schema 放行 image block；翻译层将图片提取为紧随 `function_call_output` 的 user message（`input_image`）
 - 代理自动检测使用 `host.docker.internal` 主机名导致 curl 无法解析（#114）

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -388,6 +388,16 @@ export class AccountPool {
     this.schedulePersist();
   }
 
+  /** Clear rate_limited status and rate_limit_until (quota refresher confirms recovery). */
+  clearRateLimit(entryId: string): void {
+    const entry = this.accounts.get(entryId);
+    if (!entry) return;
+    entry.status = "active";
+    entry.usage.rate_limit_until = null;
+    this.acquireLocks.delete(entryId);
+    this.schedulePersist();
+  }
+
   resetUsage(entryId: string): boolean {
     const entry = this.accounts.get(entryId);
     if (!entry) return false;

--- a/src/auth/usage-refresher.ts
+++ b/src/auth/usage-refresher.ts
@@ -83,7 +83,7 @@ async function fetchQuotaForAllAccounts(
       const windowSec = usage.rate_limit.primary_window?.limit_window_seconds ?? null;
       pool.syncRateLimitWindow(entry.id, resetAt, windowSec);
 
-      // Mark exhausted if limit reached (primary or secondary)
+      // Mark exhausted if limit reached, or recover if no longer exhausted
       if (config.quota.skip_exhausted) {
         const primaryExhausted = quota.rate_limit.limit_reached;
         const secondaryExhausted = quota.secondary_rate_limit?.limit_reached ?? false;
@@ -93,6 +93,10 @@ async function fetchQuotaForAllAccounts(
             : quota.secondary_rate_limit?.reset_at ?? null;
           pool.markQuotaExhausted(entry.id, exhaustResetAt);
           console.log(`[QuotaRefresh] Account ${entry.id} (${entry.email ?? "?"}) quota exhausted — marked rate_limited`);
+        } else if (entry.status === "rate_limited") {
+          // Quota no longer exhausted — recover to active and clear rate_limit_until
+          pool.clearRateLimit(entry.id);
+          console.log(`[QuotaRefresh] Account ${entry.id} (${entry.email ?? "?"}) quota recovered — marked active`);
         }
       }
 


### PR DESCRIPTION
## Summary
- usage-refresher 标记账号 `rate_limited` 后，额度恢复时（`limit_reached: false`）不会主动恢复
- 账号一直卡在 `rate_limited` 直到 `rate_limit_until` 到期（可能是几天后）
- 新增 `AccountPool.clearRateLimit()`：恢复 active + 清除 `rate_limit_until`
- usage-refresher 每次刷新时检查：如果 `limit_reached: false` 且账号是 `rate_limited`，立即恢复

## Test plan
- [x] 1083 tests pass
- [ ] 手动验证：限速账号在额度恢复后下一次 quota refresh（5min）自动恢复 active

Closes #162