### PR TITLE
ci: fix release workflow — remove deleted desktop frontend steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,17 +53,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install web frontend dependencies
-        run: cd web && npm ci
-
-      - name: Install desktop frontend dependencies
-        run: cd packages/electron/desktop && npm ci
-
       - name: Build core (web + tsc)
         run: npm run build
-
-      - name: Build desktop frontend
-        run: cd packages/electron/desktop && npx vite build
 
       - name: Bundle Electron (esbuild)
         working-directory: packages/electron
@@ -125,17 +116,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install web frontend dependencies
-        run: cd web && npm ci
-
-      - name: Install desktop frontend dependencies
-        run: cd packages/electron/desktop && npm ci
-
       - name: Build core (web + tsc)
         run: npm run build
-
-      - name: Build desktop frontend
-        run: cd packages/electron/desktop && npx vite build
 
       - name: Bundle Electron (esbuild)
         working-directory: packages/electron


### PR DESCRIPTION
## Summary

Phase 1 (PR #198) deleted `packages/electron/desktop/` — Electron now loads `web/` directly. But the release workflow still had 4 steps referencing the deleted directory:

- `cd packages/electron/desktop && npm ci` (x2, build + build-mac-x64 jobs)
- `cd packages/electron/desktop && npx vite build` (x2)

This caused **all release builds since v2.0.2 to fail** (tags v2.0.3–v2.0.7 have no GitHub releases).

Also removed the now-redundant `cd web && npm ci` step — root `npm ci` already installs web deps.

## Test plan

- [x] Merge and trigger `workflow_dispatch` on latest tag to verify builds succeed