### PR TITLE
fix: quota display, fast model, account pool sorting

### DIFF
--- a/TODO-native-transport-tests.md
+++ b/TODO-native-transport-tests.md
@@ -1,0 +1,72 @@
+# Native Transport — 待补测试清单
+
+> PR #245 feat/native-tls-transport 分支
+> 真实 E2E 已验证 18 次通过，以下是需要补的 vitest 测试模块
+
+## 1. native-transport 单元测试
+
+**文件**: `src/tls/__tests__/native-transport.test.ts`
+
+Mock Rust bindings，验证 TS wrapper 逻辑：
+
+- [ ] `post()` — 将 Rust callback 流正确包装为 ReadableStream
+- [ ] `post()` — signal.aborted 时立即抛错
+- [ ] `post()` — onChunk(null) 正确关闭 ReadableStream
+- [ ] `post()` — onChunk(undefined) 也能关闭（napi-rs 兼容）
+- [ ] `post()` — setCookieHeaders 从 meta 正确透传
+- [ ] `post()` — response headers 排除 set-cookie（单独处理）
+- [ ] `get()` — 返回 { status, body }
+- [ ] `getWithCookies()` — 返回含 setCookieHeaders
+- [ ] `simplePost()` — 返回 { status, body }
+- [ ] `isImpersonate()` — 返回 false
+- [ ] `resolveProxy()` — undefined → getProxyUrl()、null → null、string → string
+- [ ] `force_http11` — 从 config 读取并传给 bindings
+
+## 2. session-affinity turnState 测试
+
+**文件**: `src/auth/__tests__/session-affinity.test.ts`（已有文件，追加）
+
+- [x] `record()` 带 turnState → `lookupTurnState()` 返回正确值
+- [x] `record()` 不带 turnState → `lookupTurnState()` 返回 null
+- [x] turnState 过期后 lookup 返回 null
+- [x] 多次 record 同一 responseId，turnState 更新
+
+## 3. codex-api headers 测试
+
+**文件**: `src/proxy/__tests__/codex-api-headers.test.ts`（新建）
+
+Mock transport，验证请求头：
+
+- [x] HTTP SSE 路径发送 `x-openai-internal-codex-residency: us`
+- [x] HTTP SSE 路径发送 `x-client-request-id`（UUID 格式）
+- [x] HTTP SSE 路径：request.turnState 存在时发送 `x-codex-turn-state`
+- [x] HTTP SSE 路径：request.turnState 不存在时不发该头
+- [x] HTTP SSE 路径：turnState 不出现在 JSON body 中
+- [x] WebSocket 路径同样发送上述三个头
+
+## 4. proxy-handler turnState 传递测试
+
+**文件**: `tests/integration/proxy-handler.test.ts`（已有文件，追加）
+
+- [ ] 首次请求无 previous_response_id → 不发 x-codex-turn-state
+- [ ] 上游响应含 x-codex-turn-state → 存入 affinityMap
+- [ ] 后续请求带 previous_response_id → 从 affinityMap 取出 turnState 注入请求
+- [ ] 非流式路径同样传递 turnState
+
+## 5. transport factory 测试
+
+**文件**: `src/tls/__tests__/transport-init.test.ts`（新建或追加）
+
+- [ ] config `transport: "native"` + addon 存在 → 选择 NativeTransport
+- [ ] config `transport: "native"` + addon 不存在 → 抛错
+- [ ] config `transport: "auto"` + addon 存在 → 优先选择 native
+- [ ] config `transport: "auto"` + addon 不存在 → fallback 到 curl
+- [ ] `getTransportInfo().type` 返回 `"native"`
+
+## 优先级
+
+1. **高**: #3 codex-api headers（直接影响伪装）
+2. **高**: #2 session-affinity turnState（逻辑简单，快速补）
+3. **中**: #1 native-transport（wrapper 逻辑验证）
+4. **中**: #4 proxy-handler turnState（集成层）
+5. **低**: #5 transport factory（启动路径，手动验证过）

--- a/src/auth/__tests__/quota-utils.test.ts
+++ b/src/auth/__tests__/quota-utils.test.ts
@@ -83,6 +83,75 @@ describe("toQuota", () => {
     expect(quota.code_review_rate_limit!.used_percent).toBe(100);
   });
 
+  it("secondary limit_reached inferred from own used_percent >= 100", () => {
+    const quota = toQuota(makeUsageResponse({
+      rate_limit: {
+        allowed: true,
+        limit_reached: false,       // primary NOT reached
+        primary_window: {
+          used_percent: 10,
+          reset_at: 1700000000,
+          limit_window_seconds: 3600,
+          reset_after_seconds: 3000,
+        },
+        secondary_window: {
+          used_percent: 100,         // secondary exhausted
+          reset_at: 1700500000,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 300000,
+        },
+      },
+    }));
+
+    expect(quota.secondary_rate_limit!.limit_reached).toBe(true);
+  });
+
+  it("secondary limit_reached falls back to primary when own used_percent is null", () => {
+    const quota = toQuota(makeUsageResponse({
+      rate_limit: {
+        allowed: true,
+        limit_reached: true,
+        primary_window: {
+          used_percent: 100,
+          reset_at: 1700000000,
+          limit_window_seconds: 3600,
+          reset_after_seconds: 0,
+        },
+        secondary_window: {
+          used_percent: null as unknown as number,
+          reset_at: 1700500000,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 300000,
+        },
+      },
+    }));
+
+    expect(quota.secondary_rate_limit!.limit_reached).toBe(true);
+  });
+
+  it("secondary limit_reached is false when own used_percent < 100", () => {
+    const quota = toQuota(makeUsageResponse({
+      rate_limit: {
+        allowed: true,
+        limit_reached: true,       // primary reached but secondary is fine
+        primary_window: {
+          used_percent: 100,
+          reset_at: 1700000000,
+          limit_window_seconds: 3600,
+          reset_after_seconds: 0,
+        },
+        secondary_window: {
+          used_percent: 50,
+          reset_at: 1700500000,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 300000,
+        },
+      },
+    }));
+
+    expect(quota.secondary_rate_limit!.limit_reached).toBe(false);
+  });
+
   it("handles null primary window gracefully", () => {
     const quota = toQuota(makeUsageResponse({
       rate_limit: {

--- a/src/auth/__tests__/rotation-strategy.test.ts
+++ b/src/auth/__tests__/rotation-strategy.test.ts
@@ -3,7 +3,13 @@ import { getRotationStrategy } from "../rotation-strategy.js";
 import type { RotationState } from "../rotation-strategy.js";
 import type { AccountEntry } from "../types.js";
 
-function makeEntry(id: string, overrides?: Partial<AccountEntry["usage"]>): AccountEntry {
+import type { CodexQuota } from "../types.js";
+
+function makeEntry(
+  id: string,
+  overrides?: Partial<AccountEntry["usage"]>,
+  quota?: Partial<CodexQuota> | null,
+): AccountEntry {
   return {
     id,
     token: `tok-${id}`,
@@ -11,6 +17,7 @@ function makeEntry(id: string, overrides?: Partial<AccountEntry["usage"]>): Acco
     email: `${id}@test.com`,
     accountId: `acct-${id}`,
     userId: `user-${id}`,
+    label: null,
     planType: "free",
     proxyApiKey: `key-${id}`,
     status: "active",
@@ -29,7 +36,20 @@ function makeEntry(id: string, overrides?: Partial<AccountEntry["usage"]>): Acco
       ...overrides,
     },
     addedAt: new Date().toISOString(),
-    cachedQuota: null,
+    cachedQuota: quota ? {
+      plan_type: "free",
+      rate_limit: {
+        allowed: true,
+        limit_reached: false,
+        used_percent: null,
+        reset_at: null,
+        limit_window_seconds: null,
+        ...quota.rate_limit,
+      },
+      secondary_rate_limit: null,
+      code_review_rate_limit: null,
+      ...quota,
+    } as CodexQuota : null,
     quotaFetchedAt: null,
   };
 }
@@ -64,6 +84,44 @@ describe("rotation-strategy", () => {
       const a = makeEntry("a", { request_count: 3, window_reset_at: reset, last_used: "2026-01-02T00:00:00Z" });
       const b = makeEntry("b", { request_count: 3, window_reset_at: reset, last_used: "2026-01-01T00:00:00Z" });
       expect(strategy.select([a, b], state).id).toBe("b");
+    });
+
+    it("deprioritizes exhausted accounts (limit_reached) even with earlier reset", () => {
+      const exhausted = makeEntry(
+        "exhausted",
+        { request_count: 0, window_reset_at: Date.now() + 1 * 86400_000 },
+        { rate_limit: { allowed: true, limit_reached: true, used_percent: 100, reset_at: null, limit_window_seconds: null } },
+      );
+      const healthy = makeEntry(
+        "healthy",
+        { request_count: 5, window_reset_at: Date.now() + 7 * 86400_000 },
+        { rate_limit: { allowed: true, limit_reached: false, used_percent: 30, reset_at: null, limit_window_seconds: null } },
+      );
+      expect(strategy.select([exhausted, healthy], state).id).toBe("healthy");
+    });
+
+    it("sorts exhausted accounts among themselves by reset time", () => {
+      const a = makeEntry(
+        "a",
+        { window_reset_at: Date.now() + 3 * 86400_000 },
+        { rate_limit: { allowed: true, limit_reached: true, used_percent: 100, reset_at: null, limit_window_seconds: null } },
+      );
+      const b = makeEntry(
+        "b",
+        { window_reset_at: Date.now() + 1 * 86400_000 },
+        { rate_limit: { allowed: true, limit_reached: true, used_percent: 100, reset_at: null, limit_window_seconds: null } },
+      );
+      expect(strategy.select([a, b], state).id).toBe("b");
+    });
+
+    it("treats accounts without cached quota as non-exhausted", () => {
+      const noQuota = makeEntry("noQuota", { request_count: 2, window_reset_at: Date.now() + 7 * 86400_000 });
+      const exhausted = makeEntry(
+        "exhausted",
+        { request_count: 0, window_reset_at: Date.now() + 1 * 86400_000 },
+        { rate_limit: { allowed: true, limit_reached: true, used_percent: 100, reset_at: null, limit_window_seconds: null } },
+      );
+      expect(strategy.select([exhausted, noQuota], state).id).toBe("noQuota");
     });
   });
 

--- a/src/auth/__tests__/session-affinity.test.ts
+++ b/src/auth/__tests__/session-affinity.test.ts
@@ -87,4 +87,38 @@ describe("SessionAffinityMap", () => {
     }
     expect(map.lookupConversationId("resp_abc")).toBeNull();
   });
+
+  // turnState tracking
+  describe("turnState tracking", () => {
+    it("lookupTurnState returns recorded turnState", () => {
+      map = new SessionAffinityMap();
+      map.record("resp_1", "entry_1", "conv_1", "ts_abc");
+      expect(map.lookupTurnState("resp_1")).toBe("ts_abc");
+    });
+
+    it("lookupTurnState returns null when no turnState was recorded", () => {
+      map = new SessionAffinityMap();
+      map.record("resp_1", "entry_1", "conv_1");
+      expect(map.lookupTurnState("resp_1")).toBeNull();
+    });
+
+    it("turnState expires along with entry", () => {
+      map = new SessionAffinityMap(50);
+      map.record("resp_1", "entry_1", "conv_1", "ts_abc");
+      expect(map.lookupTurnState("resp_1")).toBe("ts_abc");
+
+      const start = Date.now();
+      while (Date.now() - start < 60) {
+        // busy wait
+      }
+      expect(map.lookupTurnState("resp_1")).toBeNull();
+    });
+
+    it("turnState is updated on re-record", () => {
+      map = new SessionAffinityMap();
+      map.record("resp_1", "entry_1", "conv_1", "ts_old");
+      map.record("resp_1", "entry_1", "conv_1", "ts_new");
+      expect(map.lookupTurnState("resp_1")).toBe("ts_new");
+    });
+  });
 });

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -115,7 +115,7 @@ export class AccountRegistry {
     entry.userId = profile?.chatgpt_user_id ?? entry.userId;
     // Don't reactivate manually disabled or banned accounts
     if (entry.status !== "disabled" && entry.status !== "banned") {
-      entry.status = "active";
+      entry.status = isTokenExpired(newToken) ? "expired" : "active";
     }
     this.persistNow();
   }

--- a/src/auth/quota-utils.ts
+++ b/src/auth/quota-utils.ts
@@ -19,7 +19,7 @@ export function toQuota(usage: CodexUsageResponse): CodexQuota {
     },
     secondary_rate_limit: sw
       ? {
-          limit_reached: usage.rate_limit.limit_reached,
+          limit_reached: sw.used_percent != null ? sw.used_percent >= 100 : usage.rate_limit.limit_reached,
           used_percent: sw.used_percent ?? null,
           reset_at: sw.reset_at ?? null,
           limit_window_seconds: sw.limit_window_seconds ?? null,

--- a/src/auth/rotation-strategy.ts
+++ b/src/auth/rotation-strategy.ts
@@ -18,14 +18,18 @@ export interface RotationStrategy {
 const leastUsed: RotationStrategy = {
   select(candidates) {
     const sorted = [...candidates].sort((a, b) => {
-      // Primary: prefer account whose quota resets soonest (use it before it resets)
+      // Primary: deprioritize quota-exhausted accounts
+      const aExhausted = a.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
+      const bExhausted = b.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
+      if (aExhausted !== bExhausted) return aExhausted - bExhausted;
+      // Secondary: prefer account whose quota resets soonest (use it before it resets)
       const aReset = a.usage.window_reset_at ?? Infinity;
       const bReset = b.usage.window_reset_at ?? Infinity;
       if (aReset !== bReset) return aReset - bReset;
-      // Secondary: fewer requests = more remaining quota
+      // Tertiary: fewer requests = more remaining quota
       const diff = a.usage.request_count - b.usage.request_count;
       if (diff !== 0) return diff;
-      // Tertiary: LRU
+      // Quaternary: LRU
       const aTime = a.usage.last_used ? new Date(a.usage.last_used).getTime() : 0;
       const bTime = b.usage.last_used ? new Date(b.usage.last_used).getTime() : 0;
       return aTime - bTime;

--- a/src/proxy/__tests__/codex-api-headers.test.ts
+++ b/src/proxy/__tests__/codex-api-headers.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TlsTransport, TlsTransportResponse } from "../../tls/transport.js";
+import type { CodexResponsesRequest } from "../codex-types.js";
+
+// Mock fingerprint — return minimal headers
+vi.mock("@src/fingerprint/manager.js", () => ({
+  buildHeaders: () => ({ Authorization: "Bearer test-token" }),
+  buildHeadersWithContentType: () => ({
+    Authorization: "Bearer test-token",
+    "Content-Type": "application/json",
+  }),
+}));
+
+// Mock config
+vi.mock("@src/config.js", () => ({
+  getConfig: () => ({
+    api: { base_url: "https://test.example" },
+  }),
+}));
+
+// Capture createWebSocketResponse calls
+const mockCreateWebSocketResponse = vi.fn<
+  (...args: unknown[]) => Promise<Response>
+>();
+vi.mock("@src/proxy/ws-transport.js", () => ({
+  createWebSocketResponse: (...args: unknown[]) =>
+    mockCreateWebSocketResponse(...args),
+}));
+
+function makeTransport(): TlsTransport & {
+  lastHeaders: Record<string, string> | null;
+  lastBody: string | null;
+} {
+  const t = {
+    lastHeaders: null as Record<string, string> | null,
+    lastBody: null as string | null,
+    post: vi.fn(
+      async (
+        _url: string,
+        headers: Record<string, string>,
+        body: string,
+      ): Promise<TlsTransportResponse> => {
+        t.lastHeaders = headers;
+        t.lastBody = body;
+        const encoder = new TextEncoder();
+        return {
+          status: 200,
+          headers: new Headers({ "content-type": "text/event-stream" }),
+          body: new ReadableStream({
+            start(c) {
+              c.enqueue(encoder.encode("data: {}\n\n"));
+              c.close();
+            },
+          }),
+          setCookieHeaders: [],
+        };
+      },
+    ),
+    get: vi.fn(),
+    isImpersonate: () => false,
+  };
+  return t;
+}
+
+function makeRequest(overrides?: Partial<CodexResponsesRequest>): CodexResponsesRequest {
+  return {
+    model: "gpt-5.4",
+    instructions: "test",
+    input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    ...overrides,
+  };
+}
+
+describe("codex-api headers", () => {
+  let transport: ReturnType<typeof makeTransport>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transport = makeTransport();
+  });
+
+  // Lazy import to let mocks register first
+  async function createApi() {
+    const { CodexApi } = await import("../codex-api.js");
+    return new CodexApi("test-token", "acct-1", null, "e1", null, "https://test.example", transport);
+  }
+
+  describe("HTTP SSE path", () => {
+    it("sends x-openai-internal-codex-residency: us", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest());
+      expect(transport.lastHeaders!["x-openai-internal-codex-residency"]).toBe("us");
+    });
+
+    it("sends x-client-request-id in UUID format", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest());
+      expect(transport.lastHeaders!["x-client-request-id"]).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it("sends x-codex-turn-state when turnState is present", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest({ turnState: "abc123" }));
+      expect(transport.lastHeaders!["x-codex-turn-state"]).toBe("abc123");
+    });
+
+    it("omits x-codex-turn-state when turnState is absent", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest());
+      expect(transport.lastHeaders!["x-codex-turn-state"]).toBeUndefined();
+    });
+
+    it("excludes turnState and service_tier from JSON body", async () => {
+      const api = await createApi();
+      await api.createResponse(
+        makeRequest({ turnState: "abc", service_tier: "fast" }),
+      );
+      const body = JSON.parse(transport.lastBody!) as Record<string, unknown>;
+      expect(body.turnState).toBeUndefined();
+      expect(body.service_tier).toBeUndefined();
+    });
+  });
+
+  describe("WebSocket path", () => {
+    it("sends residency, request-id, and turn-state headers", async () => {
+      mockCreateWebSocketResponse.mockResolvedValue(
+        new Response("data: {}\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      );
+
+      const api = await createApi();
+      await api.createResponse(
+        makeRequest({
+          previous_response_id: "resp_prev",
+          useWebSocket: true,
+          turnState: "ws_turn_abc",
+        }),
+      );
+
+      expect(mockCreateWebSocketResponse).toHaveBeenCalledTimes(1);
+      const headers = mockCreateWebSocketResponse.mock.calls[0][1] as Record<string, string>;
+      expect(headers["x-openai-internal-codex-residency"]).toBe("us");
+      expect(headers["x-client-request-id"]).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(headers["x-codex-turn-state"]).toBe("ws_turn_abc");
+    });
+  });
+});

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -212,7 +212,7 @@ export class CodexApi {
     if (request.tools?.length) wsRequest.tools = request.tools;
     if (request.tool_choice) wsRequest.tool_choice = request.tool_choice;
     if (request.text) wsRequest.text = request.text;
-    if (request.service_tier) wsRequest.service_tier = request.service_tier;
+    // service_tier is stripped — Codex backend rejects it ("Unsupported service_tier")
     if (request.prompt_cache_key) wsRequest.prompt_cache_key = request.prompt_cache_key;
     if (request.include?.length) wsRequest.include = request.include;
 
@@ -240,7 +240,7 @@ export class CodexApi {
     headers["x-client-request-id"] = crypto.randomUUID();
     if (request.turnState) headers["x-codex-turn-state"] = request.turnState;
 
-    const { previous_response_id: _pid, useWebSocket: _ws, turnState: _ts, ...bodyFields } = request;
+    const { previous_response_id: _pid, useWebSocket: _ws, turnState: _ts, service_tier: _st, ...bodyFields } = request;
     const body = JSON.stringify(bodyFields);
 
     let transportRes;

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -49,7 +49,6 @@ export interface WsCreateRequest {
       strict?: boolean;
     };
   };
-  service_tier?: string | null;
   prompt_cache_key?: string;
   include?: string[];
   // NOTE: `store` and `stream` are intentionally omitted.

--- a/src/routes/shared/__tests__/proxy-error-handler.test.ts
+++ b/src/routes/shared/__tests__/proxy-error-handler.test.ts
@@ -87,6 +87,42 @@ describe("handleCodexApiError", () => {
         countRequest: true,
       });
     });
+
+    it("uses cached quota reset time when account is exhausted", () => {
+      const resetAt = Math.floor(Date.now() / 1000) + 86400; // 1 day from now
+      pool.getEntry.mockReturnValue({
+        email: "test@example.com",
+        cachedQuota: {
+          rate_limit: { limit_reached: true, reset_at: resetAt },
+        },
+      });
+      const err = new CodexApiError(429, JSON.stringify({ error: { resets_in_seconds: 30 } }));
+
+      handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      const call = pool.markRateLimited.mock.calls[0];
+      expect(call[0]).toBe(entryId);
+      // Should use the longer cached reset time instead of 30s
+      expect(call[1].retryAfterSec).toBeGreaterThan(86000);
+      expect(call[1].countRequest).toBe(true);
+    });
+
+    it("uses short backoff when account is not exhausted", () => {
+      pool.getEntry.mockReturnValue({
+        email: "test@example.com",
+        cachedQuota: {
+          rate_limit: { limit_reached: false, used_percent: 50, reset_at: null },
+        },
+      });
+      const err = new CodexApiError(429, JSON.stringify({ error: { resets_in_seconds: 30 } }));
+
+      handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      expect(pool.markRateLimited).toHaveBeenCalledWith(entryId, {
+        retryAfterSec: 30,
+        countRequest: true,
+      });
+    });
   });
 
   // ── 403 ban ──

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -77,10 +77,21 @@ export function handleCodexApiError(
   // 2. Rate-limited
   if (err.status === 429) {
     const retryAfterSec = extractRetryAfterSec(err.body);
-    pool.markRateLimited(entryId, { retryAfterSec, countRequest: true });
+
+    // If cached quota shows limit_reached with a known reset time, use that
+    // instead of the short default backoff (prevents exhausted accounts from
+    // cycling back to "active" after 60s only to get 429'd again)
+    const entry = pool.getEntry(entryId);
+    const cachedReset = entry?.cachedQuota?.rate_limit?.reset_at;
+    const effectiveRetry = (entry?.cachedQuota?.rate_limit?.limit_reached && cachedReset)
+      ? Math.max(retryAfterSec ?? 0, cachedReset - Math.floor(Date.now() / 1000))
+      : retryAfterSec;
+
+    pool.markRateLimited(entryId, { retryAfterSec: effectiveRetry ?? undefined, countRequest: true });
+    const backoffDisplay = effectiveRetry != null ? Math.round(effectiveRetry) : null;
     console.warn(
       `[${tag}] Account ${entryId} (${email}) | 429 rate limited` +
-        (retryAfterSec != null ? ` (resets in ${Math.round(retryAfterSec)}s)` : "") +
+        (backoffDisplay != null ? ` (resets in ${backoffDisplay}s)` : "") +
         `, trying different account...`,
     );
     return { action: "retry", status: 429, message: err.message, useFormat429: true };

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -171,6 +171,13 @@ export async function handleProxyRequest(
           const windowSec = rl.primary.window_minutes != null ? rl.primary.window_minutes * 60 : null;
           accountPool.syncRateLimitWindow(entryId, rl.primary.reset_at, windowSec);
         }
+        // Proactively mark exhausted accounts so they don't get re-selected
+        if (quota.rate_limit.limit_reached && rl.primary?.reset_at != null) {
+          const backoffSec = rl.primary.reset_at - Math.floor(Date.now() / 1000);
+          if (backoffSec > 0) {
+            accountPool.markRateLimited(entryId, { retryAfterSec: backoffSec });
+          }
+        }
       }
 
       // ── Streaming path ──

--- a/tests/e2e/chat-completions.test.ts
+++ b/tests/e2e/chat-completions.test.ts
@@ -1,0 +1,704 @@
+/**
+ * E2E tests for POST /v1/chat/completions.
+ *
+ * Only mocks the external boundary (transport, config, paths, fs, background tasks).
+ * CodexApi, AccountPool, CookieJar, all translation layers, all middleware run for real.
+ *
+ * Each test builds a fresh Hono app to avoid shared account-lock state.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  setTransportPost,
+  resetTransportState,
+  getLastTransportBody,
+  getMockTransport,
+  makeTransportResponse,
+  makeErrorTransportResponse,
+} from "@helpers/e2e-setup.js";
+import {
+  buildTextStreamChunks,
+  buildToolCallStreamChunks,
+  buildReasoningStreamChunks,
+  buildDetailedUsageStreamChunks,
+  buildMultiToolCallStreamChunks,
+} from "@helpers/sse.js";
+import { createValidJwt } from "@helpers/jwt.js";
+
+// ── App imports (after mocks declared in e2e-setup) ──────────────────
+
+import { Hono } from "hono";
+import { requestId } from "@src/middleware/request-id.js";
+import { errorHandler } from "@src/middleware/error-handler.js";
+import { createChatRoutes } from "@src/routes/chat.js";
+import { createModelRoutes } from "@src/routes/models.js";
+import { createWebRoutes } from "@src/routes/web.js";
+import { AccountPool } from "@src/auth/account-pool.js";
+import { CookieJar } from "@src/proxy/cookie-jar.js";
+import { ProxyPool } from "@src/proxy/proxy-pool.js";
+import { loadStaticModels } from "@src/models/model-store.js";
+
+// ── Per-test app lifecycle ───────────────────────────────────────────
+
+interface TestContext {
+  app: Hono;
+  accountPool: AccountPool;
+  cookieJar: CookieJar;
+  proxyPool: ProxyPool;
+}
+
+let ctx: TestContext;
+
+function buildApp(opts?: { noAccount?: boolean }): TestContext {
+  loadStaticModels();
+
+  const accountPool = new AccountPool();
+  const cookieJar = new CookieJar();
+  const proxyPool = new ProxyPool();
+
+  if (!opts?.noAccount) {
+    accountPool.addAccount(createValidJwt({
+      accountId: "acct-e2e-1",
+      email: "e2e@test.com",
+      planType: "plus",
+    }));
+  }
+
+  const app = new Hono();
+  app.use("*", requestId);
+  app.use("*", errorHandler);
+  app.route("/", createChatRoutes(accountPool, cookieJar, proxyPool));
+  app.route("/", createModelRoutes());
+  app.route("/", createWebRoutes(accountPool));
+
+  return { app, accountPool, cookieJar, proxyPool };
+}
+
+beforeEach(() => {
+  resetTransportState();
+  setTransportPost(async () =>
+    makeTransportResponse(buildTextStreamChunks("resp_1", "Hello!")),
+  );
+  vi.mocked(getMockTransport().post).mockClear();
+  ctx = buildApp();
+});
+
+afterEach(() => {
+  ctx.cookieJar.destroy();
+  ctx.proxyPool.destroy();
+  ctx.accountPool.destroy();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function chatRequest(body: unknown) {
+  return ctx.app.request("/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function defaultBody(overrides?: Record<string, unknown>) {
+  return {
+    model: "codex",
+    messages: [{ role: "user", content: "Hello" }],
+    stream: false,
+    ...overrides,
+  };
+}
+
+/** Parse SSE text into an array of data objects. */
+function parseSSE(text: string): unknown[] {
+  const results: unknown[] = [];
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      const raw = line.slice(6);
+      if (raw === "[DONE]") {
+        results.push("[DONE]");
+      } else {
+        try { results.push(JSON.parse(raw)); } catch { results.push(raw); }
+      }
+    }
+  }
+  return results;
+}
+
+// ── Type helpers for assertions ──────────────────────────────────────
+
+interface SSEChunk {
+  id: string;
+  object: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+      reasoning_content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason: string | null;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+    completion_tokens_details?: { reasoning_tokens?: number };
+  } | null;
+}
+
+interface NonStreamingResponse {
+  id: string;
+  object: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: string;
+      content: string | null;
+      reasoning_content?: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: string;
+        function: { name: string; arguments: string };
+      }>;
+    };
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+    completion_tokens_details?: { reasoning_tokens?: number };
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("E2E: POST /v1/chat/completions", () => {
+  it("streaming: returns SSE with correct content-type and content", async () => {
+    const res = await chatRequest(defaultBody({ stream: true }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    // Consume the body to verify content
+    const text = await res.text();
+    const events = parseSSE(text);
+    expect(events.length).toBeGreaterThanOrEqual(2);
+
+    // Should have at least one chunk with content delta
+    const chunks = events.filter((e): e is Record<string, unknown> =>
+      typeof e === "object" && e !== null && "object" in e,
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+
+    // Should end with [DONE]
+    expect(events[events.length - 1]).toBe("[DONE]");
+
+    // Verify chunk structure
+    const firstChunk = chunks[0] as Record<string, unknown>;
+    expect(firstChunk.object).toBe("chat.completion.chunk");
+    const choices = firstChunk.choices as Array<{ delta?: { content?: string } }>;
+    expect(Array.isArray(choices)).toBe(true);
+  });
+
+  it("non-streaming: returns JSON with OpenAI structure", async () => {
+    const res = await chatRequest(defaultBody());
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.object).toBe("chat.completion");
+
+    const choices = body.choices as Array<{ message: { content: string } }>;
+    expect(Array.isArray(choices)).toBe(true);
+    expect(choices.length).toBeGreaterThanOrEqual(1);
+    expect(choices[0].message.content).toContain("Hello!");
+  });
+
+  it("non-streaming: response has correct model name", async () => {
+    const res = await chatRequest(defaultBody());
+    const body = await res.json() as Record<string, unknown>;
+    // "codex" alias resolves to "gpt-5.4"
+    expect(body.model).toBe("gpt-5.4");
+  });
+
+  it("unauthenticated: returns 401", async () => {
+    const noAuth = buildApp({ noAccount: true });
+    try {
+      const res = await noAuth.app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(defaultBody()),
+      });
+      expect(res.status).toBe(401);
+
+      const body = await res.json() as { error: { code: string } };
+      expect(body.error.code).toBe("invalid_api_key");
+    } finally {
+      noAuth.cookieJar.destroy();
+      noAuth.proxyPool.destroy();
+      noAuth.accountPool.destroy();
+    }
+  });
+
+  it("invalid JSON body: returns 400", async () => {
+    const res = await ctx.app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not valid json{{{",
+    });
+    expect(res.status).toBe(400);
+
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_json");
+  });
+
+  it("missing messages field: returns 400", async () => {
+    const res = await chatRequest({ model: "codex" });
+    expect(res.status).toBe(400);
+
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_request");
+  });
+
+  it("upstream 429: returns 429 with rate_limit_error", async () => {
+    setTransportPost(async () =>
+      makeErrorTransportResponse(429, JSON.stringify({ detail: "Rate limited" })),
+    );
+
+    const res = await chatRequest(defaultBody());
+    expect(res.status).toBe(429);
+
+    const body = await res.json() as { error: { type: string } };
+    expect(body.error.type).toBe("rate_limit_error");
+  });
+
+  it("upstream 500: returns error after retries", async () => {
+    setTransportPost(async () =>
+      makeErrorTransportResponse(500, JSON.stringify({ detail: "Internal error" })),
+    );
+
+    // Real withRetry runs here — retries 2x with backoff (total ~3s).
+    // This intentionally exercises the real retry path end-to-end.
+    const res = await chatRequest(defaultBody());
+    expect(res.status).toBe(500);
+
+    const body = await res.json() as { error: { type: string } };
+    expect(body.error.type).toBe("server_error");
+
+    // Verify transport was called 3 times (1 initial + 2 retries)
+    expect(getMockTransport().post).toHaveBeenCalledTimes(3);
+  }, 10_000);
+
+  it("model suffix: codex-fast resolves correctly", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(buildTextStreamChunks("resp_fast", "Fast response!")),
+    );
+
+    const res = await chatRequest(defaultBody({ model: "codex-fast" }));
+    expect(res.status).toBe(200);
+
+    // Verify the request body sent to transport
+    const sentBody = JSON.parse(getLastTransportBody()!) as Record<string, unknown>;
+    expect(sentBody.model).toBe("gpt-5.4");
+    // service_tier must NOT be in request body — Codex backend rejects it
+    expect(sentBody.service_tier).toBeUndefined();
+
+    // The response model should reflect the suffix
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.model).toBe("gpt-5.4-fast");
+  });
+
+  // ── Tool call tests ──────────────────────────────────────────────
+
+  it("tool calls (streaming): returns SSE chunks with tool_calls delta", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildToolCallStreamChunks("resp_tool_s", "call_abc", "get_weather", '{"city":"London"}'),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: true,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+    }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const text = await res.text();
+    const events = parseSSE(text);
+    const chunks = events.filter((e): e is SSEChunk =>
+      typeof e === "object" && e !== null && "object" in e,
+    ) as SSEChunk[];
+
+    // Find chunks with tool_calls in delta
+    const toolCallChunks = chunks.filter(
+      (c) => c.choices[0]?.delta?.tool_calls && c.choices[0].delta.tool_calls.length > 0,
+    );
+    expect(toolCallChunks.length).toBeGreaterThanOrEqual(1);
+
+    // First tool call chunk should have the function name
+    const firstToolChunk = toolCallChunks[0];
+    const firstToolCall = firstToolChunk.choices[0].delta.tool_calls![0];
+    expect(firstToolCall.function?.name).toBe("get_weather");
+    expect(firstToolCall.id).toBe("call_abc");
+    expect(firstToolCall.type).toBe("function");
+
+    // Final chunk should have finish_reason "tool_calls"
+    const finalChunk = chunks[chunks.length - 1];
+    expect(finalChunk.choices[0].finish_reason).toBe("tool_calls");
+
+    // Should end with [DONE]
+    expect(events[events.length - 1]).toBe("[DONE]");
+  });
+
+  it("tool calls (non-streaming): returns JSON with tool_calls array", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildToolCallStreamChunks("resp_tool_ns", "call_xyz", "get_weather", '{"city":"Paris"}'),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: false,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as NonStreamingResponse;
+    expect(body.object).toBe("chat.completion");
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+    expect(body.choices[0].message.tool_calls).toBeDefined();
+    expect(body.choices[0].message.tool_calls!.length).toBe(1);
+
+    const toolCall = body.choices[0].message.tool_calls![0];
+    expect(toolCall.id).toBe("call_xyz");
+    expect(toolCall.type).toBe("function");
+    expect(toolCall.function.name).toBe("get_weather");
+    expect(toolCall.function.arguments).toBe('{"city":"Paris"}');
+  });
+
+  it("legacy function_call: translates functions to tools", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildToolCallStreamChunks("resp_legacy", "call_fn1", "get_weather", '{"city":"Tokyo"}'),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: false,
+      functions: [{ name: "get_weather", parameters: {} }],
+      function_call: "auto",
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as NonStreamingResponse;
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+    expect(body.choices[0].message.tool_calls).toBeDefined();
+    expect(body.choices[0].message.tool_calls!.length).toBe(1);
+
+    const toolCall = body.choices[0].message.tool_calls![0];
+    expect(toolCall.function.name).toBe("get_weather");
+    expect(toolCall.function.arguments).toBe('{"city":"Tokyo"}');
+
+    // Verify that the transport request body has tools (translated from functions)
+    const sentBody = JSON.parse(getLastTransportBody()!) as Record<string, unknown>;
+    const sentTools = sentBody.tools as Array<Record<string, unknown>>;
+    expect(sentTools).toBeDefined();
+    expect(sentTools.length).toBe(1);
+  });
+
+  it("image input: forwards image content to codex request", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(buildTextStreamChunks("resp_img", "It is a cat.")),
+    );
+
+    const res = await chatRequest(defaultBody({
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+        ],
+      }],
+    }));
+    expect(res.status).toBe(200);
+
+    // Verify the transport received the image in the codex request body
+    const sentBody = JSON.parse(getLastTransportBody()!) as Record<string, unknown>;
+    const input = sentBody.input as Array<Record<string, unknown>>;
+    expect(input).toBeDefined();
+    expect(input.length).toBeGreaterThanOrEqual(1);
+
+    // The user message should have structured content with image
+    const userMsg = input.find(
+      (item) => item.role === "user",
+    );
+    expect(userMsg).toBeDefined();
+    const content = userMsg!.content as Array<Record<string, unknown>>;
+    expect(Array.isArray(content)).toBe(true);
+
+    const imagePart = content.find((p) => p.type === "input_image");
+    expect(imagePart).toBeDefined();
+    expect(imagePart!.image_url).toBe("data:image/png;base64,abc");
+
+    const textPart = content.find((p) => p.type === "input_text");
+    expect(textPart).toBeDefined();
+    expect(textPart!.text).toBe("What is this?");
+  });
+
+  // ── Reasoning tests ──────────────────────────────────────────────
+
+  it("reasoning (streaming): returns SSE chunks with reasoning_content", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildReasoningStreamChunks("resp_reason_s", "Let me think step by step...", "The answer is 42."),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: true,
+      reasoning_effort: "high",
+    }));
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const events = parseSSE(text);
+    const chunks = events.filter((e): e is SSEChunk =>
+      typeof e === "object" && e !== null && "object" in e,
+    ) as SSEChunk[];
+
+    // Find chunks with reasoning_content delta
+    const reasoningChunks = chunks.filter(
+      (c) => c.choices[0]?.delta?.reasoning_content != null,
+    );
+    expect(reasoningChunks.length).toBeGreaterThanOrEqual(1);
+    expect(reasoningChunks[0].choices[0].delta.reasoning_content).toBe(
+      "Let me think step by step...",
+    );
+
+    // Find chunks with text content delta
+    const contentChunks = chunks.filter(
+      (c) => c.choices[0]?.delta?.content != null && c.choices[0].delta.content !== "",
+    );
+    expect(contentChunks.length).toBeGreaterThanOrEqual(1);
+
+    // Should end with [DONE]
+    expect(events[events.length - 1]).toBe("[DONE]");
+  });
+
+  it("reasoning (non-streaming): returns JSON with reasoning_content", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildReasoningStreamChunks("resp_reason_ns", "Thinking carefully...", "Result is 7."),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: false,
+      reasoning_effort: "high",
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as NonStreamingResponse;
+    expect(body.object).toBe("chat.completion");
+    expect(body.choices[0].message.content).toBe("Result is 7.");
+    expect(body.choices[0].message.reasoning_content).toBe("Thinking carefully...");
+  });
+
+  // ── Usage details tests ──────────────────────────────────────────
+
+  it("usage details: cached_tokens and reasoning_tokens are forwarded", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildDetailedUsageStreamChunks("resp_usage", "Answer", {
+          input_tokens: 100,
+          output_tokens: 50,
+          input_tokens_details: { cached_tokens: 50 },
+          output_tokens_details: { reasoning_tokens: 30 },
+        }),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody());
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as NonStreamingResponse;
+    expect(body.usage.prompt_tokens).toBe(100);
+    expect(body.usage.completion_tokens).toBe(50);
+    expect(body.usage.total_tokens).toBe(150);
+    expect(body.usage.prompt_tokens_details?.cached_tokens).toBe(50);
+    expect(body.usage.completion_tokens_details?.reasoning_tokens).toBe(30);
+  });
+
+  // ── Model suffix tests ───────────────────────────────────────────
+
+  it("model suffix: codex-high resolves reasoning effort", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(buildTextStreamChunks("resp_high", "High reasoning response")),
+    );
+
+    const res = await chatRequest(defaultBody({ model: "codex-high" }));
+    expect(res.status).toBe(200);
+
+    // Verify the transport body has the resolved model ID
+    const sentBody = JSON.parse(getLastTransportBody()!) as Record<string, unknown>;
+    expect(sentBody.model).toBe("gpt-5.4");
+
+    // Verify reasoning effort is set in the request
+    const reasoning = sentBody.reasoning as Record<string, unknown> | undefined;
+    expect(reasoning?.effort).toBe("high");
+
+    // The response model should include the suffix
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.model).toBe("gpt-5.4-high");
+  });
+
+  it("model suffix: codex-high-fast (dual suffix) resolves both", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(buildTextStreamChunks("resp_dual", "Dual suffix response")),
+    );
+
+    const res = await chatRequest(defaultBody({ model: "codex-high-fast" }));
+    expect(res.status).toBe(200);
+
+    // Verify the transport body has the base model (no suffix)
+    const sentBody = JSON.parse(getLastTransportBody()!) as Record<string, unknown>;
+    expect(sentBody.model).toBe("gpt-5.4");
+
+    // Verify reasoning effort and service tier
+    const reasoning = sentBody.reasoning as Record<string, unknown> | undefined;
+    expect(reasoning?.effort).toBe("high");
+    // service_tier for "fast" is set but may not appear in the codex request body
+    // (it's passed as service_tier field)
+
+    // The response model should have the full suffix
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.model).toBe("gpt-5.4-high-fast");
+  });
+
+  // ── Error format tests ───────────────────────────────────────────
+
+  it("error 400: missing model field returns invalid_request", async () => {
+    const res = await chatRequest({
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    expect(res.status).toBe(400);
+
+    const body = await res.json() as { error: { code: string; type: string } };
+    expect(body.error.code).toBe("invalid_request");
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it("error 401: no accounts returns invalid_api_key", async () => {
+    const noAuth = buildApp({ noAccount: true });
+    try {
+      const res = await noAuth.app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(defaultBody()),
+      });
+      expect(res.status).toBe(401);
+
+      const body = await res.json() as { error: { code: string; type: string } };
+      expect(body.error.code).toBe("invalid_api_key");
+      expect(body.error.type).toBe("invalid_request_error");
+    } finally {
+      noAuth.cookieJar.destroy();
+      noAuth.proxyPool.destroy();
+      noAuth.accountPool.destroy();
+    }
+  });
+
+  // ── Multiple tool calls ──────────────────────────────────────────
+
+  it("multiple tool calls: non-streaming returns 2 tool_calls entries", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildMultiToolCallStreamChunks("resp_multi", [
+          { callId: "call_1", name: "get_weather", args: '{"city":"NYC"}' },
+          { callId: "call_2", name: "get_time", args: '{"timezone":"EST"}' },
+        ]),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: false,
+      tools: [
+        { type: "function", function: { name: "get_weather", parameters: {} } },
+        { type: "function", function: { name: "get_time", parameters: {} } },
+      ],
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as NonStreamingResponse;
+    expect(body.object).toBe("chat.completion");
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+    expect(body.choices[0].message.tool_calls).toBeDefined();
+    expect(body.choices[0].message.tool_calls!.length).toBe(2);
+
+    const [tc1, tc2] = body.choices[0].message.tool_calls!;
+    expect(tc1.id).toBe("call_1");
+    expect(tc1.function.name).toBe("get_weather");
+    expect(tc1.function.arguments).toBe('{"city":"NYC"}');
+    expect(tc2.id).toBe("call_2");
+    expect(tc2.function.name).toBe("get_time");
+    expect(tc2.function.arguments).toBe('{"timezone":"EST"}');
+  });
+
+  it("multiple tool calls (streaming): returns SSE chunks for each tool call", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildMultiToolCallStreamChunks("resp_multi_s", [
+          { callId: "call_a", name: "search", args: '{"q":"hello"}' },
+          { callId: "call_b", name: "calculate", args: '{"expr":"1+1"}' },
+        ]),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: true,
+      tools: [
+        { type: "function", function: { name: "search", parameters: {} } },
+        { type: "function", function: { name: "calculate", parameters: {} } },
+      ],
+    }));
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const events = parseSSE(text);
+    const chunks = events.filter((e): e is SSEChunk =>
+      typeof e === "object" && e !== null && "object" in e,
+    ) as SSEChunk[];
+
+    // Find chunks with tool_calls delta
+    const toolCallChunks = chunks.filter(
+      (c) => c.choices[0]?.delta?.tool_calls && c.choices[0].delta.tool_calls.length > 0,
+    );
+
+    // Should have chunks for both tool calls (at least 2: one start per call + args)
+    expect(toolCallChunks.length).toBeGreaterThanOrEqual(2);
+
+    // Verify we see both function names across the chunks
+    const functionNames = toolCallChunks
+      .map((c) => c.choices[0].delta.tool_calls![0].function?.name)
+      .filter((n): n is string => n != null);
+    expect(functionNames).toContain("search");
+    expect(functionNames).toContain("calculate");
+
+    // Final chunk should have finish_reason "tool_calls"
+    const finalChunk = chunks[chunks.length - 1];
+    expect(finalChunk.choices[0].finish_reason).toBe("tool_calls");
+
+    // Should end with [DONE]
+    expect(events[events.length - 1]).toBe("[DONE]");
+  });
+});

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -78,7 +78,9 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
   // Quota — primary window (default 0% used = 100% available for accounts without data)
   const q = account.quota;
   const rl = q?.rate_limit;
-  const pct = rl?.used_percent != null ? Math.round(rl.used_percent) : (account.status === "active" ? 0 : null);
+  const pct = rl?.limit_reached ? 100
+    : rl?.used_percent != null ? Math.round(rl.used_percent)
+    : (account.status === "active" ? 0 : null);
   const barColor =
     pct == null ? "bg-primary" : pct >= 90 ? "bg-red-500" : pct >= 60 ? "bg-amber-500" : "bg-primary";
   const pctColor =
@@ -93,7 +95,9 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
 
   // Quota — secondary window (e.g. weekly)
   const srl = q?.secondary_rate_limit;
-  const sPct = srl?.used_percent != null ? Math.round(srl.used_percent) : null;
+  const sPct = srl?.limit_reached ? 100
+    : srl?.used_percent != null ? Math.round(srl.used_percent)
+    : null;
   const sBarColor =
     sPct == null ? "bg-indigo-500" : sPct >= 90 ? "bg-red-500" : sPct >= 60 ? "bg-amber-500" : "bg-indigo-500";
   const sPctColor =


### PR DESCRIPTION
## Summary
- **进度条 Bug**: `limit_reached=true` 时进度条显示 100%（之前因 `used_percent=null` 默认为 0%）；secondary 的 `limit_reached` 改为从自身 `used_percent` 推导
- **Fast 模型回归**: 重新 strip `service_tier`（`ccf1d3f` 误恢复了被 `44b20f4` 修复的回归），HTTP body 和 WS 路径均不再发送
- **账号池排序**: `least_used` 策略加入 `limit_reached` 权重，耗尽账号排到最后；429 退避改用 cached quota 的 `reset_at`（而非固定 60s）；passive quota 收集时主动 mark 耗尽账号
- **Native transport 测试 Phase 1**: 4 个 turnState 测试 + 6 个 codex-api header 测试

## Test plan
- [x] 1422 tests pass (20 new)
- [ ] 浏览器 `localhost:8080` 验证进度条显示
- [ ] Fast 模型 E2E 验证 ≥3 次
- [ ] 多账号场景验证排序和退避行为