### PR TITLE
fix: respect local.yaml server.host in Electron mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Electron 模式下 `data/local.yaml` 中的 `server.host` 配置不生效——Electron 硬编码 `127.0.0.1` 覆盖了用户配置，现在 `local.yaml` 显式设置的 host 优先于启动参数（#175）
 - Dashboard 清空上游代理后 reload 被环境变量 `HTTPS_PROXY` 覆盖回来——`local.yaml` 显式设置的 `proxy_url` 现在优先于环境变量
 - Release 资产命名统一：`artifactName` 模板强制 `Codex-Proxy-{version}-{os}-{arch}.{ext}`，消除 `Codex.Proxy` vs `Codex-Proxy` 重复，x64 DMG 现在明确标注架构（`mac-x64`）
 - macOS x64 构建前清理旧资产，避免 release 页面出现重复文件

--- a/src/__tests__/config-local-override.test.ts
+++ b/src/__tests__/config-local-override.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for hasLocalOverride() — ensures user's local.yaml overrides
+ * are tracked and queryable (used by startServer to respect Electron host config).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { writeFileSync, mkdirSync } from "fs";
+import { resolve } from "path";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+
+// Mock model-store and model-fetcher (imported by config.ts)
+vi.mock("../models/model-store.js", () => ({
+  loadStaticModels: vi.fn(),
+}));
+vi.mock("../models/model-fetcher.js", () => ({
+  triggerImmediateRefresh: vi.fn(),
+}));
+
+function makeTempConfig(defaultYaml: string, localYaml?: string): string {
+  const id = randomUUID().slice(0, 8);
+  const base = resolve(tmpdir(), `config-test-${id}`);
+  const configDir = resolve(base, "config");
+  const dataDir = resolve(base, "data");
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(resolve(configDir, "default.yaml"), defaultYaml, "utf-8");
+  if (localYaml) {
+    writeFileSync(resolve(dataDir, "local.yaml"), localYaml, "utf-8");
+  }
+  return configDir;
+}
+
+const MINIMAL_DEFAULT = `
+api:
+  base_url: https://example.com
+  timeout_seconds: 30
+client:
+  originator: Test
+  app_version: "1.0"
+  build_number: "1"
+  platform: darwin
+  arch: arm64
+  chromium_version: "136"
+model:
+  default: test-model
+  default_reasoning_effort: medium
+  default_service_tier: null
+  inject_desktop_context: false
+  suppress_desktop_directives: false
+auth:
+  jwt_token: null
+  chatgpt_oauth: true
+  refresh_enabled: true
+  refresh_margin_seconds: 300
+  rotation_strategy: least_used
+  rate_limit_backoff_seconds: 60
+  oauth_client_id: test
+  oauth_auth_endpoint: https://example.com
+  oauth_token_endpoint: https://example.com
+server:
+  host: "::"
+  port: 8080
+  proxy_api_key: null
+session:
+  ttl_minutes: 60
+  cleanup_interval_minutes: 5
+`;
+
+describe("hasLocalOverride", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns false when no local.yaml exists", async () => {
+    const configDir = makeTempConfig(MINIMAL_DEFAULT);
+    // Remove auto-created local.yaml (loadConfig creates one if missing)
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    loadConfig(configDir);
+
+    expect(hasLocalOverride("server", "host")).toBe(false);
+    expect(hasLocalOverride("server", "port")).toBe(false);
+  });
+
+  it("returns true for keys explicitly set in local.yaml", async () => {
+    const localYaml = `
+server:
+  host: "0.0.0.0"
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    loadConfig(configDir);
+
+    expect(hasLocalOverride("server", "host")).toBe(true);
+    expect(hasLocalOverride("server", "port")).toBe(false);
+  });
+
+  it("returns false for unrelated paths", async () => {
+    const localYaml = `
+server:
+  host: "0.0.0.0"
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    loadConfig(configDir);
+
+    expect(hasLocalOverride("auth", "host")).toBe(false);
+    expect(hasLocalOverride("nonexistent")).toBe(false);
+    expect(hasLocalOverride("server", "host", "deep")).toBe(false);
+  });
+
+  it("reflects updated overrides after reloadConfig", async () => {
+    const configDir = makeTempConfig(MINIMAL_DEFAULT);
+    const { loadConfig, reloadConfig, hasLocalOverride } = await import("../config.js");
+    loadConfig(configDir);
+    expect(hasLocalOverride("server", "host")).toBe(false);
+
+    // Write a local.yaml and reload
+    const dataDir = resolve(configDir, "..", "data");
+    writeFileSync(resolve(dataDir, "local.yaml"), 'server:\n  host: "0.0.0.0"\n', "utf-8");
+    reloadConfig(configDir);
+
+    expect(hasLocalOverride("server", "host")).toBe(true);
+  });
+
+  it("returns false when local.yaml has unrelated keys only", async () => {
+    const localYaml = `
+auth:
+  rotation_strategy: round_robin
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    loadConfig(configDir);
+
+    expect(hasLocalOverride("server", "host")).toBe(false);
+    expect(hasLocalOverride("auth", "rotation_strategy")).toBe(true);
+  });
+
+  it("merged config uses local.yaml value over default", async () => {
+    const localYaml = `
+server:
+  host: "0.0.0.0"
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig } = await import("../config.js");
+    const config = loadConfig(configDir);
+
+    expect(config.server.host).toBe("0.0.0.0");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,11 +180,13 @@ function applyEnvOverrides(
 
 let _config: AppConfig | null = null;
 let _fingerprint: FingerprintConfig | null = null;
+let _localOverrides: Record<string, unknown> | null = null;
 
 export function loadConfig(configDir?: string): AppConfig {
   if (_config) return _config;
   const { raw, local } = loadMergedConfig(configDir);
   applyEnvOverrides(raw, local);
+  _localOverrides = local;
   _config = ConfigSchema.parse(raw);
   return _config;
 }
@@ -212,6 +214,19 @@ export function getLocalConfigPath(): string {
   return resolve(getDataDir(), "local.yaml");
 }
 
+/**
+ * Check whether a config key was explicitly set in data/local.yaml.
+ * Usage: hasLocalOverride("server", "host") → true if local.yaml contains server.host
+ */
+export function hasLocalOverride(...path: string[]): boolean {
+  let obj: unknown = _localOverrides;
+  for (const key of path) {
+    if (obj === null || obj === undefined || typeof obj !== "object") return false;
+    obj = (obj as Record<string, unknown>)[key];
+  }
+  return obj !== undefined;
+}
+
 export function mutateClientConfig(patch: Partial<AppConfig["client"]>): void {
   if (!_config) throw new Error("Config not loaded");
   Object.assign(_config.client, patch);
@@ -222,6 +237,7 @@ export function mutateClientConfig(patch: Partial<AppConfig["client"]>): void {
 export function reloadConfig(configDir?: string): AppConfig {
   const { raw, local } = loadMergedConfig(configDir);
   applyEnvOverrides(raw, local);
+  _localOverrides = local;
   const fresh = ConfigSchema.parse(raw);
   _config = fresh;
   return _config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { loadConfig, loadFingerprint, getConfig } from "./config.js";
+import { loadConfig, loadFingerprint, getConfig, hasLocalOverride } from "./config.js";
 import { AccountPool } from "./auth/account-pool.js";
 import { RefreshScheduler } from "./auth/refresh-scheduler.js";
 
@@ -98,8 +98,11 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   app.route("/", webRoutes);
 
   // Start server
+  // User's explicit local.yaml host wins over programmatic options (e.g. Electron's 127.0.0.1 default)
   const port = options?.port ?? config.server.port;
-  const host = options?.host ?? config.server.host;
+  const host = hasLocalOverride("server", "host")
+    ? config.server.host
+    : (options?.host ?? config.server.host);
 
   const poolSummary = accountPool.getPoolSummary();
   const displayHost = (host === "0.0.0.0" || host === "::") ? "localhost" : host;


### PR DESCRIPTION
## Summary

- Electron 入口硬编码 `startServer({ host: "127.0.0.1" })`，`options.host` 优先级高于 `config.server.host`，导致用户在 `data/local.yaml` 设置的 `server.host: "0.0.0.0"` 被无条件覆盖，无法开启局域网访问
- 新增 `hasLocalOverride(...path)` 查询 `local.yaml` 是否显式配置了某字段，显式配置时 config 值优先于启动参数
- Electron `main.ts` 无需改动，保持安全默认 `127.0.0.1`

Closes #175

## Changes

- `src/config.ts` — 存储 `_localOverrides`，新增 `hasLocalOverride()` helper
- `src/index.ts` — host 解析：`hasLocalOverride("server", "host")` 为 true 时用 config 值
- `src/__tests__/config-local-override.test.ts` — 6 个测试

## Test plan

- [x] 6 unit tests for `hasLocalOverride` (no local.yaml, explicit host, unrelated keys, reload, merge)
- [x] Full test suite: 1118 tests / 96 files passing
- [ ] Electron 端验证：`local.yaml` 设 `host: "0.0.0.0"` 后重启，确认局域网可访问