### PR TITLE
test: verify Docker image builds and starts successfully #120

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,18 +28,39 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - type: default
+            port: 8080
+          - type: custom
+            port: 8090
     steps:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
         run: docker build -t codex-proxy:smoke .
 
+      - name: Prepare custom config
+        if: matrix.type == 'custom'
+        run: |
+          cp config/default.yaml config/custom.yaml
+          sed -i 's/port: 8080/port: 8090/g' config/custom.yaml
+
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
-            -e NODE_ENV=production \
-            codex-proxy:smoke
+          if [ "${{ matrix.type }}" = "custom" ]; then
+            docker run -d --name smoke-test \
+              -p 18080:8090 \
+              -e NODE_ENV=production \
+              -v $(pwd)/config/custom.yaml:/app/config/default.yaml \
+              codex-proxy:smoke
+          else
+            docker run -d --name smoke-test \
+              -p 18080:8080 \
+              -e NODE_ENV=production \
+              codex-proxy:smoke
+          fi
           echo "Container started"
 
       - name: Wait for healthy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -7364,7 +7364,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to test the Docker image build and start process against both default and custom port configurations as requested in issue #120.

It utilizes a `strategy.matrix` to iterate over a `default` port (8080) and a `custom` port (8090). For the custom port case, it modifies the `config/default.yaml` and mounts it so that the internal `docker-healthcheck.sh` operates correctly against the non-default port.

---
*PR created automatically by Jules for task [13712751129371280831](https://jules.google.com/task/13712751129371280831) started by @icebear0828*