### PR TITLE
feat: Claude Code model mapping + account enable/disable toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Added
 
+- Claude Code Setup 卡片：Dashboard 按 Opus/Sonnet/Haiku/自定义 层级一键复制环境变量（推荐模型 gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex）
+- 账号启用/禁用 toggle：AccountCard 和 AccountTable 新增 per-account 开关，无需批量操作即可快速切换账号状态
+- Codex CLI 配置说明：README 新增 `~/.codex/config.toml` 配置示例
 - Token 刷新并发控制（`auth.refresh_concurrency`，默认 2）：多账号同时到期时限制并发数，避免上游限流
 - Dashboard 基础设置新增「刷新并发数」配置项
 - README 添加局域网访问说明（`0.0.0.0` 配置 + Electron 路径）

--- a/README.md
+++ b/README.md
@@ -221,7 +221,29 @@ export ANTHROPIC_API_KEY=your-api-key
 claude
 ```
 
-> 控制面板的 **Anthropic SDK Setup** 卡片可一键复制环境变量。
+> 控制面板的 **Anthropic SDK Setup** 卡片可一键复制环境变量（含 Opus / Sonnet / Haiku 层级模型配置）。
+>
+> 推荐模型：Opus → `gpt-5.4`，Sonnet → `gpt-5.4-mini`，Haiku → `gpt-5.3-codex`。
+
+### Codex CLI
+
+`~/.codex/config.toml`:
+```toml
+[model_providers.proxy_codex]
+name = "Codex Proxy"
+base_url = "http://localhost:8080/v1"
+wire_api = "responses"
+env_key = "PROXY_API_KEY"
+
+[profiles.default]
+model = "gpt-5.4"
+model_provider = "proxy_codex"
+```
+
+```bash
+export PROXY_API_KEY=your-api-key
+codex
+```
 
 ### Claude for VSCode / JetBrains
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -197,7 +197,29 @@ export ANTHROPIC_API_KEY=your-api-key
 claude
 ```
 
-> Copy env vars from the **Anthropic SDK Setup** card in the dashboard.
+> Copy env vars from the **Anthropic SDK Setup** card in the dashboard (includes Opus / Sonnet / Haiku tier model config).
+>
+> Recommended models: Opus → `gpt-5.4`, Sonnet → `gpt-5.4-mini`, Haiku → `gpt-5.3-codex`.
+
+### Codex CLI
+
+`~/.codex/config.toml`:
+```toml
+[model_providers.proxy_codex]
+name = "Codex Proxy"
+base_url = "http://localhost:8080/v1"
+wire_api = "responses"
+env_key = "PROXY_API_KEY"
+
+[profiles.default]
+model = "gpt-5.4"
+model_provider = "proxy_codex"
+```
+
+```bash
+export PROXY_API_KEY=your-api-key
+codex
+```
 
 ### Claude for VSCode / JetBrains
 

--- a/shared/hooks/use-accounts.ts
+++ b/shared/hooks/use-accounts.ts
@@ -253,6 +253,11 @@ export function useAccounts() {
     }
   }, [loadAccounts]);
 
+  const toggleStatus = useCallback(async (id: string, currentStatus: string): Promise<string | null> => {
+    const newStatus = currentStatus === "disabled" ? "active" : "disabled";
+    return batchSetStatus([id], newStatus);
+  }, [batchSetStatus]);
+
   return {
     list,
     loading,
@@ -270,5 +275,6 @@ export function useAccounts() {
     importAccounts,
     batchDelete,
     batchSetStatus,
+    toggleStatus,
   };
 }

--- a/shared/i18n/translations.ts
+++ b/shared/i18n/translations.ts
@@ -262,6 +262,9 @@ export const translations = {
     collapse: "Collapse",
     refreshAllQuota: "Refresh All Quota",
     refreshQuota: "Refresh Quota",
+    claudeCodeCustom: "Custom",
+    enableAccount: "Enable account",
+    disableAccount: "Disable account",
   },
   zh: {
     serverOnline: "\u670d\u52a1\u8fd0\u884c\u4e2d",
@@ -529,6 +532,9 @@ export const translations = {
     collapse: "收起",
     refreshAllQuota: "刷新全部配额",
     refreshQuota: "刷新配额",
+    claudeCodeCustom: "自定义",
+    enableAccount: "启用账号",
+    disableAccount: "禁用账号",
   },
 } as const;
 

--- a/shared/utils/clipboard.ts
+++ b/shared/utils/clipboard.ts
@@ -1,9 +1,11 @@
 function fallbackCopy(text: string): boolean {
   const ta = document.createElement("textarea");
   ta.value = text;
-  ta.style.cssText = "position:fixed;left:-9999px;opacity:0";
+  ta.style.cssText = "position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;opacity:0";
   document.body.appendChild(ta);
+  ta.focus();
   ta.select();
+  ta.setSelectionRange(0, text.length);
   let ok = false;
   try {
     ok = document.execCommand("copy");
@@ -12,12 +14,25 @@ function fallbackCopy(text: string): boolean {
   return ok;
 }
 
+/**
+ * Last-resort: show a prompt dialog with the text pre-selected so the user
+ * can Ctrl+C / Cmd+C manually. Works on any origin regardless of security.
+ */
+function promptCopy(text: string): void {
+  window.prompt("Ctrl+C / Cmd+C", text);
+}
+
 export async function clipboardCopy(text: string): Promise<boolean> {
-  if (navigator.clipboard?.writeText) {
+  // Clipboard API only works in secure contexts (HTTPS or localhost)
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(text);
       return true;
     } catch {}
   }
-  return fallbackCopy(text);
+  // execCommand fallback
+  if (fallbackCopy(text)) return true;
+  // Last resort: prompt dialog
+  promptCopy(text);
+  return true;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -135,6 +135,7 @@ function Dashboard() {
             onProxyChange={handleProxyChange}
             onExport={accounts.exportAccounts}
             onImport={accounts.importAccounts}
+            onToggleStatus={accounts.toggleStatus}
           />
           <ProxyPool proxies={proxies} />
           <ApiConfig

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -48,9 +48,10 @@ interface AccountCardProps {
   selected?: boolean;
   onToggleSelect?: (id: string) => void;
   onRefreshQuota?: (id: string) => Promise<void>;
+  onToggleStatus?: (id: string, currentStatus: string) => Promise<string | null>;
 }
 
-export function AccountCard({ account, index, onDelete, proxies, onProxyChange, selected, onToggleSelect, onRefreshQuota }: AccountCardProps) {
+export function AccountCard({ account, index, onDelete, proxies, onProxyChange, selected, onToggleSelect, onRefreshQuota, onToggleStatus }: AccountCardProps) {
   const t = useT();
   const { lang } = useI18n();
   const email = account.email || "Unknown";
@@ -122,6 +123,21 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
     onToggleSelect?.(account.id);
   }, [account.id, onToggleSelect]);
 
+  const [statusToggling, setStatusToggling] = useState(false);
+  const isEnabled = account.status !== "disabled";
+  const canToggle = account.status === "active" || account.status === "disabled" || account.status === "rate_limited" || account.status === "refreshing";
+
+  const handleStatusToggle = useCallback(async () => {
+    if (!onToggleStatus || !canToggle) return;
+    setStatusToggling(true);
+    try {
+      const err = await onToggleStatus(account.id, account.status);
+      if (err) console.error(err);
+    } finally {
+      setStatusToggling(false);
+    }
+  }, [account.id, account.status, canToggle, onToggleStatus]);
+
   return (
     <div class={`bg-white dark:bg-card-dark border rounded-xl p-4 shadow-sm hover:shadow-md transition-all ${selected ? "border-primary ring-1 ring-primary/30" : "border-gray-200 dark:border-border-dark hover:border-primary/30 dark:hover:border-primary/50"}`}>
       {/* Header */}
@@ -151,6 +167,22 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
           </div>
         </div>
         <div class="flex items-center gap-2">
+          {onToggleStatus && (
+            <button
+              onClick={handleStatusToggle}
+              disabled={!canToggle || statusToggling}
+              title={canToggle ? (isEnabled ? t("disableAccount") : t("enableAccount")) : undefined}
+              class={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+                !canToggle ? "opacity-40 cursor-not-allowed" : "cursor-pointer"
+              } ${isEnabled ? "bg-primary" : "bg-slate-300 dark:bg-slate-600"}`}
+            >
+              <span
+                class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform duration-200 ${
+                  isEnabled ? "translate-x-4" : "translate-x-0"
+                }`}
+              />
+            </button>
+          )}
           <span class={`px-2.5 py-1 rounded-full ${statusCls} text-xs font-medium border`}>
             {t(statusKey as TranslationKey)}
           </span>

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -15,11 +15,12 @@ interface AccountListProps {
   onProxyChange?: (accountId: string, proxyId: string) => void;
   onExport?: (selectedIds?: string[]) => Promise<void>;
   onImport?: (file: File) => Promise<{ success: boolean; added: number; updated: number; failed: number; errors: string[] }>;
+  onToggleStatus?: (id: string, currentStatus: string) => Promise<string | null>;
 }
 
 const PAGE_SIZE = 10;
 
-export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing, lastUpdated, proxies, onProxyChange, onExport, onImport }: AccountListProps) {
+export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing, lastUpdated, proxies, onProxyChange, onExport, onImport, onToggleStatus }: AccountListProps) {
   const t = useT();
   const { lang } = useI18n();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -203,7 +204,7 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
           </div>
         ) : (
           accounts.slice(0, visibleCount).map((acct, i) => (
-            <AccountCard key={acct.id} account={acct} index={i} onDelete={onDelete} proxies={proxies} onProxyChange={onProxyChange} selected={selectedIds.has(acct.id)} onToggleSelect={toggleSelect} onRefreshQuota={async (id) => { await fetch(`/auth/accounts?quota=fresh&id=${id}`); onRefresh(); }} />
+            <AccountCard key={acct.id} account={acct} index={i} onDelete={onDelete} proxies={proxies} onProxyChange={onProxyChange} selected={selectedIds.has(acct.id)} onToggleSelect={toggleSelect} onRefreshQuota={async (id) => { await fetch(`/auth/accounts?quota=fresh&id=${id}`); onRefresh(); }} onToggleStatus={onToggleStatus} />
           ))
         )}
       </div>

--- a/web/src/components/AccountTable.tsx
+++ b/web/src/components/AccountTable.tsx
@@ -42,6 +42,7 @@ interface AccountTableProps {
   filterGroup?: string | null;
   statusFilter: string;
   onStatusFilterChange: (status: string) => void;
+  onToggleStatus?: (id: string, currentStatus: string) => Promise<string | null>;
 }
 
 export function AccountTable({
@@ -53,6 +54,7 @@ export function AccountTable({
   filterGroup = null,
   statusFilter,
   onStatusFilterChange,
+  onToggleStatus,
 }: AccountTableProps) {
   const t = useT();
   const showProxy = !!proxies;
@@ -183,6 +185,7 @@ export function AccountTable({
           </label>
           <span class="flex-1 min-w-0">Email</span>
           <span class="w-20 text-center hidden sm:block">{t("statusFilter")}</span>
+          {onToggleStatus && <span class="w-12 text-center hidden sm:block" />}
           {showProxy && <span class="w-40 text-center hidden md:block">{t("proxyAssignment")}</span>}
         </div>
 
@@ -225,6 +228,28 @@ export function AccountTable({
                     {t(statusKey)}
                   </span>
                 </span>
+                {onToggleStatus && (() => {
+                  const isEnabled = acct.status !== "disabled";
+                  const canToggle = acct.status === "active" || acct.status === "disabled" || acct.status === "rate_limited" || acct.status === "refreshing";
+                  return (
+                    <span class="w-12 hidden sm:flex justify-center" onClick={(e) => e.stopPropagation()}>
+                      <button
+                        onClick={() => { if (canToggle) onToggleStatus(acct.id, acct.status); }}
+                        disabled={!canToggle}
+                        title={canToggle ? (isEnabled ? t("disableAccount") : t("enableAccount")) : undefined}
+                        class={`relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+                          !canToggle ? "opacity-40 cursor-not-allowed" : "cursor-pointer"
+                        } ${isEnabled ? "bg-primary" : "bg-slate-300 dark:bg-slate-600"}`}
+                      >
+                        <span
+                          class={`pointer-events-none inline-block h-3 w-3 rounded-full bg-white shadow transform transition-transform duration-200 ${
+                            isEnabled ? "translate-x-3" : "translate-x-0"
+                          }`}
+                        />
+                      </button>
+                    </span>
+                  );
+                })()}
                 {showProxy && (
                   <span class="w-40 hidden md:block" onClick={(e) => e.stopPropagation()}>
                     <select

--- a/web/src/components/AnthropicSetup.tsx
+++ b/web/src/components/AnthropicSetup.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "preact/hooks";
+import { useState, useMemo, useCallback, useEffect } from "preact/hooks";
 import { useT } from "../../../shared/i18n/context";
 import { CopyButton } from "./CopyButton";
 
@@ -9,34 +9,71 @@ interface AnthropicSetupProps {
   serviceTier: string | null;
 }
 
+const PRESETS: Array<{ label: string; value: string }> = [
+  { label: "gpt-5.4 (Opus)", value: "gpt-5.4" },
+  { label: "gpt-5.4-mini (Sonnet)", value: "gpt-5.4-mini" },
+  { label: "gpt-5.3-codex (Haiku)", value: "gpt-5.3-codex" },
+];
+
 export function AnthropicSetup({ apiKey, selectedModel, reasoningEffort, serviceTier }: AnthropicSetupProps) {
   const t = useT();
-
   const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost:8080";
 
-  // Build compound model name with suffixes
-  const displayModel = useMemo(() => {
+  const [opusModel, setOpusModel] = useState("gpt-5.4");
+  const [sonnetModel, setSonnetModel] = useState("gpt-5.4-mini");
+  const [haikuModel, setHaikuModel] = useState("gpt-5.3-codex");
+
+  // Custom model from ApiConfig
+  const customModel = useMemo(() => {
     let name = selectedModel;
     if (reasoningEffort && reasoningEffort !== "medium") name += `-${reasoningEffort}`;
     if (serviceTier === "fast") name += "-fast";
     return name;
   }, [selectedModel, reasoningEffort, serviceTier]);
 
-  const envLines = useMemo(() => ({
-    ANTHROPIC_BASE_URL: origin,
-    ANTHROPIC_API_KEY: apiKey,
-    ANTHROPIC_MODEL: displayModel,
-  }), [origin, apiKey, displayModel]);
+  // Fetch all models for dropdowns
+  const [allModels, setAllModels] = useState<string[]>([]);
+  useEffect(() => {
+    fetch("/v1/models")
+      .then((r) => r.json())
+      .then((data) => setAllModels(data.data?.map((m: { id: string }) => m.id) ?? []))
+      .catch(() => {});
+  }, []);
 
-  const allEnvText = useMemo(
-    () => Object.entries(envLines).map(([k, v]) => `${k}=${v}`).join("\n"),
-    [envLines],
+  const presetValues = new Set(PRESETS.map((p) => p.value));
+  const extraModels = allModels.filter((id) => !presetValues.has(id));
+
+  const envText = useMemo(() => [
+    `ANTHROPIC_BASE_URL=${origin}`,
+    `ANTHROPIC_API_KEY=${apiKey}`,
+    `ANTHROPIC_DEFAULT_OPUS_MODEL=${opusModel}`,
+    `ANTHROPIC_DEFAULT_SONNET_MODEL=${sonnetModel}`,
+    `ANTHROPIC_DEFAULT_HAIKU_MODEL=${haikuModel}`,
+    `ANTHROPIC_MODEL=${customModel}`,
+  ].join("\n"), [origin, apiKey, opusModel, sonnetModel, haikuModel, customModel]);
+
+  const getEnvText = useCallback(() => envText, [envText]);
+
+  const inputCls = "w-full pl-3 pr-10 py-2 bg-slate-100 dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-[0.78rem] font-mono text-slate-500 dark:text-text-dim outline-none cursor-default select-all";
+  const selectCls = "w-full pl-3 pr-2 py-2 bg-slate-100 dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-[0.78rem] font-mono text-slate-500 dark:text-text-dim outline-none focus:ring-1 focus:ring-primary cursor-pointer";
+
+  const modelDropdown = (value: string, onChange: (v: string) => void) => (
+    <select class={selectCls} value={value} onChange={(e) => onChange((e.target as HTMLSelectElement).value)}>
+      {PRESETS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+      {extraModels.length > 0 && <option disabled>───</option>}
+      {extraModels.map((id) => <option key={id} value={id}>{id}</option>)}
+      {!presetValues.has(value) && !extraModels.includes(value) && <option value={value}>{value}</option>}
+    </select>
   );
 
-  const getAllEnv = useCallback(() => allEnvText, [allEnvText]);
-  const getBaseUrl = useCallback(() => envLines.ANTHROPIC_BASE_URL, [envLines]);
-  const getApiKey = useCallback(() => envLines.ANTHROPIC_API_KEY, [envLines]);
-  const getModel = useCallback(() => envLines.ANTHROPIC_MODEL, [envLines]);
+  const rows: Array<{ label: string; node: preact.VNode }> = [
+    { label: "ANTHROPIC_BASE_URL", node: <div class="relative flex items-center"><input class={inputCls} type="text" value={origin} readOnly /><CopyButton getText={() => origin} class="absolute right-2" /></div> },
+    { label: "ANTHROPIC_API_KEY", node: <div class="relative flex items-center"><input class={inputCls} type="text" value={apiKey} readOnly /><CopyButton getText={() => apiKey} class="absolute right-2" /></div> },
+    { label: "ANTHROPIC_DEFAULT_OPUS_MODEL", node: modelDropdown(opusModel, setOpusModel) },
+    { label: "ANTHROPIC_DEFAULT_SONNET_MODEL", node: modelDropdown(sonnetModel, setSonnetModel) },
+    { label: "ANTHROPIC_DEFAULT_HAIKU_MODEL", node: modelDropdown(haikuModel, setHaikuModel) },
+    { label: "ANTHROPIC_MODEL", node: <div class="relative flex items-center"><input class={inputCls} type="text" value={customModel} readOnly /><CopyButton getText={() => customModel} class="absolute right-2" /></div> },
+  ];
 
   return (
     <section class="bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-xl p-5 shadow-sm transition-colors">
@@ -49,30 +86,17 @@ export function AnthropicSetup({ apiKey, selectedModel, reasoningEffort, service
         </div>
       </div>
 
-      {/* Env vars */}
       <div class="space-y-3">
-        {(["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL"] as const).map((key) => {
-          const getter = key === "ANTHROPIC_BASE_URL" ? getBaseUrl : key === "ANTHROPIC_API_KEY" ? getApiKey : getModel;
-          return (
-            <div key={key} class="flex items-center gap-3">
-              <label class="text-xs font-mono font-semibold text-slate-600 dark:text-text-dim w-44 shrink-0">{key}</label>
-              <div class="relative flex items-center flex-1">
-                <input
-                  class="w-full pl-3 pr-10 py-2 bg-slate-100 dark:bg-bg-dark border border-gray-200 dark:border-border-dark rounded-lg text-[0.78rem] font-mono text-slate-500 dark:text-text-dim outline-none cursor-default select-all"
-                  type="text"
-                  value={envLines[key]}
-                  readOnly
-                />
-                <CopyButton getText={getter} class="absolute right-2" />
-              </div>
-            </div>
-          );
-        })}
+        {rows.map((r) => (
+          <div key={r.label} class="flex items-center gap-3">
+            <label class="text-[0.68rem] font-mono font-semibold text-slate-600 dark:text-text-dim w-64 shrink-0 truncate">{r.label}</label>
+            <div class="flex-1">{r.node}</div>
+          </div>
+        ))}
       </div>
 
-      {/* Copy all button */}
       <div class="mt-5 flex items-center gap-3">
-        <CopyButton getText={getAllEnv} variant="label" />
+        <CopyButton getText={getEnvText} variant="label" />
         <span class="text-xs text-slate-400 dark:text-text-dim">{t("anthropicCopyAllHint")}</span>
       </div>
     </section>

--- a/web/src/pages/AccountManagement.tsx
+++ b/web/src/pages/AccountManagement.tsx
@@ -18,7 +18,7 @@ const statusOrder: Array<{ key: string; label: TranslationKey }> = [
 
 export function AccountManagement() {
   const t = useT();
-  const { list, loading: listLoading, batchDelete, batchSetStatus, exportAccounts, importAccounts } = useAccounts();
+  const { list, loading: listLoading, batchDelete, batchSetStatus, toggleStatus, exportAccounts, importAccounts } = useAccounts();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [statusFilter, setStatusFilter] = useState("all");
   const [message, setMessage] = useState<{ text: string; error?: boolean } | null>(null);
@@ -169,6 +169,7 @@ export function AccountManagement() {
             onSelectionChange={setSelectedIds}
             statusFilter={statusFilter}
             onStatusFilterChange={setStatusFilter}
+            onToggleStatus={toggleStatus}
           />
         )}
       </main>


### PR DESCRIPTION
## Summary

- **Anthropic SDK Setup**: show 6 env vars (BASE_URL, API_KEY, DEFAULT_OPUS/SONNET/HAIKU_MODEL, MODEL) with per-tier model dropdowns and Copy All
- **Account toggle**: per-account enable/disable toggle switch on AccountCard and AccountTable
- **Clipboard**: fallback for non-secure HTTP (LAN IP access)
- **README**: Claude Code recommended models + Codex CLI config.toml

Closes #176

## Test plan

- [x] `npm run build` — OK
- [x] 1125 tests pass (97 files)
- [ ] Dashboard: Anthropic SDK Setup 显示 6 行 env var，下拉选模型，Copy All 复制全部
- [ ] Dashboard: AccountCard / AccountTable toggle 开关切换账号状态
- [ ] LAN 访问 clipboard 复制可用