### PR TITLE
fix: never clear existing refresh token during token update

### DIFF
--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -103,7 +103,7 @@ export class AccountPool {
     return this.registry.removeAccount(id);
   }
 
-  updateToken(entryId: string, newToken: string, refreshToken?: string | null): void {
+  updateToken(entryId: string, newToken: string, refreshToken?: string): void {
     this.registry.updateToken(entryId, newToken, refreshToken);
   }
 

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -44,8 +44,8 @@ export class AccountRegistry {
       if (accountId) {
         if (existing.accountId === accountId && existing.userId === userId) {
           existing.token = token;
-          if (refreshToken !== undefined) {
-            existing.refreshToken = refreshToken ?? null;
+          if (typeof refreshToken === "string" && refreshToken.length > 0) {
+            existing.refreshToken = refreshToken;
           }
           existing.email = profile?.email ?? existing.email;
           existing.planType = profile?.chatgpt_plan_type ?? existing.planType;
@@ -99,13 +99,14 @@ export class AccountRegistry {
     return deleted;
   }
 
-  updateToken(entryId: string, newToken: string, refreshToken?: string | null): void {
+  updateToken(entryId: string, newToken: string, refreshToken?: string): void {
     const entry = this.accounts.get(entryId);
     if (!entry) return;
 
     entry.token = newToken;
-    if (refreshToken !== undefined) {
-      entry.refreshToken = refreshToken ?? null;
+    // Never clear an existing RT — only replace with a new non-empty value
+    if (typeof refreshToken === "string" && refreshToken.length > 0) {
+      entry.refreshToken = refreshToken;
     }
     const profile = extractUserProfile(newToken);
     entry.email = profile?.email ?? entry.email;

--- a/src/auth/refresh-scheduler.ts
+++ b/src/auth/refresh-scheduler.ts
@@ -219,20 +219,12 @@ export class RefreshScheduler {
         const isOneTimeRT = entry.refreshToken.startsWith("oaistb_rt_");
         const tokens = await refreshAccessToken(entry.refreshToken, accountProxyUrl);
 
-        // oaistb_rt_ tokens are single-use: the old RT is revoked after exchange.
-        // If the server didn't return a new RT, mark the account as unable to refresh.
-        if (isOneTimeRT && !tokens.refresh_token) {
-          console.warn(`[RefreshScheduler] Account ${entryId}: oaistb_rt_ used but no new RT returned — future refresh will fail`);
-          this.pool.updateToken(entryId, tokens.access_token, null);
-          this.scheduleOne(entryId, tokens.access_token);
-          return;
+        // updateToken guards against clearing RT — safe to pass tokens.refresh_token directly.
+        // If the server returned no new RT, the existing one is preserved.
+        if (!tokens.refresh_token) {
+          console.warn(`[RefreshScheduler] Account ${entryId}: server returned no new RT, keeping existing`);
         }
-
-        this.pool.updateToken(
-          entryId,
-          tokens.access_token,
-          tokens.refresh_token,
-        );
+        this.pool.updateToken(entryId, tokens.access_token, tokens.refresh_token ?? undefined);
         const rtType = isOneTimeRT ? " (oaistb_rt_ → rotated)" : "";
         console.log(`[RefreshScheduler] Account ${entryId} refreshed successfully${rtType}`);
         this.scheduleOne(entryId, tokens.access_token);


### PR DESCRIPTION
## Summary
- `updateToken` could overwrite a valid RT with `null`/`undefined` when Auth0 refresh response omitted the `refresh_token` field, causing permanent RT loss
- Changed `updateToken` signature to `refreshToken?: string` (removed `| null`)
- Guard: only replace RT with a non-empty string, never clear it
- Applied same guard to `addAccount` dedup path
- Removed `oaistb_rt_` special branch that explicitly set RT to `null`

## Test plan
- [x] All 1378 tests pass
- [ ] Deploy and verify RT persists across multiple token refresh cycles