### PR TITLE
test: add CI smoke tests for Docker, Electron, and Web

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,56 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Run container on default port 8080
+        run: |
+          docker run -d --name proxy-8080 -p 8080:8080 codex-proxy-test
+          # Wait up to 30s for healthcheck
+          for i in {1..30}; do
+            if curl -s http://localhost:8080/health | grep -q "ok"; then
+              echo "Healthcheck passed on 8080"
+              break
+            fi
+            sleep 1
+          done
+          # Final curl to verify 200 and fail if not
+          curl -f -s http://localhost:8080/health > /dev/null
+
+      - name: Cleanup default container
+        run: |
+          docker stop proxy-8080
+          docker rm proxy-8080
+
+      - name: Test custom port 8090
+        run: |
+          # Create a custom config with port 8090
+          mkdir -p custom-config
+          cp config/default.yaml custom-config/default.yaml
+          sed -i 's/port: 8080/port: 8090/g' custom-config/default.yaml
+
+          # Run container mapping 8090
+          docker run -d --name proxy-8090 -p 8090:8090 -v $(pwd)/custom-config/default.yaml:/app/config/default.yaml codex-proxy-test
+
+          # Wait up to 30s for healthcheck
+          for i in {1..30}; do
+            if curl -s http://localhost:8090/health | grep -q "ok"; then
+              echo "Healthcheck passed on 8090"
+              break
+            fi
+            sleep 1
+          done
+          # Final curl to verify 200 and fail if not
+          curl -f -s http://localhost:8090/health > /dev/null

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,43 @@
+name: Electron Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    paths:
+      - 'packages/electron/**'
+
+jobs:
+  electron-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build root workspace
+        run: npm run build
+
+      - name: Build Electron app
+        run: cd packages/electron && npm run build
+
+      - name: Prepare packaging
+        run: cd packages/electron && node electron/prepare-pack.mjs
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Package for Linux (dir mode)
+        run: cd packages/electron && npx electron-builder --linux --dir -c.publish=never
+
+      - name: Run smoke test
+        env:
+          CI: "true"
+        run: xvfb-run -a npx vitest run packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,27 @@
+name: Web Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  web-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build root workspace
+        run: npm run build
+
+      - name: Run web smoke test
+        run: npm run test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.25",
+  "version": "2.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.25",
+      "version": "2.0.38",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -30,6 +30,7 @@
         "js-beautify": "^1.15.0",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
+        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^3.2.4"
       },
       "optionalDependencies": {
@@ -1222,6 +1223,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4195,6 +4212,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5622,6 +5646,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -6745,6 +6816,27 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmmirror.com/tsx/-/tsx-4.21.0.tgz",
@@ -6981,6 +7073,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
       }
     },
     "node_modules/vitest": {
@@ -7364,14 +7471,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.25",
+      "version": "2.0.38",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.59.1"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "js-beautify": "^1.15.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
+    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,26 @@
+import { _electron as electron } from "playwright";
+import { expect, test } from "vitest";
+
+test.runIf(process.env.CI || process.env.RUN_E2E_SMOKE)(
+  "electron smoke test - packaging and launch",
+  async () => {
+    // Launch the electron app
+    const electronApp = await electron.launch({
+      args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "."],
+      cwd: import.meta.dirname + "/../../",
+    });
+
+    const window = await electronApp.firstWindow();
+
+    // Wait for the window to load
+    await window.waitForLoadState("domcontentloaded");
+
+    // Check that we can get the title, which means the app didn't crash
+    const title = await window.title();
+    expect(title).toBeDefined();
+
+    // Close cleanly
+    await electronApp.close();
+  },
+  60000 // 60 seconds timeout
+);

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.59.1"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,104 @@
+import { expect, test, describe, afterAll } from "vitest";
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs";
+import path from "path";
+
+describe("web frontend smoke test", () => {
+  let serverProcess: ChildProcess | null = null;
+
+  afterAll(() => {
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+    // Clean up local config created for tests
+    const dataDir = path.join(import.meta.dirname, "../../data");
+    const localYamlPath = path.join(dataDir, "local.yaml");
+    if (fs.existsSync(localYamlPath)) {
+      fs.unlinkSync(localYamlPath);
+    }
+  });
+
+  test("public/assets/ contains .css files with both light and dark theme rules", () => {
+    const assetsDir = path.join(import.meta.dirname, "../../public/assets");
+    expect(fs.existsSync(assetsDir)).toBe(true);
+
+    const files = fs.readdirSync(assetsDir);
+    const cssFiles = files.filter(f => f.endsWith(".css"));
+
+    expect(cssFiles.length).toBeGreaterThan(0);
+
+    let hasDarkTheme = false;
+    for (const cssFile of cssFiles) {
+      const content = fs.readFileSync(path.join(assetsDir, cssFile), "utf-8");
+      // The CSS uses Tailwind's .dark class strategy, not prefers-color-scheme media query
+      if (content.includes(".dark") && content.includes("color-scheme:dark")) {
+        hasDarkTheme = true;
+      }
+    }
+
+    expect(hasDarkTheme).toBe(true);
+  });
+
+  test("GET / returns HTML containing <div id=\"app\"></div>", async () => {
+    const port = 8081;
+
+    // Create local.yaml if needed to disable native transport properly
+    const dataDir = path.join(import.meta.dirname, "../../data");
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+    const localYamlPath = path.join(dataDir, "local.yaml");
+    fs.writeFileSync(localYamlPath, "tls:\n  transport: curl-cli\n");
+
+    const configDir = path.join(import.meta.dirname, "../../config");
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+    const defaultYamlPath = path.join(configDir, "default.yaml");
+    if (!fs.existsSync(defaultYamlPath)) {
+      fs.writeFileSync(defaultYamlPath, "server:\n  port: 8080\n");
+    }
+
+    const fingerprintYamlPath = path.join(configDir, "fingerprint.yaml");
+    if (!fs.existsSync(fingerprintYamlPath)) {
+      fs.writeFileSync(fingerprintYamlPath, "");
+    }
+
+    // Start the server
+    serverProcess = spawn("node", ["dist/index.js"], {
+      env: {
+        ...process.env,
+        PORT: port.toString(),
+        DISABLE_NATIVE_TRANSPORT: "1",
+      },
+    });
+
+    // Wait for the server to be ready
+    await new Promise<void>((resolve, reject) => {
+      if (!serverProcess) return reject(new Error("Process not started"));
+
+      const timeout = setTimeout(() => {
+        reject(new Error("Timeout waiting for server to start"));
+      }, 10000);
+
+      serverProcess.stdout?.on("data", (data) => {
+        const output = data.toString();
+        if (output.includes("Codex Proxy Server") || output.includes("Listen:")) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      serverProcess.stderr?.on("data", (data) => {
+        console.error(`Server stderr: ${data}`);
+      });
+    });
+
+    // Fetch the frontend
+    const response = await fetch(`http://localhost:${port}/`);
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain('<div id="app"></div>');
+  }, 15000);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vitest/config"
+import tsconfigPaths from "vite-tsconfig-paths";
 import { resolve } from "path";
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   resolve: {
     alias: {
       "@src": resolve(__dirname, "src"),


### PR DESCRIPTION
Added comprehensive smoke tests to verify building and running across different mediums.

1. **Docker**: `.github/workflows/docker-smoke-test.yml` checks that building the Dockerfile locally and making `GET /health` requests on default and custom ports using a modified `config/default.yaml` works as intended.
2. **Electron**: Adds `packages/electron/__tests__/launch/smoke.test.ts` to spin up the packaged app with Playwright. Tests `.github/workflows/electron-smoke-test.yml` running it headless using `xvfb-run` and validating main window creation without crashes. Added Playwright deps to `packages/electron/package.json`.
3. **Web**: Added `src/__tests__/web-smoke.test.ts` to build the app and ensure `public/assets/` output matches Tailwind configuration (`.dark`). Starts a backend process to assure `GET /` serves HTML rendering `<div id="app"></div>`. Includes `.github/workflows/web-smoke-test.yml`. Added `vite-tsconfig-paths` to correctly configure aliases for test execution.

---
*PR created automatically by Jules for task [16609391939614067093](https://jules.google.com/task/16609391939614067093) started by @icebear0828*