### PR TITLE
feat: 4-tab dashboard layout + responsive card fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - `proxy-handler.ts`（353 LOC）拆分为 3 个独立可测试模块：`account-acquisition.ts`（acquire/release + 幂等 guard）、`proxy-error-handler.ts`（4 种错误分类 + 池状态变更）、`response-processor.ts`（流式/非流式响应），26 个新测试
 - `AccountPool`（673 LOC）拆分为 `AccountRegistry`（状态 + CRUD + 查询，423 LOC）+ `AccountLifecycle`（锁 + 轮换，154 LOC），facade 219 LOC 编排。37 个 importer 零改动
 - `model-fetcher.ts` 和 `usage-refresher.ts` 从模块级单例重构为 `ModelFetcher` / `UsageRefresher` class，自由函数 wrapper 保持后向兼容
+- Dashboard 改为 4-tab 布局（概览/管理账号/代理分配/设置），设置面板从首页移至独立 tab，首页保留账号卡片 + 代理池
+- AccountCard 响应式修复：窄屏时操作按钮自动换行不再溢出
 
 ### Fixed
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,17 +5,10 @@ import { I18nProvider } from "../../shared/i18n/context";
 import { ThemeProvider } from "../../shared/theme/context";
 import { Header } from "./components/Header";
 import { UpdateModal } from "./components/UpdateModal";
-import { AccountList } from "./components/AccountList";
 import { AddAccount } from "./components/AddAccount";
+import { AccountList } from "./components/AccountList";
+import { SettingsTab } from "./components/SettingsTab";
 import { ProxyPool } from "./components/ProxyPool";
-import { ApiConfig } from "./components/ApiConfig";
-import { AnthropicSetup } from "./components/AnthropicSetup";
-import { CodeExamples } from "./components/CodeExamples";
-import { SettingsPanel } from "./components/SettingsPanel";
-import { GeneralSettings } from "./components/GeneralSettings";
-import { QuotaSettings } from "./components/QuotaSettings";
-import { RotationSettings } from "./components/RotationSettings";
-import { TestConnection } from "./components/TestConnection";
 import { Footer } from "./components/Footer";
 import { ProxySettings } from "./pages/ProxySettings";
 import { AccountManagement } from "./pages/AccountManagement";
@@ -24,10 +17,10 @@ import { useAccounts } from "../../shared/hooks/use-accounts";
 import { useProxies } from "../../shared/hooks/use-proxies";
 import { useStatus } from "../../shared/hooks/use-status";
 import { useUpdateStatus } from "../../shared/hooks/use-update-status";
-import { useI18n } from "../../shared/i18n/context";
+import { useI18n, useT } from "../../shared/i18n/context";
 import { useDashboardAuth } from "../../shared/hooks/use-dashboard-auth";
+import type { TranslationKey } from "../../shared/i18n/translations";
 
-/** Context for dashboard session state (logout button, remote session indicator). */
 const DashboardAuthCtx = createContext<{ onLogout?: () => void }>({});
 function useDashboardAuthCtx() { return useContext(DashboardAuthCtx); }
 
@@ -41,43 +34,56 @@ function useUpdateMessage() {
   if (!update.checking && update.result) {
     const parts: string[] = [];
     const r = update.result;
-
-    if (r.proxy?.error) {
-      parts.push(`Proxy: ${r.proxy.error}`);
-      color = "text-red-500";
-    } else if (r.proxy?.update_available) {
-      parts.push(t("updateAvailable"));
-      color = "text-amber-500";
-    }
-
-    if (r.codex?.error) {
-      parts.push(`Codex: ${r.codex.error}`);
-      color = "text-red-500";
-    } else if (r.codex_update_in_progress) {
-      parts.push(t("fingerprintUpdating"));
-    } else if (r.codex?.version_changed) {
-      parts.push(`Codex: v${r.codex.current_version}`);
-      color = "text-blue-500";
-    }
-
+    if (r.proxy?.error) { parts.push(`Proxy: ${r.proxy.error}`); color = "text-red-500"; }
+    else if (r.proxy?.update_available) { parts.push(t("updateAvailable")); color = "text-amber-500"; }
+    if (r.codex?.error) { parts.push(`Codex: ${r.codex.error}`); color = "text-red-500"; }
+    else if (r.codex_update_in_progress) { parts.push(t("fingerprintUpdating")); }
+    else if (r.codex?.version_changed) { parts.push(`Codex: v${r.codex.current_version}`); color = "text-blue-500"; }
     msg = parts.length > 0 ? parts.join(" · ") : t("upToDate");
-  } else if (!update.checking && update.error) {
-    msg = update.error;
-    color = "text-red-500";
-  }
+  } else if (!update.checking && update.error) { msg = update.error; color = "text-red-500"; }
 
   const hasUpdate = update.status?.proxy.update_available ?? false;
   const proxyUpdateInfo = hasUpdate
-    ? {
-        mode: update.status!.proxy.mode,
-        commits: update.status!.proxy.commits,
-        changelog: update.status!.proxy.changelog ?? null,
-        release: update.status!.proxy.release,
-      }
+    ? { mode: update.status!.proxy.mode, commits: update.status!.proxy.commits, changelog: update.status!.proxy.changelog ?? null, release: update.status!.proxy.release }
     : null;
 
   return { ...update, msg, color, hasUpdate, proxyUpdateInfo };
 }
+
+// ── Tab definitions ─────────────────────────────────────────────────
+
+const TABS: Array<{ hash: string; label: TranslationKey }> = [
+  { hash: "", label: "overview" },
+  { hash: "#/accounts", label: "manageAccounts" },
+  { hash: "#/proxies", label: "proxySettings" },
+  { hash: "#/settings", label: "settings" },
+];
+
+function TabBar({ activeHash }: { activeHash: string }) {
+  const t = useT();
+  return (
+    <div class="flex items-center gap-1.5 mb-4">
+      {TABS.map((tab) => {
+        const isActive = activeHash === tab.hash;
+        return (
+          <a
+            key={tab.hash}
+            href={tab.hash || "#/"}
+            class={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              isActive
+                ? "bg-primary/10 text-primary dark:bg-primary/20"
+                : "text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark"
+            }`}
+          >
+            {t(tab.label)}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Dashboard ───────────────────────────────────────────────────────
 
 function Dashboard() {
   const accounts = useAccounts();
@@ -87,9 +93,8 @@ function Dashboard() {
   const { onLogout } = useDashboardAuthCtx();
   const [showModal, setShowModal] = useState(false);
   const prevUpdateAvailable = useRef(false);
+  const hash = useHash();
 
-  // Auto-open modal when update becomes available after a check
-  // (Electron has its own native auto-updater — don't show web modal)
   useEffect(() => {
     if (update.hasUpdate && !prevUpdateAvailable.current && update.proxyUpdateInfo?.mode !== "electron") {
       setShowModal(true);
@@ -101,6 +106,33 @@ function Dashboard() {
     accounts.patchLocal(accountId, { proxyId });
     await proxies.assignProxy(accountId, proxyId);
   };
+
+  // Redirect legacy routes
+  if (hash === "#/account-management") { location.hash = "#/accounts"; return null; }
+  if (hash === "#/proxy-settings") { location.hash = "#/proxies"; return null; }
+
+  // Usage stats stays standalone (separate page with its own header)
+  if (hash === "#/usage-stats") {
+    return (
+      <>
+        <Header
+          onAddAccount={accounts.startAdd}
+          onCheckUpdate={update.checkForUpdate}
+          onOpenUpdateModal={() => setShowModal(true)}
+          checking={update.checking}
+          updateStatusMsg={update.msg}
+          updateStatusColor={update.color}
+          version={update.status?.proxy.version ?? null}
+          commit={update.status?.proxy.commit ?? null}
+          hasUpdate={update.hasUpdate}
+          onLogout={onLogout}
+        />
+        <UsageStats />
+      </>
+    );
+  }
+
+  const activeTab = TABS.find((t) => t.hash === hash)?.hash ?? "";
 
   return (
     <>
@@ -116,8 +148,9 @@ function Dashboard() {
         hasUpdate={update.hasUpdate}
         onLogout={onLogout}
       />
+
       <main class="flex-grow px-4 md:px-8 lg:px-40 py-8 flex justify-center">
-        <div class="flex flex-col w-full max-w-[960px] gap-6">
+        <div class="flex flex-col w-full max-w-[960px]">
           <AddAccount
             visible={accounts.addVisible}
             onSubmitRelay={accounts.submitRelay}
@@ -125,54 +158,58 @@ function Dashboard() {
             addInfo={accounts.addInfo}
             addError={accounts.addError}
           />
-          <AccountList
-            accounts={accounts.list}
-            loading={accounts.loading}
-            onDelete={accounts.deleteAccount}
-            onRefresh={accounts.refresh}
-            refreshing={accounts.refreshing}
-            lastUpdated={accounts.lastUpdated}
-            proxies={proxies.proxies}
-            onProxyChange={handleProxyChange}
-            onExport={accounts.exportAccounts}
-            onImport={accounts.importAccounts}
-            onToggleStatus={accounts.toggleStatus}
-            onUpdateLabel={accounts.updateLabel}
-            onAddByRefreshToken={accounts.addByRefreshToken}
-          />
-          <ProxyPool proxies={proxies} />
-          <ApiConfig
-            baseUrl={status.baseUrl}
-            apiKey={status.apiKey}
-            models={status.models}
-            selectedModel={status.selectedModel}
-            onModelChange={status.setSelectedModel}
-            modelFamilies={status.modelFamilies}
-            selectedEffort={status.selectedEffort}
-            onEffortChange={status.setSelectedEffort}
-            selectedSpeed={status.selectedSpeed}
-            onSpeedChange={status.setSelectedSpeed}
-          />
-          <AnthropicSetup
-            apiKey={status.apiKey}
-            selectedModel={status.selectedModel}
-            reasoningEffort={status.selectedEffort}
-            serviceTier={status.selectedSpeed}
-          />
-          <CodeExamples
-            baseUrl={status.baseUrl}
-            apiKey={status.apiKey}
-            model={status.selectedModel}
-            reasoningEffort={status.selectedEffort}
-            serviceTier={status.selectedSpeed}
-          />
-          <SettingsPanel />
-          <GeneralSettings />
-          <QuotaSettings />
-          <RotationSettings />
-          <TestConnection />
+
+          <TabBar activeHash={activeTab} />
+
+          {activeTab === "" && (
+            <div class="flex flex-col gap-6">
+              <AccountList
+                accounts={accounts.list}
+                loading={accounts.loading}
+                onDelete={accounts.deleteAccount}
+                onRefresh={accounts.refresh}
+                refreshing={accounts.refreshing}
+                lastUpdated={accounts.lastUpdated}
+                proxies={proxies.proxies}
+                onProxyChange={handleProxyChange}
+                onExport={accounts.exportAccounts}
+                onImport={accounts.importAccounts}
+                onToggleStatus={accounts.toggleStatus}
+                onUpdateLabel={accounts.updateLabel}
+                onAddByRefreshToken={accounts.addByRefreshToken}
+              />
+              <ProxyPool proxies={proxies} />
+            </div>
+          )}
+
+          {activeTab === "#/accounts" && (
+            <AccountManagement embedded />
+          )}
+
+          {activeTab === "#/proxies" && (
+            <div class="flex flex-col gap-6">
+              <ProxyPool proxies={proxies} />
+              <ProxySettings embedded />
+            </div>
+          )}
+
+          {activeTab === "#/settings" && (
+            <SettingsTab
+              baseUrl={status.baseUrl}
+              apiKey={status.apiKey}
+              models={status.models}
+              selectedModel={status.selectedModel}
+              onModelChange={status.setSelectedModel}
+              modelFamilies={status.modelFamilies}
+              selectedEffort={status.selectedEffort}
+              onEffortChange={status.setSelectedEffort}
+              selectedSpeed={status.selectedSpeed}
+              onSpeedChange={status.setSelectedSpeed}
+            />
+          )}
         </div>
       </main>
+
       <Footer updateStatus={update.status} />
       {update.proxyUpdateInfo && (
         <UpdateModal
@@ -193,6 +230,8 @@ function Dashboard() {
   );
 }
 
+// ── Utilities ────────────────────────────────────────────────────────
+
 function useHash(): string {
   const [hash, setHash] = useState(location.hash);
   useEffect(() => {
@@ -201,15 +240,6 @@ function useHash(): string {
     return () => window.removeEventListener("hashchange", handler);
   }, []);
   return hash;
-}
-
-function PageRouter({ hash }: { hash: string }) {
-  switch (hash) {
-    case "#/proxy-settings": return <ProxySettingsPage />;
-    case "#/account-management": return <AccountManagement />;
-    case "#/usage-stats": return <UsageStats />;
-    default: return <Dashboard />;
-  }
 }
 
 function LoginGate({ children }: { children: ComponentChildren }) {
@@ -226,11 +256,7 @@ function LoginGate({ children }: { children: ComponentChildren }) {
   }
 
   if (auth.status === "login") {
-    const handleSubmit = (e: Event) => {
-      e.preventDefault();
-      if (password.trim()) auth.login(password.trim());
-    };
-
+    const handleSubmit = (e: Event) => { e.preventDefault(); if (password.trim()) auth.login(password.trim()); };
     return (
       <div class="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-bg-dark px-4">
         <div class="w-full max-w-sm bg-white dark:bg-card-dark border border-gray-200 dark:border-border-dark rounded-2xl shadow-lg p-8">
@@ -246,24 +272,16 @@ function LoginGate({ children }: { children: ComponentChildren }) {
           <form onSubmit={handleSubmit} class="flex flex-col gap-4">
             <div>
               <label class="block text-xs font-medium text-slate-600 dark:text-text-dim mb-1.5">{t("dashboardPassword")}</label>
-              <input
-                type="password"
-                value={password}
-                onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
+              <input type="password" value={password} onInput={(e) => setPassword((e.target as HTMLInputElement).value)}
                 class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-sm text-slate-800 dark:text-text-main focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary transition-colors"
-                placeholder="proxy_api_key"
-                autofocus
-              />
+                placeholder="proxy_api_key" autofocus />
             </div>
             {auth.error && (
               <p class="text-xs text-red-500 font-medium">
                 {auth.error.includes("Too many") ? t("dashboardTooManyAttempts") : t("dashboardLoginError")}
               </p>
             )}
-            <button
-              type="submit"
-              class="w-full py-2.5 bg-primary hover:bg-primary-hover text-white text-sm font-semibold rounded-lg transition-colors shadow-sm active:scale-[0.98]"
-            >
+            <button type="submit" class="w-full py-2.5 bg-primary hover:bg-primary-hover text-white text-sm font-semibold rounded-lg transition-colors shadow-sm active:scale-[0.98]">
               {t("dashboardLoginBtn")}
             </button>
           </form>
@@ -277,36 +295,13 @@ function LoginGate({ children }: { children: ComponentChildren }) {
 }
 
 export function App() {
-  const hash = useHash();
-
   return (
     <I18nProvider>
       <ThemeProvider>
         <LoginGate>
-          <PageRouter hash={hash} />
+          <Dashboard />
         </LoginGate>
       </ThemeProvider>
     </I18nProvider>
-  );
-}
-
-function ProxySettingsPage() {
-  const update = useUpdateMessage();
-
-  return (
-    <>
-      <Header
-        onAddAccount={() => { location.hash = ""; }}
-        onCheckUpdate={update.checkForUpdate}
-        checking={update.checking}
-        updateStatusMsg={update.msg}
-        updateStatusColor={update.color}
-        version={update.status?.proxy.version ?? null}
-        commit={update.status?.proxy.commit ?? null}
-        isProxySettings
-        hasUpdate={update.hasUpdate}
-      />
-      <ProxySettings />
-    </>
   );
 }

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -164,8 +164,8 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
   return (
     <div class={`bg-white dark:bg-card-dark border rounded-xl p-4 shadow-sm hover:shadow-md transition-all ${selected ? "border-primary ring-1 ring-primary/30" : "border-gray-200 dark:border-border-dark hover:border-primary/30 dark:hover:border-primary/50"}`}>
       {/* Header */}
-      <div class="flex justify-between items-start mb-4">
-        <div class="flex items-center gap-3">
+      <div class="flex flex-wrap justify-between items-start gap-2 mb-4">
+        <div class="flex items-center gap-3 min-w-0 flex-1">
           {onToggleSelect && (
             <input
               type="checkbox"
@@ -218,7 +218,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 shrink-0 flex-wrap">
           {onToggleStatus && (
             <button
               onClick={handleStatusToggle}

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -96,32 +96,7 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
         </div>
       </div>
 
-      {/* Row 2: Navigation tabs */}
-      <div class="flex items-center gap-1.5">
-        <span class="px-3 py-1.5 rounded-lg text-xs font-medium bg-primary/10 text-primary dark:bg-primary/20">
-          {t("overview")}
-        </span>
-        <a
-          href="#/account-management"
-          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
-        >
-          {t("manageAccounts")}
-        </a>
-        <a
-          href="#/proxy-settings"
-          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
-        >
-          {t("proxySettings")}
-        </a>
-        <a
-          href="#/usage-stats"
-          class="px-3 py-1.5 rounded-lg text-xs font-medium text-slate-500 dark:text-text-dim hover:bg-slate-100 dark:hover:bg-border-dark transition-colors"
-        >
-          {t("usageStats")}
-        </a>
-      </div>
-
-      {/* Row 3: Action toolbar */}
+      {/* Action toolbar */}
       <div class="flex items-center gap-1.5 flex-wrap">
         {/* Refresh list */}
         <button

--- a/web/src/components/SettingsTab.tsx
+++ b/web/src/components/SettingsTab.tsx
@@ -1,0 +1,58 @@
+import { GeneralSettings } from "./GeneralSettings";
+import { QuotaSettings } from "./QuotaSettings";
+import { RotationSettings } from "./RotationSettings";
+import { SettingsPanel } from "./SettingsPanel";
+import { ApiConfig } from "./ApiConfig";
+import { AnthropicSetup } from "./AnthropicSetup";
+import { CodeExamples } from "./CodeExamples";
+import { TestConnection } from "./TestConnection";
+
+interface SettingsTabProps {
+  baseUrl: string;
+  apiKey: string;
+  models: string[];
+  selectedModel: string;
+  onModelChange: (model: string) => void;
+  modelFamilies: Record<string, string[]>;
+  selectedEffort: string;
+  onEffortChange: (effort: string) => void;
+  selectedSpeed: string;
+  onSpeedChange: (speed: string) => void;
+}
+
+export function SettingsTab(props: SettingsTabProps) {
+  return (
+    <div class="flex flex-col gap-6">
+      <GeneralSettings />
+      <QuotaSettings />
+      <RotationSettings />
+      <SettingsPanel />
+      <ApiConfig
+        baseUrl={props.baseUrl}
+        apiKey={props.apiKey}
+        models={props.models}
+        selectedModel={props.selectedModel}
+        onModelChange={props.onModelChange}
+        modelFamilies={props.modelFamilies}
+        selectedEffort={props.selectedEffort}
+        onEffortChange={props.onEffortChange}
+        selectedSpeed={props.selectedSpeed}
+        onSpeedChange={props.onSpeedChange}
+      />
+      <AnthropicSetup
+        apiKey={props.apiKey}
+        selectedModel={props.selectedModel}
+        reasoningEffort={props.selectedEffort}
+        serviceTier={props.selectedSpeed}
+      />
+      <CodeExamples
+        baseUrl={props.baseUrl}
+        apiKey={props.apiKey}
+        model={props.selectedModel}
+        reasoningEffort={props.selectedEffort}
+        serviceTier={props.selectedSpeed}
+      />
+      <TestConnection />
+    </div>
+  );
+}

--- a/web/src/pages/AccountManagement.tsx
+++ b/web/src/pages/AccountManagement.tsx
@@ -16,7 +16,7 @@ const statusOrder: Array<{ key: string; label: TranslationKey }> = [
   { key: "banned", label: "banned" },
 ];
 
-export function AccountManagement() {
+export function AccountManagement({ embedded }: { embedded?: boolean } = {}) {
   const t = useT();
   const { list, loading: listLoading, batchDelete, batchSetStatus, toggleStatus, exportAccounts, importAccounts } = useAccounts();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -98,31 +98,16 @@ export function AccountManagement() {
     setStatusFilter((prev) => (prev === status ? "all" : status));
   }, []);
 
-  return (
-    <div class="min-h-screen bg-slate-50 dark:bg-bg-dark flex flex-col">
-      {/* Header */}
-      <header class="sticky top-0 z-50 bg-white dark:bg-card-dark border-b border-gray-200 dark:border-border-dark px-4 py-3">
-        <div class="max-w-[1100px] mx-auto flex items-center gap-3">
-          <a
-            href="#/"
-            class="text-sm text-slate-500 dark:text-text-dim hover:text-primary transition-colors"
-          >
-            &larr; {t("backToDashboard")}
-          </a>
-          <h1 class="text-base font-semibold text-slate-800 dark:text-text-main">
-            {t("accountManagement")}
-          </h1>
-          <div class="flex-1" />
-          <AccountImportExport
-            onExport={exportAccounts}
-            onImport={importAccounts}
-            selectedIds={selectedIds}
-          />
-        </div>
-      </header>
-
-      {/* Main content */}
-      <main class="flex-grow px-4 md:px-8 py-6 max-w-[1100px] mx-auto w-full">
+  const content = (
+    <>
+      {/* Import/Export toolbar (always shown) */}
+      <div class="flex items-center justify-end mb-3">
+        <AccountImportExport
+          onExport={exportAccounts}
+          onImport={importAccounts}
+          selectedIds={selectedIds}
+        />
+      </div>
         {/* Status summary chips */}
         <div class="flex flex-wrap gap-2 mb-4">
           {statusOrder.map(({ key, label }) => {
@@ -172,7 +157,6 @@ export function AccountManagement() {
             onToggleStatus={toggleStatus}
           />
         )}
-      </main>
 
       {/* Bulk actions bar */}
       <AccountBulkActions
@@ -182,6 +166,24 @@ export function AccountManagement() {
         onSetActive={handleSetActive}
         onSetDisabled={handleSetDisabled}
       />
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <div class="min-h-screen bg-slate-50 dark:bg-bg-dark flex flex-col">
+      <header class="sticky top-0 z-50 bg-white dark:bg-card-dark border-b border-gray-200 dark:border-border-dark px-4 py-3">
+        <div class="max-w-[1100px] mx-auto flex items-center gap-3">
+          <a href="#/" class="text-sm text-slate-500 dark:text-text-dim hover:text-primary transition-colors">
+            &larr; {t("backToDashboard")}
+          </a>
+          <h1 class="text-base font-semibold text-slate-800 dark:text-text-main">{t("accountManagement")}</h1>
+        </div>
+      </header>
+      <main class="flex-grow px-4 md:px-8 py-6 max-w-[1100px] mx-auto w-full">
+        {content}
+      </main>
     </div>
   );
 }

--- a/web/src/pages/ProxySettings.tsx
+++ b/web/src/pages/ProxySettings.tsx
@@ -7,7 +7,7 @@ import { BulkActions } from "../components/BulkActions";
 import { ImportExport } from "../components/ImportExport";
 import { RuleAssign } from "../components/RuleAssign";
 
-export function ProxySettings() {
+export function ProxySettings({ embedded }: { embedded?: boolean } = {}) {
   const t = useT();
   const data = useProxyAssignments();
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
@@ -64,25 +64,39 @@ export function ProxySettings() {
 
   return (
     <div class="flex flex-col flex-grow">
-      {/* Top bar */}
-      <div class="px-4 md:px-8 lg:px-40 py-4 border-b border-gray-200 dark:border-border-dark bg-white dark:bg-card-dark">
-        <div class="flex items-center justify-between max-w-[1200px] mx-auto">
-          <div>
-            <h2 class="text-lg font-bold">{t("proxySettings")}</h2>
-            <p class="text-xs text-slate-500 dark:text-text-dim mt-0.5">
-              {t("proxySettingsDesc")}
-            </p>
+      {/* Top bar — hidden when embedded in tabs */}
+      {!embedded && (
+        <div class="px-4 md:px-8 lg:px-40 py-4 border-b border-gray-200 dark:border-border-dark bg-white dark:bg-card-dark">
+          <div class="flex items-center justify-between max-w-[1200px] mx-auto">
+            <div>
+              <h2 class="text-lg font-bold">{t("proxySettings")}</h2>
+              <p class="text-xs text-slate-500 dark:text-text-dim mt-0.5">
+                {t("proxySettingsDesc")}
+              </p>
+            </div>
+            <ImportExport
+              onExport={data.exportAssignments}
+              onImportPreview={data.importPreview}
+              onApplyImport={data.applyImport}
+            />
           </div>
+        </div>
+      )}
+
+      {/* Import/Export toolbar when embedded */}
+      {embedded && (
+        <div class="flex items-center justify-between mb-3">
+          <p class="text-xs text-slate-500 dark:text-text-dim">{t("proxySettingsDesc")}</p>
           <ImportExport
             onExport={data.exportAssignments}
             onImportPreview={data.importPreview}
             onApplyImport={data.applyImport}
           />
         </div>
-      </div>
+      )}
 
       {/* Main content */}
-      <div class="flex-grow px-4 md:px-8 lg:px-40 py-6">
+      <div class={embedded ? "" : "flex-grow px-4 md:px-8 lg:px-40 py-6"}>
         <div class="flex gap-6 max-w-[1200px] mx-auto">
           {/* Left sidebar — proxy groups */}
           <div class="w-56 shrink-0 hidden lg:block">


### PR DESCRIPTION
## Summary

- Dashboard restructured into 4 tabs: Overview / Accounts / Proxies / Settings
- Overview tab = original account cards + proxy pool (unchanged)
- Settings tab consolidates all config panels (General, Quota, Rotation, API Key, Anthropic Setup, Code Examples, Test Connection)
- AccountManagement and ProxySettings support `embedded` prop for tab embedding
- Removed duplicate tab bar from AccountList
- Fixed AccountCard header overflow on narrow screens (flex-wrap)
- Legacy routes (#/account-management, #/proxy-settings) auto-redirect

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 1242 tests pass
- [ ] Visual: Overview tab shows cards + proxy pool
- [ ] Visual: Settings tab shows all config panels
- [ ] Visual: Narrow window — card buttons wrap correctly
- [ ] Visual: Light/dark theme