### PR TITLE
feat: Dashboard 提示词注入开关 + 默认值修复

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -13,7 +13,7 @@ model:
   default_reasoning_effort: medium
   default_service_tier: null
   inject_desktop_context: false
-  suppress_desktop_directives: true
+  suppress_desktop_directives: false
 auth:
   jwt_token: null
   chatgpt_oauth: true

--- a/shared/hooks/use-general-settings.ts
+++ b/shared/hooks/use-general-settings.ts
@@ -4,6 +4,8 @@ export interface GeneralSettingsData {
   port: number;
   proxy_url: string | null;
   force_http11: boolean;
+  inject_desktop_context: boolean;
+  suppress_desktop_directives: boolean;
 }
 
 interface GeneralSettingsSaveResponse extends GeneralSettingsData {
@@ -53,6 +55,8 @@ export function useGeneralSettings(apiKey: string | null) {
         port: result.port,
         proxy_url: result.proxy_url,
         force_http11: result.force_http11,
+        inject_desktop_context: result.inject_desktop_context,
+        suppress_desktop_directives: result.suppress_desktop_directives,
       });
       setRestartRequired(result.restart_required);
       setSaved(true);

--- a/shared/i18n/translations.ts
+++ b/shared/i18n/translations.ts
@@ -234,6 +234,10 @@ export const translations = {
     generalSettingsProxyUrlHint: "SOCKS5/HTTP proxy for upstream. Leave empty for direct.",
     generalSettingsForceHttp11: "Force HTTP/1.1",
     generalSettingsForceHttp11Hint: "Disable HTTP/2 for upstream",
+    generalSettingsInjectContext: "Inject Desktop Context",
+    generalSettingsInjectContextHint: "Prepend Codex Desktop context to instructions",
+    generalSettingsSuppressDirectives: "Suppress Desktop Directives",
+    generalSettingsSuppressDirectivesHint: "Override desktop-specific behaviors (requires inject enabled)",
     generalSettingsRestartRequired: "Port changed. Restart to apply.",
   },
   zh: {
@@ -474,6 +478,10 @@ export const translations = {
     generalSettingsProxyUrlHint: "上游代理地址，留空直连",
     generalSettingsForceHttp11: "强制 HTTP/1.1",
     generalSettingsForceHttp11Hint: "禁用上游 HTTP/2",
+    generalSettingsInjectContext: "注入桌面上下文",
+    generalSettingsInjectContextHint: "在指令前注入 Codex 桌面上下文",
+    generalSettingsSuppressDirectives: "压制桌面指令",
+    generalSettingsSuppressDirectivesHint: "覆盖桌面特定行为（需先开启注入）",
     generalSettingsRestartRequired: "端口已更改，需重启生效",
   },
 } as const;

--- a/src/routes/__tests__/general-settings.test.ts
+++ b/src/routes/__tests__/general-settings.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockConfig = {
   server: { port: 8080, proxy_api_key: null as string | null },
   tls: { proxy_url: null as string | null, force_http11: false },
+  model: { inject_desktop_context: false, suppress_desktop_directives: true },
   quota: {
     refresh_interval_minutes: 5,
     warning_thresholds: { primary: [80, 90], secondary: [80, 90] },
@@ -99,6 +100,8 @@ describe("GET /admin/general-settings", () => {
     mockConfig.server.proxy_api_key = null;
     mockConfig.tls.proxy_url = null;
     mockConfig.tls.force_http11 = false;
+    mockConfig.model.inject_desktop_context = false;
+    mockConfig.model.suppress_desktop_directives = true;
   });
 
   it("returns current values", async () => {
@@ -110,6 +113,8 @@ describe("GET /admin/general-settings", () => {
       port: 8080,
       proxy_url: null,
       force_http11: false,
+      inject_desktop_context: false,
+      suppress_desktop_directives: true,
     });
   });
 });
@@ -121,6 +126,8 @@ describe("POST /admin/general-settings", () => {
     mockConfig.server.proxy_api_key = null;
     mockConfig.tls.proxy_url = null;
     mockConfig.tls.force_http11 = false;
+    mockConfig.model.inject_desktop_context = false;
+    mockConfig.model.suppress_desktop_directives = true;
   });
 
   it("changing port sets restart_required: true", async () => {
@@ -191,6 +198,38 @@ describe("POST /admin/general-settings", () => {
       body: JSON.stringify({ proxy_url: "not-a-url" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("changing inject_desktop_context sets restart_required: false", async () => {
+    const app = makeApp();
+    const res = await app.request("/admin/general-settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ inject_desktop_context: true }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.restart_required).toBe(false);
+    expect(data.inject_desktop_context).toBe(false); // mockConfig unchanged
+    expect(mutateYaml).toHaveBeenCalledOnce();
+    expect(reloadAllConfigs).toHaveBeenCalledOnce();
+  });
+
+  it("changing suppress_desktop_directives sets restart_required: false", async () => {
+    const app = makeApp();
+    const res = await app.request("/admin/general-settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ suppress_desktop_directives: false }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.restart_required).toBe(false);
+    expect(data.suppress_desktop_directives).toBe(true); // mockConfig unchanged
+    expect(mutateYaml).toHaveBeenCalledOnce();
+    expect(reloadAllConfigs).toHaveBeenCalledOnce();
   });
 
   it("requires auth when proxy_api_key is set", async () => {

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -98,6 +98,8 @@ export function createSettingsRoutes(): Hono {
       port: config.server.port,
       proxy_url: config.tls.proxy_url,
       force_http11: config.tls.force_http11,
+      inject_desktop_context: config.model.inject_desktop_context,
+      suppress_desktop_directives: config.model.suppress_desktop_directives,
     });
   });
 
@@ -118,6 +120,8 @@ export function createSettingsRoutes(): Hono {
       port?: number;
       proxy_url?: string | null;
       force_http11?: boolean;
+      inject_desktop_context?: boolean;
+      suppress_desktop_directives?: boolean;
     };
 
     // --- validation ---
@@ -152,6 +156,14 @@ export function createSettingsRoutes(): Hono {
         if (!data.tls) data.tls = {};
         (data.tls as Record<string, unknown>).force_http11 = body.force_http11;
       }
+      if (body.inject_desktop_context !== undefined) {
+        if (!data.model) data.model = {};
+        (data.model as Record<string, unknown>).inject_desktop_context = body.inject_desktop_context;
+      }
+      if (body.suppress_desktop_directives !== undefined) {
+        if (!data.model) data.model = {};
+        (data.model as Record<string, unknown>).suppress_desktop_directives = body.suppress_desktop_directives;
+      }
     });
     reloadAllConfigs();
 
@@ -161,6 +173,8 @@ export function createSettingsRoutes(): Hono {
       port: updated.server.port,
       proxy_url: updated.tls.proxy_url,
       force_http11: updated.tls.force_http11,
+      inject_desktop_context: updated.model.inject_desktop_context,
+      suppress_desktop_directives: updated.model.suppress_desktop_directives,
       restart_required: body.port !== undefined && body.port !== oldPort,
     });
   });

--- a/web/src/components/GeneralSettings.tsx
+++ b/web/src/components/GeneralSettings.tsx
@@ -11,20 +11,28 @@ export function GeneralSettings() {
   const [draftPort, setDraftPort] = useState<string | null>(null);
   const [draftProxyUrl, setDraftProxyUrl] = useState<string | null>(null);
   const [draftForceHttp11, setDraftForceHttp11] = useState<boolean | null>(null);
+  const [draftInjectContext, setDraftInjectContext] = useState<boolean | null>(null);
+  const [draftSuppressDirectives, setDraftSuppressDirectives] = useState<boolean | null>(null);
   const [collapsed, setCollapsed] = useState(true);
 
   const currentPort = gs.data?.port ?? 8080;
   const currentProxyUrl = gs.data?.proxy_url ?? "";
   const currentForceHttp11 = gs.data?.force_http11 ?? false;
+  const currentInjectContext = gs.data?.inject_desktop_context ?? false;
+  const currentSuppressDirectives = gs.data?.suppress_desktop_directives ?? false;
 
   const displayPort = draftPort ?? String(currentPort);
   const displayProxyUrl = draftProxyUrl ?? currentProxyUrl;
   const displayForceHttp11 = draftForceHttp11 ?? currentForceHttp11;
+  const displayInjectContext = draftInjectContext ?? currentInjectContext;
+  const displaySuppressDirectives = draftSuppressDirectives ?? currentSuppressDirectives;
 
   const isDirty =
     draftPort !== null ||
     draftProxyUrl !== null ||
-    draftForceHttp11 !== null;
+    draftForceHttp11 !== null ||
+    draftInjectContext !== null ||
+    draftSuppressDirectives !== null;
 
   const handleSave = useCallback(async () => {
     const patch: Record<string, unknown> = {};
@@ -43,11 +51,21 @@ export function GeneralSettings() {
       patch.force_http11 = draftForceHttp11;
     }
 
+    if (draftInjectContext !== null) {
+      patch.inject_desktop_context = draftInjectContext;
+    }
+
+    if (draftSuppressDirectives !== null) {
+      patch.suppress_desktop_directives = draftSuppressDirectives;
+    }
+
     await gs.save(patch);
     setDraftPort(null);
     setDraftProxyUrl(null);
     setDraftForceHttp11(null);
-  }, [draftPort, draftProxyUrl, draftForceHttp11, gs]);
+    setDraftInjectContext(null);
+    setDraftSuppressDirectives(null);
+  }, [draftPort, draftProxyUrl, draftForceHttp11, draftInjectContext, draftSuppressDirectives, gs]);
 
   const inputCls =
     "w-full px-3 py-2 bg-white dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-[0.78rem] font-mono text-slate-700 dark:text-text-main outline-none focus:ring-1 focus:ring-primary";
@@ -118,6 +136,50 @@ export function GeneralSettings() {
               </label>
             </div>
             <p class="text-xs text-slate-400 dark:text-text-dim ml-6">{t("generalSettingsForceHttp11Hint")}</p>
+          </div>
+
+          {/* Inject Desktop Context */}
+          <div class="space-y-1">
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="inject-desktop-context"
+                checked={displayInjectContext}
+                onChange={(e) => setDraftInjectContext((e.target as HTMLInputElement).checked)}
+                class="w-4 h-4 rounded border-gray-300 dark:border-border-dark text-primary focus:ring-primary cursor-pointer"
+              />
+              <label for="inject-desktop-context" class="text-xs font-semibold text-slate-700 dark:text-text-main cursor-pointer">
+                {t("generalSettingsInjectContext")}
+              </label>
+            </div>
+            <p class="text-xs text-slate-400 dark:text-text-dim ml-6">{t("generalSettingsInjectContextHint")}</p>
+          </div>
+
+          {/* Suppress Desktop Directives */}
+          <div class="space-y-1">
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="suppress-desktop-directives"
+                checked={displaySuppressDirectives}
+                onChange={(e) => setDraftSuppressDirectives((e.target as HTMLInputElement).checked)}
+                disabled={!displayInjectContext}
+                class={`w-4 h-4 rounded border-gray-300 dark:border-border-dark text-primary focus:ring-primary ${
+                  displayInjectContext ? "cursor-pointer" : "cursor-not-allowed opacity-50"
+                }`}
+              />
+              <label
+                for="suppress-desktop-directives"
+                class={`text-xs font-semibold cursor-pointer ${
+                  displayInjectContext
+                    ? "text-slate-700 dark:text-text-main"
+                    : "text-slate-400 dark:text-text-dim"
+                }`}
+              >
+                {t("generalSettingsSuppressDirectives")}
+              </label>
+            </div>
+            <p class="text-xs text-slate-400 dark:text-text-dim ml-6">{t("generalSettingsSuppressDirectivesHint")}</p>
           </div>
 
           {/* Save button + status */}


### PR DESCRIPTION
## Summary

- 基础设置面板新增「注入桌面上下文」和「压制桌面指令」开关
- `suppress_desktop_directives` 默认值从 `true` 改为 `false`（之前 inject 关闭时 suppress 开着没意义）
- suppress 开关在 inject 关闭时自动禁用并置灰

## Test plan

- [x] 9 个后端测试通过（含 2 个新增）
- [x] 完整 1102 passed