### PR TITLE
test: verify Docker image builds and starts successfully with custom ports

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,46 +28,64 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
-        run: docker build -t codex-proxy:smoke .
+        run: docker build -t codex-proxy-test .
+
+      - name: Create custom config
+        if: matrix.port != 8080
+        run: |
+          mkdir -p config_override
+          echo "server:" > config_override/default.yaml
+          echo "  port: ${{ matrix.port }}" >> config_override/default.yaml
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
-            -e NODE_ENV=production \
-            codex-proxy:smoke
+          if [ "${{ matrix.port }}" != "8080" ]; then
+            docker run -d --name test-container \
+              -p ${{ matrix.port }}:${{ matrix.port }} \
+              -e NODE_ENV=production \
+              -v $(pwd)/config_override/default.yaml:/app/config/default.yaml \
+              codex-proxy-test
+          else
+            docker run -d --name test-container \
+              -p 8080:8080 \
+              -e NODE_ENV=production \
+              codex-proxy-test
+          fi
           echo "Container started"
 
       - name: Wait for healthy
         run: |
           echo "Waiting for container to become healthy..."
           for i in $(seq 1 30); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' test-container 2>/dev/null || echo "starting")
             echo "  [$i/30] status: $STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Container is healthy"
               exit 0
             fi
-            sleep 2
+            sleep 1
           done
-          echo "::error::Container did not become healthy within 60s"
-          docker logs smoke-test
+          echo "::error::Container did not become healthy within 30s"
+          docker logs test-container
           exit 1
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          RESPONSE=$(curl -sf http://localhost:${{ matrix.port }}/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
           # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${{ matrix.port }}/v1/models)
           echo "/v1/models status: $STATUS"
           # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then
@@ -78,5 +96,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
-          docker rm -f smoke-test || true
+          docker logs test-container 2>&1 | tail -30
+          docker rm -f test-container || true


### PR DESCRIPTION
This implements a CI smoke test in the existing GitHub Actions workflow (`.github/workflows/ci-docker.yml`) that verifies the Docker image can build and start successfully.

Changes:
- Replaced the single `smoke` job with a `strategy.matrix` to test ports `8080` and `8090`.
- Added logic to generate a custom `config_override/default.yaml` to override the application's configuration when running on the custom port.
- Updated the `docker run` command to map the correct ports and mount the custom YAML configuration.
- Shortened the wait-for-healthcheck polling loop to wait up to 30 seconds (30 attempts at 1-second intervals).
- Updated the `/health` and `/v1/models` curl commands to dynamically fetch from `${{ matrix.port }}`.
- Ensured proper resource cleanup at the end.

---
*PR created automatically by Jules for task [8266443933047342907](https://jules.google.com/task/8266443933047342907) started by @icebear0828*