### PR TITLE
feat: enhance account status visual distinction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `proxy-handler.ts`（353 LOC）拆分为 3 个独立可测试模块：`account-acquisition.ts`（acquire/release + 幂等 guard）、`proxy-error-handler.ts`（4 种错误分类 + 池状态变更）、`response-processor.ts`（流式/非流式响应），26 个新测试
 - `AccountPool`（673 LOC）拆分为 `AccountRegistry`（状态 + CRUD + 查询，423 LOC）+ `AccountLifecycle`（锁 + 轮换，154 LOC），facade 219 LOC 编排。37 个 importer 零改动
 - `model-fetcher.ts` 和 `usage-refresher.ts` 从模块级单例重构为 `ModelFetcher` / `UsageRefresher` class，自由函数 wrapper 保持后向兼容
+- Dashboard 账号状态视觉增强：卡片加彩色左边框、banned/expired/disabled 行背景色区分、badge 加图标前缀（● ⏱ ⏳ ↻ ○ ⛔）
 
 ### Fixed
 

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -12,30 +12,49 @@ const avatarColors = [
   ["bg-red-100 dark:bg-[#3f1a1a]", "text-red-600 dark:text-red-400"],
 ];
 
-const statusStyles: Record<string, [string, string]> = {
+/** [badgeClasses, i18nKey, icon, leftBorderClass, cardBgClass] */
+const statusStyles: Record<string, [string, string, string, string, string]> = {
   active: [
     "bg-green-100 text-green-700 border-green-200 dark:bg-[#11281d] dark:text-primary dark:border-[#1a442e]",
     "active",
+    "●",
+    "border-l-green-500",
+    "",
   ],
   expired: [
     "bg-red-100 text-red-600 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800/30",
     "expired",
+    "⏱",
+    "border-l-red-400",
+    "bg-red-50/40 dark:bg-red-950/10",
   ],
   rate_limited: [
     "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800/30",
     "rateLimited",
+    "⏳",
+    "border-l-amber-400",
+    "",
   ],
   refreshing: [
     "bg-blue-100 text-blue-600 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800/30",
     "refreshing",
+    "↻",
+    "border-l-blue-400",
+    "",
   ],
   disabled: [
     "bg-slate-100 text-slate-500 border-slate-200 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-700/30",
     "disabled",
+    "○",
+    "border-l-slate-300 dark:border-l-slate-600",
+    "opacity-60",
   ],
   banned: [
     "bg-rose-100 text-rose-700 border-rose-300 dark:bg-rose-900/30 dark:text-rose-400 dark:border-rose-800/40",
     "banned",
+    "⛔",
+    "border-l-rose-500",
+    "bg-rose-50/50 dark:bg-rose-950/15",
   ],
 };
 
@@ -67,7 +86,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
   const windowSec = account.quota?.rate_limit?.limit_window_seconds;
   const windowDur = windowSec ? formatWindowDuration(windowSec, lang === "zh") : null;
 
-  const [statusCls, statusKey] = statusStyles[account.status] || statusStyles.disabled;
+  const [statusCls, statusKey, statusIcon, borderCls, cardBgCls] = statusStyles[account.status] || statusStyles.disabled;
 
   const handleDelete = useCallback(async () => {
     if (!confirm(t("removeConfirm"))) return;
@@ -162,7 +181,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
   }, [handleLabelSave]);
 
   return (
-    <div class={`bg-white dark:bg-card-dark border rounded-xl p-4 shadow-sm hover:shadow-md transition-all ${selected ? "border-primary ring-1 ring-primary/30" : "border-gray-200 dark:border-border-dark hover:border-primary/30 dark:hover:border-primary/50"}`}>
+    <div class={`border rounded-xl p-4 shadow-sm hover:shadow-md transition-all border-l-4 ${borderCls} ${cardBgCls || "bg-white dark:bg-card-dark"} ${selected ? "border-primary ring-1 ring-primary/30" : "border-gray-200 dark:border-border-dark hover:border-primary/30 dark:hover:border-primary/50"}`}>
       {/* Header */}
       <div class="flex justify-between items-start mb-4">
         <div class="flex items-center gap-3">
@@ -236,7 +255,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
             </button>
           )}
           <span class={`px-2.5 py-1 rounded-full ${statusCls} text-xs font-medium border`}>
-            {t(statusKey as TranslationKey)}
+            {statusIcon} {t(statusKey as TranslationKey)}
           </span>
           {onRefreshQuota && (
             <button

--- a/web/src/components/AccountTable.tsx
+++ b/web/src/components/AccountTable.tsx
@@ -6,30 +6,43 @@ import type { ProxyEntry } from "../../../shared/types";
 
 const PAGE_SIZE = 50;
 
-const statusStyles: Record<string, [string, TranslationKey]> = {
+/** [badgeClasses, i18nKey, icon, rowBgClass] */
+const statusStyles: Record<string, [string, TranslationKey, string, string]> = {
   active: [
     "bg-green-100 text-green-700 border-green-200 dark:bg-[#11281d] dark:text-primary dark:border-[#1a442e]",
     "active",
+    "●",
+    "",
   ],
   expired: [
     "bg-red-100 text-red-600 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800/30",
     "expired",
+    "⏱",
+    "bg-red-50/40 dark:bg-red-950/10",
   ],
   rate_limited: [
     "bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800/30",
     "rateLimited",
+    "⏳",
+    "",
   ],
   refreshing: [
     "bg-blue-100 text-blue-600 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800/30",
     "refreshing",
+    "↻",
+    "",
   ],
   disabled: [
     "bg-slate-100 text-slate-500 border-slate-200 dark:bg-slate-800/30 dark:text-slate-400 dark:border-slate-700/30",
     "disabled",
+    "○",
+    "opacity-60",
   ],
   banned: [
     "bg-rose-100 text-rose-700 border-rose-300 dark:bg-rose-900/30 dark:text-rose-400 dark:border-rose-800/40",
     "banned",
+    "⛔",
+    "bg-rose-50/50 dark:bg-rose-950/15",
   ],
 };
 
@@ -184,7 +197,7 @@ export function AccountTable({
             />
           </label>
           <span class="flex-1 min-w-0">Email</span>
-          <span class="w-20 text-center hidden sm:block">{t("statusFilter")}</span>
+          <span class="w-24 text-center hidden sm:block">{t("statusFilter")}</span>
           {onToggleStatus && <span class="w-12 text-center hidden sm:block" />}
           {showProxy && <span class="w-40 text-center hidden md:block">{t("proxyAssignment")}</span>}
         </div>
@@ -197,15 +210,15 @@ export function AccountTable({
         ) : (
           pageAccounts.map((acct, idx) => {
             const isSelected = selectedIds.has(acct.id);
-            const [statusCls, statusKey] = statusStyles[acct.status] || statusStyles.disabled;
+            const [statusCls, statusKey, statusIcon, rowBgCls] = statusStyles[acct.status] || statusStyles.disabled;
 
             return (
               <div
                 key={acct.id}
-                class={`flex items-center gap-3 px-4 py-2.5 border-b border-gray-50 dark:border-border-dark/50 transition-colors cursor-pointer ${
+                class={`flex items-center gap-3 px-4 py-2.5 border-b border-gray-50 dark:border-border-dark/50 transition-colors cursor-pointer ${rowBgCls} ${
                   isSelected
                     ? "bg-primary/5 dark:bg-primary/10"
-                    : "hover:bg-slate-50 dark:hover:bg-border-dark/30"
+                    : rowBgCls ? "" : "hover:bg-slate-50 dark:hover:bg-border-dark/30"
                 }`}
                 onClick={(e) => {
                   if ((e.target as HTMLElement).tagName === "SELECT") return;
@@ -223,9 +236,9 @@ export function AccountTable({
                 <span class="flex-1 min-w-0 text-sm font-medium truncate text-slate-700 dark:text-text-main">
                   {acct.label ? `${acct.label} (${acct.email})` : acct.email}
                 </span>
-                <span class="w-20 hidden sm:flex justify-center">
+                <span class="w-24 hidden sm:flex justify-center">
                   <span class={`px-2 py-0.5 rounded-full text-[0.65rem] font-medium border ${statusCls}`}>
-                    {t(statusKey)}
+                    {statusIcon} {t(statusKey)}
                   </span>
                 </span>
                 {onToggleStatus && (() => {


### PR DESCRIPTION
## Summary

- Account cards: 4px colored left border by status (green/red/amber/blue/slate/rose)
- Banned and expired cards have tinted background (rose/red), disabled cards dimmed (opacity-60)
- Status badges now include icon prefix for instant recognition:
  - ● Active, ⏱ Expired, ⏳ Rate Limited, ↻ Refreshing, ○ Disabled, ⛔ Banned
- Table rows: banned/expired/disabled rows have matching background tint
- Table status column widened (w-20 → w-24) to fit icon + text

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — 1242 tests pass
- [ ] Visual check at `localhost:8080` — card view + table view, light/dark theme