### PR TITLE
test: verify Electron app packages and launches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.25",
+  "version": "2.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.25",
+      "version": "2.0.38",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -1222,6 +1222,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0.tgz",
+      "integrity": "sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5622,6 +5638,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
+      "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
+      "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7364,14 +7427,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.25",
+      "version": "2.0.38",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.0",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.59.0"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch.test.ts
+++ b/packages/electron/__tests__/launch.test.ts
@@ -1,0 +1,81 @@
+import { _electron as electron } from "playwright";
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync } from "child_process";
+import { resolve } from "path";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import os from "os";
+
+describe("Electron app smoke test", () => {
+  const PKG_DIR = resolve(__dirname, "..");
+
+  beforeAll(() => {
+    // 1. Build and pack (unpacked mode to save time)
+    // First run the build script to generate main.cjs and server.mjs
+    execSync("npm run build", { cwd: PKG_DIR, stdio: "ignore" });
+    // Run prepack to copy config, public, bin
+    execSync("npm run prepack", { cwd: PKG_DIR, stdio: "ignore" });
+    // Package unpacked app
+    execSync("npx electron-builder --config electron-builder.yml --dir -c.mac.identity=null", {
+      cwd: PKG_DIR,
+      stdio: "ignore",
+      env: { ...process.env, PUBLISH_NEVER: "1" }
+    });
+  }, 120_000); // 2 minutes for packaging
+
+  it("launches and opens main window", async () => {
+    // 2. Find executable
+    const platform = os.platform();
+    let executablePath = "";
+    if (platform === "win32") {
+      executablePath = resolve(PKG_DIR, "release/win-unpacked/Codex Proxy.exe");
+    } else if (platform === "darwin") {
+      executablePath = resolve(PKG_DIR, "release/mac/Codex Proxy.app/Contents/MacOS/Codex Proxy");
+      if (!existsSync(executablePath)) {
+        executablePath = resolve(PKG_DIR, "release/mac-arm64/Codex Proxy.app/Contents/MacOS/Codex Proxy");
+      }
+    } else {
+      executablePath = resolve(PKG_DIR, "release/linux-unpacked/@codex-proxyelectron");
+    }
+
+    expect(existsSync(executablePath)).toBe(true);
+
+    // Create a dummy user data dir to bypass native transport errors
+    const userDataDir = resolve(os.tmpdir(), `codex-proxy-test-${Date.now()}`);
+    const dataDir = resolve(userDataDir, "data");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(resolve(dataDir, "local.yaml"), "tls:\n  transport: curl-cli\n");
+
+    // 3. Launch with Playwright
+    const app = await electron.launch({
+      executablePath,
+      args: [
+        "--no-sandbox",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        `--user-data-dir=${userDataDir}`
+      ],
+      env: {
+        ...process.env,
+        DISABLE_NATIVE_TRANSPORT: "1"
+      }
+    });
+
+    // 4. Verify main window
+    const window = await app.firstWindow();
+    expect(window).toBeTruthy();
+
+    // The window might take a moment to load the URL
+    await window.waitForLoadState("domcontentloaded");
+
+    const title = await window.title();
+    expect(title).toContain("Codex Proxy");
+
+    // 5. Exit cleanly
+    await app.close();
+
+    // Cleanup
+    try {
+      rmSync(userDataDir, { recursive: true, force: true });
+    } catch (e) {}
+  }, 60_000);
+});

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.0",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.59.0"
   }
 }


### PR DESCRIPTION
Fixes #121 by adding a dedicated smoke test that uses Playwright to launch an unpacked electron-builder build.

---
*PR created automatically by Jules for task [5748017310058716111](https://jules.google.com/task/5748017310058716111) started by @icebear0828*