### PR TITLE
fix: oaistb_rt_ single-use handling + footer sticky to bottom (#213)

### DIFF
--- a/src/auth/refresh-scheduler.ts
+++ b/src/auth/refresh-scheduler.ts
@@ -18,7 +18,7 @@ import type { AccountPool } from "./account-pool.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 
 /** Errors that indicate the refresh token itself is invalid (permanent failure). */
-const PERMANENT_ERRORS = ["invalid_grant", "invalid_token", "access_denied", "refresh_token_expired", "account has been deactivated"];
+const PERMANENT_ERRORS = ["invalid_grant", "invalid_token", "access_denied", "refresh_token_expired", "refresh_token_reused", "account has been deactivated"];
 
 const MAX_ATTEMPTS = 5;
 const BASE_DELAY_MS = 5_000;
@@ -201,14 +201,25 @@ export class RefreshScheduler {
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
+        const isOneTimeRT = entry.refreshToken.startsWith("oaistb_rt_");
         const tokens = await refreshAccessToken(entry.refreshToken, accountProxyUrl);
-        // Update token and refresh_token (if a new one was issued)
+
+        // oaistb_rt_ tokens are single-use: the old RT is revoked after exchange.
+        // If the server didn't return a new RT, mark the account as unable to refresh.
+        if (isOneTimeRT && !tokens.refresh_token) {
+          console.warn(`[RefreshScheduler] Account ${entryId}: oaistb_rt_ used but no new RT returned — future refresh will fail`);
+          this.pool.updateToken(entryId, tokens.access_token, null);
+          this.scheduleOne(entryId, tokens.access_token);
+          return;
+        }
+
         this.pool.updateToken(
           entryId,
           tokens.access_token,
           tokens.refresh_token,
         );
-        console.log(`[RefreshScheduler] Account ${entryId} refreshed successfully`);
+        const rtType = isOneTimeRT ? " (oaistb_rt_ → rotated)" : "";
+        console.log(`[RefreshScheduler] Account ${entryId} refreshed successfully${rtType}`);
         this.scheduleOne(entryId, tokens.access_token);
         return;
       } catch (err) {

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -145,10 +145,13 @@ export class AccountImportService {
           kind: "validation",
         };
       }
+      // oaistb_rt_ tokens are single-use — if no new RT returned, the old one is dead
+      const isOneTimeRT = rt?.startsWith("oaistb_rt_");
+      const newRT = tokens.refresh_token ?? (isOneTimeRT ? null : rt);
       return {
         ok: true,
         token: tokens.access_token,
-        rt: tokens.refresh_token ?? rt,
+        rt: newRT,
       };
     } catch (err) {
       return {

--- a/src/tls/curl-cli-transport.ts
+++ b/src/tls/curl-cli-transport.ts
@@ -13,7 +13,7 @@ import type { TlsTransport, TlsTransportResponse } from "./transport.js";
 import { getConfig } from "../config.js";
 
 const STATUS_SEPARATOR = "\n__CURL_HTTP_STATUS__";
-const DEFAULT_HEADER_TIMEOUT_MS = 30_000;
+const DEFAULT_HEADER_TIMEOUT_MS = 120_000;
 
 function getHeaderTimeoutMs(): number {
   try {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -135,7 +135,7 @@ function Dashboard() {
   const activeTab = TABS.find((t) => t.hash === hash)?.hash ?? "";
 
   return (
-    <>
+    <div class="min-h-screen flex flex-col bg-slate-50 dark:bg-bg-dark">
       <Header
         onAddAccount={accounts.startAdd}
         onCheckUpdate={update.checkForUpdate}
@@ -226,7 +226,7 @@ function Dashboard() {
           updateSteps={update.updateSteps}
         />
       )}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Handle `oaistb_rt_` single-use refresh tokens: store new RT on rotation, null if none returned
- Add `refresh_token_reused` to permanent error list
- Increase header timeout from 30s to 120s for high-reasoning models
- Fix footer not sticking to bottom on short pages (Closes #213): wrap Dashboard in `min-h-screen flex flex-col`

## Test plan

- [x] `npm run build` + `npm test` — 1242 pass
- [ ] Visual: footer sticks to bottom with few accounts on maximized window