### PR TITLE
test: add CI smoke tests for Docker, Electron, and Web frontend

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,80 @@
+name: CI — Docker Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Run container on default port 8080
+        run: |
+          docker run -d --name smoke-test-8080 -p 8080:8080 codex-proxy-test
+
+          echo "Waiting for container to become healthy..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-8080)
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Container failed to become healthy"
+            docker logs smoke-test-8080
+            exit 1
+          fi
+
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+          if [ "$RESPONSE" != "200" ]; then
+            echo "Expected 200 OK from /health on 8080, got $RESPONSE"
+            exit 1
+          fi
+
+      - name: Cleanup default container
+        if: always()
+        run: docker rm -f smoke-test-8080 || true
+
+      - name: Test custom port 8090
+        run: |
+          # Modify config file to use port 8090
+          sed -i 's/port: 8080/port: 8090/g' config/default.yaml
+
+          # Run container with custom port 8090, mounting the modified config
+          docker run -d --name smoke-test-8090 -p 8090:8090 -v $(pwd)/config/default.yaml:/app/config/default.yaml codex-proxy-test
+
+          echo "Waiting for container to become healthy on port 8090..."
+          for i in $(seq 1 15); do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-8090)
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy"
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Container failed to become healthy on port 8090"
+            docker logs smoke-test-8090
+            exit 1
+          fi
+
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/health)
+          if [ "$RESPONSE" != "200" ]; then
+            echo "Expected 200 OK from /health on 8090, got $RESPONSE"
+            exit 1
+          fi
+
+      - name: Cleanup custom port container
+        if: always()
+        run: docker rm -f smoke-test-8090 || true

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,40 @@
+name: CI — Electron Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'packages/electron/**'
+  pull_request:
+    paths:
+      - 'packages/electron/**'
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Playwright and Chromium deps
+        run: npx playwright install --with-deps chromium
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build backend and web frontend
+        run: npm run build
+
+      - name: Build desktop frontend
+        run: cd packages/electron && npm run build
+
+      - name: Prepare electron pack
+        run: cd packages/electron && node electron/prepare-pack.mjs
+
+      - name: Package with electron-builder
+        run: cd packages/electron && npx electron-builder --linux --dir -c.publish=never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Electron launch smoke test
+        run: xvfb-run -a npm run test -- packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,22 @@
+name: CI — Web Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run Web smoke test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.38",
+  "version": "2.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.38",
-      "hasInstallScript": true,
+      "version": "2.0.41",
       "workspaces": [
         "packages/*"
       ],
@@ -31,9 +30,6 @@
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
         "vitest": "^3.2.4"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.15.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1222,6 +1218,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4815,17 +4827,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/koffi": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmmirror.com/koffi/-/koffi-2.15.1.tgz",
-      "integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
@@ -5620,6 +5621,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {
@@ -7364,14 +7412,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.38",
+      "version": "2.0.41",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.59.1"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,66 @@
+import { _electron as electron } from "playwright";
+import { test, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { describe } from "vitest";
+
+describe.runIf(process.env.CI || process.env.RUN_E2E_SMOKE)("Smoke E2E", () => {
+test("Electron app packages and launches main window", async () => {
+  const unpackedDir = path.resolve(import.meta.dirname, "../../release/linux-unpacked");
+
+  // Find the executable dynamically
+  const files = fs.readdirSync(unpackedDir);
+  let executableName = "";
+  for (const file of files) {
+    // Looking for the main binary without extension on linux, avoiding .so and others
+    if (!file.includes(".") && !file.includes("chrome-sandbox") && !file.includes("chrome_crashpad_handler")) {
+      const stats = fs.statSync(path.join(unpackedDir, file));
+      // check if it is a file and executable
+      if (stats.isFile() && (stats.mode & 0o111)) { // is executable
+        executableName = file;
+        break;
+      }
+    }
+  }
+
+  // fallback to @codex-proxyelectron or codex-proxy just in case
+  if (!executableName) {
+    if (fs.existsSync(path.join(unpackedDir, "@codex-proxyelectron"))) {
+      executableName = "@codex-proxyelectron";
+    } else {
+      executableName = "codex-proxy";
+    }
+  }
+
+  const executablePath = path.join(unpackedDir, executableName);
+
+  // Explicitly set the path to data/local.yaml inside the unpacked directory to disable native transport
+  const userDataDir = path.join(unpackedDir, ".test-user-data");
+  if (!fs.existsSync(userDataDir)) fs.mkdirSync(userDataDir, { recursive: true });
+  const dataDir = path.join(userDataDir, "data");
+  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+  fs.writeFileSync(path.join(dataDir, "local.yaml"), "tls:\n  transport: curl-cli\n");
+
+  const electronApp = await electron.launch({
+    executablePath,
+    args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage", "--disable-software-rasterizer", `--user-data-dir=${userDataDir}`],
+    env: { ...process.env, DISABLE_NATIVE_TRANSPORT: "1" }
+  });
+
+  electronApp.process().stdout?.on('data', data => console.log('stdout:', data.toString()));
+  electronApp.process().stderr?.on('data', data => console.error('stderr:', data.toString()));
+
+  // Wait for the first window to be created
+  const window = await electronApp.firstWindow();
+  expect(window).toBeTruthy();
+
+  // Evaluate the number of windows
+  const windowsLength = await electronApp.evaluate(({ app }) => {
+    return app.getAllWindows().length;
+  });
+  expect(windowsLength).toBeGreaterThan(0);
+
+  // Close the app cleanly
+  await electronApp.close();
+}, 60000); // Increased timeout for the smoke test
+});

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.59.1"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,98 @@
+import { test, expect, describe, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import { spawn, ChildProcess } from "child_process";
+
+describe("Web Frontend Smoke Test", () => {
+  let serverProcess: ChildProcess | null = null;
+  const PORT = 8081;
+
+  afterAll(() => {
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+  });
+
+  test("Vite build outputs CSS with dark mode rules", () => {
+    const assetsDir = path.resolve(import.meta.dirname, "../../public/assets");
+
+    // Check if assets directory exists
+    expect(fs.existsSync(assetsDir)).toBe(true);
+
+    const files = fs.readdirSync(assetsDir);
+    const cssFiles = files.filter(f => f.endsWith(".css"));
+
+    expect(cssFiles.length).toBeGreaterThan(0);
+
+    let foundDarkTheme = false;
+    for (const cssFile of cssFiles) {
+      const content = fs.readFileSync(path.join(assetsDir, cssFile), "utf-8");
+      if (content.includes(".dark\\:") && content.includes("color-scheme: dark")) {
+        foundDarkTheme = true;
+        break;
+      } else if (content.includes(".dark") || content.includes("color-scheme: dark")) {
+        foundDarkTheme = true;
+        break;
+      }
+    }
+
+    expect(foundDarkTheme).toBe(true);
+  });
+
+  test("Server responds with HTML containing <div id=\"app\"></div>", async () => {
+    // Explicitly set local.yaml with curl-cli transport to override native requirement for tests
+    const dataDir = path.resolve(import.meta.dirname, "../../data");
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "local.yaml"), "tls:\n  transport: curl-cli\n");
+
+    // Start server process
+    const serverEntry = path.resolve(import.meta.dirname, "../../dist/index.js");
+
+    serverProcess = spawn("node", [serverEntry], {
+      env: {
+        ...process.env,
+        PORT: PORT.toString(),
+        DISABLE_NATIVE_TRANSPORT: "1",
+      },
+    });
+
+    // Wait for server to be ready
+    await new Promise<void>((resolve, reject) => {
+      let isResolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!isResolved) {
+          reject(new Error("Timeout waiting for server to start"));
+        }
+      }, 15000);
+
+      serverProcess?.stdout?.on("data", (data) => {
+        const output = data.toString();
+        if (output.includes("Listen:") || output.includes("Codex Proxy Server")) {
+          isResolved = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      serverProcess?.stderr?.on("data", (data) => {
+        // Just log errors for debugging, but we rely on stdout or fetch to resolve
+        console.error(`Server stderr: ${data}`);
+      });
+
+      serverProcess?.on("close", (code) => {
+        if (!isResolved) {
+          clearTimeout(timeout);
+          reject(new Error(`Server closed with code ${code} before starting`));
+        }
+      });
+    });
+
+    // Fetch from server
+    const response = await fetch(`http://localhost:${PORT}/`);
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain("<div id=\"app\"></div>");
+  }, 30000); // Higher timeout to give server time to start
+});


### PR DESCRIPTION
Implements three distinct smoke tests and GitHub Actions workflows for continuous integration.
- `docker-smoke-test.yml`: Checks Docker build and dynamic port handling.
- `electron-smoke-test.yml`: Validates Electron app build, packaging, and basic window instantiation via Playwright.
- `web-smoke-test.yml`: Ensures the frontend builds properly and the backend successfully serves the compiled static assets.

---
*PR created automatically by Jules for task [16012788748424753546](https://jules.google.com/task/16012788748424753546) started by @icebear0828*