### PR TITLE
test: verify Electron app packages and launches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22,12 +22,14 @@
       },
       "devDependencies": {
         "@electron/asar": "^3.2.0",
+        "@playwright/test": "^1.58.2",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^3.2.4",
         "electron-to-chromium": "^1.5.302",
         "js-beautify": "^1.15.0",
+        "playwright": "^1.58.2",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
         "vitest": "^3.2.4"
@@ -1222,6 +1224,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5622,6 +5640,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7364,14 +7429,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.58.2"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
   },
   "devDependencies": {
     "@electron/asar": "^3.2.0",
+    "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.4",
     "electron-to-chromium": "^1.5.302",
     "js-beautify": "^1.15.0",
+    "playwright": "^1.58.2",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
     "vitest": "^3.2.4"

--- a/packages/electron/__tests__/launch.test.ts
+++ b/packages/electron/__tests__/launch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "child_process";
+import { _electron as electron, ElectronApplication } from "playwright";
+import { resolve } from "path";
+import { existsSync, readdirSync } from "fs";
+
+const PKG_DIR = resolve(import.meta.dirname, "..");
+
+describe("Electron app launch smoke test", () => {
+  let app: ElectronApplication | undefined;
+
+  beforeAll(() => {
+    // We want to avoid rebuilding if we don't have to for local testing,
+    // but the test should ideally build it from scratch. Let's do it in the tests.
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("builds the electron app successfully", () => {
+    execSync("npm run build", { cwd: PKG_DIR, stdio: "inherit" });
+    expect(existsSync(resolve(PKG_DIR, "dist-electron/main.cjs"))).toBe(true);
+    expect(existsSync(resolve(PKG_DIR, "dist-electron/server.mjs"))).toBe(true);
+  });
+
+  it("packages the electron app for linux successfully", () => {
+    execSync("npm run pack:linux", { cwd: PKG_DIR, stdio: "inherit" });
+    const linuxUnpackedPath = resolve(PKG_DIR, "release/linux-unpacked");
+    expect(existsSync(linuxUnpackedPath)).toBe(true);
+  }, 60000);
+
+  it("launches the packaged app and exits cleanly", async () => {
+    const linuxUnpackedPath = resolve(PKG_DIR, "release/linux-unpacked");
+    expect(existsSync(linuxUnpackedPath)).toBe(true);
+
+    // Find the executable in the unpacked directory
+    const files = readdirSync(linuxUnpackedPath);
+    // On Linux, the executable usually lacks an extension, so we look for files
+    // without a dot and ignore common non-executables.
+    const possibleBinaries = files.filter(f => !f.includes(".") && !f.endsWith("so") && !["locales", "resources"].includes(f));
+    expect(possibleBinaries.length).toBeGreaterThan(0);
+    const executableName = possibleBinaries[0];
+    const executablePath = resolve(linuxUnpackedPath, executableName);
+
+    expect(existsSync(executablePath)).toBe(true);
+
+    // Launch the app
+    app = await electron.launch({
+      executablePath,
+      args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--headless"],
+    });
+
+    // Wait for the main window to open
+    const window = await app.firstWindow();
+    expect(window).toBeDefined();
+
+    // Verify it loads a page (e.g. checks title or basic content)
+    // Adjust selector and timeout based on the expected initial UI
+    await window.waitForLoadState("domcontentloaded");
+
+    // We'll just check that it has opened
+    const title = await window.title();
+    expect(typeof title).toBe("string");
+
+    // Close the app and verify clean exit
+    await app.close();
+    app = undefined; // clear reference
+  }, 60000);
+});

--- a/packages/electron/electron/prepare-pack.mjs
+++ b/packages/electron/electron/prepare-pack.mjs
@@ -22,7 +22,7 @@ for (const dir of DIRS) {
 
   if (isClean) {
     if (existsSync(dest)) {
-      rmSync(dest, { recursive: true });
+      rmSync(dest, { recursive: true, force: true });
       console.log(`[prepare-pack] removed ${dir}/`);
     }
   } else {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.58.2"
   }
 }

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -16,8 +16,8 @@ interface CodexLikeError {
 function isCodexLike(err: unknown): err is CodexLikeError {
   return (
     err instanceof Error &&
-    typeof (err as Record<string, unknown>).status === "number" &&
-    typeof (err as Record<string, unknown>).body === "string"
+    typeof (err as unknown as Record<string, unknown>).status === "number" &&
+    typeof (err as unknown as Record<string, unknown>).body === "string"
   );
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "@src": resolve(__dirname, "src"),
       "@helpers": resolve(__dirname, "tests/_helpers"),
       "@fixtures": resolve(__dirname, "tests/_fixtures"),
+      "preact": resolve(__dirname, "node_modules/preact"),
     },
   },
   test: {


### PR DESCRIPTION
Fixes #121 by adding an automated smoke test for the electron app, verifying that it can be built, packaged via `electron-builder` and correctly launched headlessly using Playwright. Also resolves some outstanding type-checking and path-aliasing configurations impeding tests.

---
*PR created automatically by Jules for task [13911265882493407172](https://jules.google.com/task/13911265882493407172) started by @icebear0828*