### PR TITLE
fix: new account with null window_reset_at no longer starved by least_used strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
+
 - 默认不再发送 `reasoning.effort`：移除 `modelInfo.defaultReasoningEffort` 自动兜底，`default_reasoning_effort` 默认改为 `null`，彻底消除简单对话触发 medium 推理导致的 token 暴涨；Dashboard 新增 "Disabled (no reasoning)" 选项，用户可按需开启
 
 - 上游 401 时立即触发 RT→AT 刷新，而非等待定时器（修复 token 被提前作废后账号一直显示 expired 的问题）

--- a/src/auth/__tests__/rotation-strategy.test.ts
+++ b/src/auth/__tests__/rotation-strategy.test.ts
@@ -66,9 +66,17 @@ describe("rotation-strategy", () => {
       expect(strategy.select([a, b], state).id).toBe("b");
     });
 
-    it("treats missing window_reset_at as Infinity (picks known reset first)", () => {
-      const a = makeEntry("a", { request_count: 1 }); // no reset info
+    it("does not penalize new accounts without window_reset_at — falls through to request_count", () => {
+      // Account A is brand-new (no window info yet), account B has a known window.
+      // A has fewer requests so it should win: null window must not count as Infinity.
+      const a = makeEntry("a", { request_count: 1 }); // no window info
       const b = makeEntry("b", { request_count: 5, window_reset_at: Date.now() + 86400_000 });
+      expect(strategy.select([a, b], state).id).toBe("a");
+    });
+
+    it("falls through to request_count when both accounts have no window_reset_at", () => {
+      const a = makeEntry("a", { request_count: 3 });
+      const b = makeEntry("b", { request_count: 1 });
       expect(strategy.select([a, b], state).id).toBe("b");
     });
 

--- a/src/auth/rotation-strategy.ts
+++ b/src/auth/rotation-strategy.ts
@@ -22,10 +22,13 @@ const leastUsed: RotationStrategy = {
       const aExhausted = a.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
       const bExhausted = b.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
       if (aExhausted !== bExhausted) return aExhausted - bExhausted;
-      // Secondary: prefer account whose quota resets soonest (use it before it resets)
-      const aReset = a.usage.window_reset_at ?? Infinity;
-      const bReset = b.usage.window_reset_at ?? Infinity;
-      if (aReset !== bReset) return aReset - bReset;
+      // Secondary: prefer account whose quota resets soonest (use it before it resets).
+      // Only compare when both have a known window — an account without window_reset_at
+      // (e.g. brand new, never received rate-limit headers) must not be permanently
+      // deprioritized behind one that has.  Fall through to request_count instead.
+      const aReset = a.usage.window_reset_at;
+      const bReset = b.usage.window_reset_at;
+      if (aReset != null && bReset != null && aReset !== bReset) return aReset - bReset;
       // Tertiary: fewer requests = more remaining quota
       const diff = a.usage.request_count - b.usage.request_count;
       if (diff !== 0) return diff;


### PR DESCRIPTION
## Summary

- **Root cause**: `least_used` rotation sort used `window_reset_at ?? Infinity` — any brand-new account (no quota window yet) always sorted behind an account with a known window, so the second OAuth account never received requests, its `__cf_bm` cookie was never captured, and `cachedQuota` stayed null indefinitely
- **Fix**: only compare `window_reset_at` when both accounts have non-null values; otherwise fall through to `request_count` (fewer requests wins), which correctly routes traffic to the newer/less-used account
- Tests updated: the test that previously documented the broken behaviour is corrected; a new test covers the both-null case

Closes #342

## Test plan

- [ ] `npx vitest run src/auth/__tests__/rotation-strategy.test.ts` — 14 tests pass
- [ ] Full `npm test` — 1332 tests pass
- [ ] Manual: add two OAuth accounts, send requests, verify both accounts receive traffic and both get `__cf_bm` in `cookies.json`