### PR TITLE
fix: mark deactivated accounts as banned

### DIFF
--- a/src/routes/shared/__tests__/proxy-error-handler.test.ts
+++ b/src/routes/shared/__tests__/proxy-error-handler.test.ts
@@ -159,6 +159,18 @@ describe("handleCodexApiError", () => {
       expect(result.action).toBe("retry");
       expect(pool.markStatus).toHaveBeenCalledWith(entryId, "expired");
     });
+
+    it("marks account banned when deactivated", () => {
+      const err = new CodexApiError(
+        401,
+        "Your OpenAI account has been deactivated, please check your email",
+      );
+
+      const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      expect(result.action).toBe("retry");
+      expect(pool.markStatus).toHaveBeenCalledWith(entryId, "banned");
+    });
   });
 
   // ── generic errors ──

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -106,11 +106,13 @@ export function handleCodexApiError(
     return { action: "retry", status: 403, message: err.message };
   }
 
-  // 4. Token invalidated
+  // 4. Token invalidated / account deactivated
   if (isTokenInvalidError(err)) {
-    pool.markStatus(entryId, "expired");
+    const isDeactivated = err.message.toLowerCase().includes("deactivated");
+    const newStatus = isDeactivated ? "banned" : "expired";
+    pool.markStatus(entryId, newStatus);
     console.warn(
-      `[${tag}] Account ${entryId} (${email}) | 401 token invalidated, trying different account...`,
+      `[${tag}] Account ${entryId} (${email}) | 401 ${isDeactivated ? "deactivated (banned)" : "token invalidated"}, trying different account...`,
     );
     return { action: "retry", status: 401, message: err.message };
   }


### PR DESCRIPTION
## Summary
- 401 "account has been deactivated" 标记为 `banned` 而非 `expired`
- `banned` 状态受 `updateToken` 保护，刷新不会覆盖
- 探活保持 OAuth-only，不加 API 请求

## Test plan
- [x] 1423 tests pass (1 new)
- [ ] 用已知 deactivated 账号验证