### PR TITLE
test: verify Docker image builds and starts successfully on custom ports

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,6 +28,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
@@ -37,8 +40,9 @@ jobs:
       - name: Start container
         run: |
           docker run -d --name smoke-test \
-            -p 18080:8080 \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
             -e NODE_ENV=production \
+            -e PORT=${{ matrix.port }} \
             codex-proxy:smoke
           echo "Container started"
 
@@ -60,14 +64,14 @@ jobs:
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          RESPONSE=$(curl -sf http://localhost:${{ matrix.port }}/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
           # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${{ matrix.port }}/v1/models)
           echo "/v1/models status: $STATUS"
           # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
-# Read server port from config, fallback to 8080
-PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+# Read server port from PORT env var, fallback to local config, then default config, then 8080
+if [ -z "$PORT" ]; then
+  PORT=$(grep -A5 '^server:' /app/data/local.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+  if [ -z "$PORT" ]; then
+    PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+  fi
+fi
 curl -fs "http://localhost:${PORT:-8080}/health" || exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.41",
+  "version": "2.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.41",
+      "version": "2.0.54",
       "workspaces": [
         "packages/*"
       ],
@@ -7349,7 +7349,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.41",
+      "version": "2.0.54",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },


### PR DESCRIPTION
This PR addresses the issue of verifying the Docker image builds and executes the health checks correctly on alternate ports.

**Changes introduced:**
- Adds a matrix strategy in `.github/workflows/ci-docker.yml` testing both `8080` and `8090`.
- Passes the matrix port down into the container via the `-e PORT=${{ matrix.port }}` argument.
- Updates the host-binding in `docker run` to match the matrix target.
- Updates the test's subsequent HTTP polling to query the dynamically assigned matrix port instead of hardcoding `18080`.
- Modifies `docker-healthcheck.sh` to prioritize the injected `PORT` env variable for `curl` connectivity before reading local config or default overrides.

---
*PR created automatically by Jules for task [13855028842721639643](https://jules.google.com/task/13855028842721639643) started by @icebear0828*