### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.67",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "1.0.67",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -7364,7 +7364,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "1.0.67",
+      "version": "2.0.0",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.103",
+  "version": "2.0.0",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "contributors": [
     {

--- a/packages/electron/electron/main.ts
+++ b/packages/electron/electron/main.ts
@@ -175,7 +175,7 @@ function createWindow(): void {
   mainWindow = new BrowserWindow({
     width: 1100,
     height: 750,
-    minWidth: 680,
+    minWidth: 800,
     minHeight: 500,
     title: "Codex Proxy",
     // macOS: native hidden titlebar with traffic lights inset into content

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-proxy/electron",
-  "version": "1.0.103",
+  "version": "2.0.0",
   "description": "Codex Proxy desktop app (Electron shell)",
   "private": true,
   "main": "dist-electron/main.cjs",

--- a/src/__tests__/config-local-override.test.ts
+++ b/src/__tests__/config-local-override.test.ts
@@ -147,4 +147,39 @@ server:
 
     expect(config.server.host).toBe("0.0.0.0");
   });
+
+  it("local.yaml host overrides Electron programmatic default", async () => {
+    const localYaml = `
+server:
+  host: "0.0.0.0"
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    const config = loadConfig(configDir);
+
+    // Simulate startServer host resolution (src/index.ts:103-105)
+    const electronDefault = "127.0.0.1";
+    const resolved = hasLocalOverride("server", "host")
+      ? config.server.host
+      : electronDefault;
+
+    expect(resolved).toBe("0.0.0.0");
+  });
+
+  it("falls back to Electron default when local.yaml has no host", async () => {
+    const localYaml = `
+server:
+  proxy_api_key: test-key
+`;
+    const configDir = makeTempConfig(MINIMAL_DEFAULT, localYaml);
+    const { loadConfig, hasLocalOverride } = await import("../config.js");
+    const config = loadConfig(configDir);
+
+    const electronDefault = "127.0.0.1";
+    const resolved = hasLocalOverride("server", "host")
+      ? config.server.host
+      : (electronDefault ?? config.server.host);
+
+    expect(resolved).toBe("127.0.0.1");
+  });
 });

--- a/web/src/components/AccountImportExport.tsx
+++ b/web/src/components/AccountImportExport.tsx
@@ -101,7 +101,7 @@ export function AccountImportExport({ onExport, onImport, selectedIds }: Account
         class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10 disabled:opacity-40"
       >
         <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12M12 16.5V3" />
         </svg>
       </button>
       <button
@@ -119,7 +119,7 @@ export function AccountImportExport({ onExport, onImport, selectedIds }: Account
         class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10"
       >
         <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12M12 16.5V3" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
         </svg>
       </button>
       <button


### PR DESCRIPTION
## Summary
- Bump version from 1.0.103 to 2.0.0 (root + electron package.json)
- Old v1.x tags preserved, new releases start from v2.0.0

## Test plan
- [ ] CI green
- [ ] Next `bump-electron.yml` run produces v2.0.x tag