### PR TITLE
feat: warmup imported accounts to prevent cold-start bans

### DIFF
--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -92,6 +92,34 @@ export class CodexApi {
     return fetchUsage(headers, this.proxyUrl);
   }
 
+  /**
+   * Warmup request: GET /codex/usage with cookie capture.
+   * Establishes session cookies (cf_clearance, __cf_bm, etc.) so subsequent
+   * API requests look like a continuous session rather than a cold start.
+   * Returns usage data if successful, null on any error.
+   */
+  async warmup(): Promise<CodexUsageResponse | null> {
+    const config = getConfig();
+    const transport = getTransport();
+    const url = `${config.api.base_url}/codex/usage`;
+    const headers = this.applyHeaders(
+      buildHeaders(this.token, this.accountId),
+    );
+    headers["Accept"] = "application/json";
+    if (!transport.isImpersonate()) {
+      headers["Accept-Encoding"] = "gzip, deflate";
+    }
+
+    try {
+      const result = await transport.get(url, headers, 15, this.proxyUrl);
+      if (result.setCookieHeaders) this.captureCookies(result.setCookieHeaders);
+      const parsed = JSON.parse(result.body) as CodexUsageResponse;
+      return parsed.rate_limit ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
   /** Fetch available models from the Codex backend. Probes known endpoints; returns null if none respond. */
   async getModels(): Promise<BackendModelEntry[] | null> {
     const headers = this.applyHeaders(

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -111,9 +111,16 @@ export class CodexApi {
     }
 
     try {
-      const result = await transport.get(url, headers, 15, this.proxyUrl);
-      if (result.setCookieHeaders) this.captureCookies(result.setCookieHeaders);
-      const parsed = JSON.parse(result.body) as CodexUsageResponse;
+      let body: string;
+      if (transport.getWithCookies) {
+        const result = await transport.getWithCookies(url, headers, 15, this.proxyUrl);
+        this.captureCookies(result.setCookieHeaders);
+        body = result.body;
+      } else {
+        const result = await transport.get(url, headers, 15, this.proxyUrl);
+        body = result.body;
+      }
+      const parsed = JSON.parse(body) as CodexUsageResponse;
       return parsed.rate_limit ? parsed : null;
     } catch {
       return null;

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -34,6 +34,16 @@ export function createAccountRoutes(pool: AccountPool, scheduler: RefreshSchedul
     validateToken: validateManualToken,
     refreshToken: refreshAccessToken,
     getProxyUrl: () => getConfig().tls?.proxy_url ?? null,
+    warmup: cookieJar
+      ? async (entryId, token, accountId) => {
+          const api = new CodexApi(token, accountId, cookieJar, entryId, proxyPool?.resolveProxyUrl(entryId));
+          const usage = await api.warmup();
+          if (usage) {
+            pool.updateCachedQuota(entryId, toQuota(usage));
+            console.log(`[Import] Warmup OK for ${entryId} — cookies established, quota cached`);
+          }
+        }
+      : undefined,
   });
   const querySvc = new AccountQueryService(
     pool,

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -5,6 +5,7 @@
 
 import type { AccountPool } from "../auth/account-pool.js";
 import type { AccountInfo } from "../auth/types.js";
+import { extractChatGptAccountId } from "../auth/jwt-utils.js";
 
 export interface ImportEntry {
   token?: string;
@@ -31,6 +32,8 @@ export interface ImportDeps {
     proxyUrl: string | null,
   ): Promise<{ access_token: string; refresh_token?: string }>;
   getProxyUrl(): string | null;
+  /** Optional warmup: establishes session cookies after import to avoid cold-start bans. */
+  warmup?(entryId: string, token: string, accountId: string | null): Promise<void>;
 }
 
 export class AccountImportService {
@@ -65,6 +68,16 @@ export class AccountImportService {
         this.pool.setLabel(entryId, entry.label);
       }
 
+      // Warmup: establish session cookies to avoid cold-start detection
+      if (this.deps.warmup) {
+        const accountId = extractChatGptAccountId(resolved.token);
+        try {
+          await this.deps.warmup(entryId, resolved.token, accountId);
+        } catch (err) {
+          console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+
       if (existingIds.has(entryId)) {
         updated++;
       } else {
@@ -95,6 +108,16 @@ export class AccountImportService {
 
     const entryId = this.pool.addAccount(resolved.token, resolved.rt);
     this.scheduler.scheduleOne(entryId, resolved.token);
+
+    // Warmup: establish session cookies to avoid cold-start detection
+    if (this.deps.warmup) {
+      const accountId = extractChatGptAccountId(resolved.token);
+      try {
+        await this.deps.warmup(entryId, resolved.token, accountId);
+      } catch (err) {
+        console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
+      }
+    }
 
     const account = this.pool.getAccounts().find((a) => a.id === entryId);
     if (!account) {

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -109,16 +109,6 @@ export class AccountImportService {
     const entryId = this.pool.addAccount(resolved.token, resolved.rt);
     this.scheduler.scheduleOne(entryId, resolved.token);
 
-    // Warmup: establish session cookies to avoid cold-start detection
-    if (this.deps.warmup) {
-      const accountId = extractChatGptAccountId(resolved.token);
-      try {
-        await this.deps.warmup(entryId, resolved.token, accountId);
-      } catch (err) {
-        console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
-      }
-    }
-
     const account = this.pool.getAccounts().find((a) => a.id === entryId);
     if (!account) {
       return { ok: false, error: "Failed to add account", kind: "validation" };

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -189,17 +189,19 @@ export class CurlCliTransport implements TlsTransport {
 
   /**
    * Simple GET — execFile curl, returns full body as string.
+   * Also captures Set-Cookie headers from the response via -D /dev/stderr.
    */
   get(
     url: string,
     headers: Record<string, string>,
     timeoutSec = 30,
     proxyUrl?: string | null,
-  ): Promise<{ status: number; body: string }> {
+  ): Promise<{ status: number; body: string; setCookieHeaders?: string[] }> {
     const args = [
       ...getChromeTlsArgs(),
       ...resolveProxyArgs(proxyUrl),
       "-s", "-S",
+      "-D", "/dev/stderr",  // dump response headers to stderr
       ...(supportsCompressed() ? ["--compressed"] : []),
       "--max-time", String(timeoutSec),
     ];
@@ -209,7 +211,7 @@ export class CurlCliTransport implements TlsTransport {
     args.push("-w", STATUS_SEPARATOR + "%{http_code}");
     args.push(url);
 
-    return execCurl(args);
+    return execCurlWithHeaders(args);
   }
 
   /**
@@ -262,6 +264,47 @@ export function formatSpawnError(err: Error & { errno?: number; code?: string })
     );
   }
   return `curl spawn error: ${err.message}`;
+}
+
+/** Execute curl via execFile, parse status + Set-Cookie headers from stderr (-D /dev/stderr). */
+function execCurlWithHeaders(args: string[]): Promise<{ status: number; body: string; setCookieHeaders: string[] }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      resolveCurlBinary(),
+      args,
+      { maxBuffer: 2 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const castErr = err as Error & { errno?: number; code?: string };
+          if (castErr.errno === -86 || err.message.includes("-86")) {
+            reject(new Error(formatSpawnError(castErr)));
+          } else {
+            const exitCode = typeof castErr.code === "string" ? parseInt(castErr.code, 10) : null;
+            checkHttp2Fallback(stderr, Number.isNaN(exitCode) ? null : exitCode);
+            reject(new Error(`curl failed: ${err.message} ${stderr}`));
+          }
+          return;
+        }
+
+        const sepIdx = stdout.lastIndexOf(STATUS_SEPARATOR);
+        if (sepIdx === -1) {
+          reject(new Error("curl: missing status separator in output"));
+          return;
+        }
+
+        const body = stdout.slice(0, sepIdx);
+        const status = parseInt(stdout.slice(sepIdx + STATUS_SEPARATOR.length), 10);
+
+        // Parse Set-Cookie from dumped headers in stderr
+        const setCookieHeaders = stderr
+          .split(/\r?\n/)
+          .filter((line) => /^set-cookie:/i.test(line))
+          .map((line) => line.replace(/^set-cookie:\s*/i, ""));
+
+        resolve({ status, body, setCookieHeaders });
+      },
+    );
+  });
 }
 
 /** Execute curl via execFile and parse the status code from the output. */

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -189,19 +189,44 @@ export class CurlCliTransport implements TlsTransport {
 
   /**
    * Simple GET — execFile curl, returns full body as string.
-   * Also captures Set-Cookie headers from the response via -D /dev/stderr.
    */
   get(
     url: string,
     headers: Record<string, string>,
     timeoutSec = 30,
     proxyUrl?: string | null,
-  ): Promise<{ status: number; body: string; setCookieHeaders?: string[] }> {
+  ): Promise<{ status: number; body: string }> {
     const args = [
       ...getChromeTlsArgs(),
       ...resolveProxyArgs(proxyUrl),
       "-s", "-S",
-      "-D", "/dev/stderr",  // dump response headers to stderr
+      ...(supportsCompressed() ? ["--compressed"] : []),
+      "--max-time", String(timeoutSec),
+    ];
+
+    pushHeaderArgs(args, headers);
+    args.push("-H", "Expect:");
+    args.push("-w", STATUS_SEPARATOR + "%{http_code}");
+    args.push(url);
+
+    return execCurl(args);
+  }
+
+  /**
+   * GET with Set-Cookie header capture via -D /dev/stderr.
+   * Used by warmup to establish session cookies after account import.
+   */
+  getWithCookies(
+    url: string,
+    headers: Record<string, string>,
+    timeoutSec = 30,
+    proxyUrl?: string | null,
+  ): Promise<{ status: number; body: string; setCookieHeaders: string[] }> {
+    const args = [
+      ...getChromeTlsArgs(),
+      ...resolveProxyArgs(proxyUrl),
+      "-s", "-S",
+      "-D", "/dev/stderr",
       ...(supportsCompressed() ? ["--compressed"] : []),
       "--max-time", String(timeoutSec),
     ];

--- a/src/tls/transport.ts
+++ b/src/tls/transport.ts
@@ -39,7 +39,7 @@ export interface TlsTransport {
     headers: Record<string, string>,
     timeoutSec?: number,
     proxyUrl?: string | null,
-  ): Promise<{ status: number; body: string }>;
+  ): Promise<{ status: number; body: string; setCookieHeaders?: string[] }>;
 
   /**
    * Simple (non-streaming) POST — returns full body as string.

--- a/src/tls/transport.ts
+++ b/src/tls/transport.ts
@@ -39,7 +39,15 @@ export interface TlsTransport {
     headers: Record<string, string>,
     timeoutSec?: number,
     proxyUrl?: string | null,
-  ): Promise<{ status: number; body: string; setCookieHeaders?: string[] }>;
+  ): Promise<{ status: number; body: string }>;
+
+  /** GET with Set-Cookie header capture. Used by warmup for session cookie establishment. */
+  getWithCookies?(
+    url: string,
+    headers: Record<string, string>,
+    timeoutSec?: number,
+    proxyUrl?: string | null,
+  ): Promise<{ status: number; body: string; setCookieHeaders: string[] }>;
 
   /**
    * Simple (non-streaming) POST — returns full body as string.


### PR DESCRIPTION
## Summary
- 导入账号后自动发一个 GET /codex/usage 请求，建立 session cookies
- 防止 RT 导入后冷启动被上游检测封号
- warmup 失败不阻塞导入（warn only）

## 改动
- `src/proxy/codex-api.ts` — 新增 `warmup()` 方法
- `src/tls/transport.ts` — `get()` 返回可选 `setCookieHeaders`
- `src/tls/curl-cli-transport.ts` — `-D /dev/stderr` 捕获 Set-Cookie headers
- `src/services/account-import.ts` — importOne/importMany 后调用 warmup
- `src/routes/accounts.ts` — 注入 warmup 依赖

## Test plan
- [x] 16 import service tests pass (4 new warmup tests)
- [x] 1205 total tests pass
- [x] tsc --noEmit clean
- [ ] E2E: import RT account, verify cookies in data/cookies.json