### PR TITLE
test: Add CI smoke tests for Docker, Electron, and Web

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,87 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  docker-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t codex-proxy-test .
+
+      - name: Run container (default port 8080)
+        run: |
+          docker run -d --name codex-proxy-8080 -p 8080:8080 codex-proxy-test
+
+          echo "Waiting for container to become healthy..."
+          for i in {1..30}; do
+            HEALTH_STATUS=$(docker inspect --format='{{.State.Health.Status}}' codex-proxy-8080 2>/dev/null || echo "starting")
+            if [ "$HEALTH_STATUS" = "healthy" ]; then
+              echo "Container is healthy!"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Container failed to become healthy within 30 seconds."
+              docker logs codex-proxy-8080
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Testing /health endpoint..."
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Expected 200 OK, got $STATUS_CODE"
+            exit 1
+          fi
+          echo "/health returned 200 OK"
+
+      - name: Cleanup default container
+        run: |
+          docker stop codex-proxy-8080
+          docker rm codex-proxy-8080
+
+      - name: Modify config for custom port (8090)
+        run: |
+          mkdir -p custom-config
+          cp config/default.yaml custom-config/
+          sed -i 's/port: 8080/port: 8090/' custom-config/default.yaml
+
+      - name: Run container (custom port 8090)
+        run: |
+          # Mount the modified config/default.yaml to override the default config
+          docker run -d --name codex-proxy-8090 -p 8090:8090 -v "$(pwd)/custom-config/default.yaml:/app/config/default.yaml" codex-proxy-test
+
+          echo "Waiting for container to become healthy..."
+          for i in {1..30}; do
+            HEALTH_STATUS=$(docker inspect --format='{{.State.Health.Status}}' codex-proxy-8090 2>/dev/null || echo "starting")
+            if [ "$HEALTH_STATUS" = "healthy" ]; then
+              echo "Container is healthy!"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Container failed to become healthy within 30 seconds."
+              docker logs codex-proxy-8090
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Testing /health endpoint on 8090..."
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8090/health)
+          if [ "$STATUS_CODE" -ne 200 ]; then
+            echo "Expected 200 OK, got $STATUS_CODE"
+            exit 1
+          fi
+          echo "/health returned 200 OK on 8090"
+
+      - name: Cleanup custom container
+        run: |
+          docker stop codex-proxy-8090
+          docker rm codex-proxy-8090

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,43 @@
+name: Electron Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    paths:
+      - 'packages/electron/**'
+
+jobs:
+  electron-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd packages/electron && npm install
+
+      - name: Build root
+        run: npm run build
+
+      - name: Build Electron frontend
+        run: cd packages/electron && npm run build
+
+      - name: Prepare pack
+        run: cd packages/electron && node electron/prepare-pack.mjs
+
+      - name: Package Electron (dir mode)
+        run: cd packages/electron && npx electron-builder --linux --dir
+
+      - name: Install Playwright & Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Smoke Test
+        run: RUN_E2E_SMOKE=1 xvfb-run -a npm test -- packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,29 @@
+name: Web Smoke Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  web-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd web && npm install
+
+      - name: Build web dashboard
+        run: npm run build
+
+      - name: Run Web Smoke Test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.41",
+  "version": "2.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.41",
+      "version": "2.0.54",
       "workspaces": [
         "packages/*"
       ],
@@ -1218,6 +1218,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5607,6 +5623,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7349,14 +7412,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.41",
+      "version": "2.0.54",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.59.1"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,88 @@
+import { _electron as electron } from "playwright";
+import { test, expect, describe, beforeAll, afterAll } from "vitest";
+import { resolve } from "node:path";
+import fs from "node:fs";
+
+describe.runIf(process.env.CI || process.env.RUN_E2E_SMOKE)(
+  "Electron App Smoke Test",
+  () => {
+    let electronApp: Awaited<ReturnType<typeof electron.launch>>;
+
+    beforeAll(async () => {
+      const isLinux = process.platform === "linux";
+
+      let executablePath = "";
+      if (isLinux) {
+        executablePath = resolve(
+          import.meta.dirname,
+          "../../release/linux-unpacked/@codex-proxyelectron"
+        );
+      } else if (process.platform === "darwin") {
+        executablePath = resolve(
+          import.meta.dirname,
+          "../../release/mac/Codex Proxy.app/Contents/MacOS/Codex Proxy"
+        );
+      } else if (process.platform === "win32") {
+        executablePath = resolve(
+          import.meta.dirname,
+          "../../release/win-unpacked/Codex Proxy.exe"
+        );
+      }
+
+      if (!fs.existsSync(executablePath)) {
+        throw new Error(`Executable not found at ${executablePath}. Did you run electron-builder?`);
+      }
+
+      const userDataDir = resolve(
+        import.meta.dirname,
+        "../../.test-user-data"
+      );
+
+      // Create local.yaml to avoid native transport issues
+      const localYamlPath = resolve(userDataDir, "data", "local.yaml");
+      fs.mkdirSync(resolve(userDataDir, "data"), { recursive: true });
+      fs.writeFileSync(localYamlPath, "tls:\n  transport: curl-cli\n");
+
+      electronApp = await electron.launch({
+        executablePath,
+        args: [
+          "--no-sandbox",
+          "--disable-gpu",
+          "--disable-dev-shm-usage",
+          `--user-data-dir=${userDataDir}`,
+        ],
+        env: {
+          ...process.env,
+          ELECTRON_ENABLE_LOGGING: "1",
+          DISABLE_NATIVE_TRANSPORT: "1",
+        },
+      });
+
+      electronApp.process().stdout?.on("data", (data: Buffer) => {
+        console.log(`[Electron STDOUT]: ${data.toString()}`);
+      });
+      electronApp.process().stderr?.on("data", (data: Buffer) => {
+        console.error(`[Electron STDERR]: ${data.toString()}`);
+      });
+    }, 60000);
+
+    afterAll(async () => {
+      if (electronApp) {
+        await electronApp.close();
+      }
+    });
+
+    test("launches and opens a window", async () => {
+      // Get the first window
+      const window = await electronApp.firstWindow();
+      expect(window).toBeDefined();
+
+      // Wait for the window to load
+      await window.waitForLoadState("domcontentloaded");
+
+      // Verify the title (it could be anything, but let's check it's a string)
+      const title = await window.title();
+      expect(typeof title).toBe("string");
+    }, 30000);
+  }
+);

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.59.1"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import { resolve } from "node:path";
+import { spawn, ChildProcess } from "node:child_process";
+
+describe("Web Dashboard Smoke Test", () => {
+  let serverProcess: ChildProcess;
+  const PORT = 8081;
+
+  beforeAll(async () => {
+    // Start the server
+    serverProcess = spawn("node", ["dist/index.js"], {
+      env: { ...process.env, PORT: PORT.toString(), DISABLE_NATIVE_TRANSPORT: "1" },
+      stdio: "pipe",
+    });
+
+    serverProcess.stdout?.on("data", (data) => {
+      console.log(`[Server STDOUT]: ${data.toString()}`);
+    });
+
+    serverProcess.stderr?.on("data", (data) => {
+      console.error(`[Server STDERR]: ${data.toString()}`);
+    });
+
+    // Wait for the server to be ready
+    await new Promise<void>((resolve, reject) => {
+      let isReady = false;
+      const timeout = setTimeout(() => {
+        if (!isReady) {
+          reject(new Error("Server start timeout"));
+        }
+      }, 10000);
+
+      const checkHealth = async () => {
+        try {
+          const res = await fetch(`http://localhost:${PORT}/v1/models`);
+          if (res.status === 200 || res.status === 401) {
+            isReady = true;
+            clearTimeout(timeout);
+            resolve();
+          } else {
+            setTimeout(checkHealth, 500);
+          }
+        } catch (e) {
+          setTimeout(checkHealth, 500);
+        }
+      };
+
+      checkHealth();
+    });
+  }, 15000);
+
+  afterAll(() => {
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+  });
+
+  test("Vite builds CSS with light and dark theme rules", () => {
+    const assetsDir = resolve(import.meta.dirname, "../../public/assets");
+    expect(fs.existsSync(assetsDir)).toBe(true);
+
+    const files = fs.readdirSync(assetsDir);
+    const cssFiles = files.filter(file => file.endsWith(".css"));
+    expect(cssFiles.length).toBeGreaterThan(0);
+
+    const cssContent = fs.readFileSync(resolve(assetsDir, cssFiles[0]), "utf-8");
+    // Tailwind class strategy dark mode output
+    expect(cssContent).toMatch(/\.dark\\?:/);
+    expect(cssContent).toContain("color-scheme");
+  });
+
+  test("Server responds with HTML containing <div id=\"app\"></div>", async () => {
+    const res = await fetch(`http://localhost:${PORT}/`);
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    expect(text).toContain("<div id=\"app\"></div>");
+  });
+});


### PR DESCRIPTION
This commit addresses #133, #134, and #135 by implementing independent CI smoke tests for each of the core components of the Codex Proxy application.

1. **Docker**: A workflow builds the image and checks its default and custom port behavior through port mapping + mounted config overlays, verifying the healthcheck status and endpoint response.
2. **Electron**: Playwright dependencies were added to the electron workspace, along with a `smoke.test.ts` that relies on xvfb and an unpacked application to assert basic window-launch behavior. A CI workflow handles the full build, prepare, unpack, and launch sequence.
3. **Web**: A new vitest file in `src/__tests__/` validates Tailwind's CSS compilation (checking for `color-scheme` properties from dark mode plugin classes) and ensures the built Hono Node server can host the index.html payload appropriately on an arbitrary port.

---
*PR created automatically by Jules for task [9084205728708085973](https://jules.google.com/task/9084205728708085973) started by @icebear0828*