### PR TITLE
fix: extract error messages correctly from nested API error responses

### DIFF
--- a/shared/hooks/use-general-settings.ts
+++ b/shared/hooks/use-general-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export interface GeneralSettingsData {
   port: number;
@@ -54,8 +55,8 @@ export function useGeneralSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as GeneralSettingsSaveResponse;
       setData({

--- a/shared/hooks/use-quota-settings.ts
+++ b/shared/hooks/use-quota-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export interface QuotaSettingsData {
   refresh_interval_minutes: number;
@@ -40,8 +41,8 @@ export function useQuotaSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as { success: boolean } & QuotaSettingsData;
       setData({

--- a/shared/hooks/use-rotation-settings.ts
+++ b/shared/hooks/use-rotation-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export type RotationStrategy = "least_used" | "round_robin" | "sticky";
 
@@ -39,8 +40,8 @@ export function useRotationSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as { success: boolean } & RotationSettingsData;
       setData({ rotation_strategy: result.rotation_strategy });

--- a/shared/hooks/use-settings.ts
+++ b/shared/hooks/use-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export function useSettings() {
   const [apiKey, setApiKey] = useState<string | null>(null);
@@ -36,8 +37,8 @@ export function useSettings() {
         body: JSON.stringify({ proxy_api_key: newKey }),
       });
       if (!resp.ok) {
-        const data = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((data as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result: { proxy_api_key: string | null } = await resp.json();
       setApiKey(result.proxy_api_key);

--- a/shared/utils/__tests__/extract-error.test.ts
+++ b/shared/utils/__tests__/extract-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { extractErrorMessage } from "../extract-error";
+
+describe("extractErrorMessage", () => {
+  it("extracts from flat admin format: { error: 'string' }", () => {
+    expect(extractErrorMessage({ error: "Invalid current API key" }, "fallback"))
+      .toBe("Invalid current API key");
+  });
+
+  it("extracts from nested OpenAI format: { error: { message: '...' } }", () => {
+    expect(extractErrorMessage(
+      { error: { message: "Config validation failed", type: "server_error", param: null, code: "internal_error" } },
+      "fallback",
+    )).toBe("Config validation failed");
+  });
+
+  it("returns fallback for null body", () => {
+    expect(extractErrorMessage(null, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback for empty object", () => {
+    expect(extractErrorMessage({}, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback for body with non-string, non-object error", () => {
+    expect(extractErrorMessage({ error: 42 }, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback when nested error.message is not a string", () => {
+    expect(extractErrorMessage({ error: { message: 123 } }, "HTTP 500")).toBe("HTTP 500");
+  });
+});

--- a/shared/utils/extract-error.ts
+++ b/shared/utils/extract-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract a human-readable error message from an API error response body.
+ *
+ * Handles both formats:
+ *  - Admin endpoints (flat):   { error: "message" }
+ *  - OpenAI error handler:     { error: { message: "..." } }
+ */
+export function extractErrorMessage(
+  body: unknown,
+  fallback: string,
+): string {
+  if (body && typeof body === "object" && "error" in body) {
+    const err = (body as Record<string, unknown>).error;
+    if (typeof err === "string") return err;
+    if (err && typeof err === "object" && "message" in err) {
+      const msg = (err as Record<string, unknown>).message;
+      if (typeof msg === "string") return msg;
+    }
+  }
+  return fallback;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "src/**/*.{test,spec}.ts",
+      "shared/**/*.{test,spec}.ts",
       "tests/unit/**/*.{test,spec}.ts",
       "tests/integration/**/*.{test,spec}.ts",
       "packages/electron/__tests__/**/*.{test,spec}.ts",


### PR DESCRIPTION
## Summary
- Dashboard settings hooks were casting `{error: {message: "..."}}` as `{error: string}`, showing `[object Object]` to the user on 500 errors — making them impossible to debug from the UI
- Added `shared/utils/extract-error.ts` that handles both flat (`{error: "msg"}`) and nested (`{error: {message: "msg"}}`) error formats
- Fixed all 4 settings hooks: `use-settings`, `use-general-settings`, `use-quota-settings`, `use-rotation-settings`
- Added `shared/**` to vitest include paths

## Test plan
- [x] Unit tests for `extractErrorMessage` (6 cases: flat, nested, null, empty, non-string, nested non-string)
- [x] Full test suite passes (114 files, 1320 tests)