### PR TITLE
test: add smoke tests for docker, electron, and web

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,101 @@
+name: CI — Docker smoke test
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: docker-smoke-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Start container on default port 8080
+        run: |
+          docker run -d --name smoke-test-8080 \
+            -p 8080:8080 \
+            codex-proxy-test
+          echo "Container started"
+
+      - name: Wait for healthy (default port)
+        run: |
+          echo "Waiting for container to become healthy..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-8080 2>/dev/null || echo "starting")
+            echo "  [$i/15] status: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Container did not become healthy within 30s"
+          docker logs smoke-test-8080
+          exit 1
+
+      - name: Verify /health returns 200 (default port)
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+          if [ "$RESPONSE" != "200" ]; then
+            echo "::error::Expected 200 OK, got $RESPONSE"
+            docker logs smoke-test-8080
+            exit 1
+          fi
+          echo "Health check passed!"
+
+      - name: Cleanup default container
+        if: always()
+        run: docker rm -f smoke-test-8080 || true
+
+      - name: Modify config/default.yaml for custom port
+        run: |
+          mkdir -p config-override
+          cp config/default.yaml config-override/default.yaml
+          sed -i 's/port: 8080/port: 8090/g' config-override/default.yaml
+          cat config-override/default.yaml
+
+      - name: Start container on custom port 8090
+        run: |
+          docker run -d --name smoke-test-8090 \
+            -p 8090:8090 \
+            -v $(pwd)/config-override/default.yaml:/app/config/default.yaml \
+            codex-proxy-test
+
+      - name: Wait for healthy (custom port)
+        run: |
+          echo "Waiting for custom container to become healthy..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-8090 2>/dev/null || echo "starting")
+            echo "  [$i/15] status: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Custom container did not become healthy within 30s"
+          docker logs smoke-test-8090
+          exit 1
+
+      - name: Verify /health returns 200 (custom port)
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/health)
+          if [ "$RESPONSE" != "200" ]; then
+            echo "::error::Expected 200 OK, got $RESPONSE"
+            docker logs smoke-test-8090
+            exit 1
+          fi
+          echo "Health check passed on custom port!"
+
+      - name: Cleanup custom container
+        if: always()
+        run: docker rm -f smoke-test-8090 || true

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,50 @@
+name: CI — Electron smoke test
+
+on:
+  pull_request:
+    paths:
+      - "packages/electron/**"
+  push:
+    branches: [master]
+    paths:
+      - "packages/electron/**"
+
+concurrency:
+  group: electron-smoke-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  electron-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Build web frontend and backend
+        run: npm run build
+
+      - name: Build desktop frontend
+        run: cd packages/electron && npm run build
+
+      - name: Prepare electron resources
+        run: cd packages/electron && node electron/prepare-pack.mjs
+
+      - name: Package Electron App (Linux)
+        run: cd packages/electron && npx electron-builder --linux --dir
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run launch smoke test
+        run: cd packages/electron && xvfb-run npm test __tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,32 @@
+name: CI — Web smoke test
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: web-smoke-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web and backend
+        run: npm run build
+
+      - name: Run Web Smoke test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.0",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -5622,6 +5622,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7364,14 +7411,15 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.0",
+      "version": "2.0.5",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.58.2"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,53 @@
+import { _electron as electron } from "playwright";
+import { expect, test } from "vitest";
+import { join } from "path";
+import { readdirSync } from "fs";
+import fs from "fs";
+
+test("Smoke test: Electron app packages and launches", async () => {
+  // Find the packaged linux executable in the release directory
+  const releaseDir = join(import.meta.dirname, "..", "..", "release", "linux-unpacked");
+
+  // Verify directory exists
+  expect(fs.existsSync(releaseDir)).toBe(true);
+
+  // Find binary dynamically (files with no extension, excluding certain ones)
+  const files = readdirSync(releaseDir);
+  const binaryName = files.find(f =>
+    !f.includes(".") &&
+    f !== "locales" &&
+    f !== "resources" &&
+    f !== "LICENSES.chromium.html" &&
+    f !== "chrome-sandbox" &&
+    f !== "chrome_crashpad_handler"
+  );
+
+  if (!binaryName) {
+    throw new Error("Could not find executable binary in release/linux-unpacked/");
+  }
+
+  const executablePath = join(releaseDir, binaryName);
+
+  // Launch the Electron app using playwright
+  const electronApp = await electron.launch({
+    executablePath,
+    args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+  });
+
+  try {
+    // Wait for the first window to appear
+    const window = await electronApp.firstWindow();
+
+    // Check if the window is defined
+    expect(window).toBeDefined();
+
+    // Optionally wait for the app to initialize its content
+    await window.waitForLoadState("domcontentloaded");
+
+    // Close window gracefully
+    await electronApp.close();
+  } catch (error) {
+    await electronApp.close();
+    throw error;
+  }
+}, 60000); // Increased timeout for potentially slow launches

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.58.2"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs";
+import path from "path";
+
+describe("Web frontend smoke test", () => {
+  let serverProcess: ChildProcess;
+  const PORT = "8081";
+
+  beforeAll(async () => {
+    // Start the server process on an alternative port
+    serverProcess = spawn("node", ["dist/index.js"], {
+      env: { ...process.env, PORT },
+      stdio: "ignore",
+    });
+
+    // Wait for the server to be ready
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  });
+
+  afterAll(() => {
+    // Clean up server process
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+  });
+
+  it("public/assets/ contains .css files with light and dark theme rules", () => {
+    const assetsDir = path.join(import.meta.dirname, "..", "..", "public", "assets");
+
+    // Check if assets directory exists
+    expect(fs.existsSync(assetsDir)).toBe(true);
+
+    // Find CSS files
+    const files = fs.readdirSync(assetsDir);
+    const cssFiles = files.filter(f => f.endsWith(".css"));
+
+    expect(cssFiles.length).toBeGreaterThan(0);
+
+    // Check for light and dark theme content in CSS files
+    let foundDarkTheme = false;
+    let foundLightTheme = false;
+
+    for (const file of cssFiles) {
+      const content = fs.readFileSync(path.join(assetsDir, file), "utf-8");
+
+      if (content.includes(".dark") || content.includes("@media (prefers-color-scheme: dark)")) {
+        foundDarkTheme = true;
+      }
+
+      if (content.includes(":root") || content.includes("@media (prefers-color-scheme: light)")) {
+        foundLightTheme = true;
+      }
+    }
+
+    expect(foundDarkTheme).toBe(true);
+    expect(foundLightTheme).toBe(true);
+  });
+
+  it("server returns HTML containing <div id=\"app\"></div>", async () => {
+    const response = await fetch(`http://localhost:${PORT}/`);
+
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain('<div id="app"></div>');
+  });
+});

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -16,8 +16,8 @@ interface CodexLikeError {
 function isCodexLike(err: unknown): err is CodexLikeError {
   return (
     err instanceof Error &&
-    typeof (err as Record<string, unknown>).status === "number" &&
-    typeof (err as Record<string, unknown>).body === "string"
+    typeof (err as unknown as Record<string, unknown>).status === "number" &&
+    typeof (err as unknown as Record<string, unknown>).body === "string"
   );
 }
 


### PR DESCRIPTION
This commit introduces multiple standalone smoke test jobs and their respective GitHub Actions workflows to fulfill issues #133, #134, #135. It also fixes a minor typescript compilation error in `src/proxy/error-classification.ts`.

---
*PR created automatically by Jules for task [8651854743768369346](https://jules.google.com/task/8651854743768369346) started by @icebear0828*