### PR TITLE
test: verify Docker image builds and starts successfully with custom port

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -64,6 +64,39 @@ jobs:
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
+      - name: Start container (custom port)
+        run: |
+          mkdir -p test-config
+          echo -e "server:\n  port: 8090" > test-config/default.yaml
+          docker run -d --name smoke-test-custom \
+            -v $(pwd)/test-config/default.yaml:/app/config/default.yaml \
+            -p 18090:8090 \
+            -e NODE_ENV=production \
+            codex-proxy:smoke
+          echo "Custom port container started"
+
+      - name: Wait for healthy (custom port)
+        run: |
+          echo "Waiting for custom port container to become healthy..."
+          for i in $(seq 1 30); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-custom 2>/dev/null || echo "starting")
+            echo "  [$i/30] status: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Custom port container is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Custom port container did not become healthy within 60s"
+          docker logs smoke-test-custom
+          exit 1
+
+      - name: Verify /health endpoint (custom port)
+        run: |
+          RESPONSE=$(curl -sf http://localhost:18090/health)
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | jq -e '.status == "ok"'
+
       - name: Verify /v1/models returns valid JSON
         run: |
           # Without auth, should return 401 or model list — either way must be valid JSON
@@ -78,5 +111,8 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
+          docker logs smoke-test 2>&1 | tail -30 || true
           docker rm -f smoke-test || true
+          docker logs smoke-test-custom 2>&1 | tail -30 || true
+          docker rm -f smoke-test-custom || true
+          rm -rf test-config || true


### PR DESCRIPTION
Added tests to the `ci-docker.yml` workflow to verify that the Docker image builds and the container starts healthy with a custom port configured via config override.

---
*PR created automatically by Jules for task [6813099088920915927](https://jules.google.com/task/6813099088920915927) started by @icebear0828*