### PR TITLE
test: verify Docker image builds and starts successfully with custom port

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -75,8 +75,47 @@ jobs:
             exit 1
           fi
 
-      - name: Cleanup
+      - name: Cleanup default container
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
+          docker logs smoke-test 2>&1 | tail -30 || true
           docker rm -f smoke-test || true
+
+      - name: Start container with custom port
+        run: |
+          mkdir -p custom-config
+          echo -e "server:\n  port: 8090" > custom-config/default.yaml
+          docker run -d --name smoke-test-custom \
+            -p 18090:8090 \
+            -v $(pwd)/custom-config:/app/config \
+            -e NODE_ENV=production \
+            codex-proxy:smoke
+          echo "Container started on custom port 8090"
+
+      - name: Wait for healthy (custom port)
+        run: |
+          echo "Waiting for container to become healthy..."
+          for i in $(seq 1 30); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-custom 2>/dev/null || echo "starting")
+            echo "  [$i/30] status: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Container did not become healthy within 60s"
+          docker logs smoke-test-custom
+          exit 1
+
+      - name: Verify /health endpoint (custom port)
+        run: |
+          RESPONSE=$(curl -sf http://localhost:18090/health)
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | jq -e '.status == "ok"'
+
+      - name: Cleanup custom container
+        if: always()
+        run: |
+          docker logs smoke-test-custom 2>&1 | tail -30 || true
+          docker rm -f smoke-test-custom || true


### PR DESCRIPTION
Resolves issue #120 by adding a custom port verification job to `.github/workflows/ci-docker.yml`. This creates a custom `default.yaml` on the fly, mounts it as a volume to the Docker container, maps port 18090 to 8090, and verifies the `/health` endpoint correctly responds to verify that `docker-healthcheck.sh` correctly reads from `config/default.yaml`.

---
*PR created automatically by Jules for task [11084911568072133511](https://jules.google.com/task/11084911568072133511) started by @icebear0828*