### PR TITLE
fix: usage stats baseline + restore usage tab

### DIFF
--- a/src/auth/__tests__/usage-stats.test.ts
+++ b/src/auth/__tests__/usage-stats.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests for UsageStatsStore — snapshot recording, delta computation, aggregation.
+ * Tests for UsageStatsStore — snapshot recording, delta computation, aggregation,
+ * and baseline preservation across account pool resets.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -8,15 +9,20 @@ vi.mock("../../paths.js", () => ({
   getDataDir: vi.fn(() => "/tmp/test-data"),
 }));
 
-import { UsageStatsStore, type UsageStatsPersistence, type UsageSnapshot } from "../usage-stats.js";
+import { UsageStatsStore, type UsageStatsPersistence, type UsageSnapshot, type UsageBaseline } from "../usage-stats.js";
 import type { AccountPool } from "../account-pool.js";
 
-function createMockPersistence(initial: UsageSnapshot[] = []): UsageStatsPersistence & { saved: UsageSnapshot[] } {
+function createMockPersistence(
+  initial: UsageSnapshot[] = [],
+  baseline?: UsageBaseline,
+): UsageStatsPersistence & { saved: UsageSnapshot[]; savedBaseline?: UsageBaseline } {
   const store = {
     saved: initial,
-    load: () => ({ version: 1 as const, snapshots: [...initial] }),
-    save: vi.fn((data: { version: 1; snapshots: UsageSnapshot[] }) => {
+    savedBaseline: baseline,
+    load: () => ({ version: 1 as const, snapshots: [...initial], baseline }),
+    save: vi.fn((data: { version: 1; snapshots: UsageSnapshot[]; baseline?: UsageBaseline }) => {
       store.saved = data.snapshots;
+      store.savedBaseline = data.baseline;
     }),
   };
   return store;
@@ -89,7 +95,7 @@ describe("UsageStatsStore", () => {
   });
 
   describe("getSummary", () => {
-    it("returns live totals from pool", () => {
+    it("returns live totals from pool when no baseline", () => {
       const pool = createMockPool([
         { status: "active", input_tokens: 1000, output_tokens: 200, request_count: 5 },
         { status: "disabled", input_tokens: 500, output_tokens: 100, request_count: 3 },
@@ -103,6 +109,154 @@ describe("UsageStatsStore", () => {
         total_accounts: 2,
         active_accounts: 1,
       });
+    });
+
+    it("includes baseline in summary totals", () => {
+      persistence = createMockPersistence([], {
+        input_tokens: 10000,
+        output_tokens: 2000,
+        request_count: 100,
+      });
+      store = new UsageStatsStore(persistence);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 500, output_tokens: 50, request_count: 5 },
+      ]);
+
+      const summary = store.getSummary(pool);
+      expect(summary.total_input_tokens).toBe(10500);
+      expect(summary.total_output_tokens).toBe(2050);
+      expect(summary.total_request_count).toBe(105);
+    });
+  });
+
+  describe("baseline — pool reset detection", () => {
+    it("absorbs lost usage into baseline when pool totals drop", () => {
+      const now = Date.now();
+      const snapshots: UsageSnapshot[] = [
+        {
+          timestamp: new Date(now - 3600_000).toISOString(),
+          totals: { input_tokens: 10000, output_tokens: 2000, request_count: 100, active_accounts: 5 },
+        },
+      ];
+
+      persistence = createMockPersistence(snapshots);
+      store = new UsageStatsStore(persistence);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 500, output_tokens: 50, request_count: 5 },
+      ]);
+
+      store.recordSnapshot(pool);
+
+      expect(store.currentBaseline).toEqual({
+        input_tokens: 9500,
+        output_tokens: 1950,
+        request_count: 95,
+      });
+
+      const lastSnapshot = persistence.saved[persistence.saved.length - 1];
+      expect(lastSnapshot.totals.input_tokens).toBe(10000);
+      expect(lastSnapshot.totals.output_tokens).toBe(2000);
+      expect(lastSnapshot.totals.request_count).toBe(100);
+    });
+
+    it("accumulates baseline across multiple resets", () => {
+      const now = Date.now();
+
+      const snapshots: UsageSnapshot[] = [
+        {
+          timestamp: new Date(now - 3600_000).toISOString(),
+          totals: { input_tokens: 15000, output_tokens: 3000, request_count: 150, active_accounts: 3 },
+        },
+      ];
+      const existingBaseline: UsageBaseline = {
+        input_tokens: 5000,
+        output_tokens: 1000,
+        request_count: 50,
+      };
+
+      persistence = createMockPersistence(snapshots, existingBaseline);
+      store = new UsageStatsStore(persistence);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 200, output_tokens: 20, request_count: 2 },
+      ]);
+
+      store.recordSnapshot(pool);
+
+      expect(store.currentBaseline.input_tokens).toBe(14800);
+      expect(store.currentBaseline.output_tokens).toBe(2980);
+      expect(store.currentBaseline.request_count).toBe(148);
+    });
+
+    it("does not adjust baseline when pool totals increase normally", () => {
+      const now = Date.now();
+      const snapshots: UsageSnapshot[] = [
+        {
+          timestamp: new Date(now - 3600_000).toISOString(),
+          totals: { input_tokens: 1000, output_tokens: 200, request_count: 10, active_accounts: 2 },
+        },
+      ];
+
+      persistence = createMockPersistence(snapshots);
+      store = new UsageStatsStore(persistence);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 1500, output_tokens: 300, request_count: 15 },
+      ]);
+
+      store.recordSnapshot(pool);
+
+      expect(store.currentBaseline).toEqual({
+        input_tokens: 0,
+        output_tokens: 0,
+        request_count: 0,
+      });
+    });
+
+    it("persists baseline to disk", () => {
+      const now = Date.now();
+      const snapshots: UsageSnapshot[] = [
+        {
+          timestamp: new Date(now - 3600_000).toISOString(),
+          totals: { input_tokens: 5000, output_tokens: 500, request_count: 50, active_accounts: 1 },
+        },
+      ];
+
+      persistence = createMockPersistence(snapshots);
+      store = new UsageStatsStore(persistence);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 100, output_tokens: 10, request_count: 1 },
+      ]);
+
+      store.recordSnapshot(pool);
+
+      expect(persistence.savedBaseline).toEqual({
+        input_tokens: 4900,
+        output_tokens: 490,
+        request_count: 49,
+      });
+    });
+
+    it("loads baseline from persisted data", () => {
+      const baseline: UsageBaseline = {
+        input_tokens: 50000,
+        output_tokens: 10000,
+        request_count: 500,
+      };
+
+      persistence = createMockPersistence([], baseline);
+      store = new UsageStatsStore(persistence);
+
+      expect(store.currentBaseline).toEqual(baseline);
+
+      const pool = createMockPool([
+        { status: "active", input_tokens: 100, output_tokens: 10, request_count: 1 },
+      ]);
+      const summary = store.getSummary(pool);
+      expect(summary.total_input_tokens).toBe(50100);
     });
   });
 
@@ -191,12 +345,8 @@ describe("UsageStatsStore", () => {
       store = new UsageStatsStore(persistence);
 
       const hourly = store.getHistory(2, "hourly");
-      // Two buckets: one before hourStart, one at/after hourStart
       expect(hourly).toHaveLength(2);
-
-      // Previous hour bucket: delta 0→100 = 100
       expect(hourly[0].input_tokens).toBe(100);
-      // Current hour bucket: delta 100→300 + 300→500 = 200 + 200 = 400
       expect(hourly[1].input_tokens).toBe(400);
     });
 
@@ -204,11 +354,11 @@ describe("UsageStatsStore", () => {
       const now = Date.now();
       const snapshots: UsageSnapshot[] = [
         {
-          timestamp: new Date(now - 48 * 3600_000).toISOString(), // 48h ago
+          timestamp: new Date(now - 48 * 3600_000).toISOString(),
           totals: { input_tokens: 100, output_tokens: 10, request_count: 1, active_accounts: 1 },
         },
         {
-          timestamp: new Date(now - 12 * 3600_000).toISOString(), // 12h ago
+          timestamp: new Date(now - 12 * 3600_000).toISOString(),
           totals: { input_tokens: 500, output_tokens: 50, request_count: 5, active_accounts: 1 },
         },
         {
@@ -220,7 +370,6 @@ describe("UsageStatsStore", () => {
       persistence = createMockPersistence(snapshots);
       store = new UsageStatsStore(persistence);
 
-      // Only last 24h → only the last two snapshots qualify → 1 delta
       const raw = store.getHistory(24, "raw");
       expect(raw).toHaveLength(1);
       expect(raw[0].input_tokens).toBe(500);
@@ -232,11 +381,11 @@ describe("UsageStatsStore", () => {
       const now = Date.now();
       const old: UsageSnapshot[] = [
         {
-          timestamp: new Date(now - 8 * 24 * 3600_000).toISOString(), // 8 days ago
+          timestamp: new Date(now - 8 * 24 * 3600_000).toISOString(),
           totals: { input_tokens: 100, output_tokens: 10, request_count: 1, active_accounts: 1 },
         },
         {
-          timestamp: new Date(now - 1 * 3600_000).toISOString(), // 1h ago
+          timestamp: new Date(now - 1 * 3600_000).toISOString(),
           totals: { input_tokens: 500, output_tokens: 50, request_count: 5, active_accounts: 1 },
         },
       ];
@@ -249,7 +398,6 @@ describe("UsageStatsStore", () => {
       ]);
       store.recordSnapshot(pool);
 
-      // Old snapshot pruned, recent + new remain
       expect(store.snapshotCount).toBe(2);
     });
   });

--- a/src/auth/usage-stats.ts
+++ b/src/auth/usage-stats.ts
@@ -4,6 +4,9 @@
  * Records periodic snapshots of cumulative token usage across all accounts.
  * Snapshots are persisted to data/usage-history.json and pruned to 7 days.
  * Aggregation (delta computation, bucketing) happens on read.
+ *
+ * A "baseline" accumulates usage from accounts that have been removed or
+ * replaced, so historical totals survive account pool resets.
  */
 
 import {
@@ -29,9 +32,16 @@ export interface UsageSnapshot {
   };
 }
 
+export interface UsageBaseline {
+  input_tokens: number;
+  output_tokens: number;
+  request_count: number;
+}
+
 interface UsageHistoryFile {
   version: 1;
   snapshots: UsageSnapshot[];
+  baseline?: UsageBaseline;
 }
 
 export interface UsageDataPoint {
@@ -100,17 +110,18 @@ export function createFsUsageStatsPersistence(): UsageStatsPersistence {
 export class UsageStatsStore {
   private persistence: UsageStatsPersistence;
   private snapshots: UsageSnapshot[];
+  private baseline: UsageBaseline;
 
   constructor(persistence?: UsageStatsPersistence) {
     this.persistence = persistence ?? createFsUsageStatsPersistence();
-    this.snapshots = this.persistence.load().snapshots;
+    const loaded = this.persistence.load();
+    this.snapshots = loaded.snapshots;
+    this.baseline = loaded.baseline ?? { input_tokens: 0, output_tokens: 0, request_count: 0 };
   }
 
-  /** Take a snapshot of current cumulative usage across all accounts. */
-  recordSnapshot(pool: AccountPool): void {
+  /** Sum current live usage from all accounts in the pool. */
+  private poolTotals(pool: AccountPool): { input_tokens: number; output_tokens: number; request_count: number; active_accounts: number; total_accounts: number } {
     const entries = pool.getAllEntries();
-    const now = new Date().toISOString();
-
     let input_tokens = 0;
     let output_tokens = 0;
     let request_count = 0;
@@ -123,9 +134,43 @@ export class UsageStatsStore {
       if (entry.status === "active") active_accounts++;
     }
 
+    return { input_tokens, output_tokens, request_count, active_accounts, total_accounts: entries.length };
+  }
+
+  /** Take a snapshot of current cumulative usage across all accounts. */
+  recordSnapshot(pool: AccountPool): void {
+    const live = this.poolTotals(pool);
+    const now = new Date().toISOString();
+
+    // Detect pool reset: if live totals dropped below previous snapshot,
+    // the difference was lost usage from removed accounts — absorb into baseline.
+    const lastSnapshot = this.snapshots.length > 0 ? this.snapshots[this.snapshots.length - 1] : null;
+    if (lastSnapshot) {
+      const prevLive = {
+        input_tokens: lastSnapshot.totals.input_tokens - this.baseline.input_tokens,
+        output_tokens: lastSnapshot.totals.output_tokens - this.baseline.output_tokens,
+        request_count: lastSnapshot.totals.request_count - this.baseline.request_count,
+      };
+      if (live.input_tokens < prevLive.input_tokens ||
+          live.output_tokens < prevLive.output_tokens ||
+          live.request_count < prevLive.request_count) {
+        this.baseline = {
+          input_tokens: this.baseline.input_tokens + Math.max(0, prevLive.input_tokens - live.input_tokens),
+          output_tokens: this.baseline.output_tokens + Math.max(0, prevLive.output_tokens - live.output_tokens),
+          request_count: this.baseline.request_count + Math.max(0, prevLive.request_count - live.request_count),
+        };
+      }
+    }
+
+    // Snapshot totals = baseline + live (monotonically increasing)
     this.snapshots.push({
       timestamp: now,
-      totals: { input_tokens, output_tokens, request_count, active_accounts },
+      totals: {
+        input_tokens: this.baseline.input_tokens + live.input_tokens,
+        output_tokens: this.baseline.output_tokens + live.output_tokens,
+        request_count: this.baseline.request_count + live.request_count,
+        active_accounts: live.active_accounts,
+      },
     });
 
     // Prune old snapshots
@@ -134,30 +179,19 @@ export class UsageStatsStore {
       (s) => new Date(s.timestamp).getTime() >= cutoff,
     );
 
-    this.persistence.save({ version: 1, snapshots: this.snapshots });
+    this.persistence.save({ version: 1, snapshots: this.snapshots, baseline: this.baseline });
   }
 
-  /** Get current cumulative summary from live pool data. */
+  /** Get current cumulative summary (baseline + live pool data). */
   getSummary(pool: AccountPool): UsageSummary {
-    const entries = pool.getAllEntries();
-    let total_input_tokens = 0;
-    let total_output_tokens = 0;
-    let total_request_count = 0;
-    let active_accounts = 0;
-
-    for (const entry of entries) {
-      total_input_tokens += entry.usage.input_tokens;
-      total_output_tokens += entry.usage.output_tokens;
-      total_request_count += entry.usage.request_count;
-      if (entry.status === "active") active_accounts++;
-    }
+    const live = this.poolTotals(pool);
 
     return {
-      total_input_tokens,
-      total_output_tokens,
-      total_request_count,
-      total_accounts: entries.length,
-      active_accounts,
+      total_input_tokens: this.baseline.input_tokens + live.input_tokens,
+      total_output_tokens: this.baseline.output_tokens + live.output_tokens,
+      total_request_count: this.baseline.request_count + live.request_count,
+      total_accounts: live.total_accounts,
+      active_accounts: live.active_accounts,
     };
   }
 
@@ -200,6 +234,11 @@ export class UsageStatsStore {
   /** Get raw snapshot count (for testing). */
   get snapshotCount(): number {
     return this.snapshots.length;
+  }
+
+  /** Get current baseline (for testing). */
+  get currentBaseline(): UsageBaseline {
+    return { ...this.baseline };
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,7 @@ const TABS: Array<{ hash: string; label: TranslationKey }> = [
   { hash: "", label: "overview" },
   { hash: "#/accounts", label: "manageAccounts" },
   { hash: "#/proxies", label: "proxySettings" },
+  { hash: "#/usage-stats", label: "usageStats" },
   { hash: "#/settings", label: "settings" },
 ];
 
@@ -110,27 +111,6 @@ function Dashboard() {
   // Redirect legacy routes
   if (hash === "#/account-management") { location.hash = "#/accounts"; return null; }
   if (hash === "#/proxy-settings") { location.hash = "#/proxies"; return null; }
-
-  // Usage stats stays standalone (separate page with its own header)
-  if (hash === "#/usage-stats") {
-    return (
-      <>
-        <Header
-          onAddAccount={accounts.startAdd}
-          onCheckUpdate={update.checkForUpdate}
-          onOpenUpdateModal={() => setShowModal(true)}
-          checking={update.checking}
-          updateStatusMsg={update.msg}
-          updateStatusColor={update.color}
-          version={update.status?.proxy.version ?? null}
-          commit={update.status?.proxy.commit ?? null}
-          hasUpdate={update.hasUpdate}
-          onLogout={onLogout}
-        />
-        <UsageStats />
-      </>
-    );
-  }
 
   const activeTab = TABS.find((t) => t.hash === hash)?.hash ?? "";
 
@@ -191,6 +171,10 @@ function Dashboard() {
               <ProxyPool proxies={proxies} />
               <ProxySettings embedded />
             </div>
+          )}
+
+          {activeTab === "#/usage-stats" && (
+            <UsageStats embedded />
           )}
 
           {activeTab === "#/settings" && (

--- a/web/src/pages/UsageStats.tsx
+++ b/web/src/pages/UsageStats.tsx
@@ -15,16 +15,101 @@ const rangeOptions: Array<{ hours: number; label: TranslationKey }> = [
   { hours: 168, label: "last7d" },
 ];
 
-export function UsageStats() {
+function UsageContent({ t, summary, summaryLoading, granularity, setGranularity, hours, setHours, dataPoints, historyLoading }: {
+  t: (key: TranslationKey) => string;
+  summary: ReturnType<typeof useUsageSummary>["summary"];
+  summaryLoading: boolean;
+  granularity: Granularity;
+  setGranularity: (g: Granularity) => void;
+  hours: number;
+  setHours: (h: number) => void;
+  dataPoints: ReturnType<typeof useUsageHistory>["dataPoints"];
+  historyLoading: boolean;
+}) {
+  return (
+    <>
+      {/* Summary cards */}
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+        <SummaryCard
+          label={t("totalInputTokens")}
+          value={summaryLoading ? "—" : formatNumber(summary?.total_input_tokens ?? 0)}
+        />
+        <SummaryCard
+          label={t("totalOutputTokens")}
+          value={summaryLoading ? "—" : formatNumber(summary?.total_output_tokens ?? 0)}
+        />
+        <SummaryCard
+          label={t("totalRequestCount")}
+          value={summaryLoading ? "—" : formatNumber(summary?.total_request_count ?? 0)}
+        />
+        <SummaryCard
+          label={t("activeAccounts")}
+          value={summaryLoading ? "—" : `${summary?.active_accounts ?? 0} / ${summary?.total_accounts ?? 0}`}
+        />
+      </div>
+
+      {/* Controls */}
+      <div class="flex flex-wrap gap-2 mb-4">
+        {granularityOptions.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setGranularity(value)}
+            class={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+              granularity === value
+                ? "bg-primary text-white border-primary"
+                : "bg-white dark:bg-card-dark border-gray-200 dark:border-border-dark text-slate-600 dark:text-text-dim hover:border-primary/50"
+            }`}
+          >
+            {t(label)}
+          </button>
+        ))}
+        <div class="w-px h-5 bg-gray-200 dark:bg-border-dark self-center" />
+        {rangeOptions.map(({ hours: h, label }) => (
+          <button
+            key={h}
+            onClick={() => setHours(h)}
+            class={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+              hours === h
+                ? "bg-primary text-white border-primary"
+                : "bg-white dark:bg-card-dark border-gray-200 dark:border-border-dark text-slate-600 dark:text-text-dim hover:border-primary/50"
+            }`}
+          >
+            {t(label)}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart */}
+      <div class="bg-white dark:bg-card-dark rounded-xl border border-gray-200 dark:border-border-dark p-4">
+        {historyLoading ? (
+          <div class="text-center py-12 text-slate-400 dark:text-text-dim text-sm">Loading...</div>
+        ) : (
+          <UsageChart data={dataPoints} />
+        )}
+      </div>
+    </>
+  );
+}
+
+export function UsageStats({ embedded }: { embedded?: boolean } = {}) {
   const t = useT();
   const { summary, loading: summaryLoading } = useUsageSummary();
   const [granularity, setGranularity] = useState<Granularity>("hourly");
   const [hours, setHours] = useState(24);
   const { dataPoints, loading: historyLoading } = useUsageHistory(granularity, hours);
 
+  const contentProps = { t, summary, summaryLoading, granularity, setGranularity, hours, setHours, dataPoints, historyLoading };
+
+  if (embedded) {
+    return (
+      <div class="flex flex-col gap-4">
+        <UsageContent {...contentProps} />
+      </div>
+    );
+  }
+
   return (
     <div class="min-h-screen bg-slate-50 dark:bg-bg-dark flex flex-col">
-      {/* Header */}
       <header class="sticky top-0 z-50 bg-white dark:bg-card-dark border-b border-gray-200 dark:border-border-dark px-4 py-3">
         <div class="max-w-[1100px] mx-auto flex items-center gap-3">
           <a
@@ -40,65 +125,7 @@ export function UsageStats() {
       </header>
 
       <main class="flex-grow px-4 md:px-8 py-6 max-w-[1100px] mx-auto w-full">
-        {/* Summary cards */}
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-          <SummaryCard
-            label={t("totalInputTokens")}
-            value={summaryLoading ? "—" : formatNumber(summary?.total_input_tokens ?? 0)}
-          />
-          <SummaryCard
-            label={t("totalOutputTokens")}
-            value={summaryLoading ? "—" : formatNumber(summary?.total_output_tokens ?? 0)}
-          />
-          <SummaryCard
-            label={t("totalRequestCount")}
-            value={summaryLoading ? "—" : formatNumber(summary?.total_request_count ?? 0)}
-          />
-          <SummaryCard
-            label={t("activeAccounts")}
-            value={summaryLoading ? "—" : `${summary?.active_accounts ?? 0} / ${summary?.total_accounts ?? 0}`}
-          />
-        </div>
-
-        {/* Controls */}
-        <div class="flex flex-wrap gap-2 mb-4">
-          {granularityOptions.map(({ value, label }) => (
-            <button
-              key={value}
-              onClick={() => setGranularity(value)}
-              class={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                granularity === value
-                  ? "bg-primary text-white border-primary"
-                  : "bg-white dark:bg-card-dark border-gray-200 dark:border-border-dark text-slate-600 dark:text-text-dim hover:border-primary/50"
-              }`}
-            >
-              {t(label)}
-            </button>
-          ))}
-          <div class="w-px h-5 bg-gray-200 dark:bg-border-dark self-center" />
-          {rangeOptions.map(({ hours: h, label }) => (
-            <button
-              key={h}
-              onClick={() => setHours(h)}
-              class={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                hours === h
-                  ? "bg-primary text-white border-primary"
-                  : "bg-white dark:bg-card-dark border-gray-200 dark:border-border-dark text-slate-600 dark:text-text-dim hover:border-primary/50"
-              }`}
-            >
-              {t(label)}
-            </button>
-          ))}
-        </div>
-
-        {/* Chart */}
-        <div class="bg-white dark:bg-card-dark rounded-xl border border-gray-200 dark:border-border-dark p-4">
-          {historyLoading ? (
-            <div class="text-center py-12 text-slate-400 dark:text-text-dim text-sm">Loading...</div>
-          ) : (
-            <UsageChart data={dataPoints} />
-          )}
-        </div>
+        <UsageContent {...contentProps} />
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Bug fix**: 删号/换号后用量统计归零。`UsageStatsStore` 新增 `baseline` 机制，检测 live totals 回落时自动吸收差值到持久化 baseline
- **Restore tab**: PR #211 layout 重构时 UsageStats tab 入口丢失，现恢复为 Dashboard 第 4 个 tab（embedded 模式）

## Test plan
- [x] 1257 tests 全部通过（含 6 个新增 baseline 测试）
- [x] `npm run build` 编译通过
- [ ] Dashboard 确认 Usage Stats tab 可见
- [ ] 等待 `recordSnapshot` 周期执行后确认 baseline 自动从旧快照恢复历史数据