### PR TITLE
fix: accept unknown Anthropic content block types for Claude Code compatibility

### DIFF
--- a/shared/hooks/use-general-settings.ts
+++ b/shared/hooks/use-general-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export interface GeneralSettingsData {
   port: number;
@@ -54,8 +55,8 @@ export function useGeneralSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as GeneralSettingsSaveResponse;
       setData({

--- a/shared/hooks/use-quota-settings.ts
+++ b/shared/hooks/use-quota-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export interface QuotaSettingsData {
   refresh_interval_minutes: number;
@@ -40,8 +41,8 @@ export function useQuotaSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as { success: boolean } & QuotaSettingsData;
       setData({

--- a/shared/hooks/use-rotation-settings.ts
+++ b/shared/hooks/use-rotation-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export type RotationStrategy = "least_used" | "round_robin" | "sticky";
 
@@ -39,8 +40,8 @@ export function useRotationSettings(apiKey: string | null) {
         body: JSON.stringify(patch),
       });
       if (!resp.ok) {
-        const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((body as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result = await resp.json() as { success: boolean } & RotationSettingsData;
       setData({ rotation_strategy: result.rotation_strategy });

--- a/shared/hooks/use-settings.ts
+++ b/shared/hooks/use-settings.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "preact/hooks";
+import { extractErrorMessage } from "../utils/extract-error";
 
 export function useSettings() {
   const [apiKey, setApiKey] = useState<string | null>(null);
@@ -36,8 +37,8 @@ export function useSettings() {
         body: JSON.stringify({ proxy_api_key: newKey }),
       });
       if (!resp.ok) {
-        const data = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-        throw new Error((data as { error?: string }).error ?? `HTTP ${resp.status}`);
+        const body = await resp.json().catch(() => null);
+        throw new Error(extractErrorMessage(body, `HTTP ${resp.status}`));
       }
       const result: { proxy_api_key: string | null } = await resp.json();
       setApiKey(result.proxy_api_key);

--- a/shared/utils/__tests__/extract-error.test.ts
+++ b/shared/utils/__tests__/extract-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { extractErrorMessage } from "../extract-error";
+
+describe("extractErrorMessage", () => {
+  it("extracts from flat admin format: { error: 'string' }", () => {
+    expect(extractErrorMessage({ error: "Invalid current API key" }, "fallback"))
+      .toBe("Invalid current API key");
+  });
+
+  it("extracts from nested OpenAI format: { error: { message: '...' } }", () => {
+    expect(extractErrorMessage(
+      { error: { message: "Config validation failed", type: "server_error", param: null, code: "internal_error" } },
+      "fallback",
+    )).toBe("Config validation failed");
+  });
+
+  it("returns fallback for null body", () => {
+    expect(extractErrorMessage(null, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback for empty object", () => {
+    expect(extractErrorMessage({}, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback for body with non-string, non-object error", () => {
+    expect(extractErrorMessage({ error: 42 }, "HTTP 500")).toBe("HTTP 500");
+  });
+
+  it("returns fallback when nested error.message is not a string", () => {
+    expect(extractErrorMessage({ error: { message: 123 } }, "HTTP 500")).toBe("HTTP 500");
+  });
+});

--- a/shared/utils/extract-error.ts
+++ b/shared/utils/extract-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract a human-readable error message from an API error response body.
+ *
+ * Handles both formats:
+ *  - Admin endpoints (flat):   { error: "message" }
+ *  - OpenAI error handler:     { error: { message: "..." } }
+ */
+export function extractErrorMessage(
+  body: unknown,
+  fallback: string,
+): string {
+  if (body && typeof body === "object" && "error" in body) {
+    const err = (body as Record<string, unknown>).error;
+    if (typeof err === "string") return err;
+    if (err && typeof err === "object" && "message" in err) {
+      const msg = (err as Record<string, unknown>).message;
+      if (typeof msg === "string") return msg;
+    }
+  }
+  return fallback;
+}

--- a/src/types/__tests__/anthropic-schema.test.ts
+++ b/src/types/__tests__/anthropic-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { AnthropicMessagesRequestSchema } from "../anthropic.js";
+
+const BASE_REQUEST = {
+  model: "claude-opus-4-5",
+  max_tokens: 1024,
+  messages: [
+    { role: "user", content: "Hello" },
+  ],
+};
+
+describe("AnthropicMessagesRequestSchema", () => {
+  it("accepts string content", () => {
+    const result = AnthropicMessagesRequestSchema.safeParse(BASE_REQUEST);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts known array content (text block)", () => {
+    const result = AnthropicMessagesRequestSchema.safeParse({
+      ...BASE_REQUEST,
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts tool_use + tool_result multi-turn", () => {
+    const result = AnthropicMessagesRequestSchema.safeParse({
+      ...BASE_REQUEST,
+      messages: [
+        { role: "user", content: "run bash" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "t1", name: "bash", input: { cmd: "ls" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "file.txt" },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts unknown content block types (forward-compatibility)", () => {
+    // Simulate a new type like "document" sent by future Claude Code versions.
+    const result = AnthropicMessagesRequestSchema.safeParse({
+      ...BASE_REQUEST,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Here is a file:" },
+            { type: "document", source: { type: "base64", media_type: "application/pdf", data: "abc" } },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts thinking blocks in assistant messages", () => {
+    const result = AnthropicMessagesRequestSchema.safeParse({
+      ...BASE_REQUEST,
+      messages: [
+        { role: "user", content: "think hard" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Let me reason...", signature: "sig" },
+            { type: "text", text: "Answer" },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -50,13 +50,19 @@ const AnthropicRedactedThinkingContentSchema = z.object({
   data: z.string(),
 });
 
-const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
-  AnthropicTextContentSchema,
-  AnthropicImageContentSchema,
-  AnthropicToolUseContentSchema,
-  AnthropicToolResultContentSchema,
-  AnthropicThinkingContentSchema,
-  AnthropicRedactedThinkingContentSchema,
+const AnthropicContentBlockSchema = z.union([
+  z.discriminatedUnion("type", [
+    AnthropicTextContentSchema,
+    AnthropicImageContentSchema,
+    AnthropicToolUseContentSchema,
+    AnthropicToolResultContentSchema,
+    AnthropicThinkingContentSchema,
+    AnthropicRedactedThinkingContentSchema,
+  ]),
+  // Catch-all: forward-compatibility for new content block types (e.g. "document")
+  // introduced by Claude Code updates. Unknown types are passed through and ignored
+  // by translation functions.
+  z.object({ type: z.string() }).passthrough(),
 ]);
 
 const AnthropicContentSchema = z.union([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "src/**/*.{test,spec}.ts",
+      "shared/**/*.{test,spec}.ts",
       "tests/unit/**/*.{test,spec}.ts",
       "tests/integration/**/*.{test,spec}.ts",
       "packages/electron/__tests__/**/*.{test,spec}.ts",


### PR DESCRIPTION
## Summary

- `AnthropicContentBlockSchema` 之前用严格的 `z.discriminatedUnion`，只接受 6 种已知 `type`（text/image/tool_use/tool_result/thinking/redacted_thinking）
- Claude Code 最新版本开始在 `messages[N].content` 数组里发送新 block type（如 `"document"`），proxy 自身 Zod 校验失败直接返回 400，请求根本未到达 Codex API
- 修复：将 discriminatedUnion 包在外层 `z.union` 中，末尾加 `z.object({ type: z.string() }).passthrough()` catch-all，未知 type 放行并由 translation 函数静默忽略

## Test plan

- [ ] 新增 `src/types/__tests__/anthropic-schema.test.ts`，覆盖：string content、known array blocks、tool_use/tool_result multi-turn、未知 block type（forward-compat）、thinking blocks
- [ ] 全量 `npm test` 通过（1325 tests）