### PR TITLE
test(ci): update Docker smoke test matrix with custom port verification

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,34 +28,52 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
-        run: docker build -t codex-proxy:smoke .
+        run: docker build -t codex-proxy-test .
+
+      - name: Handle custom port config
+        if: matrix.port != 8080
+        run: |
+          mkdir -p custom-config
+          echo "server:" > custom-config/default.yaml
+          echo "  port: ${{ matrix.port }}" >> custom-config/default.yaml
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
-            -e NODE_ENV=production \
-            codex-proxy:smoke
+          if [ "${{ matrix.port }}" != "8080" ]; then
+            docker run -d --name test-container \
+              -p 18080:${{ matrix.port }} \
+              -v $(pwd)/custom-config/default.yaml:/app/config/default.yaml \
+              -e NODE_ENV=production \
+              codex-proxy-test
+          else
+            docker run -d --name test-container \
+              -p 18080:8080 \
+              -e NODE_ENV=production \
+              codex-proxy-test
+          fi
           echo "Container started"
 
       - name: Wait for healthy
         run: |
           echo "Waiting for container to become healthy..."
           for i in $(seq 1 30); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' test-container 2>/dev/null || echo "starting")
             echo "  [$i/30] status: $STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Container is healthy"
               exit 0
             fi
-            sleep 2
+            sleep 1
           done
-          echo "::error::Container did not become healthy within 60s"
-          docker logs smoke-test
+          echo "::error::Container did not become healthy within 30s"
+          docker logs test-container
           exit 1
 
       - name: Verify /health endpoint
@@ -78,5 +96,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
-          docker rm -f smoke-test || true
+          docker logs test-container 2>&1 | tail -30
+          docker rm -f test-container || true


### PR DESCRIPTION
Fixes #120 by introducing a GitHub Actions CI matrix strategy to effectively test both standard (8080) and custom (8090) Docker application ports via overriding configurations dynamically and ensuring the built image executes correctly under health-check.

---
*PR created automatically by Jules for task [10783308453294517372](https://jules.google.com/task/10783308453294517372) started by @icebear0828*