### PR TITLE
refactor: transport DI + async cookie persist (Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - `scripts/` 按用途分类到 `infra/`、`build/`、`poc/`、`manual-test/` 子目录
 - 新增 `src/context.ts`（AppContext 容器），fingerprint/manager、codex-api、codex-usage、codex-models 支持可选 DI 参数（fallback 到全局单例）
 - `ModelStore` 从模块级单例重构为 class，自由函数 wrapper 保持后向兼容，新增 `getModelStore()` / `setModelStoreForTesting()`
+- Transport 加入 AppContext，codex-api/codex-usage/codex-models/proxy-pool/curl-fetch 支持可选 transport 注入
+- CookieJar critical cookie 写入从 `writeFileSync`（阻塞 10-50ms）改为 `writeFile`（async 非阻塞）
 
 ### Fixed
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,16 +9,22 @@
  */
 
 import type { AppConfig, FingerprintConfig } from "./config.js";
+import type { TlsTransport } from "./tls/transport.js";
 
 export interface AppContext {
   readonly config: AppConfig;
   readonly fingerprint: FingerprintConfig;
+  readonly transport?: TlsTransport;
 }
 
 let _context: AppContext | null = null;
 
-export function initContext(config: AppConfig, fingerprint: FingerprintConfig): AppContext {
-  _context = { config, fingerprint };
+export function initContext(
+  config: AppConfig,
+  fingerprint: FingerprintConfig,
+  transport?: TlsTransport,
+): AppContext {
+  _context = { config, fingerprint, transport };
   return _context;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,6 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   console.log("[Init] Loading configuration...");
   const config = loadConfig();
   const fingerprint = loadFingerprint();
-  initContext(config, fingerprint);
 
   // Load static model catalog (before transport/auth init)
   loadStaticModels();
@@ -59,7 +58,8 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   await initProxy();
 
   // Initialize TLS transport (auto-selects curl CLI or libcurl FFI)
-  await initTransport();
+  const transport = await initTransport();
+  initContext(config, fingerprint, transport);
 
   // Initialize managers
   const accountPool = new AccountPool();

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -10,7 +10,7 @@
  */
 
 import { getConfig } from "../config.js";
-import { getTransport } from "../tls/transport.js";
+import { getTransport, type TlsTransport } from "../tls/transport.js";
 import {
   buildHeaders,
   buildHeadersWithContentType,
@@ -50,6 +50,7 @@ export class CodexApi {
   private entryId: string | null;
   private proxyUrl: string | null | undefined;
   private baseUrl: string | undefined;
+  private transport: TlsTransport | undefined;
 
   constructor(
     token: string,
@@ -58,6 +59,7 @@ export class CodexApi {
     entryId?: string | null,
     proxyUrl?: string | null,
     baseUrl?: string,
+    transport?: TlsTransport,
   ) {
     this.token = token;
     this.accountId = accountId;
@@ -65,10 +67,15 @@ export class CodexApi {
     this.entryId = entryId ?? null;
     this.proxyUrl = proxyUrl;
     this.baseUrl = baseUrl;
+    this.transport = transport;
   }
 
   private resolveBaseUrl(): string {
     return this.baseUrl ?? getConfig().api.base_url;
+  }
+
+  private resolveTransport(): TlsTransport {
+    return this.transport ?? getTransport();
   }
 
   setToken(token: string): void {
@@ -107,7 +114,7 @@ export class CodexApi {
    */
   async warmup(): Promise<CodexUsageResponse | null> {
     const config = getConfig();
-    const transport = getTransport();
+    const transport = this.resolveTransport();
     const url = `${config.api.base_url}/codex/usage`;
     const headers = this.applyHeaders(
       buildHeaders(this.token, this.accountId),
@@ -216,7 +223,7 @@ export class CodexApi {
     request: CodexResponsesRequest,
     signal?: AbortSignal,
   ): Promise<Response> {
-    const transport = getTransport();
+    const transport = this.resolveTransport();
     const baseUrl = this.resolveBaseUrl();
     const url = `${baseUrl}/codex/responses`;
 

--- a/src/proxy/codex-models.ts
+++ b/src/proxy/codex-models.ts
@@ -3,7 +3,7 @@
  */
 
 import { getConfig } from "../config.js";
-import { getTransport } from "../tls/transport.js";
+import { getTransport, type TlsTransport } from "../tls/transport.js";
 import type { BackendModelEntry } from "../models/model-store.js";
 
 let _firstModelFetchLogged = false;
@@ -12,9 +12,10 @@ export async function fetchModels(
   headers: Record<string, string>,
   proxyUrl?: string | null,
   apiConfig?: { base_url: string; app_version: string },
+  injectedTransport?: TlsTransport,
 ): Promise<BackendModelEntry[] | null> {
   const config = apiConfig ? undefined : getConfig();
-  const transport = getTransport();
+  const transport = injectedTransport ?? getTransport();
   const baseUrl = apiConfig?.base_url ?? config!.api.base_url;
 
   const clientVersion = apiConfig?.app_version ?? config!.client.app_version;
@@ -80,8 +81,9 @@ export async function probeEndpoint(
   headers: Record<string, string>,
   proxyUrl?: string | null,
   baseUrl?: string,
+  injectedTransport?: TlsTransport,
 ): Promise<Record<string, unknown> | null> {
-  const transport = getTransport();
+  const transport = injectedTransport ?? getTransport();
   const url = `${baseUrl ?? getConfig().api.base_url}${path}`;
 
   headers["Accept"] = "application/json";

--- a/src/proxy/codex-usage.ts
+++ b/src/proxy/codex-usage.ts
@@ -3,16 +3,17 @@
  */
 
 import { getConfig } from "../config.js";
-import { getTransport } from "../tls/transport.js";
+import { getTransport, type TlsTransport } from "../tls/transport.js";
 import { CodexApiError, type CodexUsageResponse } from "./codex-types.js";
 
 export async function fetchUsage(
   headers: Record<string, string>,
   proxyUrl?: string | null,
   baseUrl?: string,
+  injectedTransport?: TlsTransport,
 ): Promise<CodexUsageResponse> {
   const resolvedBaseUrl = baseUrl ?? getConfig().api.base_url;
-  const transport = getTransport();
+  const transport = injectedTransport ?? getTransport();
   const url = `${resolvedBaseUrl}/codex/usage`;
 
   headers["Accept"] = "application/json";

--- a/src/proxy/cookie-jar.ts
+++ b/src/proxy/cookie-jar.ts
@@ -17,6 +17,7 @@ import {
   existsSync,
   mkdirSync,
 } from "fs";
+import { writeFile, rename } from "fs/promises";
 import { resolve, dirname } from "path";
 import { getDataDir } from "../paths.js";
 
@@ -156,7 +157,10 @@ export class CookieJar {
     if (changed) {
       this.cookies.set(accountId, existing);
       if (hasCritical) {
-        this.persistNow(); // Critical cookie — persist immediately
+        // Critical cookie — persist immediately (async, non-blocking)
+        this.persistAsync().catch((err) => {
+          console.warn("[CookieJar] Critical cookie persist failed:", err instanceof Error ? err.message : err);
+        });
       } else {
         this.schedulePersist();
       }
@@ -202,10 +206,42 @@ export class CookieJar {
     if (this.persistTimer) return;
     this.persistTimer = setTimeout(() => {
       this.persistTimer = null;
-      this.persistNow();
+      this.persistAsync().catch((err) => {
+        console.warn("[CookieJar] Scheduled persist failed:", err instanceof Error ? err.message : err);
+      });
     }, 1000);
   }
 
+  /**
+   * Persist cookies to disk asynchronously (non-blocking).
+   * Critical cookies fire-and-forget this; data is already in memory.
+   */
+  async persistAsync(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+    }
+    try {
+      const cookieFile = getCookieFile();
+      const dir = dirname(cookieFile);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+      const data: CookieFileV2 = { _version: 2, accounts: {} };
+      for (const [acct, cookies] of this.cookies) {
+        data.accounts[acct] = {};
+        for (const [k, c] of Object.entries(cookies)) {
+          data.accounts[acct][k] = { value: c.value, expires: c.expires };
+        }
+      }
+      const tmpFile = cookieFile + ".tmp";
+      await writeFile(tmpFile, JSON.stringify(data, null, 2), "utf-8");
+      await rename(tmpFile, cookieFile);
+    } catch (err) {
+      console.warn("[CookieJar] Failed to persist:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  /** Synchronous persist for shutdown (ensures data is flushed before exit). */
   persistNow(): void {
     if (this.persistTimer) {
       clearTimeout(this.persistTimer);
@@ -216,7 +252,6 @@ export class CookieJar {
       const dir = dirname(cookieFile);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
-      // Persist v2 format with expiry info
       const data: CookieFileV2 = { _version: 2, accounts: {} };
       for (const [acct, cookies] of this.cookies) {
         data.accounts[acct] = {};

--- a/src/proxy/proxy-pool.ts
+++ b/src/proxy/proxy-pool.ts
@@ -18,7 +18,7 @@ import {
 } from "fs";
 import { resolve, dirname } from "path";
 import { getDataDir } from "../paths.js";
-import { getTransport } from "../tls/transport.js";
+import { getTransport, type TlsTransport } from "../tls/transport.js";
 
 function getProxiesFile(): string {
   return resolve(getDataDir(), "proxies.json");
@@ -70,8 +70,10 @@ export class ProxyPool {
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
   private healthTimer: ReturnType<typeof setInterval> | null = null;
   private _roundRobinIndex = 0;
+  private injectedTransport: TlsTransport | undefined;
 
-  constructor() {
+  constructor(transport?: TlsTransport) {
+    this.injectedTransport = transport;
     this.load();
   }
 
@@ -255,7 +257,7 @@ export class ProxyPool {
       throw new Error(`Proxy ${id} not found`);
     }
 
-    const transport = getTransport();
+    const transport = this.injectedTransport ?? getTransport();
     const start = Date.now();
 
     try {

--- a/src/tls/curl-fetch.ts
+++ b/src/tls/curl-fetch.ts
@@ -8,7 +8,7 @@
  * Used for non-streaming requests (OAuth, appcast, etc.).
  */
 
-import { getTransport } from "./transport.js";
+import { getTransport, type TlsTransport } from "./transport.js";
 import { buildAnonymousHeaders } from "../fingerprint/manager.js";
 
 export interface CurlFetchResponse {
@@ -20,6 +20,8 @@ export interface CurlFetchResponse {
 export interface CurlFetchOptions {
   /** Proxy override: undefined = global default, null = direct, string = specific. */
   proxyUrl?: string | null;
+  /** Injected transport (skip singleton). */
+  transport?: TlsTransport;
 }
 
 /**
@@ -29,7 +31,7 @@ export async function curlFetchGet(
   url: string,
   options?: CurlFetchOptions,
 ): Promise<CurlFetchResponse> {
-  const transport = getTransport();
+  const transport = options?.transport ?? getTransport();
   const headers = buildAnonymousHeaders();
   // Let --compressed auto-negotiate Accept-Encoding based on curl's actual
   // decompression capabilities, avoiding error 61 on builds lacking br/zstd.
@@ -52,7 +54,7 @@ export async function curlFetchPost(
   body: string,
   options?: CurlFetchOptions,
 ): Promise<CurlFetchResponse> {
-  const transport = getTransport();
+  const transport = options?.transport ?? getTransport();
   const headers = buildAnonymousHeaders();
   // Let --compressed auto-negotiate Accept-Encoding based on curl's actual
   // decompression capabilities, avoiding error 61 on builds lacking br/zstd.


### PR DESCRIPTION
## Summary

- **5a**: Transport 加入 AppContext，7 个消费者（codex-api/codex-usage/codex-models/proxy-pool/curl-fetch）支持可选 `transport` 参数注入，fallback 到 `getTransport()` 单例
- **5b**: CookieJar critical cookie（`cf_clearance`、`__cf_bm`）写入从 `writeFileSync`（阻塞 event loop 10-50ms）改为 `fs/promises.writeFile`（async 非阻塞）。Shutdown 保留同步写入确保数据落盘

## Test plan

- [x] `npm test` — 1219 tests pass (106 files, 0 failures)
- [ ] 手动验证 cookie 持久化正常