### PR TITLE
test: verify Docker image builds and starts successfully

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,6 +28,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,9 +39,15 @@ jobs:
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
+          mkdir -p data
+          echo "server:" > data/local.yaml
+          echo "  port: ${{ matrix.port }}" >> data/local.yaml
+
+          docker run -d --name smoke-test-${{ matrix.port }} \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
             -e NODE_ENV=production \
+            -e PORT=${{ matrix.port }} \
+            -v $(pwd)/data/local.yaml:/app/data/local.yaml \
             codex-proxy:smoke
           echo "Container started"
 
@@ -46,7 +55,7 @@ jobs:
         run: |
           echo "Waiting for container to become healthy..."
           for i in $(seq 1 30); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-${{ matrix.port }} 2>/dev/null || echo "starting")
             echo "  [$i/30] status: $STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Container is healthy"
@@ -55,19 +64,19 @@ jobs:
             sleep 2
           done
           echo "::error::Container did not become healthy within 60s"
-          docker logs smoke-test
+          docker logs smoke-test-${{ matrix.port }}
           exit 1
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          RESPONSE=$(curl -sf http://localhost:${{ matrix.port }}/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
           # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${{ matrix.port }}/v1/models)
           echo "/v1/models status: $STATUS"
           # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then
@@ -78,5 +87,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
-          docker rm -f smoke-test || true
+          docker logs smoke-test-${{ matrix.port }} 2>&1 | tail -30
+          docker rm -f smoke-test-${{ matrix.port }} || true

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
-# Read server port from config, fallback to 8080
-PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
-curl -fs "http://localhost:${PORT:-8080}/health" || exit 1
+# Resolve server port from PORT env, local.yaml, default.yaml, fallback to 8080
+if [ -n "$PORT" ]; then
+  HEALTH_PORT="$PORT"
+elif [ -f "/app/data/local.yaml" ] && grep -A5 '^server:' /app/data/local.yaml 2>/dev/null | grep -q 'port:'; then
+  HEALTH_PORT=$(grep -A5 '^server:' /app/data/local.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+else
+  HEALTH_PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+fi
+
+curl -fs "http://localhost:${HEALTH_PORT:-8080}/health" || exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.41",
+  "version": "2.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.41",
+      "version": "2.0.47",
       "workspaces": [
         "packages/*"
       ],
@@ -7349,7 +7349,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.41",
+      "version": "2.0.47",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },


### PR DESCRIPTION
This PR resolves issue #120 by introducing a matrix strategy to `.github/workflows/ci-docker.yml` to test the Docker container on both the default port (8080) and a custom overridden port (8090).

Changes:
* Updated `ci-docker.yml` with a `strategy.matrix` configuration `[8080, 8090]`.
* Mapped `docker run` to the matrix port via `-p` and injected the `-e PORT` environment variable.
* Generated a `local.yaml` file on the fly with the port configuration to mount as a volume, effectively testing the configuration override loading flow.
* Refactored `docker-healthcheck.sh` to correctly resolve the listening port from the `PORT` env variable, the `local.yaml` overlay, or the default config, ensuring the internal healthcheck passes when the container is run on non-default ports.

---
*PR created automatically by Jules for task [17754268599624577203](https://jules.google.com/task/17754268599624577203) started by @icebear0828*