### PR TITLE
feat: align TLS fingerprint with Codex Desktop v26.318.11754

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ### Changed
 
+- TLS 指纹对齐：curl-impersonate 升级支持 chrome144 profile（v1.5.1），`KNOWN_CHROME_PROFILES` 新增 133/136/142/144
+- 默认协议从 HTTP/1.1 改为 HTTP/2，匹配真实 Codex Desktop 行为
+- 指纹版本同步至 v26.318.11754（build 1100）
+
+### Added
+
+- HTTP/2 自动降级：curl 因 H2 错误失败时自动切换 HTTP/1.1（TTL 10 分钟后重试 H2）
+  - exit code 16（H2 专属）无条件触发；其他 exit code 需 stderr 含 H2 关键词
+  - `force_http11` 配置仍可手动强制 HTTP/1.1
+
+### Fixed
+
 - 配置 overlay 机制：Dashboard 设置写入 `data/local.yaml`（gitignored），不再修改 `config/default.yaml`
   - `git pull` 不会覆盖用户自定义设置（proxy_api_key、rotation_strategy、quota 等）
   - `config/default.yaml` 的 `proxy_api_key` 默认值改为 `null`（自动生成）

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,8 +3,8 @@ api:
   timeout_seconds: 60
 client:
   originator: Codex Desktop
-  app_version: 26.311.21342
-  build_number: "993"
+  app_version: 26.318.11754
+  build_number: "1100"
   platform: darwin
   arch: arm64
   chromium_version: "144"
@@ -35,10 +35,14 @@ tls:
   curl_binary: auto
   impersonate_profile: chrome144
   proxy_url: null
-  force_http11: true
+  force_http11: false
 quota:
   refresh_interval_minutes: 5
   warning_thresholds:
-    primary: [80, 90]
-    secondary: [80, 90]
+    primary:
+      - 80
+      - 90
+    secondary:
+      - 80
+      - 90
   skip_exhausted: true

--- a/src/tls/__tests__/http2-fallback.test.ts
+++ b/src/tls/__tests__/http2-fallback.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { checkHttp2Fallback, isHttp11Fallback, resetCurlBinaryCache } from "../curl-binary.js";
+
+describe("HTTP/2 → HTTP/1.1 auto-fallback", () => {
+  beforeEach(() => {
+    resetCurlBinaryCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("activates on curl exit code 16 (HTTP/2 framing error)", () => {
+    expect(isHttp11Fallback()).toBe(false);
+    const activated = checkHttp2Fallback("", 16);
+    expect(activated).toBe(true);
+    expect(isHttp11Fallback()).toBe(true);
+  });
+
+  it("activates on exit code 56 WITH H2 stderr", () => {
+    const activated = checkHttp2Fallback("nghttp2 stream error", 56);
+    expect(activated).toBe(true);
+    expect(isHttp11Fallback()).toBe(true);
+  });
+
+  it("does NOT activate on exit code 56 WITHOUT H2 stderr", () => {
+    const activated = checkHttp2Fallback("Connection reset by peer", 56);
+    expect(activated).toBe(false);
+    expect(isHttp11Fallback()).toBe(false);
+  });
+
+  it("activates on ALPN-related error in stderr", () => {
+    const activated = checkHttp2Fallback("ALPN: server did not agree on a protocol", 35);
+    expect(activated).toBe(true);
+    expect(isHttp11Fallback()).toBe(true);
+  });
+
+  it("activates on GOAWAY frame error", () => {
+    const activated = checkHttp2Fallback("HTTP/2 GOAWAY received", 92);
+    expect(activated).toBe(true);
+    expect(isHttp11Fallback()).toBe(true);
+  });
+
+  it("does NOT activate on unrelated curl errors", () => {
+    const activated = checkHttp2Fallback("Connection refused", 7);
+    expect(activated).toBe(false);
+    expect(isHttp11Fallback()).toBe(false);
+  });
+
+  it("does NOT activate on exit code 0", () => {
+    const activated = checkHttp2Fallback("some noise", 0);
+    expect(activated).toBe(false);
+    expect(isHttp11Fallback()).toBe(false);
+  });
+
+  it("does NOT activate twice while active (idempotent)", () => {
+    checkHttp2Fallback("nghttp2 error", 56);
+    expect(isHttp11Fallback()).toBe(true);
+    const second = checkHttp2Fallback("nghttp2 error", 56);
+    expect(second).toBe(false);
+  });
+
+  it("expires after TTL and retries H2", () => {
+    checkHttp2Fallback("", 16);
+    expect(isHttp11Fallback()).toBe(true);
+
+    // Advance past 10-minute TTL
+    vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+
+    // Next check should see it expired — but isHttp11Fallback reads raw state.
+    // The expiry happens in getChromeTlsArgs(), so test via checkHttp2Fallback:
+    // After TTL, a new H2 error can re-activate (returns true, not false)
+    const reactivated = checkHttp2Fallback("", 16);
+    expect(reactivated).toBe(true);
+  });
+
+  it("resets with resetCurlBinaryCache", () => {
+    checkHttp2Fallback("", 16);
+    expect(isHttp11Fallback()).toBe(true);
+    resetCurlBinaryCache();
+    expect(isHttp11Fallback()).toBe(false);
+  });
+});

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -75,7 +75,7 @@ let _resolved: string | null = null;
 let _isImpersonate = false;
 let _supportsCompressed = true;
 let _tlsArgs: string[] | null = null;
-let _resolvedProfile = "chrome142";
+let _resolvedProfile = "chrome136";
 let _http11Fallback = false;
 let _http11FallbackUntil = 0; // epoch ms — fallback expires after this time
 const HTTP11_FALLBACK_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -132,7 +132,7 @@ export function resolveCurlBinary(): string {
  * Only these versions are valid --impersonate targets.
  * Sorted ascending — update when curl-impersonate adds new profiles.
  */
-const KNOWN_CHROME_PROFILES = [99, 100, 101, 104, 107, 110, 116, 119, 120, 123, 124, 131, 133, 136, 142, 144];
+const KNOWN_CHROME_PROFILES = [99, 100, 101, 104, 107, 110, 116, 119, 120, 123, 124, 131, 133, 136, 142];
 
 /**
  * Map a configured profile to the nearest known-supported version.
@@ -169,7 +169,7 @@ function detectImpersonateSupport(binary: string): string[] {
       timeout: 5000,
     });
     if (helpOutput.includes("--impersonate")) {
-      const configured = getConfig().tls.impersonate_profile ?? "chrome142";
+      const configured = getConfig().tls.impersonate_profile ?? "chrome136";
       const profile = resolveProfile(configured);
       _resolvedProfile = profile;
       console.log(`[TLS] Using --impersonate ${profile}`);

--- a/src/tls/curl-binary.ts
+++ b/src/tls/curl-binary.ts
@@ -22,10 +22,13 @@ const IS_WIN = process.platform === "win32";
 const BINARY_NAME = IS_WIN ? "curl-impersonate.exe" : "curl-impersonate";
 
 /**
- * Chrome 136 TLS profile parameters.
- * Extracted from curl_chrome136 wrapper (lexiforest/curl-impersonate v1.4.4).
+ * Chrome 136 TLS profile parameters (fallback when --impersonate is unavailable).
+ * Extracted from curl_chrome136 wrapper (lexiforest/curl-impersonate).
  * These control TLS fingerprint, HTTP/2 framing, and protocol negotiation.
  * HTTP-level headers are NOT included — our fingerprint manager handles those.
+ *
+ * Preferred path: --impersonate chrome142 (v1.5.1+), which handles all of
+ * this automatically. This constant is only used as a manual fallback.
  */
 const CHROME_TLS_ARGS: string[] = [
   // ── TLS cipher suites (exact Chrome 136 order) ──
@@ -72,7 +75,10 @@ let _resolved: string | null = null;
 let _isImpersonate = false;
 let _supportsCompressed = true;
 let _tlsArgs: string[] | null = null;
-let _resolvedProfile = "chrome136";
+let _resolvedProfile = "chrome142";
+let _http11Fallback = false;
+let _http11FallbackUntil = 0; // epoch ms — fallback expires after this time
+const HTTP11_FALLBACK_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
  * Resolve the curl binary path. Result is cached after first call.
@@ -126,7 +132,7 @@ export function resolveCurlBinary(): string {
  * Only these versions are valid --impersonate targets.
  * Sorted ascending — update when curl-impersonate adds new profiles.
  */
-const KNOWN_CHROME_PROFILES = [99, 100, 101, 104, 107, 110, 116, 119, 120, 123, 124, 131, 136];
+const KNOWN_CHROME_PROFILES = [99, 100, 101, 104, 107, 110, 116, 119, 120, 123, 124, 131, 133, 136, 142, 144];
 
 /**
  * Map a configured profile to the nearest known-supported version.
@@ -163,7 +169,7 @@ function detectImpersonateSupport(binary: string): string[] {
       timeout: 5000,
     });
     if (helpOutput.includes("--impersonate")) {
-      const configured = getConfig().tls.impersonate_profile ?? "chrome136";
+      const configured = getConfig().tls.impersonate_profile ?? "chrome142";
       const profile = resolveProfile(configured);
       _resolvedProfile = profile;
       console.log(`[TLS] Using --impersonate ${profile}`);
@@ -189,9 +195,14 @@ export function getChromeTlsArgs(): string[] {
     _tlsArgs = detectImpersonateSupport(_resolved!);
   }
   const args = [..._tlsArgs];
-  // Force HTTP/1.1 when configured (for proxies that don't support HTTP/2)
+  // Force HTTP/1.1 when configured or auto-detected as necessary
   const config = getConfig();
-  if (config.tls.force_http11) {
+  // Auto-expire H2 fallback after TTL
+  if (_http11Fallback && Date.now() >= _http11FallbackUntil) {
+    _http11Fallback = false;
+    console.log("[TLS] HTTP/1.1 fallback expired, retrying HTTP/2");
+  }
+  if (config.tls.force_http11 || _http11Fallback) {
     args.push("--http1.1");
   }
   return args;
@@ -338,6 +349,36 @@ export function getCurlDiagnostics(): {
 }
 
 /**
+ * Check if a curl error indicates HTTP/2 incompatibility and enable fallback.
+ * Called by transport layer when curl fails. Returns true if fallback was activated.
+ *
+ * Fallback is temporary (TTL-based) — after expiry, H2 is retried automatically.
+ * Exit code 16 is curl's dedicated HTTP/2 error and triggers unconditionally.
+ * Other exit codes require H2-related keywords in stderr to avoid false positives.
+ */
+export function checkHttp2Fallback(stderr: string, exitCode: number | null): boolean {
+  if (_http11Fallback && Date.now() < _http11FallbackUntil) return false; // active fallback
+  if (exitCode === 0) return false;
+
+  const h2Patterns = /ALPN|HTTP\/2|nghttp2|h2 error|GOAWAY/i;
+  // Exit 16 = dedicated HTTP/2 framing error — always trigger
+  const isH2 = exitCode === 16 || h2Patterns.test(stderr);
+  if (!isH2) return false;
+
+  _http11Fallback = true;
+  _http11FallbackUntil = Date.now() + HTTP11_FALLBACK_TTL_MS;
+  console.warn("[TLS] HTTP/2 failure detected, falling back to HTTP/1.1 for 10 minutes");
+  return true;
+}
+
+/**
+ * Whether HTTP/1.1 fallback is currently active.
+ */
+export function isHttp11Fallback(): boolean {
+  return _http11Fallback;
+}
+
+/**
  * Reset the cached binary path (useful for testing).
  */
 export function resetCurlBinaryCache(): void {
@@ -345,5 +386,7 @@ export function resetCurlBinaryCache(): void {
   _isImpersonate = false;
   _supportsCompressed = true;
   _tlsArgs = null;
-  _resolvedProfile = "chrome136";
+  _resolvedProfile = "chrome142";
+  _http11Fallback = false;
+  _http11FallbackUntil = 0;
 }

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawn, execFile } from "child_process";
-import { resolveCurlBinary, getChromeTlsArgs, getProxyArgs, isImpersonate as curlIsImpersonate, supportsCompressed } from "./curl-binary.js";
+import { resolveCurlBinary, getChromeTlsArgs, getProxyArgs, isImpersonate as curlIsImpersonate, supportsCompressed, checkHttp2Fallback } from "./curl-binary.js";
 import type { TlsTransport, TlsTransportResponse } from "./transport.js";
 
 const STATUS_SEPARATOR = "\n__CURL_HTTP_STATUS__";
@@ -156,6 +156,7 @@ export class CurlCliTransport implements TlsTransport {
           signal.removeEventListener("abort", onAbort);
         }
         if (!headersParsed) {
+          checkHttp2Fallback(stderrBuf, code);
           reject(new Error(`curl exited with code ${code}: ${stderrBuf}`));
         } else if (code !== 0 && code !== null) {
           // curl died mid-stream (e.g. connection reset, SIGPIPE) — signal error to reader
@@ -263,11 +264,13 @@ function execCurl(args: string[]): Promise<{ status: number; body: string }> {
       { maxBuffer: 2 * 1024 * 1024 },
       (err, stdout, stderr) => {
         if (err) {
-          const castErr = err as Error & { errno?: number };
+          const castErr = err as Error & { errno?: number; code?: string };
           // Check for EBADARCH first (architecture mismatch)
           if (castErr.errno === -86 || err.message.includes("-86")) {
             reject(new Error(formatSpawnError(castErr)));
           } else {
+            const exitCode = typeof castErr.code === "string" ? parseInt(castErr.code, 10) : null;
+            checkHttp2Fallback(stderr, Number.isNaN(exitCode) ? null : exitCode);
             reject(new Error(`curl failed: ${err.message} ${stderr}`));
           }
           return;

--- a/src/tls/libcurl-ffi-transport.ts
+++ b/src/tls/libcurl-ffi-transport.ts
@@ -12,7 +12,7 @@ import { resolve } from "path";
 import { existsSync } from "fs";
 import type { IKoffiLib, IKoffiCType, IKoffiRegisteredCallback, KoffiFunction } from "koffi";
 import type { TlsTransport, TlsTransportResponse } from "./transport.js";
-import { getProxyUrl, getResolvedProfile } from "./curl-binary.js";
+import { getProxyUrl, getResolvedProfile, checkHttp2Fallback, isHttp11Fallback } from "./curl-binary.js";
 import { getBinDir } from "../paths.js";
 import { getConfig } from "../config.js";
 
@@ -345,7 +345,9 @@ export class LibcurlFfiTransport implements TlsTransport {
           }
         } catch (err) {
           if (!resolved) {
-            reject(err instanceof Error ? err : new Error(String(err)));
+            const msg = err instanceof Error ? err.message : String(err);
+            checkHttp2Fallback(msg, null);
+            reject(err instanceof Error ? err : new Error(msg));
           }
         } finally {
           cleanup();
@@ -428,6 +430,8 @@ export class LibcurlFfiTransport implements TlsTransport {
     try {
       const result = await asyncCall(b.curl_easy_perform, easy);
       if (result !== 0) {
+        // result is CURLcode — 16 = HTTP2 error, check for fallback
+        checkHttp2Fallback("", result);
         throw new Error(`curl_easy_perform failed with code ${result}`);
       }
 
@@ -465,9 +469,9 @@ export class LibcurlFfiTransport implements TlsTransport {
     b.curl_easy_setopt_str(easy, CURLOPT_URL, url);
     b.curl_easy_setopt_long(easy, CURLOPT_NOSIGNAL, 1);
 
-    // HTTP version: use HTTP/1.1 when force_http11 is enabled (for proxies that don't support HTTP/2)
+    // HTTP version: use HTTP/1.1 when configured or auto-fallback active
     const config = getConfig();
-    const httpVersion = config.tls.force_http11 ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_2_0;
+    const httpVersion = (config.tls.force_http11 || isHttp11Fallback()) ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_2_0;
     b.curl_easy_setopt_long(easy, CURLOPT_HTTP_VERSION, httpVersion);
 
     // Accept-Encoding — let libcurl handle decompression


### PR DESCRIPTION
## Summary

- Sync fingerprint version to v26.318.11754 (build 1100), was 7 days behind
- Add chrome 133/142/144 to `KNOWN_CHROME_PROFILES` for curl-impersonate v1.5.1
- Switch default protocol from HTTP/1.1 → HTTP/2 to match real Codex Desktop behavior
- Add automatic H2 → H1.1 fallback with 10-minute TTL for users behind incompatible proxies

## Details

**TLS profile**: `chrome144` now resolves directly (v1.5.1 accepts it), no more fallback warning to chrome136.

**H2 fallback logic**:
- curl exit code 16 (HTTP/2 framing error) → unconditional trigger
- Other exit codes → only trigger if stderr contains H2 keywords (`ALPN`, `HTTP/2`, `nghttp2`, `GOAWAY`)
- Fallback auto-expires after 10 minutes, then retries H2
- `force_http11: true` in `data/local.yaml` still available as manual override

## Test plan

- [x] 10 new tests in `http2-fallback.test.ts` (exit codes, stderr patterns, TTL expiry, idempotency)
- [x] Full suite 1093 passed
- [x] E2E verified: chrome144 profile connects to chatgpt.com with HTTP/2
- [x] Verified `--impersonate chrome144` works with curl-impersonate v1.5.1