### PR TITLE
test: verify Electron app packages and launches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.0",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.0",
+      "version": "2.0.17",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@electron/asar": "^3.2.0",
+        "@playwright/test": "^1.58.2",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
@@ -30,6 +31,7 @@
         "js-beautify": "^1.15.0",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
+        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^3.2.4"
       },
       "optionalDependencies": {
@@ -1222,6 +1224,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4195,6 +4213,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5622,6 +5647,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -6745,6 +6817,27 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmmirror.com/tsx/-/tsx-4.21.0.tgz",
@@ -6981,6 +7074,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
       }
     },
     "node_modules/vitest": {
@@ -7364,7 +7472,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.0",
+      "version": "2.0.17",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@electron/asar": "^3.2.0",
+    "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
@@ -51,6 +52,7 @@
     "js-beautify": "^1.15.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
+    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/electron/__tests__/launch.test.ts
+++ b/packages/electron/__tests__/launch.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { existsSync, rmSync, readdirSync, statSync } from "fs";
+import { resolve, join } from "path";
+import { execFileSync } from "child_process";
+import { _electron as electron } from "@playwright/test";
+
+const PKG_DIR = resolve(import.meta.dirname, "..");
+const DIST = resolve(PKG_DIR, "dist-electron");
+const RELEASE_DIR = resolve(PKG_DIR, "release");
+
+describe("Electron Build, Pack & Launch", () => {
+  // Set an extensive timeout because packaging and launching Electron takes time.
+  beforeAll(() => {
+    // We clean up dist-electron and release to ensure fresh builds
+    if (existsSync(DIST)) {
+      rmSync(DIST, { recursive: true, force: true });
+    }
+    if (existsSync(RELEASE_DIR)) {
+      rmSync(RELEASE_DIR, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    // Cleanup afterwards to not leave large build artifacts behind
+    if (existsSync(RELEASE_DIR)) {
+      rmSync(RELEASE_DIR, { recursive: true, force: true });
+    }
+    if (existsSync(DIST)) {
+      rmSync(DIST, { recursive: true, force: true });
+    }
+  });
+
+  it("should successfully build the electron package", () => {
+    // Build electron workspace
+    execFileSync("npm", ["run", "build"], {
+      cwd: PKG_DIR,
+      stdio: "inherit", // to see output if it fails
+    });
+
+    // Verify esbuild output
+    expect(existsSync(resolve(DIST, "main.cjs"))).toBe(true);
+    expect(existsSync(resolve(DIST, "server.mjs"))).toBe(true);
+  }, 60000); // 1 minute for esbuild
+
+  const getPackCommand = () => {
+    if (process.platform === "win32") return "pack:win";
+    if (process.platform === "darwin") return "pack:mac";
+    return "pack:linux";
+  };
+
+  const getUnpackedDir = () => {
+    if (process.platform === "win32") return "win-unpacked";
+    if (process.platform === "darwin") return "mac-arm64"; // Might vary by host arch, simplified
+    return "linux-unpacked";
+  };
+
+  it("should package the binary via electron-builder", () => {
+    const packCmd = getPackCommand();
+    execFileSync("npm", ["run", packCmd], {
+      cwd: PKG_DIR,
+      // electron-builder sometimes pipes incorrectly when stdio isn't properly handled in sandboxes.
+      stdio: "ignore",
+      env: { ...process.env, PUBLISH: "never" } // ensure we don't accidentally publish
+    });
+
+    expect(existsSync(RELEASE_DIR)).toBe(true);
+    const unpackedDir = resolve(RELEASE_DIR, getUnpackedDir());
+    // macOS might be `mac` or `mac-arm64` etc, checking existence of release dir is main thing
+  }, 180000); // 3 minutes for packaging
+
+  it("should successfully launch the packaged app and exit cleanly", async () => {
+    const unpackedDir = resolve(RELEASE_DIR, getUnpackedDir());
+
+    // Fallback if the strict unpacked dir wasn't found (e.g. mac-arm64 vs mac)
+    const actualUnpackedDir = existsSync(unpackedDir)
+      ? unpackedDir
+      : (readdirSync(RELEASE_DIR).find(d => d.includes("mac") || d.includes("unpacked"))
+         ? resolve(RELEASE_DIR, readdirSync(RELEASE_DIR).find(d => d.includes("mac") || d.includes("unpacked"))!)
+         : unpackedDir);
+
+    expect(existsSync(actualUnpackedDir)).toBe(true);
+
+    // Find the executable. On Windows it's .exe, on macOS it's inside .app/Contents/MacOS, on Linux it's no extension
+    let executablePath = "";
+    if (process.platform === "win32") {
+      const files = readdirSync(actualUnpackedDir);
+      const exe = files.find(f => f.endsWith(".exe"));
+      executablePath = join(actualUnpackedDir, exe!);
+    } else if (process.platform === "darwin") {
+      const files = readdirSync(actualUnpackedDir);
+      const app = files.find(f => f.endsWith(".app"));
+      executablePath = join(actualUnpackedDir, app!, "Contents", "MacOS", "Codex Proxy");
+    } else {
+      const files = readdirSync(actualUnpackedDir);
+      const executableName = files.find(f => {
+        const p = join(actualUnpackedDir, f);
+        return !f.includes(".") && statSync(p).isFile() && !f.endsWith(".so");
+      });
+      executablePath = join(actualUnpackedDir, executableName!);
+    }
+    expect(existsSync(executablePath)).toBe(true);
+
+    // Launch using Playwright
+    const electronApp = await electron.launch({
+      executablePath,
+      args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    });
+
+    const window = await electronApp.firstWindow();
+
+    // Wait for the app to initialize and become ready
+    await window.waitForLoadState("domcontentloaded");
+
+    const title = await window.title();
+    expect(title).toContain("Codex Proxy");
+
+    // Close the app and ensure it exits cleanly
+    await electronApp.close();
+  }, 60000); // 1 minute for launch
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config";
 import { resolve } from "path";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   resolve: {
     alias: {
       "@src": resolve(__dirname, "src"),


### PR DESCRIPTION
Fixes #121 

This PR adds an automated test to ensure the `Codex Proxy` electron app packages and runs successfully. 
It uses `@playwright/test` to inspect the underlying `electron` packaged binary seamlessly. The electron testing utilizes existing `release` outputs out-of-the-box dynamically choosing which `npm pack:xxx` variation it launches via host's OS (`process.platform`).

---
*PR created automatically by Jules for task [1152611388216054955](https://jules.google.com/task/1152611388216054955) started by @icebear0828*