### PR TITLE
refactor: convert ModelStore to class (Phase 4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - 提取 `src/proxy/error-classification.ts`：`isBanError`/`isTokenInvalidError`/`isModelNotSupportedError`/`extractRetryAfterSec` 从 proxy-handler 和 usage-refresher 中去重，19 个新测试
 - `scripts/` 按用途分类到 `infra/`、`build/`、`poc/`、`manual-test/` 子目录
 - 新增 `src/context.ts`（AppContext 容器），fingerprint/manager、codex-api、codex-usage、codex-models 支持可选 DI 参数（fallback 到全局单例）
+- `ModelStore` 从模块级单例重构为 class，自由函数 wrapper 保持后向兼容，新增 `getModelStore()` / `setModelStoreForTesting()`
 
 ### Fixed
 

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -1,12 +1,15 @@
 /**
- * Model Store — mutable singleton for model catalog + aliases.
+ * Model Store — manages model catalog + aliases.
  *
  * Data flow:
- *   1. loadStaticModels() — load from config/models.yaml (fallback baseline)
+ *   1. loadStatic() — load from config/models.yaml (fallback baseline)
  *   2. applyBackendModels() — merge backend-fetched models (backend wins for shared IDs)
  *   3. getters — runtime reads from mutable state
  *
  * Aliases always come from YAML (user-customizable), never from backend.
+ *
+ * The ModelStore class owns all state. Module-level free functions delegate
+ * to a default instance for backward compatibility.
  */
 
 import { readFileSync, writeFile, existsSync, mkdirSync } from "fs";
@@ -14,6 +17,8 @@ import { resolve } from "path";
 import yaml from "js-yaml";
 import { getConfig } from "../config.js";
 import { getConfigDir, getDataDir } from "../paths.js";
+
+// ── Types ────────────────────────────────────────────────────────────
 
 export interface CodexModelInfo {
   id: string;
@@ -33,60 +38,6 @@ interface ModelsConfig {
   models: CodexModelInfo[];
   aliases: Record<string, string>;
 }
-
-// ── Mutable state ──────────────────────────────────────────────────
-
-let _catalog: CodexModelInfo[] = [];
-let _aliases: Record<string, string> = {};
-let _lastFetchTime: string | null = null;
-/** planType → Set<modelId> — write path: bulk replace per plan */
-let _planModelMap: Map<string, Set<string>> = new Map();
-/** modelId → Set<planType> — read path: O(1) lookup for routing */
-let _modelPlanIndex: Map<string, Set<string>> = new Map();
-
-// ── Static loading ─────────────────────────────────────────────────
-
-/**
- * Load models from config/models.yaml (synchronous).
- * Called at startup and on hot-reload.
- */
-export function loadStaticModels(configDir?: string): void {
-  const dir = configDir ?? getConfigDir();
-  const configPath = resolve(dir, "models.yaml");
-  const raw = yaml.load(readFileSync(configPath, "utf-8")) as ModelsConfig;
-
-  _catalog = (raw.models ?? []).map((m) => ({ ...m, source: "static" as const }));
-  _aliases = raw.aliases ?? {};
-  _planModelMap = new Map(); // Reset plan maps on reload
-  _modelPlanIndex = new Map();
-  console.log(`[ModelStore] Loaded ${_catalog.length} static models, ${Object.keys(_aliases).length} aliases`);
-
-  // Overlay cached backend models from data/ (cold-start fallback)
-  try {
-    const cachePath = resolve(getDataDir(), "models-cache.yaml");
-    if (existsSync(cachePath)) {
-      const cached = yaml.load(readFileSync(cachePath, "utf-8")) as ModelsConfig;
-      const cachedModels = cached.models ?? [];
-      if (cachedModels.length > 0) {
-        const staticIds = new Set(_catalog.map((m) => m.id));
-        let added = 0;
-        for (const m of cachedModels) {
-          if (!staticIds.has(m.id)) {
-            _catalog.push({ ...m, source: "backend" as const });
-            added++;
-          }
-        }
-        if (added > 0) {
-          console.log(`[ModelStore] Overlaid ${added} cached backend models from data/models-cache.yaml`);
-        }
-      }
-    }
-  } catch {
-    // Cache missing or corrupt — safe to ignore, backend fetch will repopulate
-  }
-}
-
-// ── Backend merge ──────────────────────────────────────────────────
 
 /**
  * Raw model entry from backend (fields are optional — format may vary).
@@ -120,23 +71,284 @@ export interface BackendModelEntry {
   visibility?: string;
 }
 
+export interface ParsedModelName {
+  modelId: string;
+  serviceTier: string | null;
+  reasoningEffort: string | null;
+}
+
 /** Intermediate type with explicit efforts flag for merge logic. */
 interface NormalizedModelWithMeta extends CodexModelInfo {
   _hasExplicitEfforts: boolean;
 }
 
-/**
- * Normalize a backend model entry to our CodexModelInfo format.
- */
+// ── Constants ────────────────────────────────────────────────────────
+
+const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
+const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+
+// ── Class ────────────────────────────────────────────────────────────
+
+export class ModelStore {
+  private catalog: CodexModelInfo[] = [];
+  private aliases: Record<string, string> = {};
+  private lastFetchTime: string | null = null;
+  private planModelMap = new Map<string, Set<string>>();
+  private modelPlanIndex = new Map<string, Set<string>>();
+  private defaultModelFn: () => string;
+
+  constructor(defaultModelFn?: () => string) {
+    this.defaultModelFn = defaultModelFn ?? (() => getConfig().model.default);
+  }
+
+  // ── Static loading ──────────────────────────────────────────────
+
+  loadStatic(configDir?: string): void {
+    const dir = configDir ?? getConfigDir();
+    const configPath = resolve(dir, "models.yaml");
+    const raw = yaml.load(readFileSync(configPath, "utf-8")) as ModelsConfig;
+
+    this.catalog = (raw.models ?? []).map((m) => ({ ...m, source: "static" as const }));
+    this.aliases = raw.aliases ?? {};
+    this.planModelMap = new Map();
+    this.modelPlanIndex = new Map();
+    console.log(`[ModelStore] Loaded ${this.catalog.length} static models, ${Object.keys(this.aliases).length} aliases`);
+
+    // Overlay cached backend models from data/ (cold-start fallback)
+    try {
+      const cachePath = resolve(getDataDir(), "models-cache.yaml");
+      if (existsSync(cachePath)) {
+        const cached = yaml.load(readFileSync(cachePath, "utf-8")) as ModelsConfig;
+        const cachedModels = cached.models ?? [];
+        if (cachedModels.length > 0) {
+          const staticIds = new Set(this.catalog.map((m) => m.id));
+          let added = 0;
+          for (const m of cachedModels) {
+            if (!staticIds.has(m.id)) {
+              this.catalog.push({ ...m, source: "backend" as const });
+              added++;
+            }
+          }
+          if (added > 0) {
+            console.log(`[ModelStore] Overlaid ${added} cached backend models from data/models-cache.yaml`);
+          }
+        }
+      }
+    } catch {
+      // Cache missing or corrupt — safe to ignore, backend fetch will repopulate
+    }
+  }
+
+  // ── Backend merge ───────────────────────────────────────────────
+
+  applyBackendModels(backendModels: BackendModelEntry[]): void {
+    const staticMap = new Map(this.catalog.map((m) => [m.id, m]));
+    const merged: CodexModelInfo[] = [];
+    const seenIds = new Set<string>();
+
+    for (const raw of backendModels) {
+      const normalized = normalizeBackendModel(raw);
+      seenIds.add(normalized.id);
+
+      const existing = staticMap.get(normalized.id);
+      const { _hasExplicitEfforts, ...model } = normalized;
+      if (existing) {
+        merged.push({
+          ...existing,
+          ...model,
+          description: model.description || existing.description,
+          displayName: model.displayName || existing.displayName,
+          supportedReasoningEfforts: _hasExplicitEfforts
+            ? model.supportedReasoningEfforts
+            : existing.supportedReasoningEfforts,
+          source: "backend",
+        });
+      } else {
+        merged.push(model);
+      }
+    }
+
+    for (const m of this.catalog) {
+      if (!seenIds.has(m.id)) {
+        merged.push({ ...m, source: "static" });
+      }
+    }
+
+    this.catalog = merged;
+    this.lastFetchTime = new Date().toISOString();
+    console.log(
+      `[ModelStore] Merged ${backendModels.length} backend + ${merged.length - backendModels.length} static-only = ${merged.length} total models`,
+    );
+
+    this.syncCache();
+  }
+
+  applyBackendModelsForPlan(planType: string, backendModels: BackendModelEntry[]): void {
+    this.applyBackendModels(backendModels);
+
+    const admittedIds = new Set<string>();
+    for (const raw of backendModels) {
+      const id = raw.slug ?? raw.id ?? raw.name ?? "";
+      if (id) admittedIds.add(id);
+    }
+    this.planModelMap.set(planType, admittedIds);
+
+    this.modelPlanIndex = new Map();
+    for (const [plan, modelIds] of this.planModelMap) {
+      for (const id of modelIds) {
+        let plans = this.modelPlanIndex.get(id);
+        if (!plans) {
+          plans = new Set();
+          this.modelPlanIndex.set(id, plans);
+        }
+        plans.add(plan);
+      }
+    }
+
+    console.log(`[ModelStore] Plan "${planType}": ${admittedIds.size} admitted models, ${this.planModelMap.size} plans tracked`);
+  }
+
+  // ── Getters ─────────────────────────────────────────────────────
+
+  getModelPlanTypes(modelId: string): string[] {
+    return [...(this.modelPlanIndex.get(modelId) ?? [])];
+  }
+
+  isPlanFetched(planType: string): boolean {
+    return this.planModelMap.has(planType);
+  }
+
+  resolveModelId(input: string): string {
+    const trimmed = input.trim();
+    if (this.aliases[trimmed]) return this.aliases[trimmed];
+    if (this.catalog.some((m) => m.id === trimmed)) return trimmed;
+    return this.defaultModelFn();
+  }
+
+  parseModelName(input: string): ParsedModelName {
+    const trimmed = input.trim();
+
+    if (this.aliases[trimmed] || this.catalog.some((m) => m.id === trimmed)) {
+      return { modelId: this.resolveModelId(trimmed), serviceTier: null, reasoningEffort: null };
+    }
+
+    let remaining = trimmed;
+    let serviceTier: string | null = null;
+    let reasoningEffort: string | null = null;
+
+    for (const tier of SERVICE_TIER_SUFFIXES) {
+      if (remaining.endsWith(`-${tier}`)) {
+        serviceTier = tier;
+        remaining = remaining.slice(0, -(tier.length + 1));
+        break;
+      }
+    }
+
+    for (const effort of EFFORT_SUFFIXES) {
+      if (remaining.endsWith(`-${effort}`)) {
+        reasoningEffort = effort;
+        remaining = remaining.slice(0, -(effort.length + 1));
+        break;
+      }
+    }
+
+    const modelId = this.resolveModelId(remaining);
+    return { modelId, serviceTier, reasoningEffort };
+  }
+
+  buildDisplayModelName(parsed: ParsedModelName): string {
+    let name = parsed.modelId;
+    if (parsed.reasoningEffort) name += `-${parsed.reasoningEffort}`;
+    if (parsed.serviceTier) name += `-${parsed.serviceTier}`;
+    return name;
+  }
+
+  getModelInfo(modelId: string): CodexModelInfo | undefined {
+    return this.catalog.find((m) => m.id === modelId);
+  }
+
+  getModelCatalog(): CodexModelInfo[] {
+    return [...this.catalog];
+  }
+
+  getModelAliases(): Record<string, string> {
+    return { ...this.aliases };
+  }
+
+  getModelStoreDebug(): {
+    totalModels: number;
+    backendModels: number;
+    staticOnlyModels: number;
+    aliasCount: number;
+    lastFetchTime: string | null;
+    models: Array<{ id: string; source: string }>;
+    planMap: Record<string, string[]>;
+  } {
+    const backendCount = this.catalog.filter((m) => m.source === "backend").length;
+    const planMap: Record<string, string[]> = {};
+    for (const [planType, modelIds] of this.planModelMap) {
+      planMap[planType] = [...modelIds];
+    }
+    return {
+      totalModels: this.catalog.length,
+      backendModels: backendCount,
+      staticOnlyModels: this.catalog.length - backendCount,
+      aliasCount: Object.keys(this.aliases).length,
+      lastFetchTime: this.lastFetchTime,
+      models: this.catalog.map((m) => ({ id: m.id, source: m.source ?? "static" })),
+      planMap,
+    };
+  }
+
+  // ── Private ─────────────────────────────────────────────────────
+
+  private syncCache(): void {
+    const dataDir = getDataDir();
+    const cachePath = resolve(dataDir, "models-cache.yaml");
+    const today = new Date().toISOString().slice(0, 10);
+
+    const models = this.catalog.map(({ source: _s, ...rest }) => rest);
+
+    const header = [
+      "# Codex model cache",
+      "#",
+      "# Auto-synced by model-store from backend fetch results.",
+      "# This is a runtime cache — do NOT commit to git.",
+      "#",
+      `# Last updated: ${today}`,
+      "",
+    ].join("\n");
+
+    const body = yaml.dump(
+      { models, aliases: this.aliases },
+      { lineWidth: 120, noRefs: true, sortKeys: false },
+    );
+
+    try {
+      mkdirSync(dataDir, { recursive: true });
+    } catch {
+      // already exists
+    }
+
+    writeFile(cachePath, header + body, "utf-8", (err) => {
+      if (err) {
+        console.warn(`[ModelStore] Failed to sync models cache: ${err.message}`);
+      } else {
+        console.log(`[ModelStore] Synced ${models.length} models to data/models-cache.yaml`);
+      }
+    });
+  }
+}
+
+// ── Helpers (module-level, stateless) ─────────────────────────────
+
 function normalizeBackendModel(raw: BackendModelEntry): NormalizedModelWithMeta {
   const id = raw.slug ?? raw.id ?? raw.name ?? "unknown";
 
-  // Accept both old (supported_reasoning_efforts) and new (supported_reasoning_levels) field names
   const rawEfforts = raw.supported_reasoning_efforts ?? [];
   const rawLevels = raw.supported_reasoning_levels ?? [];
   const hasExplicitEfforts = rawEfforts.length > 0 || rawLevels.length > 0;
 
-  // Normalize reasoning efforts — accept effort, reasoning_effort, reasoningEffort keys
   const efforts = rawEfforts.length > 0
     ? rawEfforts.map((e) => ({
         reasoningEffort: e.reasoningEffort ?? e.reasoning_effort ?? e.effort ?? "medium",
@@ -164,280 +376,72 @@ function normalizeBackendModel(raw: BackendModelEntry): NormalizedModelWithMeta 
   };
 }
 
-/**
- * Merge backend models into the catalog.
- *
- * Strategy:
- *   - Trust backend: all models returned by the backend are accepted
- *     (primary endpoint /codex/models only returns Codex-compatible models)
- *   - Backend models overwrite static models with the same ID
- *     (but YAML fields fill in missing backend fields)
- *   - Static-only models are preserved (YAML may know about models the backend doesn't list)
- *   - Aliases are never touched (always from YAML)
- */
+// ── Default instance + backward-compatible free functions ─────────
+
+let _instance: ModelStore = new ModelStore();
+
+/** Get the default ModelStore instance. */
+export function getModelStore(): ModelStore {
+  return _instance;
+}
+
+/** Test-only: replace the default instance. */
+export function setModelStoreForTesting(store: ModelStore): void {
+  _instance = store;
+}
+
+/** Test-only: reset to a fresh default instance. */
+export function resetModelStoreForTesting(): void {
+  _instance = new ModelStore();
+}
+
+// Free-function wrappers — delegate to _instance for backward compat.
+// Callers can gradually migrate to using ModelStore directly.
+
+export function loadStaticModels(configDir?: string): void {
+  _instance.loadStatic(configDir);
+}
+
 export function applyBackendModels(backendModels: BackendModelEntry[]): void {
-  const filtered = backendModels;
-
-  const staticMap = new Map(_catalog.map((m) => [m.id, m]));
-  const merged: CodexModelInfo[] = [];
-  const seenIds = new Set<string>();
-
-  for (const raw of filtered) {
-    const normalized = normalizeBackendModel(raw);
-    seenIds.add(normalized.id);
-
-    const existing = staticMap.get(normalized.id);
-    // Strip internal meta field before storing
-    const { _hasExplicitEfforts, ...model } = normalized;
-    if (existing) {
-      // Backend wins, but YAML fills gaps
-      merged.push({
-        ...existing,
-        ...model,
-        // Preserve YAML fields if backend is empty
-        description: model.description || existing.description,
-        displayName: model.displayName || existing.displayName,
-        supportedReasoningEfforts: _hasExplicitEfforts
-          ? model.supportedReasoningEfforts
-          : existing.supportedReasoningEfforts,
-        source: "backend",
-      });
-    } else {
-      merged.push(model);
-    }
-  }
-
-  // Preserve static-only models (not in backend)
-  for (const m of _catalog) {
-    if (!seenIds.has(m.id)) {
-      merged.push({ ...m, source: "static" });
-    }
-  }
-
-  _catalog = merged;
-  _lastFetchTime = new Date().toISOString();
-  console.log(
-    `[ModelStore] Merged ${filtered.length} backend + ${merged.length - filtered.length} static-only = ${merged.length} total models`,
-  );
-
-  // Auto-sync merged catalog back to models.yaml
-  syncStaticModels();
+  _instance.applyBackendModels(backendModels);
 }
 
-/**
- * Write the current merged catalog to data/models-cache.yaml so it serves
- * as a fallback for future cold starts.  Fire-and-forget.
- *
- * config/models.yaml stays read-only (git-tracked baseline).
- */
-function syncStaticModels(): void {
-  const dataDir = getDataDir();
-  const cachePath = resolve(dataDir, "models-cache.yaml");
-  const today = new Date().toISOString().slice(0, 10);
-
-  // Strip internal `source` field before serializing
-  const models = _catalog.map(({ source: _s, ...rest }) => rest);
-
-  const header = [
-    "# Codex model cache",
-    "#",
-    "# Auto-synced by model-store from backend fetch results.",
-    "# This is a runtime cache — do NOT commit to git.",
-    "#",
-    `# Last updated: ${today}`,
-    "",
-  ].join("\n");
-
-  const body = yaml.dump(
-    { models, aliases: _aliases },
-    { lineWidth: 120, noRefs: true, sortKeys: false },
-  );
-
-  try {
-    mkdirSync(dataDir, { recursive: true });
-  } catch {
-    // already exists
-  }
-
-  writeFile(cachePath, header + body, "utf-8", (err) => {
-    if (err) {
-      console.warn(`[ModelStore] Failed to sync models cache: ${err.message}`);
-    } else {
-      console.log(`[ModelStore] Synced ${models.length} models to data/models-cache.yaml`);
-    }
-  });
-}
-
-/**
- * Merge backend models for a specific plan type.
- * Clears old records for this planType, applies merge, then records plan→model mappings.
- */
 export function applyBackendModelsForPlan(planType: string, backendModels: BackendModelEntry[]): void {
-  // Merge into catalog (existing logic)
-  applyBackendModels(backendModels);
-
-  // Build new model set for this plan and replace atomically
-  const admittedIds = new Set<string>();
-  for (const raw of backendModels) {
-    const id = raw.slug ?? raw.id ?? raw.name ?? "";
-    if (id) admittedIds.add(id);
-  }
-  _planModelMap.set(planType, admittedIds);
-
-  // Rebuild reverse index from scratch (plan types are few, this is cheap)
-  _modelPlanIndex = new Map();
-  for (const [plan, modelIds] of _planModelMap) {
-    for (const id of modelIds) {
-      let plans = _modelPlanIndex.get(id);
-      if (!plans) {
-        plans = new Set();
-        _modelPlanIndex.set(id, plans);
-      }
-      plans.add(plan);
-    }
-  }
-
-  console.log(`[ModelStore] Plan "${planType}": ${admittedIds.size} admitted models, ${_planModelMap.size} plans tracked`);
+  _instance.applyBackendModelsForPlan(planType, backendModels);
 }
 
-/**
- * Get which plan types are known to support a given model.
- * Empty array means unknown (static-only or not yet fetched).
- */
 export function getModelPlanTypes(modelId: string): string[] {
-  return [...(_modelPlanIndex.get(modelId) ?? [])];
+  return _instance.getModelPlanTypes(modelId);
 }
 
-/**
- * Check if models have ever been successfully fetched for a given plan type.
- * Returns false when the plan's model list is unknown (fetch failed or never attempted).
- */
 export function isPlanFetched(planType: string): boolean {
-  return _planModelMap.has(planType);
+  return _instance.isPlanFetched(planType);
 }
 
-// ── Model name suffix parsing ───────────────────────────────────────
-
-export interface ParsedModelName {
-  modelId: string;
-  serviceTier: string | null;
-  reasoningEffort: string | null;
-}
-
-const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
-const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
-
-/**
- * Parse a model name that may contain embedded suffixes for service_tier and reasoning_effort.
- *
- * Resolution:
- *   1. If full name is a known model ID or alias → use as-is
- *   2. Otherwise, strip known suffixes from right:
- *      - `-fast`, `-flex` → service_tier
- *      - `-minimal`, `-low`, `-medium`, `-high`, `-xhigh` → reasoning_effort
- *   3. Resolve remaining name as model ID/alias
- */
-export function parseModelName(input: string): ParsedModelName {
-  const trimmed = input.trim();
-
-  // 1. Known model or alias? Use as-is
-  if (_aliases[trimmed] || _catalog.some((m) => m.id === trimmed)) {
-    return { modelId: resolveModelId(trimmed), serviceTier: null, reasoningEffort: null };
-  }
-
-  // 2. Try stripping suffixes from right
-  let remaining = trimmed;
-  let serviceTier: string | null = null;
-  let reasoningEffort: string | null = null;
-
-  // Strip -fast/-flex (rightmost)
-  for (const tier of SERVICE_TIER_SUFFIXES) {
-    if (remaining.endsWith(`-${tier}`)) {
-      serviceTier = tier;
-      remaining = remaining.slice(0, -(tier.length + 1));
-      break;
-    }
-  }
-
-  // Strip -high/-low/etc (next from right)
-  for (const effort of EFFORT_SUFFIXES) {
-    if (remaining.endsWith(`-${effort}`)) {
-      reasoningEffort = effort;
-      remaining = remaining.slice(0, -(effort.length + 1));
-      break;
-    }
-  }
-
-  // 3. Resolve remaining as model
-  const modelId = resolveModelId(remaining);
-  return { modelId, serviceTier, reasoningEffort };
-}
-
-/** Reconstruct display model name: resolved modelId + any parsed suffixes. */
-export function buildDisplayModelName(parsed: ParsedModelName): string {
-  let name = parsed.modelId;
-  if (parsed.reasoningEffort) name += `-${parsed.reasoningEffort}`;
-  if (parsed.serviceTier) name += `-${parsed.serviceTier}`;
-  return name;
-}
-
-// ── Getters ────────────────────────────────────────────────────────
-
-/**
- * Resolve a model name (may be an alias) to a canonical model ID.
- */
 export function resolveModelId(input: string): string {
-  const trimmed = input.trim();
-  if (_aliases[trimmed]) return _aliases[trimmed];
-  if (_catalog.some((m) => m.id === trimmed)) return trimmed;
-  return getConfig().model.default;
+  return _instance.resolveModelId(input);
 }
 
-/**
- * Get model info by ID.
- */
+export function parseModelName(input: string): ParsedModelName {
+  return _instance.parseModelName(input);
+}
+
+export function buildDisplayModelName(parsed: ParsedModelName): string {
+  return _instance.buildDisplayModelName(parsed);
+}
+
 export function getModelInfo(modelId: string): CodexModelInfo | undefined {
-  return _catalog.find((m) => m.id === modelId);
+  return _instance.getModelInfo(modelId);
 }
 
-/**
- * Get the full model catalog.
- */
 export function getModelCatalog(): CodexModelInfo[] {
-  return [..._catalog];
+  return _instance.getModelCatalog();
 }
 
-/**
- * Get the alias map.
- */
 export function getModelAliases(): Record<string, string> {
-  return { ..._aliases };
+  return _instance.getModelAliases();
 }
 
-/**
- * Debug info for /debug/models endpoint.
- */
-export function getModelStoreDebug(): {
-  totalModels: number;
-  backendModels: number;
-  staticOnlyModels: number;
-  aliasCount: number;
-  lastFetchTime: string | null;
-  models: Array<{ id: string; source: string }>;
-  planMap: Record<string, string[]>;
-} {
-  const backendCount = _catalog.filter((m) => m.source === "backend").length;
-  const planMap: Record<string, string[]> = {};
-  for (const [planType, modelIds] of _planModelMap) {
-    planMap[planType] = [...modelIds];
-  }
-  return {
-    totalModels: _catalog.length,
-    backendModels: backendCount,
-    staticOnlyModels: _catalog.length - backendCount,
-    aliasCount: Object.keys(_aliases).length,
-    lastFetchTime: _lastFetchTime,
-    models: _catalog.map((m) => ({ id: m.id, source: m.source ?? "static" })),
-    planMap,
-  };
+export function getModelStoreDebug() {
+  return _instance.getModelStoreDebug();
 }


### PR DESCRIPTION
## Summary

- `ModelStore` 从 6 个模块级变量 + 15 个自由函数重构为 class，所有状态封装为实例属性
- 保留所有自由函数 export 作为 wrapper（delegate 到默认实例），**21 个 importer 零改动**
- 新增 `getModelStore()` / `setModelStoreForTesting()` / `resetModelStoreForTesting()` 用于 DI 和测试隔离
- Constructor 接受可选 `defaultModelFn` 避免对 `getConfig()` 的硬依赖

## Test plan

- [x] `npm test` — 1219 tests pass (106 files, 0 failures)
- [x] 所有 model 相关测试通过（plan-routing, model-cache, model-plan-routing, suffix parsing）