### PR TITLE
feat: 更新弹窗显示 CHANGELOG + 配额刷新按钮 + UI 优化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - 配额自动刷新默认关闭（`refresh_interval_minutes: 0`），用户在 Dashboard 自行设置
 - 配额刷新改为有限并发（默认 10，可配 `quota.concurrency`），不再全量并发
 - Token 刷新走账号分配的代理，永久错误需连续 2 次才标 expired
-- `proxy_api_key` 默认值从 `pwd` 改为 `null`（自动生成）
+- **⚠️ 密钥变更**：首次启动自动创建 `data/local.yaml` 并设置默认密钥 `pwd`。所有自定义配置请通过 Dashboard 修改（自动保存到 `data/local.yaml`，更新不覆盖）
 - `suppress_desktop_directives` 默认值改为 `false`
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ EXPOSE 8080
 # Ensure data dir exists in the image (bind mount may override at runtime)
 RUN mkdir -p /app/data
 
+# Backup default configs so entrypoint can seed empty bind mounts
+RUN cp -r /app/config /defaults
+
 COPY docker-entrypoint.sh /
 COPY docker-healthcheck.sh /
 RUN chmod +x /docker-entrypoint.sh /docker-healthcheck.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Seed empty config bind mount with defaults from the image
+if [ -d /defaults ] && [ -z "$(ls -A /app/config 2>/dev/null)" ]; then
+  echo "[Init] Config directory is empty — seeding from image defaults"
+  cp -r /defaults/* /app/config/
+fi
+
 # Ensure mounted volumes are writable by the node user (UID 1000).
 # When Docker auto-creates bind-mount directories on the host,
 # they default to root:root — the node user can't write to them.

--- a/shared/hooks/use-update-status.ts
+++ b/shared/hooks/use-update-status.ts
@@ -8,6 +8,7 @@ export interface UpdateStatus {
     mode: "git" | "docker" | "electron";
     commits_behind: number | null;
     commits: { hash: string; message: string }[];
+    changelog: string | null;
     release: { version: string; body: string; url: string } | null;
     update_available: boolean;
     update_in_progress: boolean;
@@ -29,6 +30,7 @@ export interface CheckResult {
     current_commit: string | null;
     latest_commit: string | null;
     commits: { hash: string; message: string }[];
+    changelog: string | null;
     release: { version: string; body: string; url: string } | null;
     update_available: boolean;
     mode: "git" | "docker" | "electron";

--- a/shared/i18n/translations.ts
+++ b/shared/i18n/translations.ts
@@ -258,6 +258,8 @@ export const translations = {
     showMore: "Show More",
     showAll: "Show All",
     collapse: "Collapse",
+    refreshAllQuota: "Refresh All Quota",
+    refreshQuota: "Refresh Quota",
   },
   zh: {
     serverOnline: "\u670d\u52a1\u8fd0\u884c\u4e2d",
@@ -521,6 +523,8 @@ export const translations = {
     showMore: "显示更多",
     showAll: "显示全部",
     collapse: "收起",
+    refreshAllQuota: "刷新全部配额",
+    refreshQuota: "刷新配额",
   },
 } as const;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { resolve } from "path";
 import yaml from "js-yaml";
 import { z } from "zod";
@@ -114,6 +114,15 @@ function loadMergedConfig(configDir?: string): Record<string, unknown> {
   // otherwise use the standard data directory.
   const dataDir = configDir ? resolve(configDir, "..", "data") : getDataDir();
   const localPath = resolve(dataDir, "local.yaml");
+  if (!existsSync(localPath)) {
+    try {
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(localPath, "server:\n  proxy_api_key: pwd\n", "utf-8");
+      console.log("[Config] Created data/local.yaml with default proxy_api_key");
+    } catch (err) {
+      console.warn(`[Config] Failed to create data/local.yaml: ${err instanceof Error ? err.message : err}`);
+    }
+  }
   if (existsSync(localPath)) {
     try {
       const local = loadYaml(localPath) as Record<string, unknown> | null;

--- a/src/routes/admin/update.ts
+++ b/src/routes/admin/update.ts
@@ -20,6 +20,7 @@ export function createUpdateRoutes(): Hono {
         mode: getDeployMode(),
         commits_behind: cached?.commitsBehind ?? null,
         commits: cached?.commits ?? [],
+        changelog: cached?.changelog ?? null,
         release: cached?.release ? { version: cached.release.version, body: cached.release.body, url: cached.release.url } : null,
         update_available: cached?.updateAvailable ?? false,
         update_in_progress: isProxyUpdateInProgress(),
@@ -43,6 +44,7 @@ export function createUpdateRoutes(): Hono {
         current_commit: string | null;
         latest_commit: string | null;
         commits: Array<{ hash: string; message: string }>;
+        changelog: string | null;
         release: { version: string; body: string; url: string } | null;
         update_available: boolean;
         mode: string;
@@ -58,6 +60,7 @@ export function createUpdateRoutes(): Hono {
         current_commit: proxyResult.currentCommit,
         latest_commit: proxyResult.latestCommit,
         commits: proxyResult.commits,
+        changelog: proxyResult.changelog,
         release: proxyResult.release ? { version: proxyResult.release.version, body: proxyResult.release.body, url: proxyResult.release.url } : null,
         update_available: proxyResult.updateAvailable,
         mode: proxyResult.mode,
@@ -68,6 +71,7 @@ export function createUpdateRoutes(): Hono {
         current_commit: null,
         latest_commit: null,
         commits: [],
+        changelog: null,
         release: null,
         update_available: false,
         mode: getDeployMode(),

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -105,6 +105,7 @@ export interface ProxySelfUpdateResult {
   currentCommit: string | null;
   latestCommit: string | null;
   commits: CommitInfo[];
+  changelog: string | null;
   release: GitHubReleaseInfo | null;
   updateAvailable: boolean;
   mode: DeployMode;
@@ -223,6 +224,27 @@ async function getCommitLog(cwd: string): Promise<CommitInfo[]> {
   }
 }
 
+/** Extract [Unreleased] section from CHANGELOG.md on origin/master. */
+async function getRemoteChangelog(cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git", ["show", "origin/master:CHANGELOG.md"],
+      { cwd, timeout: 5000 },
+    );
+    const marker = "## [Unreleased]";
+    const start = stdout.indexOf(marker);
+    if (start === -1) return null;
+    // Find the next ## heading (next version section)
+    const rest = stdout.substring(start + marker.length);
+    const nextHeading = rest.indexOf("\n## ");
+    const section = nextHeading !== -1 ? rest.substring(0, nextHeading) : rest;
+    const trimmed = section.trim();
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+}
+
 /** Check GitHub Releases API for the latest version. */
 async function checkGitHubRelease(): Promise<GitHubReleaseInfo | null> {
   try {
@@ -268,7 +290,7 @@ export async function checkProxySelfUpdate(): Promise<ProxySelfUpdateResult> {
       console.warn("[SelfUpdate] git fetch failed:", err instanceof Error ? err.message : err);
       const result: ProxySelfUpdateResult = {
         commitsBehind: 0, currentCommit, latestCommit: currentCommit,
-        commits: [], release: null, updateAvailable: false, mode,
+        commits: [], changelog: null, release: null, updateAvailable: false, mode,
       };
       _cachedResult = result;
       return result;
@@ -289,10 +311,11 @@ export async function checkProxySelfUpdate(): Promise<ProxySelfUpdateResult> {
     } catch { /* ignore */ }
 
     const commits = commitsBehind > 0 ? await getCommitLog(cwd) : [];
+    const changelog = commitsBehind > 0 ? await getRemoteChangelog(cwd) : null;
 
     const result: ProxySelfUpdateResult = {
       commitsBehind, currentCommit, latestCommit,
-      commits, release: null,
+      commits, changelog, release: null,
       updateAvailable: commitsBehind > 0, mode,
     };
     _cachedResult = result;
@@ -308,7 +331,7 @@ export async function checkProxySelfUpdate(): Promise<ProxySelfUpdateResult> {
 
   const result: ProxySelfUpdateResult = {
     commitsBehind: 0, currentCommit: null, latestCommit: null,
-    commits: [], release: updateAvailable ? release : null,
+    commits: [], changelog: null, release: updateAvailable ? release : null,
     updateAvailable, mode,
   };
   _cachedResult = result;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,7 @@ function useUpdateMessage() {
     ? {
         mode: update.status!.proxy.mode,
         commits: update.status!.proxy.commits,
+        changelog: update.status!.proxy.changelog ?? null,
         release: update.status!.proxy.release,
       }
     : null;
@@ -175,6 +176,7 @@ function Dashboard() {
           onClose={() => setShowModal(false)}
           mode={update.proxyUpdateInfo.mode}
           commits={update.proxyUpdateInfo.commits}
+          changelog={update.proxyUpdateInfo.changelog}
           release={update.proxyUpdateInfo.release}
           onApply={update.applyUpdate}
           applying={update.applying}

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "preact/hooks";
+import { useCallback, useState } from "preact/hooks";
 import { useT, useI18n } from "../../../shared/i18n/context";
 import type { TranslationKey } from "../../../shared/i18n/translations";
 import { formatNumber, formatResetTime, formatWindowDuration } from "../../../shared/utils/format";
@@ -47,9 +47,10 @@ interface AccountCardProps {
   onProxyChange?: (accountId: string, proxyId: string) => void;
   selected?: boolean;
   onToggleSelect?: (id: string) => void;
+  onRefreshQuota?: (id: string) => Promise<void>;
 }
 
-export function AccountCard({ account, index, onDelete, proxies, onProxyChange, selected, onToggleSelect }: AccountCardProps) {
+export function AccountCard({ account, index, onDelete, proxies, onProxyChange, selected, onToggleSelect, onRefreshQuota }: AccountCardProps) {
   const t = useT();
   const { lang } = useI18n();
   const email = account.email || "Unknown";
@@ -105,6 +106,18 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
   const sWindowSec = srl?.limit_window_seconds;
   const sWindowDur = sWindowSec ? formatWindowDuration(sWindowSec, lang === "zh") : null;
 
+  const [quotaRefreshing, setQuotaRefreshing] = useState(false);
+
+  const handleRefreshQuota = useCallback(async () => {
+    if (!onRefreshQuota) return;
+    setQuotaRefreshing(true);
+    try {
+      await onRefreshQuota(account.id);
+    } finally {
+      setQuotaRefreshing(false);
+    }
+  }, [account.id, onRefreshQuota]);
+
   const handleToggle = useCallback(() => {
     onToggleSelect?.(account.id);
   }, [account.id, onToggleSelect]);
@@ -141,6 +154,18 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
           <span class={`px-2.5 py-1 rounded-full ${statusCls} text-xs font-medium border`}>
             {t(statusKey as TranslationKey)}
           </span>
+          {onRefreshQuota && (
+            <button
+              onClick={handleRefreshQuota}
+              disabled={quotaRefreshing}
+              class="p-1.5 text-slate-400 dark:text-text-dim hover:text-amber-500 transition-colors rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 disabled:opacity-40"
+              title={t("refreshQuota")}
+            >
+              <svg class={`size-[16px] ${quotaRefreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+              </svg>
+            </button>
+          )}
           <button
             onClick={handleDelete}
             class="p-1.5 text-slate-400 dark:text-text-dim hover:text-red-500 transition-colors rounded-md hover:bg-red-50 dark:hover:bg-red-900/20"

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -25,6 +25,17 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [warnings, setWarnings] = useState<QuotaWarning[]>([]);
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [quotaRefreshing, setQuotaRefreshing] = useState(false);
+
+  const refreshAllQuota = useCallback(async () => {
+    setQuotaRefreshing(true);
+    try {
+      await fetch("/auth/accounts?quota=fresh");
+      onRefresh();
+    } finally {
+      setQuotaRefreshing(false);
+    }
+  }, [onRefresh]);
 
   // Poll quota warnings
   useEffect(() => {
@@ -119,6 +130,45 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
             </svg>
           </button>
+          {/* Refresh all quota */}
+          <button
+            onClick={refreshAllQuota}
+            disabled={quotaRefreshing}
+            title={t("refreshAllQuota")}
+            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-amber-500 transition-colors rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <svg
+              class={`size-[18px] ${quotaRefreshing ? "animate-spin" : ""}`}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5" />
+            </svg>
+          </button>
+          {/* Pagination controls in header */}
+          {!loading && accounts.length > PAGE_SIZE && (
+            <>
+              {visibleCount < accounts.length ? (
+                <>
+                  <button
+                    onClick={() => setVisibleCount(accounts.length)}
+                    class="text-[0.7rem] px-2 py-1 text-slate-400 dark:text-text-dim hover:text-primary border border-gray-200 dark:border-border-dark rounded transition-colors"
+                  >
+                    {t("showAll")} ({accounts.length})
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={() => setVisibleCount(PAGE_SIZE)}
+                  class="text-[0.7rem] px-2 py-1 text-slate-400 dark:text-text-dim hover:text-primary border border-gray-200 dark:border-border-dark rounded transition-colors"
+                >
+                  {t("collapse")}
+                </button>
+              )}
+            </>
+          )}
         </div>
       </div>
       {/* Quota warning banners */}
@@ -153,35 +203,19 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
           </div>
         ) : (
           accounts.slice(0, visibleCount).map((acct, i) => (
-            <AccountCard key={acct.id} account={acct} index={i} onDelete={onDelete} proxies={proxies} onProxyChange={onProxyChange} selected={selectedIds.has(acct.id)} onToggleSelect={toggleSelect} />
+            <AccountCard key={acct.id} account={acct} index={i} onDelete={onDelete} proxies={proxies} onProxyChange={onProxyChange} selected={selectedIds.has(acct.id)} onToggleSelect={toggleSelect} onRefreshQuota={async (id) => { await fetch(`/auth/accounts?quota=fresh&id=${id}`); onRefresh(); }} />
           ))
         )}
       </div>
-      {!loading && accounts.length > PAGE_SIZE && (
-        <div class="flex items-center justify-center gap-3 mt-2">
-          {visibleCount < accounts.length ? (
-            <>
-              <button
-                onClick={() => setVisibleCount((c) => Math.min(c + PAGE_SIZE, accounts.length))}
-                class="px-4 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
-              >
-                {t("showMore")}
-              </button>
-              <button
-                onClick={() => setVisibleCount(accounts.length)}
-                class="px-4 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
-              >
-                {t("showAll")}
-              </button>
-            </>
-          ) : (
-            <button
-              onClick={() => setVisibleCount(PAGE_SIZE)}
-              class="px-4 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
-            >
-              {t("collapse")}
-            </button>
-          )}
+      {/* Show more at bottom when partially expanded */}
+      {!loading && accounts.length > PAGE_SIZE && visibleCount < accounts.length && visibleCount > PAGE_SIZE && (
+        <div class="flex items-center justify-center mt-2">
+          <button
+            onClick={() => setVisibleCount((c) => Math.min(c + PAGE_SIZE, accounts.length))}
+            class="px-4 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
+          >
+            {t("showMore")}
+          </button>
         </div>
       )}
     </section>

--- a/web/src/components/UpdateModal.tsx
+++ b/web/src/components/UpdateModal.tsx
@@ -15,6 +15,7 @@ interface UpdateModalProps {
   onClose: () => void;
   mode: "git" | "docker" | "electron";
   commits: { hash: string; message: string }[];
+  changelog: string | null;
   release: { version: string; body: string; url: string } | null;
   onApply: () => void;
   applying: boolean;
@@ -28,6 +29,7 @@ export function UpdateModal({
   onClose,
   mode,
   commits,
+  changelog,
   release,
   onApply,
   applying,
@@ -135,14 +137,20 @@ export function UpdateModal({
               </span>
             </div>
           ) : mode === "git" ? (
-            <ul class="space-y-1 text-sm text-slate-600 dark:text-text-dim max-h-64 overflow-y-auto">
-              {commits.map((c) => (
-                <li key={c.hash} class="flex gap-2 py-0.5">
-                  <code class="text-primary/70 text-xs shrink-0 pt-0.5">{c.hash}</code>
-                  <span class="text-xs">{c.message}</span>
-                </li>
-              ))}
-            </ul>
+            changelog ? (
+              <pre class="text-xs text-slate-600 dark:text-text-dim whitespace-pre-wrap max-h-64 overflow-y-auto leading-relaxed">
+                {changelog}
+              </pre>
+            ) : (
+              <ul class="space-y-1 text-sm text-slate-600 dark:text-text-dim max-h-64 overflow-y-auto">
+                {commits.map((c) => (
+                  <li key={c.hash} class="flex gap-2 py-0.5">
+                    <code class="text-primary/70 text-xs shrink-0 pt-0.5">{c.hash}</code>
+                    <span class="text-xs">{c.message}</span>
+                  </li>
+                ))}
+              </ul>
+            )
           ) : (
             <>
               {release && (


### PR DESCRIPTION
## Summary

- 更新弹窗 git 模式改为显示 CHANGELOG `[Unreleased]` 内容，用户能看到完整更新说明
- 账号列表右上角加"刷新全部配额"按钮
- 每个账号卡片加单独的配额刷新按钮
- 分页控制移到右上角
- 首次启动自动创建 `data/local.yaml`（默认密钥 `pwd`）

## Test plan

- [x] 1110 tests passed
- [x] 前端构建通过
- [x] TS 编译无错误