### PR TITLE
refactor: architecture cleanup Phase 1-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- **Phase 3 — Service 层提取**：`src/routes/accounts.ts` 从 518 行降至 172 行（-67%），业务逻辑拆分到 `src/services/account-import.ts`、`account-query.ts`、`account-mutation.ts` 三个 service 类，全部通过 constructor DI，29 个新测试零 `vi.mock()`
+- **Phase 2 — Config DI**：`src/config.ts` 新增 `setConfigForTesting()`/`resetConfigForTesting()`，AccountPool constructor 支持 `rotationStrategy`/`initialToken`/`rateLimitBackoffSeconds` 注入，translation 函数支持 `modelConfig` 可选参数。测试中 `vi.mock("config.js")` 从 9 处降至 2 处
 - AccountList 头部重做：标题行 + 导航标签 + 操作工具栏三层分离，按钮带文字标签，分页信息更清晰（`10 / 908` + 展开全部）
 - 暗色主题修复：图表 SVG 线条颜色改用 CSS 变量（dark mode 下更亮）、代码块 light mode 背景修正、Toggle 开关 thumb 对比度提升
 

--- a/src/auth/__tests__/account-pool-label.test.ts
+++ b/src/auth/__tests__/account-pool-label.test.ts
@@ -2,17 +2,19 @@
  * Tests for account label (user-editable disambiguation).
  */
 
-// MUST be imported before @src/ imports to activate vi.mock declarations
-import "@helpers/account-pool-setup.js";
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createValidJwt } from "@helpers/jwt.js";
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import { AccountPool } from "../account-pool.js";
 
 describe("account label", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    setConfigForTesting(createMockConfig());
+  });
+  afterEach(() => {
+    resetConfigForTesting();
   });
 
   it("new accounts have label=null", () => {

--- a/src/auth/__tests__/account-pool-label.test.ts
+++ b/src/auth/__tests__/account-pool-label.test.ts
@@ -2,43 +2,12 @@
  * Tests for account label (user-editable disambiguation).
  */
 
+// MUST be imported before @src/ imports to activate vi.mock declarations
+import "@helpers/account-pool-setup.js";
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("../../models/model-store.js", () => ({
-  getModelPlanTypes: vi.fn(() => []),
-  isPlanFetched: vi.fn(() => true),
-}));
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    server: { proxy_api_key: null },
-    auth: { jwt_token: "", rotation_strategy: "least_used", rate_limit_backoff_seconds: 60 },
-  })),
-}));
-
-vi.mock("../../auth/jwt-utils.js", () => ({
-  isTokenExpired: vi.fn(() => false),
-  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
-  extractChatGptAccountId: vi.fn((token: string) => `acct-${token}`),
-  extractUserProfile: vi.fn((token: string) => ({
-    email: `${token}@test.com`,
-    chatgpt_plan_type: "team",
-    chatgpt_user_id: `uid-${token}`,
-  })),
-}));
-
-vi.mock("../../utils/jitter.js", () => ({
-  jitter: vi.fn((val: number) => val),
-}));
-
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(() => JSON.stringify({ accounts: [] })),
-  writeFileSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
-  renameSync: vi.fn(),
-}));
-
+import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
+import { createValidJwt } from "@helpers/jwt.js";
 import { AccountPool } from "../account-pool.js";
 
 describe("account label", () => {
@@ -47,63 +16,64 @@ describe("account label", () => {
   });
 
   it("new accounts have label=null", () => {
-    const pool = new AccountPool();
-    pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     const accounts = pool.getAccounts();
     expect(accounts[0].label).toBeNull();
   });
 
   it("setLabel updates label and returns true", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id = pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     const ok = pool.setLabel(id, "Team Alpha");
     expect(ok).toBe(true);
     expect(pool.getAccounts()[0].label).toBe("Team Alpha");
   });
 
   it("setLabel returns false for nonexistent account", () => {
-    const pool = new AccountPool();
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
     expect(pool.setLabel("nonexistent", "test")).toBe(false);
   });
 
   it("setLabel with null clears existing label", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id = pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     pool.setLabel(id, "Personal");
     pool.setLabel(id, null);
     expect(pool.getAccounts()[0].label).toBeNull();
   });
 
   it("dedup preserves existing label on re-add", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const jwt = createValidJwt({ accountId: "a1", email: "a1@test.com" });
+    const id = pool.addAccount(jwt);
     pool.setLabel(id, "My Team");
 
     // Re-add same account (same accountId + userId → dedup)
-    const id2 = pool.addAccount("tok-1");
+    const id2 = pool.addAccount(jwt);
     expect(id2).toBe(id);
     expect(pool.getAccounts()[0].label).toBe("My Team");
   });
 
   it("label is included in getAccounts() response", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id = pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     pool.setLabel(id, "Production");
     const info = pool.getAccounts()[0];
     expect(info).toHaveProperty("label", "Production");
   });
 
   it("label persists through getEntry()", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id = pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     pool.setLabel(id, "Dev Team");
     const entry = pool.getEntry(id);
     expect(entry?.label).toBe("Dev Team");
   });
 
   it("label is included in getAllEntries()", () => {
-    const pool = new AccountPool();
-    const id = pool.addAccount("tok-1");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id = pool.addAccount(createValidJwt({ accountId: "a1", email: "a1@test.com" }));
     pool.setLabel(id, "Staging");
     const entries = pool.getAllEntries();
     expect(entries[0].label).toBe("Staging");

--- a/src/auth/__tests__/account-pool-quota.test.ts
+++ b/src/auth/__tests__/account-pool-quota.test.ts
@@ -5,12 +5,11 @@
  * - toInfo() populating cached quota
  */
 
-// MUST be imported before @src/ imports to activate vi.mock declarations
-import "@helpers/account-pool-setup.js";
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createValidJwt } from "@helpers/jwt.js";
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import { AccountPool } from "../account-pool.js";
 import type { CodexQuota } from "../types.js";
 
@@ -34,8 +33,11 @@ describe("AccountPool quota methods", () => {
   let pool: AccountPool;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    setConfigForTesting(createMockConfig());
     pool = new AccountPool({ persistence: createMemoryPersistence() });
+  });
+  afterEach(() => {
+    resetConfigForTesting();
   });
 
   describe("updateCachedQuota", () => {

--- a/src/auth/__tests__/account-pool-quota.test.ts
+++ b/src/auth/__tests__/account-pool-quota.test.ts
@@ -3,61 +3,14 @@
  * - updateCachedQuota()
  * - markQuotaExhausted()
  * - toInfo() populating cached quota
- * - loadPersisted() backfill
  */
 
+// MUST be imported before @src/ imports to activate vi.mock declarations
+import "@helpers/account-pool-setup.js";
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
-  writeFileSync: vi.fn(),
-  renameSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
-}));
-
-vi.mock("../../paths.js", () => ({
-  getDataDir: vi.fn(() => "/tmp/test-data"),
-  getConfigDir: vi.fn(() => "/tmp/test-config"),
-}));
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    auth: {
-      jwt_token: null,
-      rotation_strategy: "least_used",
-      rate_limit_backoff_seconds: 60,
-    },
-    server: { proxy_api_key: null },
-    quota: {
-      refresh_interval_minutes: 5,
-      warning_thresholds: { primary: [80, 90], secondary: [80, 90] },
-      skip_exhausted: true,
-    },
-  })),
-}));
-
-// Use a counter to generate unique accountIds
-let _idCounter = 0;
-vi.mock("../../auth/jwt-utils.js", () => ({
-  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
-  extractChatGptAccountId: vi.fn(() => `acct-${++_idCounter}`),
-  extractUserProfile: vi.fn(() => ({
-    email: `user${_idCounter}@test.com`,
-    chatgpt_plan_type: "plus",
-  })),
-  isTokenExpired: vi.fn(() => false),
-}));
-
-vi.mock("../../utils/jitter.js", () => ({
-  jitter: vi.fn((val: number) => val),
-}));
-
-vi.mock("../../models/model-store.js", () => ({
-  getModelPlanTypes: vi.fn(() => []),
-  isPlanFetched: vi.fn(() => true),
-}));
-
+import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
+import { createValidJwt } from "@helpers/jwt.js";
 import { AccountPool } from "../account-pool.js";
 import type { CodexQuota } from "../types.js";
 
@@ -81,12 +34,13 @@ describe("AccountPool quota methods", () => {
   let pool: AccountPool;
 
   beforeEach(() => {
-    pool = new AccountPool();
+    vi.clearAllMocks();
+    pool = new AccountPool({ persistence: createMemoryPersistence() });
   });
 
   describe("updateCachedQuota", () => {
     it("stores quota and timestamp on account", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-aaa");
+      const id = pool.addAccount(createValidJwt({ accountId: "a1", planType: "plus" }));
       const quota = makeQuota();
 
       pool.updateCachedQuota(id, quota);
@@ -104,7 +58,7 @@ describe("AccountPool quota methods", () => {
 
   describe("markQuotaExhausted", () => {
     it("sets status to rate_limited with reset time", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-bbb");
+      const id = pool.addAccount(createValidJwt({ accountId: "a2" }));
       const resetAt = Math.floor(Date.now() / 1000) + 7200;
 
       pool.markQuotaExhausted(id, resetAt);
@@ -115,7 +69,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("uses fallback when resetAt is null", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ccc");
+      const id = pool.addAccount(createValidJwt({ accountId: "a3" }));
 
       pool.markQuotaExhausted(id, null);
 
@@ -125,7 +79,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("does not override disabled status", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd");
+      const id = pool.addAccount(createValidJwt({ accountId: "a4" }));
       pool.markStatus(id, "disabled");
 
       pool.markQuotaExhausted(id, Math.floor(Date.now() / 1000) + 3600);
@@ -135,7 +89,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("does not override expired status", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd2");
+      const id = pool.addAccount(createValidJwt({ accountId: "a5" }));
       pool.markStatus(id, "expired");
 
       pool.markQuotaExhausted(id, Math.floor(Date.now() / 1000) + 3600);
@@ -145,7 +99,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("extends rate_limit_until on already rate_limited account", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd3");
+      const id = pool.addAccount(createValidJwt({ accountId: "a6" }));
       // Simulate 429 backoff (short)
       pool.markRateLimited(id, { retryAfterSec: 60 });
       const entryBefore = pool.getEntry(id);
@@ -163,7 +117,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("does not shorten existing rate_limit_until", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ddd4");
+      const id = pool.addAccount(createValidJwt({ accountId: "a7" }));
       // Mark with long reset (e.g. 7-day quota)
       const longResetAt = Math.floor(Date.now() / 1000) + 86400; // 24 hours
       pool.markQuotaExhausted(id, longResetAt);
@@ -182,7 +136,7 @@ describe("AccountPool quota methods", () => {
 
   describe("toInfo with cached quota", () => {
     it("populates quota field from cachedQuota", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-eee");
+      const id = pool.addAccount(createValidJwt({ accountId: "a8", planType: "team" }));
       const quota = makeQuota({ plan_type: "team" });
 
       pool.updateCachedQuota(id, quota);
@@ -194,7 +148,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("does not include quota when cachedQuota is null", () => {
-      const id = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-fff");
+      const id = pool.addAccount(createValidJwt({ accountId: "a9" }));
 
       const accounts = pool.getAccounts();
       const acct = accounts.find((a) => a.id === id);
@@ -204,8 +158,8 @@ describe("AccountPool quota methods", () => {
 
   describe("acquire skips exhausted accounts", () => {
     it("skips rate_limited (quota exhausted) account", () => {
-      const id1 = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-ggg");
-      const id2 = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-hhh");
+      const id1 = pool.addAccount(createValidJwt({ accountId: "b1" }));
+      const id2 = pool.addAccount(createValidJwt({ accountId: "b2" }));
 
       // Exhaust first account
       pool.markQuotaExhausted(id1, Math.floor(Date.now() / 1000) + 7200);
@@ -217,7 +171,7 @@ describe("AccountPool quota methods", () => {
     });
 
     it("returns null when all accounts exhausted", () => {
-      const id1 = pool.addAccount("eyJhbGciOiJIUzI1NiJ9.test-token-iii");
+      const id1 = pool.addAccount(createValidJwt({ accountId: "c1" }));
       pool.markQuotaExhausted(id1, Math.floor(Date.now() / 1000) + 7200);
 
       const acquired = pool.acquire();

--- a/src/auth/__tests__/account-pool-sticky.test.ts
+++ b/src/auth/__tests__/account-pool-sticky.test.ts
@@ -5,22 +5,29 @@
  * until rate-limited or quota-exhausted.
  */
 
-// MUST be imported before @src/ imports to activate vi.mock declarations
-import "@helpers/account-pool-setup.js";
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createMockConfig } from "@helpers/config.js";
 import { createValidJwt } from "@helpers/jwt.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import { AccountPool } from "../account-pool.js";
-import { getConfig } from "@src/config.js";
-import { getModelPlanTypes } from "@src/models/model-store.js";
+import { getModelPlanTypes } from "../../models/model-store.js";
+
+// Only model-store needs mocking (for model-aware selection test)
+vi.mock("../../models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+  isPlanFetched: vi.fn(() => true),
+  getModelInfo: vi.fn(() => null),
+  parseModelName: vi.fn((m: string) => ({ modelId: m, serviceTier: null, reasoningEffort: null })),
+}));
 
 describe("account-pool sticky strategy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default to sticky strategy for all tests in this suite
-    vi.mocked(getConfig).mockReturnValue(createMockConfig({ auth: { rotation_strategy: "sticky" } }));
+    setConfigForTesting(createMockConfig({ auth: { rotation_strategy: "sticky" } }));
+  });
+  afterEach(() => {
+    resetConfigForTesting();
   });
 
   it("selects account with most recent last_used", () => {
@@ -119,7 +126,7 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("least_used still works (regression guard)", () => {
-    vi.mocked(getConfig).mockReturnValue(createMockConfig({ auth: { rotation_strategy: "least_used" } }));
+    setConfigForTesting(createMockConfig({ auth: { rotation_strategy: "least_used" } }));
 
     const pool = new AccountPool({ persistence: createMemoryPersistence() });
     const idA = pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));

--- a/src/auth/__tests__/account-pool-sticky.test.ts
+++ b/src/auth/__tests__/account-pool-sticky.test.ts
@@ -5,78 +5,39 @@
  * until rate-limited or quota-exhausted.
  */
 
+// MUST be imported before @src/ imports to activate vi.mock declarations
+import "@helpers/account-pool-setup.js";
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-let mockStrategy: "least_used" | "round_robin" | "sticky" = "sticky";
-
-const mockGetModelPlanTypes = vi.fn<(id: string) => string[]>(() => []);
-
-vi.mock("../../models/model-store.js", () => ({
-  getModelPlanTypes: (...args: unknown[]) => mockGetModelPlanTypes(args[0] as string),
-  isPlanFetched: () => true,
-}));
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    server: { proxy_api_key: null },
-    auth: { jwt_token: "", rotation_strategy: mockStrategy, rate_limit_backoff_seconds: 60 },
-  })),
-}));
-
-let profileForToken: Record<string, { chatgpt_plan_type: string; email: string }> = {};
-
-vi.mock("../../auth/jwt-utils.js", () => ({
-  isTokenExpired: vi.fn(() => false),
-  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
-  extractChatGptAccountId: vi.fn((token: string) => `aid-${token}`),
-  extractUserProfile: vi.fn((token: string) => profileForToken[token] ?? null),
-}));
-
-vi.mock("../../utils/jitter.js", () => ({
-  jitter: vi.fn((val: number) => val),
-}));
-
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(() => JSON.stringify({ accounts: [] })),
-  writeFileSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
-  renameSync: vi.fn(),
-}));
-
+import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
+import { createMockConfig } from "@helpers/config.js";
+import { createValidJwt } from "@helpers/jwt.js";
 import { AccountPool } from "../account-pool.js";
+import { getConfig } from "@src/config.js";
+import { getModelPlanTypes } from "@src/models/model-store.js";
 
 describe("account-pool sticky strategy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    profileForToken = {};
-    mockStrategy = "sticky";
+    // Default to sticky strategy for all tests in this suite
+    vi.mocked(getConfig).mockReturnValue(createMockConfig({ auth: { rotation_strategy: "sticky" } }));
   });
 
   it("selects account with most recent last_used", () => {
-    profileForToken = {
-      "tok-a": { chatgpt_plan_type: "free", email: "a@test.com" },
-      "tok-b": { chatgpt_plan_type: "free", email: "b@test.com" },
-      "tok-c": { chatgpt_plan_type: "free", email: "c@test.com" },
-    };
-
-    const pool = new AccountPool();
-    const idA = pool.addAccount("tok-a");
-    const idB = pool.addAccount("tok-b");
-    const idC = pool.addAccount("tok-c");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const idA = pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));
+    const idB = pool.addAccount(createValidJwt({ accountId: "b", email: "b@test.com", planType: "free" }));
+    const idC = pool.addAccount(createValidJwt({ accountId: "c", email: "c@test.com", planType: "free" }));
 
     // Simulate: B was used most recently, then A, then C
-    const entryC = pool.getEntry(idC)!;
-    entryC.usage.last_used = new Date(Date.now() - 30_000).toISOString();
-    entryC.usage.request_count = 1;
+    pool.getEntry(idC)!.usage.last_used = new Date(Date.now() - 30_000).toISOString();
+    pool.getEntry(idC)!.usage.request_count = 1;
 
-    const entryA = pool.getEntry(idA)!;
-    entryA.usage.last_used = new Date(Date.now() - 10_000).toISOString();
-    entryA.usage.request_count = 2;
+    pool.getEntry(idA)!.usage.last_used = new Date(Date.now() - 10_000).toISOString();
+    pool.getEntry(idA)!.usage.request_count = 2;
 
-    const entryB = pool.getEntry(idB)!;
-    entryB.usage.last_used = new Date(Date.now() - 1_000).toISOString();
-    entryB.usage.request_count = 5;
+    pool.getEntry(idB)!.usage.last_used = new Date(Date.now() - 1_000).toISOString();
+    pool.getEntry(idB)!.usage.request_count = 5;
 
     // Sticky should pick B (most recent last_used) despite having most requests
     const acquired = pool.acquire();
@@ -86,14 +47,9 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("sticks to same account across multiple acquire/release cycles", () => {
-    profileForToken = {
-      "tok-a": { chatgpt_plan_type: "free", email: "a@test.com" },
-      "tok-b": { chatgpt_plan_type: "free", email: "b@test.com" },
-    };
-
-    const pool = new AccountPool();
-    pool.addAccount("tok-a");
-    pool.addAccount("tok-b");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));
+    pool.addAccount(createValidJwt({ accountId: "b", email: "b@test.com", planType: "free" }));
 
     // First acquire picks one (arbitrary from fresh pool)
     const first = pool.acquire()!;
@@ -108,19 +64,13 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("falls back when current account is rate-limited", () => {
-    profileForToken = {
-      "tok-a": { chatgpt_plan_type: "free", email: "a@test.com" },
-      "tok-b": { chatgpt_plan_type: "free", email: "b@test.com" },
-    };
-
-    const pool = new AccountPool();
-    const idA = pool.addAccount("tok-a");
-    const idB = pool.addAccount("tok-b");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const idA = pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));
+    const idB = pool.addAccount(createValidJwt({ accountId: "b", email: "b@test.com", planType: "free" }));
 
     // Make A the sticky choice
-    const entryA = pool.getEntry(idA)!;
-    entryA.usage.last_used = new Date().toISOString();
-    entryA.usage.request_count = 5;
+    pool.getEntry(idA)!.usage.last_used = new Date().toISOString();
+    pool.getEntry(idA)!.usage.request_count = 5;
 
     // Rate-limit A
     pool.markRateLimited(idA, { retryAfterSec: 300 });
@@ -133,16 +83,10 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("picks first available when no account has been used yet", () => {
-    profileForToken = {
-      "tok-a": { chatgpt_plan_type: "free", email: "a@test.com" },
-      "tok-b": { chatgpt_plan_type: "free", email: "b@test.com" },
-      "tok-c": { chatgpt_plan_type: "free", email: "c@test.com" },
-    };
-
-    const pool = new AccountPool();
-    pool.addAccount("tok-a");
-    pool.addAccount("tok-b");
-    pool.addAccount("tok-c");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));
+    pool.addAccount(createValidJwt({ accountId: "b", email: "b@test.com", planType: "free" }));
+    pool.addAccount(createValidJwt({ accountId: "c", email: "c@test.com", planType: "free" }));
 
     // All accounts have null last_used — should pick one
     const first = pool.acquire();
@@ -157,20 +101,15 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("respects model filtering", () => {
-    profileForToken = {
-      "tok-free": { chatgpt_plan_type: "free", email: "free@test.com" },
-      "tok-team": { chatgpt_plan_type: "team", email: "team@test.com" },
-    };
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
 
-    const pool = new AccountPool();
-    const idFree = pool.addAccount("tok-free");
-    const idTeam = pool.addAccount("tok-team");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const idFree = pool.addAccount(createValidJwt({ accountId: "free1", email: "free@test.com", planType: "free" }));
+    const idTeam = pool.addAccount(createValidJwt({ accountId: "team1", email: "team@test.com", planType: "team" }));
 
     // Use the free account more recently
-    const entryFree = pool.getEntry(idFree)!;
-    entryFree.usage.last_used = new Date().toISOString();
-    entryFree.usage.request_count = 10;
+    pool.getEntry(idFree)!.usage.last_used = new Date().toISOString();
+    pool.getEntry(idFree)!.usage.request_count = 10;
 
     // Model requires team plan — sticky should pick team account despite free being more recent
     const acquired = pool.acquire({ model: "gpt-5.4" });
@@ -180,23 +119,16 @@ describe("account-pool sticky strategy", () => {
   });
 
   it("least_used still works (regression guard)", () => {
-    mockStrategy = "least_used";
-    profileForToken = {
-      "tok-a": { chatgpt_plan_type: "free", email: "a@test.com" },
-      "tok-b": { chatgpt_plan_type: "free", email: "b@test.com" },
-    };
+    vi.mocked(getConfig).mockReturnValue(createMockConfig({ auth: { rotation_strategy: "least_used" } }));
 
-    const pool = new AccountPool();
-    const idA = pool.addAccount("tok-a");
-    const idB = pool.addAccount("tok-b");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const idA = pool.addAccount(createValidJwt({ accountId: "a", email: "a@test.com", planType: "free" }));
+    const idB = pool.addAccount(createValidJwt({ accountId: "b", email: "b@test.com", planType: "free" }));
 
     // A has more requests — least_used should prefer B
-    const entryA = pool.getEntry(idA)!;
-    entryA.usage.request_count = 10;
-    entryA.usage.last_used = new Date().toISOString();
-
-    const entryB = pool.getEntry(idB)!;
-    entryB.usage.request_count = 2;
+    pool.getEntry(idA)!.usage.request_count = 10;
+    pool.getEntry(idA)!.usage.last_used = new Date().toISOString();
+    pool.getEntry(idB)!.usage.request_count = 2;
 
     const acquired = pool.acquire();
     expect(acquired).not.toBeNull();

--- a/src/auth/__tests__/account-pool-team-dedup.test.ts
+++ b/src/auth/__tests__/account-pool-team-dedup.test.ts
@@ -6,19 +6,21 @@
  * See: https://github.com/icebear0828/codex-proxy/issues/126
  */
 
-// MUST be imported before @src/ imports to activate vi.mock declarations
-import "@helpers/account-pool-setup.js";
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createValidJwt } from "@helpers/jwt.js";
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import { AccountPool } from "../account-pool.js";
 
 const TEAM_ACCOUNT_ID = "acct-team-abc123";
 
 describe("team account dedup (issue #126)", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    setConfigForTesting(createMockConfig());
+  });
+  afterEach(() => {
+    resetConfigForTesting();
   });
 
   it("allows multiple team members with same accountId but different userId", () => {

--- a/src/auth/__tests__/account-pool-team-dedup.test.ts
+++ b/src/auth/__tests__/account-pool-team-dedup.test.ts
@@ -6,65 +6,28 @@
  * See: https://github.com/icebear0828/codex-proxy/issues/126
  */
 
+// MUST be imported before @src/ imports to activate vi.mock declarations
+import "@helpers/account-pool-setup.js";
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("../../models/model-store.js", () => ({
-  getModelPlanTypes: vi.fn(() => []),
-  isPlanFetched: vi.fn(() => true),
-}));
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    server: { proxy_api_key: null },
-    auth: { jwt_token: "", rotation_strategy: "least_used", rate_limit_backoff_seconds: 60 },
-  })),
-}));
-
-// Team members share the same accountId but have distinct user IDs
-const TEAM_ACCOUNT_ID = "acct-team-abc123";
-
-let profileForToken: Record<string, { chatgpt_plan_type: string; email: string; chatgpt_user_id?: string }> = {};
-
-vi.mock("../../auth/jwt-utils.js", () => ({
-  isTokenExpired: vi.fn(() => false),
-  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
-  extractChatGptAccountId: vi.fn((token: string) => {
-    // All "team-*" tokens share the same account ID
-    if (token.startsWith("team-")) return TEAM_ACCOUNT_ID;
-    return `acct-${token}`;
-  }),
-  extractUserProfile: vi.fn((token: string) => profileForToken[token] ?? null),
-}));
-
-vi.mock("../../utils/jitter.js", () => ({
-  jitter: vi.fn((val: number) => val),
-}));
-
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(() => JSON.stringify({ accounts: [] })),
-  writeFileSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
-  renameSync: vi.fn(),
-}));
-
+import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
+import { createValidJwt } from "@helpers/jwt.js";
 import { AccountPool } from "../account-pool.js";
+
+const TEAM_ACCOUNT_ID = "acct-team-abc123";
 
 describe("team account dedup (issue #126)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    profileForToken = {};
   });
 
   it("allows multiple team members with same accountId but different userId", () => {
-    profileForToken = {
-      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
-      "team-bob": { chatgpt_plan_type: "team", email: "bob@corp.com", chatgpt_user_id: "user-bob" },
-    };
+    const jwtAlice = createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-alice", email: "alice@corp.com", planType: "team" });
+    const jwtBob = createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-bob", email: "bob@corp.com", planType: "team" });
 
-    const pool = new AccountPool();
-    const idAlice = pool.addAccount("team-alice");
-    const idBob = pool.addAccount("team-bob");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const idAlice = pool.addAccount(jwtAlice);
+    const idBob = pool.addAccount(jwtBob);
 
     // Both should exist as separate entries
     expect(idAlice).not.toBe(idBob);
@@ -79,14 +42,13 @@ describe("team account dedup (issue #126)", () => {
   });
 
   it("still deduplicates when same user re-adds their token", () => {
-    profileForToken = {
-      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
-      "team-alice-refreshed": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
-    };
+    // Same userId → same identity, different token (refreshed)
+    const jwt1 = createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-alice", email: "alice@corp.com", planType: "team" });
+    const jwt2 = createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-alice", email: "alice@corp.com", planType: "team", expInSeconds: 7200 });
 
-    const pool = new AccountPool();
-    const id1 = pool.addAccount("team-alice");
-    const id2 = pool.addAccount("team-alice-refreshed");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    const id1 = pool.addAccount(jwt1);
+    const id2 = pool.addAccount(jwt2);
 
     // Same user → should update, not duplicate
     expect(id1).toBe(id2);
@@ -94,16 +56,10 @@ describe("team account dedup (issue #126)", () => {
   });
 
   it("third team member adds without overwriting existing members", () => {
-    profileForToken = {
-      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
-      "team-bob": { chatgpt_plan_type: "team", email: "bob@corp.com", chatgpt_user_id: "user-bob" },
-      "team-carol": { chatgpt_plan_type: "team", email: "carol@corp.com", chatgpt_user_id: "user-carol" },
-    };
-
-    const pool = new AccountPool();
-    pool.addAccount("team-alice");
-    pool.addAccount("team-bob");
-    pool.addAccount("team-carol");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    pool.addAccount(createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-alice", email: "alice@corp.com", planType: "team" }));
+    pool.addAccount(createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-bob", email: "bob@corp.com", planType: "team" }));
+    pool.addAccount(createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-carol", email: "carol@corp.com", planType: "team" }));
 
     expect(pool.getAccounts()).toHaveLength(3);
     const emails = pool.getAccounts().map((a) => a.email).sort();
@@ -111,29 +67,18 @@ describe("team account dedup (issue #126)", () => {
   });
 
   it("userId is included in AccountInfo", () => {
-    profileForToken = {
-      "team-alice": { chatgpt_plan_type: "team", email: "alice@corp.com", chatgpt_user_id: "user-alice" },
-    };
-
-    const pool = new AccountPool();
-    pool.addAccount("team-alice");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    pool.addAccount(createValidJwt({ accountId: TEAM_ACCOUNT_ID, userId: "user-alice", email: "alice@corp.com", planType: "team" }));
 
     const info = pool.getAccounts()[0];
     expect(info.userId).toBe("user-alice");
   });
 
   it("accounts without userId still dedup by accountId alone", () => {
-    // Legacy tokens without chatgpt_user_id
-    profileForToken = {
-      "solo-token1": { chatgpt_plan_type: "free", email: "user@test.com" },
-      "solo-token2": { chatgpt_plan_type: "free", email: "user@test.com" },
-    };
-
-    // Both map to the same accountId (acct-solo-token1 vs acct-solo-token2 — different!)
-    // but if they had the same accountId, they'd dedup since both userId are null
-    const pool = new AccountPool();
-    pool.addAccount("solo-token1");
-    pool.addAccount("solo-token2");
+    const pool = new AccountPool({ persistence: createMemoryPersistence() });
+    // Two accounts with different accountIds — both should be added (no dedup)
+    pool.addAccount(createValidJwt({ accountId: "acct-solo-1", email: "user1@test.com" }));
+    pool.addAccount(createValidJwt({ accountId: "acct-solo-2", email: "user2@test.com" }));
 
     // Different accountId → separate entries
     expect(pool.getAccounts()).toHaveLength(2);

--- a/src/auth/__tests__/dashboard-session.test.ts
+++ b/src/auth/__tests__/dashboard-session.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    session: { ttl_minutes: 1, cleanup_interval_minutes: 1 },
-  })),
-}));
-
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import {
   createSession,
   validateSession,
@@ -17,12 +12,16 @@ import {
 } from "../dashboard-session.js";
 
 beforeEach(() => {
+  setConfigForTesting(createMockConfig({
+    session: { ttl_minutes: 1, cleanup_interval_minutes: 1 },
+  }));
   _resetForTest();
 });
 
 afterEach(() => {
   stopSessionCleanup();
   _resetForTest();
+  resetConfigForTesting();
 });
 
 describe("dashboard-session", () => {

--- a/src/auth/__tests__/plan-routing-acquire.test.ts
+++ b/src/auth/__tests__/plan-routing-acquire.test.ts
@@ -6,14 +6,21 @@
  * NOT be used (return null instead of wrong account).
  */
 
-// MUST be imported before @src/ imports to activate vi.mock declarations
-import "@helpers/account-pool-setup.js";
-
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createValidJwt } from "@helpers/jwt.js";
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 import { AccountPool } from "../account-pool.js";
-import { getModelPlanTypes, isPlanFetched } from "@src/models/model-store.js";
+import { getModelPlanTypes, isPlanFetched } from "../../models/model-store.js";
+
+// Only model-store needs mocking (for plan-based routing logic)
+vi.mock("../../models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+  isPlanFetched: vi.fn(() => true),
+  getModelInfo: vi.fn(() => null),
+  parseModelName: vi.fn((m: string) => ({ modelId: m, serviceTier: null, reasoningEffort: null })),
+}));
 
 type AccountSpec = { accountId: string; planType: string; email: string };
 
@@ -31,8 +38,12 @@ function createPool(...specs: AccountSpec[]): { pool: AccountPool; jwts: Map<str
 describe("account-pool plan-based routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setConfigForTesting(createMockConfig());
     vi.mocked(getModelPlanTypes).mockReturnValue([]);
     vi.mocked(isPlanFetched).mockReturnValue(true);
+  });
+  afterEach(() => {
+    resetConfigForTesting();
   });
 
   it("returns null when model only supports team but only free accounts exist", () => {

--- a/src/auth/__tests__/plan-routing-acquire.test.ts
+++ b/src/auth/__tests__/plan-routing-acquire.test.ts
@@ -6,150 +6,113 @@
  * NOT be used (return null instead of wrong account).
  */
 
+// MUST be imported before @src/ imports to activate vi.mock declarations
+import "@helpers/account-pool-setup.js";
+
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// Mock getModelPlanTypes and isPlanFetched to control plan routing
-const mockGetModelPlanTypes = vi.fn<(id: string) => string[]>(() => []);
-const mockIsPlanFetched = vi.fn<(planType: string) => boolean>(() => true);
-
-vi.mock("../../models/model-store.js", () => ({
-  getModelPlanTypes: (...args: unknown[]) => mockGetModelPlanTypes(args[0] as string),
-  isPlanFetched: (...args: unknown[]) => mockIsPlanFetched(args[0] as string),
-}));
-
-vi.mock("../../config.js", () => ({
-  getConfig: vi.fn(() => ({
-    server: { account_strategy: "round_robin" },
-    auth: { jwt_token: "" },
-  })),
-}));
-
-// Control planType by returning it from extractUserProfile
-let profileForToken: Record<string, { chatgpt_plan_type: string; email: string }> = {};
-
-vi.mock("../../auth/jwt-utils.js", () => ({
-  isTokenExpired: vi.fn(() => false),
-  decodeJwtPayload: vi.fn(() => ({})),
-  extractChatGptAccountId: vi.fn((token: string) => `aid-${token}`),
-  extractUserProfile: vi.fn((token: string) => profileForToken[token] ?? null),
-}));
-
-vi.mock("../../utils/jitter.js", () => ({
-  jitter: vi.fn((val: number) => val),
-}));
-
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(() => JSON.stringify({ accounts: [] })),
-  writeFileSync: vi.fn(),
-  existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
-}));
-
+import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
+import { createValidJwt } from "@helpers/jwt.js";
 import { AccountPool } from "../account-pool.js";
+import { getModelPlanTypes, isPlanFetched } from "@src/models/model-store.js";
 
-function createPool(...accounts: Array<{ token: string; planType: string; email: string }>) {
-  // Set up profile mocks before creating pool
-  profileForToken = {};
-  for (const a of accounts) {
-    profileForToken[a.token] = { chatgpt_plan_type: a.planType, email: a.email };
-  }
+type AccountSpec = { accountId: string; planType: string; email: string };
 
-  const pool = new AccountPool();
-  for (const a of accounts) {
-    pool.addAccount(a.token);
+function createPool(...specs: AccountSpec[]): { pool: AccountPool; jwts: Map<string, string> } {
+  const pool = new AccountPool({ persistence: createMemoryPersistence() });
+  const jwts = new Map<string, string>();
+  for (const spec of specs) {
+    const jwt = createValidJwt({ accountId: spec.accountId, planType: spec.planType, email: spec.email });
+    jwts.set(spec.accountId, jwt);
+    pool.addAccount(jwt);
   }
-  return pool;
+  return { pool, jwts };
 }
 
 describe("account-pool plan-based routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    profileForToken = {};
+    vi.mocked(getModelPlanTypes).mockReturnValue([]);
+    vi.mocked(isPlanFetched).mockReturnValue(true);
   });
 
   it("returns null when model only supports team but only free accounts exist", () => {
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-    );
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    const { pool } = createPool({ accountId: "free1", planType: "free", email: "free@test.com" });
 
     const acquired = pool.acquire({ model: "gpt-5.4" });
     expect(acquired).toBeNull();
   });
 
   it("acquires team account when model only supports team", () => {
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-      { token: "tok-team", planType: "team", email: "team@test.com" },
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    const { pool, jwts } = createPool(
+      { accountId: "free1", planType: "free", email: "free@test.com" },
+      { accountId: "team1", planType: "team", email: "team@test.com" },
     );
 
     const acquired = pool.acquire({ model: "gpt-5.4" });
     expect(acquired).not.toBeNull();
-    expect(acquired!.token).toBe("tok-team");
+    expect(acquired!.token).toBe(jwts.get("team1"));
   });
 
   it("uses any account when model has no known plan requirements", () => {
-    mockGetModelPlanTypes.mockReturnValue([]);
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-    );
+    vi.mocked(getModelPlanTypes).mockReturnValue([]);
+    const { pool } = createPool({ accountId: "free1", planType: "free", email: "free@test.com" });
 
     const acquired = pool.acquire({ model: "unknown-model" });
     expect(acquired).not.toBeNull();
   });
 
   it("after plan map update, free account can access previously team-only model", () => {
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-    );
+    const { pool, jwts } = createPool({ accountId: "free1", planType: "free", email: "free@test.com" });
 
     // Initially: gpt-5.4 only for team
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
     const before = pool.acquire({ model: "gpt-5.4" });
     expect(before).toBeNull(); // blocked
 
     // Backend updates: gpt-5.4 now available for free too
-    mockGetModelPlanTypes.mockReturnValue(["free", "team"]);
+    vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
     const after = pool.acquire({ model: "gpt-5.4" });
     expect(after).not.toBeNull();
-    expect(after!.token).toBe("tok-free");
+    expect(after!.token).toBe(jwts.get("free1"));
   });
 
   it("prefers plan-matched accounts over others", () => {
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    const pool = createPool(
-      { token: "tok-free1", planType: "free", email: "free1@test.com" },
-      { token: "tok-free2", planType: "free", email: "free2@test.com" },
-      { token: "tok-team", planType: "team", email: "team@test.com" },
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    const { pool, jwts } = createPool(
+      { accountId: "free1", planType: "free", email: "free1@test.com" },
+      { accountId: "free2", planType: "free", email: "free2@test.com" },
+      { accountId: "team1", planType: "team", email: "team@test.com" },
     );
 
     const acquired = pool.acquire({ model: "gpt-5.4" });
     expect(acquired).not.toBeNull();
-    expect(acquired!.token).toBe("tok-team");
+    expect(acquired!.token).toBe(jwts.get("team1"));
   });
 
-  it("acquires free account when model supports both free and team", () => {
-    mockGetModelPlanTypes.mockReturnValue(["free", "team"]);
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-      { token: "tok-team", planType: "team", email: "team@test.com" },
+  it("acquires any account when model supports both free and team", () => {
+    vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
+    const { pool, jwts } = createPool(
+      { accountId: "free1", planType: "free", email: "free@test.com" },
+      { accountId: "team1", planType: "team", email: "team@test.com" },
     );
 
     const acquired = pool.acquire({ model: "gpt-5.4" });
     expect(acquired).not.toBeNull();
     // Both are valid candidates, should get one of them
-    expect(["tok-free", "tok-team"]).toContain(acquired!.token);
+    const allTokens = [jwts.get("free1"), jwts.get("team1")];
+    expect(allTokens).toContain(acquired!.token);
   });
 
   it("includes accounts whose plan was never fetched (unfetched = possibly compatible)", () => {
     // Model known to work on team, but free plan was never fetched
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    mockIsPlanFetched.mockImplementation((plan: string) => plan === "team");
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    vi.mocked(isPlanFetched).mockImplementation((plan: string) => plan === "team");
 
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-      { token: "tok-team", planType: "team", email: "team@test.com" },
+    const { pool } = createPool(
+      { accountId: "free1", planType: "free", email: "free@test.com" },
+      { accountId: "team1", planType: "team", email: "team@test.com" },
     );
 
     // Both accounts are candidates (team is known, free is unfetched → possibly compatible)
@@ -161,26 +124,25 @@ describe("account-pool plan-based routing", () => {
     expect(second).not.toBeNull();
     expect(second!.token).not.toBe(first!.token);
 
-    // Both tokens should be from our pool
-    const tokens = new Set([first!.token, second!.token]);
-    expect(tokens.has("tok-free")).toBe(true);
-    expect(tokens.has("tok-team")).toBe(true);
+    // Both tokens come from the pool
+    const allTokens = new Set([pool.getEntry(first!.entryId)?.token, pool.getEntry(second!.entryId)?.token]);
+    expect(allTokens.size).toBe(2);
   });
 
   it("excludes accounts whose plan was fetched but lacks the model", () => {
     // Model known to work on team; free plan was fetched and model is NOT in it
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    mockIsPlanFetched.mockReturnValue(true); // both plans fetched
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    vi.mocked(isPlanFetched).mockReturnValue(true); // both plans fetched
 
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-      { token: "tok-team", planType: "team", email: "team@test.com" },
+    const { pool, jwts } = createPool(
+      { accountId: "free1", planType: "free", email: "free@test.com" },
+      { accountId: "team1", planType: "team", email: "team@test.com" },
     );
 
     // Lock the team account
     const first = pool.acquire({ model: "gpt-5.4" });
     expect(first).not.toBeNull();
-    expect(first!.token).toBe("tok-team");
+    expect(first!.token).toBe(jwts.get("team1"));
 
     // Second request — free plan was fetched and model is absent → null
     const second = pool.acquire({ model: "gpt-5.4" });
@@ -189,16 +151,14 @@ describe("account-pool plan-based routing", () => {
 
   it("unfetched plans are included even when model appears plan-locked", () => {
     // Model supports team only, no plans have been fetched, but only free accounts exist
-    mockGetModelPlanTypes.mockReturnValue(["team"]);
-    mockIsPlanFetched.mockReturnValue(false); // no plans fetched yet
+    vi.mocked(getModelPlanTypes).mockReturnValue(["team"]);
+    vi.mocked(isPlanFetched).mockReturnValue(false); // no plans fetched yet
 
-    const pool = createPool(
-      { token: "tok-free", planType: "free", email: "free@test.com" },
-    );
+    const { pool, jwts } = createPool({ accountId: "free1", planType: "free", email: "free@test.com" });
 
     // Free plan is unfetched → included as possibly compatible
     const acquired = pool.acquire({ model: "gpt-5.4" });
     expect(acquired).not.toBeNull();
-    expect(acquired!.token).toBe("tok-free");
+    expect(acquired!.token).toBe(jwts.get("free1"));
   });
 });

--- a/src/auth/__tests__/refresh-scheduler-concurrency.test.ts
+++ b/src/auth/__tests__/refresh-scheduler-concurrency.test.ts
@@ -4,20 +4,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMockConfig } from "@helpers/config.js";
+import { setConfigForTesting, resetConfigForTesting } from "../../config.js";
 
 // ── Mocks ────────────────────────────────────────────────────────────
-
-let mockConfig = {
-  auth: {
-    refresh_enabled: true,
-    refresh_margin_seconds: 300,
-    refresh_concurrency: 2,
-  },
-};
-
-vi.mock("../../config.js", () => ({
-  getConfig: () => mockConfig,
-}));
 
 // Track concurrent calls
 let activeCalls = 0;
@@ -101,17 +91,14 @@ describe("RefreshScheduler concurrency control", () => {
     activeCalls = 0;
     peakConcurrency = 0;
     callLog.length = 0;
-    mockConfig = {
-      auth: {
-        refresh_enabled: true,
-        refresh_margin_seconds: 300,
-        refresh_concurrency: 2,
-      },
-    };
+    setConfigForTesting(createMockConfig({
+      auth: { refresh_enabled: true, refresh_margin_seconds: 300, refresh_concurrency: 2 },
+    }));
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    resetConfigForTesting();
   });
 
   it("limits concurrent refreshes to configured value", async () => {
@@ -132,7 +119,9 @@ describe("RefreshScheduler concurrency control", () => {
   });
 
   it("respects higher concurrency config", async () => {
-    mockConfig.auth.refresh_concurrency = 4;
+    setConfigForTesting(createMockConfig({
+      auth: { refresh_enabled: true, refresh_margin_seconds: 300, refresh_concurrency: 4 },
+    }));
     const pool = makePool(8);
 
     const { RefreshScheduler } = await import("../refresh-scheduler.js");
@@ -147,7 +136,9 @@ describe("RefreshScheduler concurrency control", () => {
   });
 
   it("works with concurrency=1 (serial)", async () => {
-    mockConfig.auth.refresh_concurrency = 1;
+    setConfigForTesting(createMockConfig({
+      auth: { refresh_enabled: true, refresh_margin_seconds: 300, refresh_concurrency: 1 },
+    }));
     const pool = makePool(3);
 
     const { RefreshScheduler } = await import("../refresh-scheduler.js");

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -16,7 +16,7 @@ import { getModelPlanTypes, isPlanFetched } from "../models/model-store.js";
 import { getRotationStrategy } from "./rotation-strategy.js";
 import { createFsPersistence } from "./account-persistence.js";
 import type { AccountPersistence } from "./account-persistence.js";
-import type { RotationStrategy, RotationState } from "./rotation-strategy.js";
+import type { RotationStrategy, RotationState, RotationStrategyName } from "./rotation-strategy.js";
 import type {
   AccountEntry,
   AccountInfo,
@@ -36,11 +36,28 @@ export class AccountPool {
   private rotationState: RotationState = { roundRobinIndex: 0 };
   private persistence: AccountPersistence;
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private rateLimitBackoffSeconds: number;
 
-  constructor(options?: { persistence?: AccountPersistence }) {
+  constructor(options?: {
+    persistence?: AccountPersistence;
+    rotationStrategy?: RotationStrategyName;
+    initialToken?: string | null;
+    rateLimitBackoffSeconds?: number;
+  }) {
     this.persistence = options?.persistence ?? createFsPersistence();
-    const config = getConfig();
-    this.strategy = getRotationStrategy(config.auth.rotation_strategy);
+
+    // Config DI: prefer explicit params, fallback to getConfig()
+    const needsConfig =
+      options?.rotationStrategy === undefined ||
+      options?.initialToken === undefined ||
+      options?.rateLimitBackoffSeconds === undefined;
+    const config = needsConfig ? getConfig() : undefined;
+
+    this.strategy = getRotationStrategy(
+      options?.rotationStrategy ?? config!.auth.rotation_strategy,
+    );
+    this.rateLimitBackoffSeconds =
+      options?.rateLimitBackoffSeconds ?? config!.auth.rate_limit_backoff_seconds;
 
     // Load persisted accounts (handles migration from legacy format)
     const { entries } = this.persistence.load();
@@ -48,9 +65,13 @@ export class AccountPool {
       this.accounts.set(entry.id, entry);
     }
 
-    // Override with config jwt_token if set
-    if (config.auth.jwt_token) {
-      this.addAccount(config.auth.jwt_token);
+    // Override with initial token if set
+    const initialToken =
+      options?.initialToken !== undefined
+        ? options.initialToken
+        : config!.auth.jwt_token;
+    if (initialToken) {
+      this.addAccount(initialToken);
     }
     const envToken = process.env.CODEX_JWT_TOKEN;
     if (envToken) {
@@ -220,9 +241,8 @@ export class AccountPool {
     const entry = this.accounts.get(entryId);
     if (!entry) return;
 
-    const config = getConfig();
     const backoff = jitter(
-      options?.retryAfterSec ?? config.auth.rate_limit_backoff_seconds,
+      options?.retryAfterSec ?? this.rateLimitBackoffSeconds,
       0.2,
     );
     const until = new Date(Date.now() + backoff * 1000);

--- a/src/config.ts
+++ b/src/config.ts
@@ -227,6 +227,17 @@ export function hasLocalOverride(...path: string[]): boolean {
   return obj !== undefined;
 }
 
+/** Test-only: replace the config singleton. Production code MUST NOT call this. */
+export function setConfigForTesting(config: AppConfig): void {
+  _config = config;
+}
+
+/** Test-only: reset config and fingerprint singletons. */
+export function resetConfigForTesting(): void {
+  _config = null;
+  _fingerprint = null;
+}
+
 export function mutateClientConfig(patch: Partial<AppConfig["client"]>): void {
   if (!_config) throw new Error("Config not loaded");
   Object.assign(_config.client, patch);

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -1,18 +1,7 @@
 /**
  * Account management API routes.
- *
- * GET    /auth/accounts            — list all accounts + usage + status
- * GET    /auth/accounts?quota=true — list all accounts with official quota
- * POST   /auth/accounts            — add account (token paste)
- * DELETE /auth/accounts/:id        — remove account
- * POST   /auth/accounts/:id/reset-usage — reset usage stats
- * GET    /auth/accounts/:id/quota  — query single account's official quota
- * GET    /auth/accounts/:id/cookies — view stored cookies
- * POST   /auth/accounts/:id/cookies — set cookies (for Cloudflare bypass)
- * DELETE /auth/accounts/:id/cookies — clear cookies
- * GET    /auth/accounts/login      — start OAuth to add a new account
+ * Business logic delegated to src/services/account-{import,query,mutation}.ts.
  */
-
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AccountPool } from "../auth/account-pool.js";
@@ -21,497 +10,162 @@ import { validateManualToken } from "../auth/chatgpt-oauth.js";
 import { startOAuthFlow, refreshAccessToken } from "../auth/oauth-pkce.js";
 import { getConfig } from "../config.js";
 import { CodexApi } from "../proxy/codex-api.js";
-import type { CodexUsageResponse } from "../proxy/codex-api.js";
-import type { CodexQuota, AccountInfo } from "../auth/types.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { toQuota } from "../auth/quota-utils.js";
 import { clearWarnings, getActiveWarnings, getWarningsLastUpdated } from "../auth/quota-warnings.js";
+import { AccountImportService } from "../services/account-import.js";
+import { AccountQueryService } from "../services/account-query.js";
+import { AccountMutationService } from "../services/account-mutation.js";
 
-const BatchIdsSchema = z.object({
-  ids: z.array(z.string()).min(1),
-});
-
-const BatchStatusSchema = z.object({
-  ids: z.array(z.string()).min(1),
-  status: z.enum(["active", "disabled"]),
-});
-
-const LabelSchema = z.object({
-  label: z.string().max(64).nullable(),
-});
-
+const BatchIdsSchema = z.object({ ids: z.array(z.string()).min(1) });
+const BatchStatusSchema = z.object({ ids: z.array(z.string()).min(1), status: z.enum(["active", "disabled"]) });
+const LabelSchema = z.object({ label: z.string().max(64).nullable() });
 const BulkImportEntrySchema = z.object({
   token: z.string().min(1).optional(),
   refreshToken: z.string().min(1).nullable().optional(),
   label: z.string().max(64).optional(),
-}).refine(
-  (d) => Boolean(d.token) || Boolean(d.refreshToken),
-  { message: "Either token or refreshToken is required" },
-);
+}).refine((d) => Boolean(d.token) || Boolean(d.refreshToken), { message: "Either token or refreshToken is required" });
+const BulkImportSchema = z.object({ accounts: z.array(BulkImportEntrySchema).min(1) });
 
-const BulkImportSchema = z.object({
-  accounts: z.array(BulkImportEntrySchema).min(1),
-});
-
-export function createAccountRoutes(
-  pool: AccountPool,
-  scheduler: RefreshScheduler,
-  cookieJar?: CookieJar,
-  proxyPool?: ProxyPool,
-): Hono {
+export function createAccountRoutes(pool: AccountPool, scheduler: RefreshScheduler, cookieJar?: CookieJar, proxyPool?: ProxyPool): Hono {
   const app = new Hono();
+  const importSvc = new AccountImportService(pool, scheduler, {
+    validateToken: validateManualToken,
+    refreshToken: refreshAccessToken,
+    getProxyUrl: () => getConfig().tls?.proxy_url ?? null,
+  });
+  const querySvc = new AccountQueryService(
+    pool,
+    proxyPool ? { getAssignment: (id) => proxyPool.getAssignment(id), getAssignmentDisplayName: (id) => proxyPool.getAssignmentDisplayName(id) } : undefined,
+    { fetchUsage: (eid, tok, aid) => new CodexApi(tok, aid, cookieJar, eid, proxyPool?.resolveProxyUrl(eid)).getUsage() },
+  );
+  const mutationSvc = new AccountMutationService(pool, {
+    clearSchedule: (id) => scheduler.clearOne(id),
+    clearCookies: cookieJar ? (id) => cookieJar.clear(id) : undefined,
+    clearWarnings,
+  });
 
-  /** Helper: build a CodexApi with cookie + proxy support. */
-  function makeApi(entryId: string, token: string, accountId: string | null): CodexApi {
-    const proxyUrl = proxyPool?.resolveProxyUrl(entryId);
-    return new CodexApi(token, accountId, cookieJar, entryId, proxyUrl);
-  }
-
-  // Start OAuth flow to add a new account — 302 redirect to Auth0
   app.get("/auth/accounts/login", (c) => {
     const config = getConfig();
-    const originalHost = c.req.header("host") || `localhost:${config.server.port}`;
-    const { authUrl } = startOAuthFlow(originalHost, "dashboard", pool, scheduler);
-    return c.redirect(authUrl);
+    const host = c.req.header("host") || `localhost:${config.server.port}`;
+    return c.redirect(startOAuthFlow(host, "dashboard", pool, scheduler).authUrl);
   });
 
-  // Export accounts (with tokens) for backup/migration
-  // ?ids=id1,id2 for selective export; omit for all
-  // ?format=minimal for refreshToken + label only (portable migration)
   app.get("/auth/accounts/export", (c) => {
-    let entries = pool.getAllEntries();
-    const idsParam = c.req.query("ids");
-    if (idsParam) {
-      const idSet = new Set(idsParam.split(",").filter(Boolean));
-      entries = entries.filter((e) => idSet.has(e.id));
-    }
-
-    if (c.req.query("format") === "minimal") {
-      const minimal = entries
-        .filter((e) => e.refreshToken)
-        .map((e) => {
-          const item: { refreshToken: string; label?: string } = { refreshToken: e.refreshToken! };
-          if (e.label) item.label = e.label;
-          return item;
-        });
-      return c.json({ accounts: minimal });
-    }
-
-    return c.json({ accounts: entries });
+    const ids = c.req.query("ids")?.split(",").filter(Boolean);
+    if (c.req.query("format") === "minimal") return c.json({ accounts: querySvc.exportMinimal(ids) });
+    return c.json({ accounts: querySvc.exportFull(ids) });
   });
 
-  // Bulk import accounts from tokens
   app.post("/auth/accounts/import", async (c) => {
     let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json({ error: "Malformed JSON request body" });
-    }
-
+    try { body = await c.req.json(); } catch { c.status(400); return c.json({ error: "Malformed JSON request body" }); }
     const parsed = BulkImportSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json({ error: "Invalid request", details: parsed.error.issues });
-    }
-
-    let added = 0;
-    let updated = 0;
-    let failed = 0;
-    const errors: string[] = [];
-    const existingIds = new Set(pool.getAccounts().map((a) => a.id));
-
-    const config = getConfig();
-    const globalProxyUrl = config.tls?.proxy_url ?? null;
-
-    for (const entry of parsed.data.accounts) {
-      let token: string;
-      let rt: string | null = entry.refreshToken ?? null;
-
-      if (entry.token) {
-        // Token provided — validate directly
-        const validation = validateManualToken(entry.token);
-        if (!validation.valid) {
-          failed++;
-          errors.push(validation.error ?? "Invalid token");
-          continue;
-        }
-        token = entry.token;
-      } else {
-        // Refresh-token-only — exchange for access token
-        // refine() guarantees refreshToken is truthy when token is absent
-        try {
-          const tokens = await refreshAccessToken(rt as string, globalProxyUrl);
-          const validation = validateManualToken(tokens.access_token);
-          if (!validation.valid) {
-            failed++;
-            errors.push(`Refresh token exchange succeeded but token invalid: ${validation.error}`);
-            continue;
-          }
-          token = tokens.access_token;
-          // Prefer the new refresh token if returned
-          rt = tokens.refresh_token ?? rt;
-        } catch (err) {
-          failed++;
-          errors.push(`Refresh token exchange failed: ${err instanceof Error ? err.message : String(err)}`);
-          continue;
-        }
-      }
-
-      const entryId = pool.addAccount(token, rt);
-      scheduler.scheduleOne(entryId, token);
-
-      if (entry.label) {
-        pool.setLabel(entryId, entry.label);
-      }
-
-      if (existingIds.has(entryId)) {
-        updated++;
-      } else {
-        added++;
-        existingIds.add(entryId);
-      }
-    }
-
-    return c.json({ success: true, added, updated, failed, errors });
+    if (!parsed.success) { c.status(400); return c.json({ error: "Invalid request", details: parsed.error.issues }); }
+    return c.json({ success: true, ...(await importSvc.importMany(parsed.data.accounts)) });
   });
 
-  // Batch delete accounts
   app.post("/auth/accounts/batch-delete", async (c) => {
     let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json({ error: "Malformed JSON request body" });
-    }
-
+    try { body = await c.req.json(); } catch { c.status(400); return c.json({ error: "Malformed JSON request body" }); }
     const parsed = BatchIdsSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json({ error: "Invalid request", details: parsed.error.issues });
-    }
-
-    let deleted = 0;
-    const notFound: string[] = [];
-
-    for (const id of parsed.data.ids) {
-      scheduler.clearOne(id);
-      const removed = pool.removeAccount(id);
-      if (removed) {
-        cookieJar?.clear(id);
-        clearWarnings(id);
-        deleted++;
-      } else {
-        notFound.push(id);
-      }
-    }
-
-    return c.json({ success: true, deleted, notFound });
+    if (!parsed.success) { c.status(400); return c.json({ error: "Invalid request", details: parsed.error.issues }); }
+    return c.json({ success: true, ...mutationSvc.deleteBatch(parsed.data.ids) });
   });
 
-  // Batch change account status
   app.post("/auth/accounts/batch-status", async (c) => {
     let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json({ error: "Malformed JSON request body" });
-    }
-
+    try { body = await c.req.json(); } catch { c.status(400); return c.json({ error: "Malformed JSON request body" }); }
     const parsed = BatchStatusSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json({ error: "Invalid request", details: parsed.error.issues });
-    }
-
-    let updated = 0;
-    const notFound: string[] = [];
-
-    for (const id of parsed.data.ids) {
-      const entry = pool.getEntry(id);
-      if (entry) {
-        pool.markStatus(id, parsed.data.status);
-        updated++;
-      } else {
-        notFound.push(id);
-      }
-    }
-
-    return c.json({ success: true, updated, notFound });
+    if (!parsed.success) { c.status(400); return c.json({ error: "Invalid request", details: parsed.error.issues }); }
+    return c.json({ success: true, ...mutationSvc.setStatusBatch(parsed.data.ids, parsed.data.status) });
   });
 
-  // Update account label
   app.patch("/auth/accounts/:id/label", async (c) => {
-    const id = c.req.param("id");
     let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json({ error: "Malformed JSON request body" });
-    }
-
+    try { body = await c.req.json(); } catch { c.status(400); return c.json({ error: "Malformed JSON request body" }); }
     const parsed = LabelSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json({ error: "Invalid request", details: parsed.error.issues });
-    }
-
-    const ok = pool.setLabel(id, parsed.data.label);
-    if (!ok) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
-
+    if (!parsed.success) { c.status(400); return c.json({ error: "Invalid request", details: parsed.error.issues }); }
+    if (!pool.setLabel(c.req.param("id"), parsed.data.label)) { c.status(404); return c.json({ error: "Account not found" }); }
     return c.json({ success: true });
   });
 
-  // List all accounts
-  // ?quota=true  → return cached quota (fast, from background refresh)
-  // ?quota=fresh → force live fetch from upstream (manual refresh button)
   app.get("/auth/accounts", async (c) => {
-    const quotaParam = c.req.query("quota");
-    const wantFresh = quotaParam === "fresh";
-
-    if (wantFresh) {
-      // Live fetch quota for every active account in parallel
-      const accounts = pool.getAccounts();
-      const enriched: AccountInfo[] = await Promise.all(
-        accounts.map(async (acct) => {
-          if (acct.status !== "active") {
-            return {
-              ...acct,
-              proxyId: proxyPool?.getAssignment(acct.id) ?? "global",
-              proxyName: proxyPool?.getAssignmentDisplayName(acct.id) ?? "Global Default",
-            };
-          }
-
-          const entry = pool.getEntry(acct.id);
-          if (!entry) {
-            return {
-              ...acct,
-              proxyId: proxyPool?.getAssignment(acct.id) ?? "global",
-              proxyName: proxyPool?.getAssignmentDisplayName(acct.id) ?? "Global Default",
-            };
-          }
-
-          try {
-            const api = makeApi(acct.id, entry.token, entry.accountId);
-            const usage = await api.getUsage();
-            const quota = toQuota(usage);
-            // Cache the fresh quota
-            pool.updateCachedQuota(acct.id, quota);
-            // Sync rate limit window — auto-reset local counters on window rollover
-            const resetAt = usage.rate_limit.primary_window?.reset_at ?? null;
-            const windowSec = usage.rate_limit.primary_window?.limit_window_seconds ?? null;
-            pool.syncRateLimitWindow(acct.id, resetAt, windowSec);
-            // Re-read usage after potential reset
-            const freshAcct = pool.getAccounts().find((a) => a.id === acct.id) ?? acct;
-            return {
-              ...freshAcct,
-              quota,
-              proxyId: proxyPool?.getAssignment(acct.id) ?? "global",
-              proxyName: proxyPool?.getAssignmentDisplayName(acct.id) ?? "Global Default",
-            };
-          } catch {
-            return {
-              ...acct,
-              proxyId: proxyPool?.getAssignment(acct.id) ?? "global",
-              proxyName: proxyPool?.getAssignmentDisplayName(acct.id) ?? "Global Default",
-            };
-          }
-        }),
-      );
-      return c.json({ accounts: enriched });
-    }
-
-    // Default: return accounts with cached quota (populated by toInfo())
-    const accounts = pool.getAccounts();
-    const enriched = accounts.map((acct) => ({
-      ...acct,
-      proxyId: proxyPool?.getAssignment(acct.id) ?? "global",
-      proxyName: proxyPool?.getAssignmentDisplayName(acct.id) ?? "Global Default",
-    }));
-    return c.json({ accounts: enriched });
+    const accounts = c.req.query("quota") === "fresh" ? await querySvc.listFresh() : querySvc.listCached();
+    return c.json({ accounts });
   });
 
-  // Add account (token or refreshToken)
   app.post("/auth/accounts", async (c) => {
     const body = await c.req.json<{ token?: string; refreshToken?: string }>();
-    const token = body.token?.trim();
-    const rt = body.refreshToken?.trim();
-
-    if (!token && !rt) {
-      c.status(400);
-      return c.json({ error: "Either token or refreshToken is required" });
-    }
-
-    let finalToken: string;
-    let finalRt: string | null = rt ?? null;
-
-    if (token) {
-      const validation = validateManualToken(token);
-      if (!validation.valid) {
-        c.status(400);
-        return c.json({ error: validation.error });
-      }
-      finalToken = token;
-    } else {
-      // Refresh-token-only — exchange for access token
-      const config = getConfig();
-      const proxyUrl = config.tls?.proxy_url ?? null;
-      try {
-        const tokens = await refreshAccessToken(finalRt as string, proxyUrl);
-        const validation = validateManualToken(tokens.access_token);
-        if (!validation.valid) {
-          c.status(400);
-          return c.json({ error: `Refresh succeeded but token invalid: ${validation.error}` });
-        }
-        finalToken = tokens.access_token;
-        finalRt = tokens.refresh_token ?? finalRt;
-      } catch (err) {
-        c.status(502);
-        return c.json({ error: `Refresh token exchange failed: ${err instanceof Error ? err.message : String(err)}` });
-      }
-    }
-
-    const entryId = pool.addAccount(finalToken, finalRt);
-    scheduler.scheduleOne(entryId, finalToken);
-
-    const accounts = pool.getAccounts();
-    const added = accounts.find((a) => a.id === entryId);
-    return c.json({ success: true, account: added });
+    const result = await importSvc.importOne(body.token?.trim(), body.refreshToken?.trim());
+    if (!result.ok) { c.status(result.kind === "refresh_failed" ? 502 : 400); return c.json({ error: result.error }); }
+    return c.json({ success: true, account: result.account });
   });
 
-  // Remove account
   app.delete("/auth/accounts/:id", (c) => {
-    const id = c.req.param("id");
-    scheduler.clearOne(id);
-    const removed = pool.removeAccount(id);
-    if (!removed) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
-    cookieJar?.clear(id);
-    clearWarnings(id);
+    const { deleted } = mutationSvc.deleteBatch([c.req.param("id")]);
+    if (!deleted) { c.status(404); return c.json({ error: "Account not found" }); }
     return c.json({ success: true });
   });
 
-  // Reset usage
   app.post("/auth/accounts/:id/reset-usage", (c) => {
-    const id = c.req.param("id");
-    const reset = pool.resetUsage(id);
-    if (!reset) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
+    if (!pool.resetUsage(c.req.param("id"))) { c.status(404); return c.json({ error: "Account not found" }); }
     return c.json({ success: true });
   });
 
-  // Query single account's official quota
   app.get("/auth/accounts/:id/quota", async (c) => {
     const id = c.req.param("id");
     const entry = pool.getEntry(id);
-
-    if (!entry) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
-
-    if (entry.status !== "active") {
-      c.status(409);
-      return c.json({ error: `Account is ${entry.status}, cannot query quota` });
-    }
-
-    const hasCookies = !!(cookieJar?.getCookieHeader(id));
-
+    if (!entry) { c.status(404); return c.json({ error: "Account not found" }); }
+    if (entry.status !== "active") { c.status(409); return c.json({ error: `Account is ${entry.status}, cannot query quota` }); }
     try {
-      const api = makeApi(id, entry.token, entry.accountId);
-      const usage = await api.getUsage();
+      const usage = await new CodexApi(entry.token, entry.accountId, cookieJar, id, proxyPool?.resolveProxyUrl(id)).getUsage();
       return c.json({ quota: toQuota(usage), raw: usage });
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       const isCf = detail.includes("403") || detail.includes("cf_chl");
       c.status(502);
       return c.json({
-        error: "Failed to fetch quota from Codex API",
-        detail,
-        hint: isCf && !hasCookies
+        error: "Failed to fetch quota from Codex API", detail,
+        hint: isCf && !cookieJar?.getCookieHeader(id)
           ? "Cloudflare blocked this request. Set cookies via POST /auth/accounts/:id/cookies with your browser's cf_clearance cookie."
           : undefined,
       });
     }
   });
 
-  // ── Cookie management ──────────────────────────────────────────
-
-  // View cookies for an account
   app.get("/auth/accounts/:id/cookies", (c) => {
     const id = c.req.param("id");
-    if (!pool.getEntry(id)) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
-
+    if (!pool.getEntry(id)) { c.status(404); return c.json({ error: "Account not found" }); }
     const cookies = cookieJar?.get(id) ?? null;
     return c.json({
       cookies,
-      hint: !cookies
-        ? "No cookies set. POST cookies from your browser to bypass Cloudflare. Example: { \"cookies\": \"cf_clearance=VALUE; __cf_bm=VALUE\" }"
-        : undefined,
+      hint: !cookies ? "No cookies set. POST cookies from your browser to bypass Cloudflare. Example: { \"cookies\": \"cf_clearance=VALUE; __cf_bm=VALUE\" }" : undefined,
     });
   });
 
-  // Set cookies for an account
   app.post("/auth/accounts/:id/cookies", async (c) => {
     const id = c.req.param("id");
-    if (!pool.getEntry(id)) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
-
-    if (!cookieJar) {
-      c.status(500);
-      return c.json({ error: "CookieJar not initialized" });
-    }
-
+    if (!pool.getEntry(id)) { c.status(404); return c.json({ error: "Account not found" }); }
+    if (!cookieJar) { c.status(500); return c.json({ error: "CookieJar not initialized" }); }
     const body = await c.req.json<{ cookies: string | Record<string, string> }>();
-    if (!body.cookies) {
-      c.status(400);
-      return c.json({
-        error: "cookies field is required",
-        example: { cookies: "cf_clearance=VALUE; __cf_bm=VALUE" },
-      });
-    }
-
+    if (!body.cookies) { c.status(400); return c.json({ error: "cookies field is required", example: { cookies: "cf_clearance=VALUE; __cf_bm=VALUE" } }); }
     cookieJar.set(id, body.cookies);
     const stored = cookieJar.get(id);
     console.log(`[Cookies] Set ${Object.keys(stored ?? {}).length} cookie(s) for account ${id}`);
     return c.json({ success: true, cookies: stored });
   });
 
-  // Clear cookies for an account
   app.delete("/auth/accounts/:id/cookies", (c) => {
     const id = c.req.param("id");
-    if (!pool.getEntry(id)) {
-      c.status(404);
-      return c.json({ error: "Account not found" });
-    }
+    if (!pool.getEntry(id)) { c.status(404); return c.json({ error: "Account not found" }); }
     cookieJar?.clear(id);
     return c.json({ success: true });
   });
 
-  // ── Quota warnings ──────────────────────────────────────────────
-
   app.get("/auth/quota/warnings", (c) => {
-    return c.json({
-      warnings: getActiveWarnings(),
-      updatedAt: getWarningsLastUpdated(),
-    });
+    return c.json({ warnings: getActiveWarnings(), updatedAt: getWarningsLastUpdated() });
   });
 
   return app;

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -1,0 +1,148 @@
+/**
+ * AccountImportService — token validation + account creation orchestration.
+ * Extracted from routes/accounts.ts (Phase 3).
+ */
+
+import type { AccountPool } from "../auth/account-pool.js";
+import type { AccountInfo } from "../auth/types.js";
+
+export interface ImportEntry {
+  token?: string;
+  refreshToken?: string | null;
+  label?: string;
+}
+
+export interface ImportResult {
+  added: number;
+  updated: number;
+  failed: number;
+  errors: string[];
+}
+
+export type ImportOneResult =
+  | { ok: true; entryId: string; account: AccountInfo }
+  | { ok: false; error: string; kind: "validation" | "refresh_failed" };
+
+/** Injected dependencies — keeps the service testable without vi.mock. */
+export interface ImportDeps {
+  validateToken(token: string): { valid: boolean; error?: string };
+  refreshToken(
+    rt: string,
+    proxyUrl: string | null,
+  ): Promise<{ access_token: string; refresh_token?: string }>;
+  getProxyUrl(): string | null;
+}
+
+export class AccountImportService {
+  constructor(
+    private pool: AccountPool,
+    private scheduler: { scheduleOne(entryId: string, token: string): void },
+    private deps: ImportDeps,
+  ) {}
+
+  async importMany(entries: ImportEntry[]): Promise<ImportResult> {
+    let added = 0;
+    let updated = 0;
+    let failed = 0;
+    const errors: string[] = [];
+    const existingIds = new Set(this.pool.getAccounts().map((a) => a.id));
+
+    for (const entry of entries) {
+      const resolved = await this.resolveToken(
+        entry.token,
+        entry.refreshToken ?? null,
+      );
+      if (!resolved.ok) {
+        failed++;
+        errors.push(resolved.error);
+        continue;
+      }
+
+      const entryId = this.pool.addAccount(resolved.token, resolved.rt);
+      this.scheduler.scheduleOne(entryId, resolved.token);
+
+      if (entry.label) {
+        this.pool.setLabel(entryId, entry.label);
+      }
+
+      if (existingIds.has(entryId)) {
+        updated++;
+      } else {
+        added++;
+        existingIds.add(entryId);
+      }
+    }
+
+    return { added, updated, failed, errors };
+  }
+
+  async importOne(
+    token?: string,
+    refreshToken?: string,
+  ): Promise<ImportOneResult> {
+    if (!token && !refreshToken) {
+      return {
+        ok: false,
+        error: "Either token or refreshToken is required",
+        kind: "validation",
+      };
+    }
+
+    const resolved = await this.resolveToken(token, refreshToken ?? null);
+    if (!resolved.ok) {
+      return { ok: false, error: resolved.error, kind: resolved.kind };
+    }
+
+    const entryId = this.pool.addAccount(resolved.token, resolved.rt);
+    this.scheduler.scheduleOne(entryId, resolved.token);
+
+    const account = this.pool.getAccounts().find((a) => a.id === entryId);
+    if (!account) {
+      return { ok: false, error: "Failed to add account", kind: "validation" };
+    }
+
+    return { ok: true, entryId, account };
+  }
+
+  /** Validate or exchange a token, returning the resolved access token + refresh token. */
+  private async resolveToken(
+    token: string | undefined,
+    rt: string | null,
+  ): Promise<
+    | { ok: true; token: string; rt: string | null }
+    | { ok: false; error: string; kind: "validation" | "refresh_failed" }
+  > {
+    if (token) {
+      const v = this.deps.validateToken(token);
+      if (!v.valid) {
+        return { ok: false, error: v.error ?? "Invalid token", kind: "validation" };
+      }
+      return { ok: true, token, rt };
+    }
+
+    // Refresh-token-only path
+    try {
+      const proxyUrl = this.deps.getProxyUrl();
+      const tokens = await this.deps.refreshToken(rt as string, proxyUrl);
+      const v = this.deps.validateToken(tokens.access_token);
+      if (!v.valid) {
+        return {
+          ok: false,
+          error: `Refresh token exchange succeeded but token invalid: ${v.error}`,
+          kind: "validation",
+        };
+      }
+      return {
+        ok: true,
+        token: tokens.access_token,
+        rt: tokens.refresh_token ?? rt,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Refresh token exchange failed: ${err instanceof Error ? err.message : String(err)}`,
+        kind: "refresh_failed",
+      };
+    }
+  }
+}

--- a/src/services/account-mutation.ts
+++ b/src/services/account-mutation.ts
@@ -1,0 +1,68 @@
+/**
+ * AccountMutationService — batch delete and status changes.
+ * Extracted from routes/accounts.ts (Phase 3).
+ */
+
+import type { AccountPool } from "../auth/account-pool.js";
+
+export interface DeleteResult {
+  deleted: number;
+  notFound: string[];
+}
+
+export interface StatusResult {
+  updated: number;
+  notFound: string[];
+}
+
+export interface MutationDeps {
+  clearSchedule(entryId: string): void;
+  clearCookies?(entryId: string): void;
+  clearWarnings?(entryId: string): void;
+}
+
+export class AccountMutationService {
+  constructor(
+    private pool: AccountPool,
+    private deps: MutationDeps,
+  ) {}
+
+  deleteBatch(ids: string[]): DeleteResult {
+    let deleted = 0;
+    const notFound: string[] = [];
+
+    for (const id of ids) {
+      this.deps.clearSchedule(id);
+      const removed = this.pool.removeAccount(id);
+      if (removed) {
+        this.deps.clearCookies?.(id);
+        this.deps.clearWarnings?.(id);
+        deleted++;
+      } else {
+        notFound.push(id);
+      }
+    }
+
+    return { deleted, notFound };
+  }
+
+  setStatusBatch(
+    ids: string[],
+    status: "active" | "disabled",
+  ): StatusResult {
+    let updated = 0;
+    const notFound: string[] = [];
+
+    for (const id of ids) {
+      const entry = this.pool.getEntry(id);
+      if (entry) {
+        this.pool.markStatus(id, status);
+        updated++;
+      } else {
+        notFound.push(id);
+      }
+    }
+
+    return { updated, notFound };
+  }
+}

--- a/src/services/account-query.ts
+++ b/src/services/account-query.ts
@@ -1,0 +1,113 @@
+/**
+ * AccountQueryService — list, enrich, and export accounts.
+ * Extracted from routes/accounts.ts (Phase 3).
+ */
+
+import type { AccountPool } from "../auth/account-pool.js";
+import type { AccountEntry, AccountInfo, CodexQuota } from "../auth/types.js";
+import type { CodexUsageResponse } from "../proxy/codex-types.js";
+import { toQuota } from "../auth/quota-utils.js";
+
+export type EnrichedAccountInfo = AccountInfo & {
+  proxyId: string;
+  proxyName: string;
+  quota?: CodexQuota;
+};
+
+export interface ProxyResolver {
+  getAssignment(accountId: string): string;
+  getAssignmentDisplayName(accountId: string): string;
+}
+
+export interface UsageFetcher {
+  fetchUsage(
+    entryId: string,
+    token: string,
+    accountId: string | null,
+  ): Promise<CodexUsageResponse>;
+}
+
+export class AccountQueryService {
+  constructor(
+    private pool: AccountPool,
+    private proxyResolver?: ProxyResolver,
+    private usageFetcher?: UsageFetcher,
+  ) {}
+
+  listCached(): EnrichedAccountInfo[] {
+    return this.pool.getAccounts().map((acct) => this.enrich(acct));
+  }
+
+  async listFresh(): Promise<EnrichedAccountInfo[]> {
+    const accounts = this.pool.getAccounts();
+    return Promise.all(
+      accounts.map(async (acct) => {
+        if (acct.status !== "active") return this.enrich(acct);
+
+        const entry = this.pool.getEntry(acct.id);
+        if (!entry || !this.usageFetcher) return this.enrich(acct);
+
+        try {
+          const usage = await this.usageFetcher.fetchUsage(
+            acct.id,
+            entry.token,
+            entry.accountId,
+          );
+          const quota = toQuota(usage);
+          this.pool.updateCachedQuota(acct.id, quota);
+
+          const resetAt =
+            usage.rate_limit.primary_window?.reset_at ?? null;
+          const windowSec =
+            usage.rate_limit.primary_window?.limit_window_seconds ?? null;
+          this.pool.syncRateLimitWindow(acct.id, resetAt, windowSec);
+
+          // Re-read after potential counter reset
+          const freshAcct =
+            this.pool.getAccounts().find((a) => a.id === acct.id) ?? acct;
+          return { ...this.enrich(freshAcct), quota };
+        } catch {
+          return this.enrich(acct);
+        }
+      }),
+    );
+  }
+
+  exportFull(ids?: string[]): AccountEntry[] {
+    let entries = this.pool.getAllEntries();
+    if (ids) {
+      const idSet = new Set(ids);
+      entries = entries.filter((e) => idSet.has(e.id));
+    }
+    return entries;
+  }
+
+  exportMinimal(
+    ids?: string[],
+  ): Array<{ refreshToken: string; label?: string }> {
+    let entries = this.pool.getAllEntries();
+    if (ids) {
+      const idSet = new Set(ids);
+      entries = entries.filter((e) => idSet.has(e.id));
+    }
+    return entries
+      .filter((e) => e.refreshToken)
+      .map((e) => {
+        const item: { refreshToken: string; label?: string } = {
+          refreshToken: e.refreshToken!,
+        };
+        if (e.label) item.label = e.label;
+        return item;
+      });
+  }
+
+  private enrich(acct: AccountInfo): EnrichedAccountInfo {
+    return {
+      ...acct,
+      proxyId: this.proxyResolver?.getAssignment(acct.id) ?? "global",
+      proxyName:
+        this.proxyResolver?.getAssignmentDisplayName(acct.id) ??
+        "Global Default",
+    };
+  }
+}

--- a/src/translation/anthropic-to-codex.ts
+++ b/src/translation/anthropic-to-codex.ts
@@ -11,6 +11,7 @@ import type {
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
 import { buildInstructions, budgetToEffort } from "./shared-utils.js";
+import type { ModelConfigOverride } from "./shared-utils.js";
 import { anthropicToolsToCodex, anthropicToolChoiceToCodex } from "./tool-format.js";
 
 /**
@@ -172,6 +173,7 @@ function contentToInputItems(
  */
 export function translateAnthropicToCodexRequest(
   req: AnthropicMessagesRequest,
+  modelConfig?: ModelConfigOverride,
 ): CodexResponsesRequest {
   // Extract system instructions
   let userInstructions: string;
@@ -184,7 +186,8 @@ export function translateAnthropicToCodexRequest(
   } else {
     userInstructions = "You are a helpful assistant.";
   }
-  const instructions = buildInstructions(userInstructions);
+  const cfg = modelConfig ?? getConfig().model;
+  const instructions = buildInstructions(userInstructions, cfg);
 
   // Build input items from messages
   const input: CodexInputItem[] = [];
@@ -205,7 +208,6 @@ export function translateAnthropicToCodexRequest(
   const parsed = parseModelName(req.model);
   const modelId = parsed.modelId;
   const modelInfo = getModelInfo(modelId);
-  const config = getConfig();
 
   // Convert tools to Codex format
   const codexTools = req.tools?.length ? anthropicToolsToCodex(req.tools) : [];
@@ -232,13 +234,13 @@ export function translateAnthropicToCodexRequest(
     thinkingEffort ??
     parsed.reasoningEffort ??
     modelInfo?.defaultReasoningEffort ??
-    config.model.default_reasoning_effort;
+    cfg.default_reasoning_effort;
   request.reasoning = { summary: "auto", ...(effort ? { effort } : {}) };
 
   // Service tier: suffix > config default
   const serviceTier =
     parsed.serviceTier ??
-    config.model.default_service_tier ??
+    cfg.default_service_tier ??
     null;
   if (serviceTier) {
     request.service_tier = serviceTier;

--- a/src/translation/gemini-to-codex.ts
+++ b/src/translation/gemini-to-codex.ts
@@ -15,6 +15,7 @@ import type {
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
 import { buildInstructions, budgetToEffort, prepareSchema } from "./shared-utils.js";
+import type { ModelConfigOverride } from "./shared-utils.js";
 import { geminiToolsToCodex, geminiToolConfigToCodex } from "./tool-format.js";
 
 /**
@@ -166,6 +167,7 @@ export interface GeminiTranslationResult {
 export function translateGeminiToCodexRequest(
   req: GeminiGenerateContentRequest,
   geminiModel: string,
+  modelConfig?: ModelConfigOverride,
 ): GeminiTranslationResult {
   // Extract system instructions
   let userInstructions: string;
@@ -174,7 +176,8 @@ export function translateGeminiToCodexRequest(
   } else {
     userInstructions = "You are a helpful assistant.";
   }
-  const instructions = buildInstructions(userInstructions);
+  const cfg = modelConfig ?? getConfig().model;
+  const instructions = buildInstructions(userInstructions, cfg);
 
   // Build input items from contents
   const input: CodexInputItem[] = [];
@@ -196,7 +199,6 @@ export function translateGeminiToCodexRequest(
   const parsed = parseModelName(geminiModel);
   const modelId = parsed.modelId;
   const modelInfo = getModelInfo(modelId);
-  const config = getConfig();
 
   // Convert tools to Codex format
   const codexTools = req.tools?.length ? geminiToolsToCodex(req.tools) : [];
@@ -225,13 +227,13 @@ export function translateGeminiToCodexRequest(
     thinkingEffort ??
     parsed.reasoningEffort ??
     modelInfo?.defaultReasoningEffort ??
-    config.model.default_reasoning_effort;
+    cfg.default_reasoning_effort;
   request.reasoning = { summary: "auto", ...(effort ? { effort } : {}) };
 
   // Service tier: suffix > config default
   const serviceTier =
     parsed.serviceTier ??
-    config.model.default_service_tier ??
+    cfg.default_service_tier ??
     null;
   if (serviceTier) {
     request.service_tier = serviceTier;

--- a/src/translation/openai-to-codex.ts
+++ b/src/translation/openai-to-codex.ts
@@ -11,6 +11,7 @@ import type {
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
 import { buildInstructions, prepareSchema } from "./shared-utils.js";
+import type { ModelConfigOverride } from "./shared-utils.js";
 import {
   openAIToolsToCodex,
   openAIToolChoiceToCodex,
@@ -86,6 +87,7 @@ export interface TranslationResult {
 
 export function translateToCodexRequest(
   req: ChatCompletionRequest,
+  modelConfig?: ModelConfigOverride,
 ): TranslationResult {
   // Collect system/developer messages as instructions
   const systemMessages = req.messages.filter(
@@ -94,7 +96,8 @@ export function translateToCodexRequest(
   const userInstructions =
     systemMessages.map((m) => extractText(m.content)).join("\n\n") ||
     "You are a helpful assistant.";
-  const instructions = buildInstructions(userInstructions);
+  const cfg = modelConfig ?? getConfig().model;
+  const instructions = buildInstructions(userInstructions, cfg);
 
   // Build input items from non-system messages
   // Handles new format (tool/tool_calls) and legacy format (function/function_call)
@@ -155,7 +158,6 @@ export function translateToCodexRequest(
   const parsed = parseModelName(req.model);
   const modelId = parsed.modelId;
   const modelInfo = getModelInfo(modelId);
-  const config = getConfig();
 
   // Convert tools to Codex format
   const codexTools = req.tools?.length
@@ -185,14 +187,14 @@ export function translateToCodexRequest(
     req.reasoning_effort ??
     parsed.reasoningEffort ??
     modelInfo?.defaultReasoningEffort ??
-    config.model.default_reasoning_effort;
+    cfg.default_reasoning_effort;
   request.reasoning = { summary: "auto", ...(effort ? { effort } : {}) };
 
   // Service tier: explicit API field > suffix > config default
   const serviceTier =
     req.service_tier ??
     parsed.serviceTier ??
-    config.model.default_service_tier ??
+    cfg.default_service_tier ??
     null;
   if (serviceTier) {
     request.service_tier = serviceTier;

--- a/src/translation/shared-utils.ts
+++ b/src/translation/shared-utils.ts
@@ -7,8 +7,15 @@
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { getConfig } from "../config.js";
+import type { AppConfig } from "../config.js";
 import { getConfigDir } from "../paths.js";
 import { hasTupleSchemas, convertTupleSchemas } from "./tuple-schema.js";
+
+/** Subset of model config used by translation functions. */
+export type ModelConfigOverride = Pick<
+  AppConfig["model"],
+  "default_reasoning_effort" | "default_service_tier" | "inject_desktop_context" | "suppress_desktop_directives"
+>;
 
 let cachedDesktopContext: string | null = null;
 
@@ -42,11 +49,15 @@ const SUPPRESS_PROMPT =
  * When suppress_desktop_directives is enabled, appends a suppress prompt
  * to override desktop-specific behaviors.
  */
-export function buildInstructions(userInstructions: string): string {
-  if (!getConfig().model.inject_desktop_context) return userInstructions;
+export function buildInstructions(
+  userInstructions: string,
+  modelConfig?: Pick<ModelConfigOverride, "inject_desktop_context" | "suppress_desktop_directives">,
+): string {
+  const cfg = modelConfig ?? getConfig().model;
+  if (!cfg.inject_desktop_context) return userInstructions;
   const ctx = getDesktopContext();
   if (!ctx) return userInstructions;
-  if (getConfig().model.suppress_desktop_directives) {
+  if (cfg.suppress_desktop_directives) {
     return `${ctx}\n\n${SUPPRESS_PROMPT}\n\n${userInstructions}`;
   }
   return `${ctx}\n\n${userInstructions}`;


### PR DESCRIPTION
## Summary

- **Phase 1** — 测试基础设施：新增 shared helpers（`createMemoryPersistence`、`createValidJwt`、`createMockConfig`），迁移 5 个 auth 测试文件，删除 239 行模板代码
- **Phase 2** — Config DI：`setConfigForTesting()`/`resetConfigForTesting()` + AccountPool constructor 注入 + translation `modelConfig` 参数。`vi.mock("config.js")` 从 9 处降至 2 处
- **Phase 3** — Service 层提取：`accounts.ts` 518→172 行（-67%），业务逻辑拆分到 `account-import`/`account-query`/`account-mutation` 三个 service，全部 constructor DI

18 files changed, -192 net lines, 29 new service tests (zero `vi.mock()`)

## Test plan

- [x] `npm test` — 1196 passed（4 pre-existing failures: auto-updater ×1, release-pipeline ×1, free-model-access ×2）
- [x] E2E 验证（port 8099）：accounts list（682）、fresh quota（550/682）、minimal export（83）、single quota、warnings
- [x] `accounts.ts` 172 lines ≤ 180 target