### PR TITLE
fix: include native addon in Electron packaging

### DIFF
--- a/packages/electron/__tests__/builder-config.test.ts
+++ b/packages/electron/__tests__/builder-config.test.ts
@@ -95,6 +95,25 @@ describe("electron-builder.yml", () => {
     ).toBe(true);
   });
 
+  it("extraResources native/ maps to correct root directory", () => {
+    const nativeResource = config.extraResources.find(
+      (r) => r.to === "native/" || r.to === "native",
+    );
+    expect(nativeResource).toBeDefined();
+    // native/ is copied from root by prepare-pack before packing
+    const rootNative = resolve(ROOT_DIR, "native");
+    expect(
+      existsSync(rootNative),
+      `Root native/ directory should exist at ${rootNative}`,
+    ).toBe(true);
+  });
+
+  it("root native/ contains required runtime files", () => {
+    const rootNative = resolve(ROOT_DIR, "native");
+    expect(existsSync(resolve(rootNative, "index.js"))).toBe(true);
+    expect(existsSync(resolve(rootNative, "package.json"))).toBe(true);
+  });
+
   it("asarUnpack includes all runtime directories", () => {
     const unpacked = config.asarUnpack;
     expect(unpacked).toContain("config/**/*");

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -37,6 +37,10 @@ extraResources:
     to: bin/
     filter:
       - "**/*"
+  - from: native/
+    to: native/
+    filter:
+      - "**/*"
 
 win:
   target:

--- a/packages/electron/electron/prepare-pack.mjs
+++ b/packages/electron/electron/prepare-pack.mjs
@@ -34,3 +34,29 @@ for (const dir of DIRS) {
     console.log(`[prepare-pack] copied ${dir}/ → packages/electron/${dir}/`);
   }
 }
+
+// Native addon — copy only runtime files (index.js, index.d.ts, *.node, package.json),
+// skip Rust source, build artifacts (target/), and node_modules.
+const nativeSrc = resolve(ROOT, "native");
+const nativeDest = resolve(PKG, "native");
+
+if (isClean) {
+  if (existsSync(nativeDest)) {
+    rmSync(nativeDest, { recursive: true });
+    console.log("[prepare-pack] removed native/");
+  }
+} else if (!existsSync(nativeSrc)) {
+  console.warn(`[prepare-pack] skipping native/ (not found at ${nativeSrc})`);
+} else {
+  cpSync(nativeSrc, nativeDest, {
+    recursive: true,
+    filter: (src) => {
+      const rel = src.slice(nativeSrc.length);
+      // Skip Rust source, build artifacts, and node_modules
+      if (/\/(target|node_modules|src)(\/|$)/.test(rel)) return false;
+      if (/\/(Cargo\.(toml|lock)|build\.rs|\.cargo)/.test(rel)) return false;
+      return true;
+    },
+  });
+  console.log("[prepare-pack] copied native/ (runtime only) → packages/electron/native/");
+}


### PR DESCRIPTION
## Summary
- `prepare-pack.mjs` copies `native/` runtime files (index.js, *.node, package.json), excluding Rust source and build artifacts (target/, src/, Cargo.*)
- `electron-builder.yml` adds `native/` to `extraResources`, placing it at `resources/native/` — matching the bundled `server.mjs` path resolution (`../../native`)
- Adds builder-config tests for the new native resource entry

Fixes: `Native addon not found at ...\resources\native\index.js` on Windows Electron builds.

## Test plan
- [x] `builder-config.test.ts` passes (13 tests)
- [x] `prepare-pack.mjs` dry run copies only runtime files
- [ ] Windows Electron build produces working `resources/native/` with platform `.node` binary