### PR TITLE
fix: seed empty config bind mount on first Docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ EXPOSE 8080
 # Ensure data dir exists in the image (bind mount may override at runtime)
 RUN mkdir -p /app/data
 
+# Backup default configs so entrypoint can seed empty bind mounts
+RUN cp -r /app/config /defaults
+
 COPY docker-entrypoint.sh /
 COPY docker-healthcheck.sh /
 RUN chmod +x /docker-entrypoint.sh /docker-healthcheck.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Seed empty config bind mount with defaults from the image
+if [ -d /defaults ] && [ -z "$(ls -A /app/config 2>/dev/null)" ]; then
+  echo "[Init] Config directory is empty — seeding from image defaults"
+  cp -r /defaults/* /app/config/
+fi
+
 # Ensure mounted volumes are writable by the node user (UID 1000).
 # When Docker auto-creates bind-mount directories on the host,
 # they default to root:root — the node user can't write to them.


### PR DESCRIPTION
## Summary
- Docker 用户首次 `docker compose up` 时，`./config` 挂载目录为空，覆盖镜像内置配置导致 ENOENT 崩溃
- Dockerfile 新增 `/defaults` 备份层，entrypoint 检测空目录时自动 seed
- 已有配置的用户不受影响（非空目录跳过）

## Changes
- `Dockerfile`: 构建时 `cp -r /app/config /defaults`
- `docker-entrypoint.sh`: 空目录检测 + 自动复制

## Test plan
- [ ] `docker build` 验证 `/defaults` 存在
- [ ] 空 `./config` 目录 → `docker compose up` → 自动 seed，正常启动
- [ ] 已有 `./config/default.yaml` → 不覆盖