### PR TITLE
fix: extract rate-limit quota from WebSocket codex.rate_limits event

### DIFF
--- a/src/proxy/__tests__/rate-limit-event.test.ts
+++ b/src/proxy/__tests__/rate-limit-event.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for parseRateLimitsEvent — extracts quota from the
+ * `codex.rate_limits` WebSocket SSE event payload.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseRateLimitsEvent } from "../rate-limit-headers.js";
+
+describe("parseRateLimitsEvent", () => {
+  it("parses a full codex.rate_limits event with primary + secondary", () => {
+    const data = {
+      type: "codex.rate_limits",
+      plan_type: "plus",
+      rate_limits: {
+        primary: { used_percent: 42.0, window_minutes: 300, reset_at: 1700000000 },
+        secondary: { used_percent: 18.0, window_minutes: 10080, reset_at: 1700500000 },
+      },
+    };
+    const result = parseRateLimitsEvent(data);
+    expect(result).toEqual({
+      primary: { used_percent: 42.0, window_minutes: 300, reset_at: 1700000000 },
+      secondary: { used_percent: 18.0, window_minutes: 10080, reset_at: 1700500000 },
+    });
+  });
+
+  it("parses event with only primary window", () => {
+    const data = {
+      type: "codex.rate_limits",
+      rate_limits: {
+        primary: { used_percent: 80.5, window_minutes: 300, reset_at: 1700000000 },
+      },
+    };
+    const result = parseRateLimitsEvent(data);
+    expect(result).toEqual({
+      primary: { used_percent: 80.5, window_minutes: 300, reset_at: 1700000000 },
+      secondary: null,
+    });
+  });
+
+  it("parses event with only secondary window", () => {
+    const data = {
+      type: "codex.rate_limits",
+      rate_limits: {
+        secondary: { used_percent: 50.0, window_minutes: 10080, reset_at: 1700500000 },
+      },
+    };
+    const result = parseRateLimitsEvent(data);
+    expect(result).toEqual({
+      primary: null,
+      secondary: { used_percent: 50.0, window_minutes: 10080, reset_at: 1700500000 },
+    });
+  });
+
+  it("returns null for missing rate_limits field", () => {
+    expect(parseRateLimitsEvent({ type: "codex.rate_limits" })).toBeNull();
+    expect(parseRateLimitsEvent({})).toBeNull();
+    expect(parseRateLimitsEvent(null)).toBeNull();
+    expect(parseRateLimitsEvent("string")).toBeNull();
+  });
+
+  it("returns null when rate_limits has no windows", () => {
+    expect(parseRateLimitsEvent({ rate_limits: {} })).toBeNull();
+    expect(parseRateLimitsEvent({ rate_limits: { primary: null } })).toBeNull();
+  });
+
+  it("handles missing optional fields in window", () => {
+    const data = {
+      rate_limits: {
+        primary: { used_percent: 10 },
+      },
+    };
+    const result = parseRateLimitsEvent(data);
+    expect(result).toEqual({
+      primary: { used_percent: 10, window_minutes: null, reset_at: null },
+      secondary: null,
+    });
+  });
+
+  it("handles invalid used_percent gracefully", () => {
+    const data = {
+      rate_limits: {
+        primary: { used_percent: "not_a_number", window_minutes: 300, reset_at: 1700000000 },
+      },
+    };
+    expect(parseRateLimitsEvent(data)).toBeNull();
+  });
+});

--- a/src/proxy/__tests__/rate-limit-event.test.ts
+++ b/src/proxy/__tests__/rate-limit-event.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests for parseRateLimitsEvent — extracts quota from the
  * `codex.rate_limits` WebSocket SSE event payload.
+ *
+ * Also tests the WS transport integration: callback invocation + event suppression.
  */
 
-import { describe, it, expect } from "vitest";
-import { parseRateLimitsEvent } from "../rate-limit-headers.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseRateLimitsEvent, type ParsedRateLimit } from "../rate-limit-headers.js";
 
 describe("parseRateLimitsEvent", () => {
   it("parses a full codex.rate_limits event with primary + secondary", () => {
@@ -83,5 +85,132 @@ describe("parseRateLimitsEvent", () => {
       },
     };
     expect(parseRateLimitsEvent(data)).toBeNull();
+  });
+});
+
+// ── WS transport integration: callback invocation + event suppression ───
+
+function createMockWsClass(messageSequence: Record<string, unknown>[]) {
+  return class {
+    private handlers = new Map<string, ((...args: unknown[]) => void)[]>();
+    constructor(_url: string, _opts: unknown) {
+      queueMicrotask(() => {
+        this.emit("upgrade", { headers: {} });
+        this.emit("open");
+        let step = Promise.resolve();
+        for (const msg of messageSequence) {
+          step = step.then(
+            () =>
+              new Promise<void>((resolve) =>
+                queueMicrotask(() => {
+                  this.emit("message", JSON.stringify(msg));
+                  resolve();
+                }),
+              ),
+          );
+        }
+        step.then(
+          () =>
+            new Promise<void>((resolve) =>
+              queueMicrotask(() => {
+                this.emit("close", 1000, Buffer.from(""));
+                resolve();
+              }),
+            ),
+        );
+      });
+    }
+    on(event: string, handler: (...args: unknown[]) => void) {
+      const list = this.handlers.get(event) ?? [];
+      list.push(handler);
+      this.handlers.set(event, list);
+    }
+    private emit(event: string, ...args: unknown[]) {
+      for (const handler of this.handlers.get(event) ?? []) {
+        handler(...args);
+      }
+    }
+    send = vi.fn();
+    close = vi.fn();
+  };
+}
+
+async function collectSSE(response: Response): Promise<string> {
+  const reader = response.body!.pipeThrough(new TextDecoderStream()).getReader();
+  const chunks: string[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks.join("");
+}
+
+describe("ws-transport rate_limits callback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("invokes onRateLimits callback and suppresses event from SSE stream", async () => {
+    const rateLimitsMsg = {
+      type: "codex.rate_limits",
+      plan_type: "plus",
+      rate_limits: {
+        primary: { used_percent: 55.0, window_minutes: 300, reset_at: 1700000000 },
+      },
+    };
+
+    vi.doMock("ws", () => ({
+      default: createMockWsClass([
+        { type: "response.created", response: { id: "resp_1" } },
+        rateLimitsMsg,
+        { type: "response.completed", response: { id: "resp_1" } },
+      ]),
+    }));
+
+    const { createWebSocketResponse } = await import("../ws-transport.js");
+
+    const captured: ParsedRateLimit[] = [];
+    const response = await createWebSocketResponse(
+      "wss://example.com/ws",
+      { Authorization: "Bearer test" },
+      { type: "response.create", model: "test", instructions: "", input: [] },
+      undefined,
+      undefined,
+      (rl) => captured.push(rl),
+    );
+
+    const output = await collectSSE(response);
+
+    // Callback was invoked with parsed data
+    expect(captured).toHaveLength(1);
+    expect(captured[0].primary?.used_percent).toBe(55.0);
+
+    // rate_limits event NOT forwarded to downstream SSE
+    expect(output).not.toContain("codex.rate_limits");
+    // Normal events still present
+    expect(output).toContain("event: response.created");
+    expect(output).toContain("event: response.completed");
+  });
+
+  it("does not invoke callback when no onRateLimits provided", async () => {
+    vi.doMock("ws", () => ({
+      default: createMockWsClass([
+        { type: "codex.rate_limits", rate_limits: { primary: { used_percent: 10, window_minutes: 300, reset_at: 1 } } },
+        { type: "response.completed", response: { id: "resp_1" } },
+      ]),
+    }));
+
+    const { createWebSocketResponse } = await import("../ws-transport.js");
+    const response = await createWebSocketResponse(
+      "wss://example.com/ws",
+      { Authorization: "Bearer test" },
+      { type: "response.create", model: "test", instructions: "", input: [] },
+    );
+
+    const output = await collectSSE(response);
+
+    // Without callback, rate_limits event IS forwarded as SSE (no interception)
+    expect(output).toContain("codex.rate_limits");
   });
 });

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -16,6 +16,7 @@ import {
   buildHeadersWithContentType,
 } from "../fingerprint/manager.js";
 import { createWebSocketResponse, type WsCreateRequest } from "./ws-transport.js";
+import type { ParsedRateLimit } from "./rate-limit-headers.js";
 import { parseSSEBlock, parseSSEStream } from "./codex-sse.js";
 import { fetchUsage } from "./codex-usage.js";
 import { fetchModels, probeEndpoint as probeEndpointFn } from "./codex-models.js";
@@ -165,10 +166,11 @@ export class CodexApi {
   async createResponse(
     request: CodexResponsesRequest,
     signal?: AbortSignal,
+    onRateLimits?: (rl: ParsedRateLimit) => void,
   ): Promise<Response> {
     if (request.useWebSocket) {
       try {
-        return await this.createResponseViaWebSocket(request, signal);
+        return await this.createResponseViaWebSocket(request, signal, onRateLimits);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[CodexApi] WebSocket failed (${msg}), falling back to HTTP SSE`);
@@ -187,6 +189,7 @@ export class CodexApi {
   private async createResponseViaWebSocket(
     request: CodexResponsesRequest,
     signal?: AbortSignal,
+    onRateLimits?: (rl: ParsedRateLimit) => void,
   ): Promise<Response> {
     const baseUrl = this.resolveBaseUrl();
     const wsUrl = baseUrl.replace(/^https?:/, "wss:") + "/codex/responses";
@@ -216,7 +219,7 @@ export class CodexApi {
     if (request.prompt_cache_key) wsRequest.prompt_cache_key = request.prompt_cache_key;
     if (request.include?.length) wsRequest.include = request.include;
 
-    return createWebSocketResponse(wsUrl, headers, wsRequest, signal, this.proxyUrl);
+    return createWebSocketResponse(wsUrl, headers, wsRequest, signal, this.proxyUrl, onRateLimits);
   }
 
   /**

--- a/src/proxy/rate-limit-headers.ts
+++ b/src/proxy/rate-limit-headers.ts
@@ -82,6 +82,55 @@ export function rateLimitToQuota(
   };
 }
 
+// ── Window shape (shared by header parsing and event parsing) ───
+
+interface RateLimitWindowData {
+  used_percent: number;
+  window_minutes: number | null;
+  reset_at: number | null;
+}
+
+/**
+ * Parse rate-limit data from a `codex.rate_limits` WebSocket SSE event.
+ * Returns null if the payload is not a valid rate_limits event.
+ *
+ * Expected shape (from codex-rs `codex.rate_limits` event):
+ * ```json
+ * {
+ *   "rate_limits": {
+ *     "primary": { "used_percent": 42.0, "window_minutes": 300, "reset_at": 1700000000 },
+ *     "secondary": { "used_percent": 18.0, "window_minutes": 10080, "reset_at": 1700500000 }
+ *   }
+ * }
+ * ```
+ */
+export function parseRateLimitsEvent(data: unknown): ParsedRateLimit | null {
+  if (!data || typeof data !== "object") return null;
+  const obj = data as Record<string, unknown>;
+  const rl = obj.rate_limits;
+  if (!rl || typeof rl !== "object") return null;
+
+  const rlObj = rl as Record<string, unknown>;
+  const primary = parseWindowFromObject(rlObj.primary);
+  const secondary = parseWindowFromObject(rlObj.secondary);
+
+  if (!primary && !secondary) return null;
+  return { primary, secondary };
+}
+
+function parseWindowFromObject(win: unknown): RateLimitWindowData | null {
+  if (!win || typeof win !== "object") return null;
+  const w = win as Record<string, unknown>;
+  const pct = typeof w.used_percent === "number" ? w.used_percent : NaN;
+  if (!isFinite(pct)) return null;
+
+  return {
+    used_percent: pct,
+    window_minutes: typeof w.window_minutes === "number" ? w.window_minutes : null,
+    reset_at: typeof w.reset_at === "number" ? w.reset_at : null,
+  };
+}
+
 function parseWindow(
   get: (name: string) => string | null,
   prefix: string,

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -15,6 +15,8 @@
  */
 
 import type { CodexInputItem } from "./codex-api.js";
+import type { ParsedRateLimit } from "./rate-limit-headers.js";
+import { parseRateLimitsEvent } from "./rate-limit-headers.js";
 
 /** Cached ws module — loaded once on first use. */
 let _WS: typeof import("ws").default | undefined;
@@ -68,6 +70,7 @@ export async function createWebSocketResponse(
   request: WsCreateRequest,
   signal?: AbortSignal,
   proxyUrl?: string | null,
+  onRateLimits?: (rl: ParsedRateLimit) => void,
 ): Promise<Response> {
   const WS = await getWS();
 
@@ -153,6 +156,14 @@ export async function createWebSocketResponse(
       try {
         const msg = JSON.parse(raw) as Record<string, unknown>;
         const type = (msg.type as string) ?? "unknown";
+
+        // Extract rate-limit data from codex.rate_limits event (WS-only)
+        if (type === "codex.rate_limits" && onRateLimits) {
+          const rl = parseRateLimitsEvent(msg);
+          if (rl) onRateLimits(rl);
+          // Don't forward internal rate-limit events to downstream clients
+          return;
+        }
 
         // Re-encode as SSE: event: <type>\ndata: <full json>\n\n
         const sse = `event: ${type}\ndata: ${raw}\n\n`;

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -23,7 +23,7 @@ import { acquireAccount, releaseAccount } from "./account-acquisition.js";
 import { handleCodexApiError, toErrorStatus } from "./proxy-error-handler.js";
 import { streamResponse } from "./response-processor.js";
 import type { UsageInfo } from "../../translation/codex-event-extractor.js";
-import { parseRateLimitHeaders, rateLimitToQuota } from "../../proxy/rate-limit-headers.js";
+import { parseRateLimitHeaders, rateLimitToQuota, type ParsedRateLimit } from "../../proxy/rate-limit-headers.js";
 import { getConfig } from "../../config.js";
 import { jitterInt } from "../../utils/jitter.js";
 import { getSessionAffinityMap, type SessionAffinityMap } from "../../auth/session-affinity.js";
@@ -153,17 +153,8 @@ export async function handleProxyRequest(
 
   for (;;) {
     try {
-      const rawResponse = await withRetry(
-        () => codexApi.createResponse(req.codexRequest, abortController.signal),
-        { tag: fmt.tag },
-      );
-
-      // Capture upstream turn-state for sticky routing
-      const upstreamTurnState = rawResponse.headers.get("x-codex-turn-state") ?? undefined;
-
-      // Extract rate-limit quota from upstream response headers (passive collection)
-      const rl = parseRateLimitHeaders(rawResponse.headers);
-      if (rl) {
+      // Apply parsed rate-limit data to the account pool (shared by header + WS event paths)
+      const applyRateLimits = (rl: ParsedRateLimit): void => {
         const entry = accountPool.getEntry(entryId);
         const quota = rateLimitToQuota(rl, entry?.planType ?? null);
         accountPool.updateCachedQuota(entryId, quota);
@@ -178,7 +169,19 @@ export async function handleProxyRequest(
             accountPool.markRateLimited(entryId, { retryAfterSec: backoffSec });
           }
         }
-      }
+      };
+
+      const rawResponse = await withRetry(
+        () => codexApi.createResponse(req.codexRequest, abortController.signal, applyRateLimits),
+        { tag: fmt.tag },
+      );
+
+      // Capture upstream turn-state for sticky routing
+      const upstreamTurnState = rawResponse.headers.get("x-codex-turn-state") ?? undefined;
+
+      // Extract rate-limit quota from upstream response headers (passive collection — HTTP path)
+      const rl = parseRateLimitHeaders(rawResponse.headers);
+      if (rl) applyRateLimits(rl);
 
       // ── Streaming path ──
       if (req.isStreaming) {


### PR DESCRIPTION
## Summary
- Plus accounts use WebSocket transport where quota data arrives as a `codex.rate_limits` SSE event instead of HTTP response headers
- Previously only HTTP headers were parsed → Plus accounts never showed the 5-hour quota balance in the dashboard
- Add `parseRateLimitsEvent()` to parse the WS event, intercept it in `ws-transport.ts`, and thread the callback through `CodexApi.createResponse`

## Root Cause
- Free accounts: HTTP POST → `x-codex-primary-*` response headers → passive quota collection works
- Plus accounts: WebSocket → quota in `codex.rate_limits` SSE event → **not parsed** → 5h balance always null

## Changes
| File | Change |
|------|--------|
| `src/proxy/rate-limit-headers.ts` | New `parseRateLimitsEvent()` for WS event JSON |
| `src/proxy/ws-transport.ts` | Intercept `codex.rate_limits` message, call `onRateLimits` callback |
| `src/proxy/codex-api.ts` | Thread `onRateLimits` through `createResponse` → WS transport |
| `src/routes/shared/proxy-handler.ts` | Extract `applyRateLimits` helper, pass to both HTTP + WS paths |
| `src/proxy/__tests__/rate-limit-event.test.ts` | 7 test cases for event parsing |

Closes #275

## Test plan
- [x] `parseRateLimitsEvent` unit tests (7 cases) pass
- [x] All 1241 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: deploy and verify Plus account shows 5h quota in dashboard after a WS request