### PR TITLE
fix: handle SIGTERM for graceful shutdown on system shutdown/logout

### DIFF
--- a/packages/electron/electron/main.ts
+++ b/packages/electron/electron/main.ts
@@ -354,6 +354,13 @@ app.on("activate", () => {
   createWindow();
 });
 
+// Handle OS-initiated termination (system shutdown, logout).
+// SIGTERM → quitApplication() sets allowProcessExit synchronously before
+// before-quit fires, enabling graceful server cleanup instead of SIGKILL.
+process.on("SIGTERM", () => {
+  if (!isQuitting) quitApplication();
+});
+
 app.on("before-quit", (event) => {
   if (IS_MAC && !allowProcessExit) {
     event.preventDefault();


### PR DESCRIPTION
Follow-up to #324.

## Problem

`before-quit` intercepts all quit events on macOS (`event.preventDefault()`), including OS-initiated ones (system shutdown, logout). macOS sends SIGTERM, Electron converts it to `app.quit()` → `before-quit`, but `allowProcessExit` is still `false` → event is blocked. macOS waits ~5s then SIGKILL.

## Fix

```typescript
process.on("SIGTERM", () => {
  if (!isQuitting) quitApplication();
});
```

`quitApplication()` sets `allowProcessExit = true` synchronously. Since `before-quit` is dispatched as a Chromium task (asynchronous), the flag is set before `before-quit` fires — server gets a graceful cleanup window before exit.

## Test plan

- [ ] System shutdown / logout → app exits gracefully (no SIGKILL delay)
- [ ] Window close / Cmd+Q still hides to tray (existing behavior unchanged)
- [ ] Tray "Quit" still does graceful shutdown
- [ ] `npm test` passes