### PR TITLE
fix: bump workflow + version 2.0.0 + CHANGELOG

### DIFF
--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -27,10 +27,26 @@ jobs:
       - name: Check for new commits since last tag
         id: check
         run: |
-          LAST_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1 || echo "")
+          # Read major.minor from package.json (source of truth for version series)
+          PKG_VERSION=$(node -e "console.log(require('./package.json').version)")
+          IFS='.' read -r PKG_MAJOR PKG_MINOR _PKG_PATCH <<< "$PKG_VERSION"
+          SERIES="${PKG_MAJOR}.${PKG_MINOR}"
+
+          # Find latest tag in this series (e.g. v2.0.x)
+          LAST_TAG=$(git tag --sort=-v:refname | grep "^v${SERIES}\." | head -1 || echo "")
           if [ -z "$LAST_TAG" ]; then
-            echo "No previous tag, skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            # First release in this series — use any previous tag for commit check
+            LAST_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1 || echo "")
+            if [ -z "$LAST_TAG" ]; then
+              echo "No previous tag, skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "New series ${SERIES}.x — will start at ${SERIES}.0"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "new_series=true" >> "$GITHUB_OUTPUT"
+            echo "series=$SERIES" >> "$GITHUB_OUTPUT"
+            echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -46,6 +62,7 @@ jobs:
           echo "Found $NEW_COMMITS new commit(s) since $LAST_TAG"
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+          echo "series=$SERIES" >> "$GITHUB_OUTPUT"
 
       - name: Bump version + tag
         id: bump
@@ -54,11 +71,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          LAST_TAG="${{ steps.check.outputs.last_tag }}"
-          CURRENT="${LAST_TAG#v}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          NEW_PATCH=$((PATCH + 1))
-          NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+          SERIES="${{ steps.check.outputs.series }}"
+          if [ "${{ steps.check.outputs.new_series }}" = "true" ]; then
+            NEW_VERSION="${SERIES}.0"
+          else
+            LAST_TAG="${{ steps.check.outputs.last_tag }}"
+            CURRENT="${LAST_TAG#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+            NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          fi
           NEW_TAG="v${NEW_VERSION}"
 
           # Check tag doesn't already exist

--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -99,7 +99,12 @@ jobs:
           "
 
           git add package.json packages/electron/package.json
-          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
+          # If version already matches (e.g. first tag in a new series), skip the commit
+          if git diff --cached --quiet; then
+            echo "package.json already at ${NEW_VERSION}, tagging without version commit"
+          else
+            git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
+          fi
           git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"
 
           # Retry push with rebase on conflict (other workflows may push concurrently)

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,82 @@
+name: CI — Docker smoke test
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+      - "docker-healthcheck.sh"
+      - "docker-compose.yml"
+      - "package*.json"
+      - "src/**"
+      - "web/**"
+      - "shared/**"
+      - "config/**"
+      - "scripts/**"
+  push:
+    branches: [master]
+    paths:
+      - "Dockerfile"
+      - "docker-entrypoint.sh"
+      - "docker-healthcheck.sh"
+
+concurrency:
+  group: ci-docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy:smoke .
+
+      - name: Start container
+        run: |
+          docker run -d --name smoke-test \
+            -p 18080:8080 \
+            -e NODE_ENV=production \
+            codex-proxy:smoke
+          echo "Container started"
+
+      - name: Wait for healthy
+        run: |
+          echo "Waiting for container to become healthy..."
+          for i in $(seq 1 30); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            echo "  [$i/30] status: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Container did not become healthy within 60s"
+          docker logs smoke-test
+          exit 1
+
+      - name: Verify /health endpoint
+        run: |
+          RESPONSE=$(curl -sf http://localhost:18080/health)
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | jq -e '.status == "ok"'
+
+      - name: Verify /v1/models returns valid JSON
+        run: |
+          # Without auth, should return 401 or model list — either way must be valid JSON
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          echo "/v1/models status: $STATUS"
+          # 200 (no key set) or 401 (key set) are both acceptable
+          if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then
+            echo "::error::Unexpected status $STATUS from /v1/models"
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker logs smoke-test 2>&1 | tail -30
+          docker rm -f smoke-test || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 导入/导出按钮图标反了——导入改为下箭头、导出改为上箭头（#191）
+- Windows 桌面端按钮溢出——Electron 最小宽度从 680px 提高到 800px，覆盖 Tailwind md: 断点（#192）
+- `local.yaml` 的 `server.host` 覆盖已有测试验证，Electron 模式下正确生效（#190）
+
 ### Changed
+
+- 版本号从 1.0.x 跳到 2.0.0，CI bump workflow 改为从 package.json 读取 major.minor 系列
 
 - **Phase 3 — Service 层提取**：`src/routes/accounts.ts` 从 518 行降至 172 行（-67%），业务逻辑拆分到 `src/services/account-import.ts`、`account-query.ts`、`account-mutation.ts` 三个 service 类，全部通过 constructor DI，29 个新测试零 `vi.mock()`
 - **Phase 2 — Config DI**：`src/config.ts` 新增 `setConfigForTesting()`/`resetConfigForTesting()`，AccountPool constructor 支持 `rotationStrategy`/`initialToken`/`rateLimitBackoffSeconds` 注入，translation 函数支持 `modelConfig` 可选参数。测试中 `vi.mock("config.js")` 从 9 处降至 2 处

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "1.0.104",
+  "version": "2.0.0",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "contributors": [
     {

--- a/packages/electron/__tests__/auto-updater.test.ts
+++ b/packages/electron/__tests__/auto-updater.test.ts
@@ -31,6 +31,11 @@ vi.mock("electron", () => ({
   },
 }));
 
+vi.mock("../electron/constants.js", () => ({
+  IS_MAC: false,
+  GITHUB_REPO: "icebear0828/codex-proxy",
+}));
+
 // Import after mocks are set up
 const { getAutoUpdateState, initAutoUpdater, stopAutoUpdater } = await import(
   "../electron/auto-updater.js"

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-proxy/electron",
-  "version": "1.0.104",
+  "version": "2.0.0",
   "description": "Codex Proxy desktop app (Electron shell)",
   "private": true,
   "main": "dist-electron/main.cjs",


### PR DESCRIPTION
## Summary
- Bump workflow 改为从 package.json 读 major.minor，不再完全依赖 tag 推导版本
- 修复 CI 覆盖版本号的问题（1.0.104 → 2.0.0）
- 补 CHANGELOG（#190 #191 #192 修复记录）

## 改动
- `.github/workflows/bump-electron.yml` — 版本系列从 package.json 读取
- `package.json` + `packages/electron/package.json` → 2.0.0
- `CHANGELOG.md` — 补 PR #195 的 Fixed/Changed 条目

## Test plan
- [ ] CI green
- [ ] Merge 后 workflow 应创建 v2.0.0 tag（而非 v1.0.105）