### PR TITLE
feat: redesign AccountList header + fix dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- AccountList 头部重做：标题行 + 导航标签 + 操作工具栏三层分离，按钮带文字标签，分页信息更清晰（`10 / 908` + 展开全部）
+- 暗色主题修复：图表 SVG 线条颜色改用 CSS 变量（dark mode 下更亮）、代码块 light mode 背景修正、Toggle 开关 thumb 对比度提升
+
 ### Added
 
 - Claude Code Setup 卡片：Dashboard 按 Opus/Sonnet/Haiku/自定义 层级一键复制环境变量（推荐模型 gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex）

--- a/shared/i18n/translations.ts
+++ b/shared/i18n/translations.ts
@@ -265,6 +265,10 @@ export const translations = {
     claudeCodeCustom: "Custom",
     enableAccount: "Enable account",
     disableAccount: "Disable account",
+    overview: "Overview",
+    expandAll: "Expand All",
+    refreshList: "Refresh",
+    quotaShort: "Quota",
   },
   zh: {
     serverOnline: "\u670d\u52a1\u8fd0\u884c\u4e2d",
@@ -535,6 +539,10 @@ export const translations = {
     claudeCodeCustom: "自定义",
     enableAccount: "启用账号",
     disableAccount: "禁用账号",
+    overview: "概览",
+    expandAll: "展开全部",
+    refreshList: "刷新",
+    quotaShort: "配额",
   },
 } as const;
 

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -177,7 +177,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
               } ${isEnabled ? "bg-primary" : "bg-slate-300 dark:bg-slate-600"}`}
             >
               <span
-                class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform duration-200 ${
+                class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white dark:bg-slate-200 shadow transform transition-transform duration-200 ${
                   isEnabled ? "translate-x-4" : "translate-x-0"
                 }`}
               />

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -72,105 +72,121 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
     ? lastUpdated.toLocaleTimeString(lang === "zh" ? "zh-CN" : "en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit" })
     : null;
 
+  const activeCount = accounts.filter((a) => a.status === "active").length;
+
   return (
     <section class="flex flex-col gap-4">
-      <div class="flex items-center justify-between">
+      {/* Row 1: Title + stats */}
+      <div class="flex items-start justify-between">
         <div class="flex flex-col gap-1">
           <h2 class="text-[0.95rem] font-bold tracking-tight">{t("connectedAccounts")}</h2>
           <p class="text-slate-500 dark:text-text-dim text-[0.8rem]">{t("connectedAccountsDesc")}</p>
         </div>
-        <div class="flex items-center gap-2 shrink-0">
+        <div class="flex flex-col items-end gap-1 shrink-0">
+          <span class="text-[0.82rem] font-semibold">
+            <span class="text-primary">{activeCount}</span>
+            <span class="text-slate-400 dark:text-text-dim"> / {accounts.length}</span>
+          </span>
           {updatedAtText && (
-            <span class="text-[0.75rem] text-slate-400 dark:text-text-dim hidden sm:inline">
+            <span class="text-[0.7rem] text-slate-400 dark:text-text-dim">
               {t("updatedAt")} {updatedAtText}
             </span>
           )}
-          <a
-            href="#/account-management"
-            class="text-[0.75rem] text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            {t("manageAccounts")} &rarr;
-          </a>
-          <a
-            href="#/usage-stats"
-            class="text-[0.75rem] text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            {t("usageStats")} &rarr;
-          </a>
-          {onExport && onImport && (
-            <AccountImportExport onExport={onExport} onImport={onImport} selectedIds={selectedIds} />
-          )}
-          {accounts.length > 0 && (
-            <button
-              onClick={toggleSelectAll}
-              title={selectedIds.size === accounts.length ? t("deselectAll") : t("selectAll")}
-              class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10"
-            >
-              <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-                {selectedIds.size === accounts.length ? (
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                ) : (
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                )}
-              </svg>
-            </button>
-          )}
-          <button
-            onClick={onRefresh}
-            disabled={refreshing}
-            title={t("refresh")}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <svg
-              class={`size-[18px] ${refreshing ? "animate-spin" : ""}`}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-            </svg>
-          </button>
-          {/* Refresh all quota */}
-          <button
-            onClick={refreshAllQuota}
-            disabled={quotaRefreshing}
-            title={t("refreshAllQuota")}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-amber-500 transition-colors rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            <svg
-              class={`size-[18px] ${quotaRefreshing ? "animate-spin" : ""}`}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5" />
-            </svg>
-          </button>
-          {/* Pagination controls in header */}
-          {!loading && accounts.length > PAGE_SIZE && (
-            <>
-              {visibleCount < accounts.length ? (
-                <>
-                  <button
-                    onClick={() => setVisibleCount(accounts.length)}
-                    class="text-[0.7rem] px-2 py-1 text-slate-400 dark:text-text-dim hover:text-primary border border-gray-200 dark:border-border-dark rounded transition-colors"
-                  >
-                    {t("showAll")} ({accounts.length})
-                  </button>
-                </>
-              ) : (
-                <button
-                  onClick={() => setVisibleCount(PAGE_SIZE)}
-                  class="text-[0.7rem] px-2 py-1 text-slate-400 dark:text-text-dim hover:text-primary border border-gray-200 dark:border-border-dark rounded transition-colors"
-                >
-                  {t("collapse")}
-                </button>
-              )}
-            </>
-          )}
         </div>
+      </div>
+
+      {/* Row 2: Navigation tabs */}
+      <div class="flex items-center gap-1.5">
+        <span class="px-3 py-1.5 rounded-lg text-xs font-medium bg-primary/10 text-primary dark:bg-primary/20">
+          {t("overview")}
+        </span>
+        <a
+          href="#/account-management"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
+        >
+          {t("manageAccounts")}
+        </a>
+        <a
+          href="#/proxy-settings"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
+        >
+          {t("proxySettings")}
+        </a>
+        <a
+          href="#/usage-stats"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
+        >
+          {t("usageStats")}
+        </a>
+      </div>
+
+      {/* Row 3: Action toolbar */}
+      <div class="flex items-center gap-1.5 flex-wrap">
+        {/* Refresh list */}
+        <button
+          onClick={onRefresh}
+          disabled={refreshing}
+          class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-600 dark:text-text-dim hover:text-primary hover:bg-slate-100 dark:hover:bg-border-dark rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <svg class={`size-3.5 ${refreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+          </svg>
+          <span class="hidden sm:inline">{t("refreshList")}</span>
+        </button>
+        {/* Refresh all quota */}
+        <button
+          onClick={refreshAllQuota}
+          disabled={quotaRefreshing}
+          class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-600 dark:text-text-dim hover:text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <svg class={`size-3.5 ${quotaRefreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5" />
+          </svg>
+          <span class="hidden sm:inline">{t("quotaShort")}</span>
+        </button>
+        {/* Import / Export */}
+        {onExport && onImport && (
+          <AccountImportExport onExport={onExport} onImport={onImport} selectedIds={selectedIds} />
+        )}
+        {/* Select all */}
+        {accounts.length > 0 && (
+          <button
+            onClick={toggleSelectAll}
+            class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-600 dark:text-text-dim hover:text-primary hover:bg-slate-100 dark:hover:bg-border-dark rounded-lg transition-colors"
+          >
+            <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              {selectedIds.size === accounts.length ? (
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              ) : (
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              )}
+            </svg>
+            <span class="hidden sm:inline">{selectedIds.size === accounts.length ? t("deselectAll") : t("selectAll")}</span>
+          </button>
+        )}
+        {/* Pagination — right side */}
+        {!loading && accounts.length > PAGE_SIZE && (
+          <div class="flex items-center gap-2 ml-auto pl-3 border-l border-gray-200 dark:border-border-dark">
+            <span class="text-xs text-slate-400 dark:text-text-dim tabular-nums">
+              {Math.min(visibleCount, accounts.length)} / {accounts.length}
+            </span>
+            {visibleCount < accounts.length ? (
+              <button
+                onClick={() => setVisibleCount(accounts.length)}
+                class="px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors"
+              >
+                {t("expandAll")}
+              </button>
+            ) : (
+              <button
+                onClick={() => setVisibleCount(PAGE_SIZE)}
+                class="px-2.5 py-1 text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark rounded-lg transition-colors"
+              >
+                {t("collapse")}
+              </button>
+            )}
+          </div>
+        )}
       </div>
       {/* Quota warning banners */}
       {warnings.filter((w) => w.level === "critical").length > 0 && (

--- a/web/src/components/AccountTable.tsx
+++ b/web/src/components/AccountTable.tsx
@@ -242,7 +242,7 @@ export function AccountTable({
                         } ${isEnabled ? "bg-primary" : "bg-slate-300 dark:bg-slate-600"}`}
                       >
                         <span
-                          class={`pointer-events-none inline-block h-3 w-3 rounded-full bg-white shadow transform transition-transform duration-200 ${
+                          class={`pointer-events-none inline-block h-3 w-3 rounded-full bg-white dark:bg-slate-200 shadow transform transition-transform duration-200 ${
                             isEnabled ? "translate-x-3" : "translate-x-0"
                           }`}
                         />

--- a/web/src/components/CodeExamples.tsx
+++ b/web/src/components/CodeExamples.tsx
@@ -217,7 +217,7 @@ export function CodeExamples({ baseUrl, apiKey, model, reasoningEffort, serviceT
             </div>
           </div>
           {/* Code Block */}
-          <div class="relative group rounded-lg overflow-hidden bg-[#0d1117] text-slate-300 font-mono text-xs border border-slate-800 dark:border-border-dark">
+          <div class="relative group rounded-lg overflow-hidden bg-slate-50 dark:bg-[#0d1117] text-slate-800 dark:text-slate-300 font-mono text-xs border border-slate-200 dark:border-border-dark">
             <div class="absolute right-2 top-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity">
               <CopyButton getText={getCode} variant="label" />
             </div>

--- a/web/src/components/UsageChart.tsx
+++ b/web/src/components/UsageChart.tsx
@@ -141,14 +141,14 @@ export function UsageChart({ data, height = 260 }: UsageChartProps) {
           <polyline
             points={inputPoints}
             fill="none"
-            stroke="#3b82f6"
+            stroke="var(--chart-blue)"
             stroke-width="2"
             stroke-linejoin="round"
           />
           <polyline
             points={outputPoints}
             fill="none"
-            stroke="#10b981"
+            stroke="var(--chart-green)"
             stroke-width="2"
             stroke-linejoin="round"
           />
@@ -210,7 +210,7 @@ export function UsageChart({ data, height = 260 }: UsageChartProps) {
           <polyline
             points={requestPoints}
             fill="none"
-            stroke="#f59e0b"
+            stroke="var(--chart-amber)"
             stroke-width="2"
             stroke-linejoin="round"
           />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,12 +5,18 @@
 :root {
   --primary: 16 162 53;
   --primary-hover: 14 140 46;
+  --chart-blue: #3b82f6;
+  --chart-green: #10b981;
+  --chart-amber: #f59e0b;
   color-scheme: light;
 }
 
 .dark {
   --primary: 16 163 127;
   --primary-hover: 14 140 108;
+  --chart-blue: #60a5fa;
+  --chart-green: #34d399;
+  --chart-amber: #fbbf24;
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary

- **AccountList 头部重做**：9 个元素挤一行 → 三层清晰分离
  - Row 1: 标题 + 账号统计（`191 / 908`）+ 更新时间
  - Row 2: 导航标签（概览 / 账号管理 / 代理分配 / 用量统计）
  - Row 3: 操作工具栏（刷新 / 配额 / 导入导出 / 全选）+ 分页（`10 / 908` 展开全部）
- **暗色主题修复**：
  - 图表 SVG 线条颜色改用 CSS 变量（dark mode 下更亮）
  - 代码块 light mode 背景从 `#0d1117` 改为 `bg-slate-50`
  - Toggle 开关 thumb 加 `dark:bg-slate-200` 提高对比度

## Test plan

- [x] `npm test` — 1125 tests passed
- [x] `npm run build` — 构建成功
- [ ] 浏览器验证 light + dark 模式下 AccountList 头部排版
- [ ] 验证导航标签跳转正确
- [ ] 验证响应式（sm 隐藏按钮文字 / md 两列卡片 / lg 完整显示）