### PR TITLE
fix: show default quota bar for active accounts

### DIFF
--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -128,12 +128,22 @@ export async function createWebSocketResponse(
       },
     });
 
+    // Capture upgrade response headers (contains x-codex-* rate limit data)
+    let upgradeHeaders: Record<string, string | string[]> = {};
+    ws.on("upgrade", (response: { headers: Record<string, string | string[]> }) => {
+      upgradeHeaders = response.headers;
+    });
+
     ws.on("open", () => {
       connected = true;
       ws.send(JSON.stringify(request));
 
-      // Return the Response immediately — events will flow into the stream
+      // Build response headers from WS upgrade headers
       const responseHeaders = new Headers({ "content-type": "text/event-stream" });
+      for (const [key, value] of Object.entries(upgradeHeaders)) {
+        const v = Array.isArray(value) ? value[0] : value;
+        if (v != null) responseHeaders.set(key, v);
+      }
       resolve(new Response(stream, { status: 200, headers: responseHeaders }));
     });
 

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -245,7 +245,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
               class="p-1.5 text-slate-400 dark:text-text-dim hover:text-amber-500 transition-colors rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 disabled:opacity-40"
               title={t("refreshQuota")}
             >
-              <svg class={`size-[16px] ${quotaRefreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <svg class="size-[16px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
               </svg>
             </button>

--- a/web/src/components/AccountList.tsx
+++ b/web/src/components/AccountList.tsx
@@ -104,7 +104,7 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
           disabled={refreshing}
           class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-600 dark:text-text-dim hover:text-primary hover:bg-slate-100 dark:hover:bg-border-dark rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <svg class={`size-3.5 ${refreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
           </svg>
           <span class="hidden sm:inline">{t("refreshList")}</span>
@@ -115,7 +115,7 @@ export function AccountList({ accounts, loading, onDelete, onRefresh, refreshing
           disabled={quotaRefreshing}
           class="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-600 dark:text-text-dim hover:text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <svg class={`size-3.5 ${quotaRefreshing ? "animate-spin" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5" />
           </svg>
           <span class="hidden sm:inline">{t("quotaShort")}</span>


### PR DESCRIPTION
## Summary

- Active accounts without cached quota data now show a 0% green progress bar
- Previously the quota section was hidden until the account made its first API request

## Test plan

- [x] `npm run build` passes
- [x] Visual: active accounts without quota show empty green bar