### PR TITLE
test: add CI smoke tests for Docker, Electron, and web frontend

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,91 @@
+name: CI — Docker smoke test (Issue 133)
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  smoke-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Start container on default port (8080)
+        run: |
+          docker run -d --name test-container -p 8080:8080 codex-proxy-test
+
+      - name: Wait for healthcheck (8080)
+        run: |
+          echo "Waiting for container to be healthy..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' test-container 2>/dev/null || echo "starting")
+            echo "Attempt $i: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy!"
+              break
+            fi
+            sleep 2
+          done
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Container failed to become healthy. Logs:"
+            docker logs test-container
+            exit 1
+          fi
+
+      - name: Verify /health returns 200 (8080)
+        run: |
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Expected 200, got $STATUS_CODE"
+            exit 1
+          fi
+
+      - name: Cleanup (8080)
+        run: docker rm -f test-container
+
+      - name: Prepare custom config for 8090
+        run: |
+          mkdir -p custom-config
+          cp config/default.yaml custom-config/default.yaml
+          sed -i 's/port: 8080/port: 8090/g' custom-config/default.yaml
+
+      - name: Start container on custom port (8090)
+        run: |
+          docker run -d --name test-container-8090 \
+            -p 8090:8090 \
+            -v $(pwd)/custom-config/default.yaml:/app/config/default.yaml \
+            codex-proxy-test
+
+      - name: Wait for healthcheck (8090)
+        run: |
+          echo "Waiting for container to be healthy..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' test-container-8090 2>/dev/null || echo "starting")
+            echo "Attempt $i: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy!"
+              break
+            fi
+            sleep 2
+          done
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Container failed to become healthy. Logs:"
+            docker logs test-container-8090
+            exit 1
+          fi
+
+      - name: Verify /health returns 200 (8090)
+        run: |
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/health)
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Expected 200, got $STATUS_CODE"
+            exit 1
+          fi
+
+      - name: Cleanup (8090)
+        if: always()
+        run: docker rm -f test-container-8090 || true

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,51 @@
+name: CI — Electron smoke test (Issue 134)
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "packages/electron/**"
+  pull_request:
+    paths:
+      - "packages/electron/**"
+
+jobs:
+  smoke-electron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Root Install
+        run: npm ci
+
+      - name: Build full project
+        run: npm run build
+
+      - name: Build Electron desktop
+        run: |
+          cd packages/electron
+          npm run build
+
+      - name: Prepare pack
+        run: |
+          cd packages/electron
+          node electron/prepare-pack.mjs
+
+      - name: Package Electron (Linux dir mode)
+        run: |
+          cd packages/electron
+          npx electron-builder --linux --dir
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed if electron-builder complains, although --dir usually bypasses
+
+      - name: Install Playwright & Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright Launch Smoke Test
+        run: |
+          xvfb-run npm test -- packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,26 @@
+name: CI — Web smoke test (Issue 135)
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  smoke-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Root Install
+        run: npm ci
+
+      - name: Build web + backend
+        run: npm run build
+
+      - name: Run Web Smoke Test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.0",
+  "version": "2.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.0",
+      "version": "2.0.21",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -5622,6 +5622,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7364,14 +7411,15 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.0",
+      "version": "2.0.21",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.58.2"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "vitest";
+import { _electron as electron } from "playwright";
+import fs from "fs";
+import path from "path";
+
+test("Electron app packages and launches", async () => {
+  // Find the linux-unpacked directory
+  const releaseDir = path.join(import.meta.dirname, "../../release/linux-unpacked");
+
+  if (!fs.existsSync(releaseDir)) {
+    throw new Error(`Release directory not found: ${releaseDir}`);
+  }
+
+  // Find the executable
+  const files = fs.readdirSync(releaseDir);
+  const executable = files.find(f => {
+    const fullPath = path.join(releaseDir, f);
+    return fs.statSync(fullPath).isFile() && !f.includes(".") && f !== "chrome-sandbox" && f !== "chrome_crashpad_handler";
+  });
+
+  if (!executable) {
+    throw new Error(`Executable not found in ${releaseDir}`);
+  }
+
+  const executablePath = path.join(releaseDir, executable);
+
+  // Launch the app
+  const app = await electron.launch({
+    executablePath,
+    args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"]
+  });
+
+  try {
+    // Wait for the first window
+    const window = await app.firstWindow();
+
+    // Check if window is visible
+    expect(window).toBeDefined();
+
+    // Get title
+    const title = await window.title();
+    expect(title).toBeDefined();
+  } finally {
+    // Cleanly close
+    await app.close();
+  }
+}, 60000);

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.58.2"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,89 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs";
+import path from "path";
+
+let serverProcess: ChildProcess;
+const PORT = 8081;
+
+beforeAll(async () => {
+  // Start server
+  serverProcess = spawn("node", ["dist/index.js"], {
+    env: { ...process.env, PORT: PORT.toString(), NODE_ENV: "production" }
+  });
+
+  // Wait for server to start
+  await new Promise<void>((resolve, reject) => {
+    let output = "";
+    const timeout = setTimeout(() => {
+      reject(new Error(`Server did not start in time. Output: ${output}`));
+    }, 5000);
+
+    serverProcess.stdout?.on("data", (data) => {
+      output += data.toString();
+      if (output.includes(`Server is running on port ${PORT}`) || output.includes(`Server started`)) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    serverProcess.stderr?.on("data", (data) => {
+      console.error(`Server stderr: ${data}`);
+    });
+
+    // We should fallback to just wait some time if we can't see the console message.
+    const fallbackTimeout = setTimeout(() => {
+        clearTimeout(timeout);
+        resolve();
+    }, 2000);
+
+    // Clean up fallback timeout if server starts up successfully before fallback triggers
+    serverProcess.stdout?.on("data", (data) => {
+      const outputStr = data.toString();
+      if (outputStr.includes(`Server is running on port ${PORT}`) || outputStr.includes(`Server started`)) {
+        clearTimeout(fallbackTimeout);
+      }
+    });
+  });
+});
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+test("CSS output contains light and dark theme classes", () => {
+  const assetsDir = path.join(import.meta.dirname, "../../public/assets");
+  expect(fs.existsSync(assetsDir)).toBe(true);
+
+  const files = fs.readdirSync(assetsDir);
+  const cssFiles = files.filter(f => f.endsWith(".css"));
+
+  expect(cssFiles.length).toBeGreaterThan(0);
+
+  let hasDark = false;
+  let hasLight = false;
+
+  for (const file of cssFiles) {
+    const content = fs.readFileSync(path.join(assetsDir, file), "utf-8");
+    if (content.includes(".dark")) {
+      hasDark = true;
+    }
+    // Often tailwind has :root for light variables or explicit .light
+    if (content.includes(".light") || content.includes(":root")) {
+      hasLight = true;
+    }
+  }
+
+  expect(hasDark).toBe(true);
+  expect(hasLight).toBe(true);
+});
+
+test("Server serves HTML with <div id=\"app\"></div>", async () => {
+  const response = await fetch(`http://localhost:${PORT}/`);
+  expect(response.status).toBe(200);
+
+  const text = await response.text();
+  expect(text).toContain('<div id="app"></div>');
+});

--- a/src/auth/account-persistence.ts
+++ b/src/auth/account-persistence.ts
@@ -186,7 +186,7 @@ function loadPersisted(): { entries: AccountEntry[]; needsPersist: boolean } {
         needsPersist = true;
       }
       // Backfill window_reset_at (missing causes NaN in refreshStatus)
-      if ((entry.usage as Record<string, unknown>).window_reset_at === undefined) {
+      if ((entry.usage as unknown as Record<string, unknown>).window_reset_at === undefined) {
         entry.usage.window_reset_at = null;
         needsPersist = true;
       }


### PR DESCRIPTION
Resolves #133, #134, #135.

This PR adds core CI smoke test workflows:

1. **Docker:** Tests the `Dockerfile` build and container start, verifying the healthcheck mechanisms on both default and custom port configurations.
2. **Electron:** Tests that the Electron application can build, pack into `linux-unpacked` via `electron-builder`, and physically launch without crashing using Playwright and `xvfb`.
3. **Web:** Verifies that the Vite/Preact frontend builds properly (asserting the CSS asset output contains the expected themes) and is served correctly via the Node.js API backend index script on a custom port.

Also includes a minor TypeScript cast adjustment in `account-persistence.ts` to allow local compilations to succeed. Constraints from the issues (such as `npm`, `master` branch target, and specific test file paths) were strictly followed.

---
*PR created automatically by Jules for task [8932995128760980743](https://jules.google.com/task/8932995128760980743) started by @icebear0828*