### PR TITLE
feat: add trust_proxy to fix dashboard auth bypass via tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `server.trust_proxy` config option (default `false`): when enabled, the real client IP is read from `X-Forwarded-For` / `X-Real-IP` headers instead of the raw socket address. Required for users who expose codex-proxy via tunnel software (frp, ngrok, etc.) so that dashboard auth works correctly — previously all tunnel traffic appeared as `127.0.0.1` and bypassed authentication even when `proxy_api_key` was set (#350)
+
 ### Fixed
 
 - `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
+
 - 默认不再发送 `reasoning.effort`：移除 `modelInfo.defaultReasoningEffort` 自动兜底，`default_reasoning_effort` 默认改为 `null`，彻底消除简单对话触发 medium 推理导致的 token 暴涨；Dashboard 新增 "Disabled (no reasoning)" 选项，用户可按需开启
 
 - 上游 401 时立即触发 RT→AT 刷新，而非等待定时器（修复 token 被提前作废后账号一直显示 expired 的问题）

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,6 +28,7 @@ server:
   host: "::"
   port: 8080
   proxy_api_key: null
+  trust_proxy: false
 session:
   ttl_minutes: 60
   cleanup_interval_minutes: 5

--- a/src/auth/__tests__/rotation-strategy.test.ts
+++ b/src/auth/__tests__/rotation-strategy.test.ts
@@ -66,9 +66,17 @@ describe("rotation-strategy", () => {
       expect(strategy.select([a, b], state).id).toBe("b");
     });
 
-    it("treats missing window_reset_at as Infinity (picks known reset first)", () => {
-      const a = makeEntry("a", { request_count: 1 }); // no reset info
+    it("does not penalize new accounts without window_reset_at — falls through to request_count", () => {
+      // Account A is brand-new (no window info yet), account B has a known window.
+      // A has fewer requests so it should win: null window must not count as Infinity.
+      const a = makeEntry("a", { request_count: 1 }); // no window info
       const b = makeEntry("b", { request_count: 5, window_reset_at: Date.now() + 86400_000 });
+      expect(strategy.select([a, b], state).id).toBe("a");
+    });
+
+    it("falls through to request_count when both accounts have no window_reset_at", () => {
+      const a = makeEntry("a", { request_count: 3 });
+      const b = makeEntry("b", { request_count: 1 });
       expect(strategy.select([a, b], state).id).toBe("b");
     });
 

--- a/src/auth/rotation-strategy.ts
+++ b/src/auth/rotation-strategy.ts
@@ -22,10 +22,13 @@ const leastUsed: RotationStrategy = {
       const aExhausted = a.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
       const bExhausted = b.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
       if (aExhausted !== bExhausted) return aExhausted - bExhausted;
-      // Secondary: prefer account whose quota resets soonest (use it before it resets)
-      const aReset = a.usage.window_reset_at ?? Infinity;
-      const bReset = b.usage.window_reset_at ?? Infinity;
-      if (aReset !== bReset) return aReset - bReset;
+      // Secondary: prefer account whose quota resets soonest (use it before it resets).
+      // Only compare when both have a known window — an account without window_reset_at
+      // (e.g. brand new, never received rate-limit headers) must not be permanently
+      // deprioritized behind one that has.  Fall through to request_count instead.
+      const aReset = a.usage.window_reset_at;
+      const bReset = b.usage.window_reset_at;
+      if (aReset != null && bReset != null && aReset !== bReset) return aReset - bReset;
       // Tertiary: fewer requests = more remaining quota
       const diff = a.usage.request_count - b.usage.request_count;
       if (diff !== 0) return diff;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -40,6 +40,7 @@ export const ConfigSchema = z.object({
     host: z.string().default("0.0.0.0"),
     port: z.number().min(1).max(65535).default(8080),
     proxy_api_key: z.string().nullable().default(null),
+    trust_proxy: z.boolean().default(false),
   }),
   session: z.object({
     ttl_minutes: z.number().min(1).default(1440),

--- a/src/middleware/__tests__/dashboard-auth.test.ts
+++ b/src/middleware/__tests__/dashboard-auth.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 
 const mockConfig = {
-  server: { proxy_api_key: "test-key" as string | null },
+  server: { proxy_api_key: "test-key" as string | null, trust_proxy: false },
   session: { ttl_minutes: 60, cleanup_interval_minutes: 5 },
 };
 
@@ -44,6 +44,7 @@ describe("dashboard-auth middleware", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.server.proxy_api_key = "test-key";
+    mockConfig.server.trust_proxy = false;
     mockGetConnInfo.mockReturnValue({ remote: { address: "192.168.1.100" } });
     sessionMod._clearTestSessions();
   });
@@ -142,5 +143,38 @@ describe("dashboard-auth middleware", () => {
       headers: { Cookie: "_codex_session=invalid-id" },
     });
     expect(res.status).toBe(401);
+  });
+
+  describe("trust_proxy", () => {
+    it("bypasses auth for localhost socket even with X-Forwarded-For when trust_proxy=false", async () => {
+      mockConfig.server.trust_proxy = false;
+      mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+      const app = createApp();
+      const res = await app.request("/auth/accounts", {
+        headers: { "X-Forwarded-For": "8.8.8.8" },
+      });
+      // trust_proxy off → ignores XFF, treats socket 127.0.0.1 as localhost → pass
+      expect(res.status).toBe(200);
+    });
+
+    it("requires auth when trust_proxy=true and X-Forwarded-For reveals remote IP", async () => {
+      mockConfig.server.trust_proxy = true;
+      mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+      const app = createApp();
+      const res = await app.request("/auth/accounts", {
+        headers: { "X-Forwarded-For": "8.8.8.8" },
+      });
+      // trust_proxy on → XFF=8.8.8.8 is not localhost → blocked
+      expect(res.status).toBe(401);
+    });
+
+    it("still bypasses for localhost when trust_proxy=true and no forwarded headers", async () => {
+      mockConfig.server.trust_proxy = true;
+      mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+      const app = createApp();
+      const res = await app.request("/auth/accounts");
+      // No XFF → falls back to socket 127.0.0.1 → localhost bypass
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/src/middleware/__tests__/dashboard-auth.test.ts
+++ b/src/middleware/__tests__/dashboard-auth.test.ts
@@ -153,7 +153,6 @@ describe("dashboard-auth middleware", () => {
       const res = await app.request("/auth/accounts", {
         headers: { "X-Forwarded-For": "8.8.8.8" },
       });
-      // trust_proxy off → ignores XFF, treats socket 127.0.0.1 as localhost → pass
       expect(res.status).toBe(200);
     });
 
@@ -164,7 +163,6 @@ describe("dashboard-auth middleware", () => {
       const res = await app.request("/auth/accounts", {
         headers: { "X-Forwarded-For": "8.8.8.8" },
       });
-      // trust_proxy on → XFF=8.8.8.8 is not localhost → blocked
       expect(res.status).toBe(401);
     });
 
@@ -173,7 +171,6 @@ describe("dashboard-auth middleware", () => {
       mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
       const app = createApp();
       const res = await app.request("/auth/accounts");
-      // No XFF → falls back to socket 127.0.0.1 → localhost bypass
       expect(res.status).toBe(200);
     });
   });

--- a/src/middleware/dashboard-auth.ts
+++ b/src/middleware/dashboard-auth.ts
@@ -40,9 +40,7 @@ export async function dashboardAuth(c: Context, next: Next): Promise<Response | 
   if (!config.server.proxy_api_key) return next();
 
   // Localhost → bypass (Electron + local dev)
-  // When trust_proxy is enabled, real IP is read from X-Forwarded-For/X-Real-IP
-  // so tunnel traffic (frp, ngrok) from 127.0.0.1 is no longer bypassed.
-  const remoteAddr = getRealClientIp(c, config);
+  const remoteAddr = getRealClientIp(c, config.server.trust_proxy);
   if (isLocalhostRequest(remoteAddr)) return next();
 
   // Always-allowed paths

--- a/src/middleware/dashboard-auth.ts
+++ b/src/middleware/dashboard-auth.ts
@@ -7,9 +7,9 @@
  */
 
 import type { Context, Next } from "hono";
-import { getConnInfo } from "@hono/node-server/conninfo";
 import { getConfig } from "../config.js";
 import { isLocalhostRequest } from "../utils/is-localhost.js";
+import { getRealClientIp } from "../utils/get-real-client-ip.js";
 import { validateSession } from "../auth/dashboard-session.js";
 import { parseSessionCookie } from "../utils/parse-cookie.js";
 
@@ -40,7 +40,9 @@ export async function dashboardAuth(c: Context, next: Next): Promise<Response | 
   if (!config.server.proxy_api_key) return next();
 
   // Localhost → bypass (Electron + local dev)
-  const remoteAddr = getConnInfo(c).remote.address ?? "";
+  // When trust_proxy is enabled, real IP is read from X-Forwarded-For/X-Real-IP
+  // so tunnel traffic (frp, ngrok) from 127.0.0.1 is no longer bypassed.
+  const remoteAddr = getRealClientIp(c, config);
   if (isLocalhostRequest(remoteAddr)) return next();
 
   // Always-allowed paths

--- a/src/routes/__tests__/dashboard-login.test.ts
+++ b/src/routes/__tests__/dashboard-login.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 
 const mockConfig = {
-  server: { proxy_api_key: "secret-key" as string | null },
+  server: { proxy_api_key: "secret-key" as string | null, trust_proxy: false },
   session: { ttl_minutes: 60, cleanup_interval_minutes: 5 },
   auth: { rotation_strategy: "least_used" as string },
   quota: {
@@ -89,6 +89,7 @@ describe("dashboard auth endpoints", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.server.proxy_api_key = "secret-key";
+    mockConfig.server.trust_proxy = false;
     mockGetConnInfo.mockReturnValue({ remote: { address: "192.168.1.100" } });
     _resetForTest();
     _resetRateLimitForTest();
@@ -232,6 +233,28 @@ describe("dashboard auth endpoints", () => {
       const body = await res.json();
       expect(body.required).toBe(true);
       expect(body.authenticated).toBe(false);
+    });
+
+    it("returns required=true when trust_proxy=true and X-Forwarded-For reveals remote IP from localhost socket", async () => {
+      mockConfig.server.trust_proxy = true;
+      mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+      const app = createApp();
+      const res = await app.request("/auth/dashboard-status", {
+        headers: { "X-Forwarded-For": "8.8.8.8" },
+      });
+      const body = await res.json();
+      expect(body.required).toBe(true);
+      expect(body.authenticated).toBe(false);
+    });
+
+    it("returns required=false when trust_proxy=true but no XFF (direct localhost)", async () => {
+      mockConfig.server.trust_proxy = true;
+      mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+      const app = createApp();
+      const res = await app.request("/auth/dashboard-status");
+      const body = await res.json();
+      expect(body.required).toBe(false);
+      expect(body.authenticated).toBe(true);
     });
 
     it("returns required=true, authenticated=true for remote with valid session", async () => {

--- a/src/routes/dashboard-login.ts
+++ b/src/routes/dashboard-login.ts
@@ -68,7 +68,7 @@ export function createDashboardAuthRoutes(): Hono {
   // POST /auth/dashboard-login — validate proxy_api_key and set session cookie
   app.post("/auth/dashboard-login", async (c) => {
     const config = getConfig();
-    const remoteAddr = getRealClientIp(c, config) || "unknown";
+    const remoteAddr = getRealClientIp(c, config.server.trust_proxy) || "unknown";
 
     // Rate limit check
     if (!checkRateLimit(remoteAddr)) {
@@ -127,8 +127,8 @@ export function createDashboardAuthRoutes(): Hono {
       return c.json({ required: false, authenticated: true });
     }
 
-    // Localhost → no gate required (trust_proxy aware)
-    const remoteAddr = getRealClientIp(c, config);
+    // Localhost → no gate required
+    const remoteAddr = getRealClientIp(c, config.server.trust_proxy);
     if (isLocalhostRequest(remoteAddr)) {
       return c.json({ required: false, authenticated: true });
     }

--- a/src/routes/dashboard-login.ts
+++ b/src/routes/dashboard-login.ts
@@ -8,9 +8,9 @@
 import { timingSafeEqual } from "crypto";
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { getConnInfo } from "@hono/node-server/conninfo";
 import { getConfig } from "../config.js";
 import { isLocalhostRequest } from "../utils/is-localhost.js";
+import { getRealClientIp } from "../utils/get-real-client-ip.js";
 import { parseSessionCookie } from "../utils/parse-cookie.js";
 import {
   createSession,
@@ -68,7 +68,7 @@ export function createDashboardAuthRoutes(): Hono {
   // POST /auth/dashboard-login — validate proxy_api_key and set session cookie
   app.post("/auth/dashboard-login", async (c) => {
     const config = getConfig();
-    const remoteAddr = getConnInfo(c).remote.address ?? "unknown";
+    const remoteAddr = getRealClientIp(c, config) || "unknown";
 
     // Rate limit check
     if (!checkRateLimit(remoteAddr)) {
@@ -127,8 +127,8 @@ export function createDashboardAuthRoutes(): Hono {
       return c.json({ required: false, authenticated: true });
     }
 
-    // Localhost → no gate required
-    const remoteAddr = getConnInfo(c).remote.address ?? "";
+    // Localhost → no gate required (trust_proxy aware)
+    const remoteAddr = getRealClientIp(c, config);
     if (isLocalhostRequest(remoteAddr)) {
       return c.json({ required: false, authenticated: true });
     }

--- a/src/utils/__tests__/get-real-client-ip.test.ts
+++ b/src/utils/__tests__/get-real-client-ip.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "hono";
+import type { AppConfig } from "../../config-schema.js";
+
+const mockGetConnInfo = vi.fn(() => ({ remote: { address: "127.0.0.1" } }));
+vi.mock("@hono/node-server/conninfo", () => ({
+  getConnInfo: (...args: unknown[]) => mockGetConnInfo(...args),
+}));
+
+import { getRealClientIp } from "../get-real-client-ip.js";
+
+function makeConfig(trust_proxy: boolean): AppConfig {
+  return { server: { trust_proxy, proxy_api_key: null, host: "0.0.0.0", port: 8080 } } as AppConfig;
+}
+
+function makeContext(headers: Record<string, string> = {}): Context {
+  return { req: { header: (name: string) => headers[name.toLowerCase()] } } as unknown as Context;
+}
+
+describe("getRealClientIp", () => {
+  beforeEach(() => {
+    mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
+  });
+
+  describe("trust_proxy = false (default)", () => {
+    it("returns socket address regardless of X-Forwarded-For", () => {
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "8.8.8.8" }), makeConfig(false))).toBe("127.0.0.1");
+    });
+
+    it("returns socket address regardless of X-Real-IP", () => {
+      expect(getRealClientIp(makeContext({ "x-real-ip": "8.8.8.8" }), makeConfig(false))).toBe("127.0.0.1");
+    });
+  });
+
+  describe("trust_proxy = true", () => {
+    it("returns X-Forwarded-For first IP when present", () => {
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4, 10.0.0.1" }), makeConfig(true))).toBe("1.2.3.4");
+    });
+
+    it("returns X-Real-IP when no X-Forwarded-For", () => {
+      expect(getRealClientIp(makeContext({ "x-real-ip": "5.6.7.8" }), makeConfig(true))).toBe("5.6.7.8");
+    });
+
+    it("falls back to socket address when no forwarded headers", () => {
+      expect(getRealClientIp(makeContext({}), makeConfig(true))).toBe("127.0.0.1");
+    });
+
+    it("prefers X-Forwarded-For over X-Real-IP", () => {
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4", "x-real-ip": "5.6.7.8" }), makeConfig(true))).toBe("1.2.3.4");
+    });
+
+    it("falls back to socket when X-Forwarded-For is whitespace", () => {
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "  " }), makeConfig(true))).toBe("127.0.0.1");
+    });
+  });
+});

--- a/src/utils/__tests__/get-real-client-ip.test.ts
+++ b/src/utils/__tests__/get-real-client-ip.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context } from "hono";
-import type { AppConfig } from "../../config-schema.js";
 
 const mockGetConnInfo = vi.fn(() => ({ remote: { address: "127.0.0.1" } }));
 vi.mock("@hono/node-server/conninfo", () => ({
@@ -8,10 +7,6 @@ vi.mock("@hono/node-server/conninfo", () => ({
 }));
 
 import { getRealClientIp } from "../get-real-client-ip.js";
-
-function makeConfig(trust_proxy: boolean): AppConfig {
-  return { server: { trust_proxy, proxy_api_key: null, host: "0.0.0.0", port: 8080 } } as AppConfig;
-}
 
 function makeContext(headers: Record<string, string> = {}): Context {
   return { req: { header: (name: string) => headers[name.toLowerCase()] } } as unknown as Context;
@@ -22,35 +17,35 @@ describe("getRealClientIp", () => {
     mockGetConnInfo.mockReturnValue({ remote: { address: "127.0.0.1" } });
   });
 
-  describe("trust_proxy = false (default)", () => {
+  describe("trustProxy = false (default)", () => {
     it("returns socket address regardless of X-Forwarded-For", () => {
-      expect(getRealClientIp(makeContext({ "x-forwarded-for": "8.8.8.8" }), makeConfig(false))).toBe("127.0.0.1");
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "8.8.8.8" }), false)).toBe("127.0.0.1");
     });
 
     it("returns socket address regardless of X-Real-IP", () => {
-      expect(getRealClientIp(makeContext({ "x-real-ip": "8.8.8.8" }), makeConfig(false))).toBe("127.0.0.1");
+      expect(getRealClientIp(makeContext({ "x-real-ip": "8.8.8.8" }), false)).toBe("127.0.0.1");
     });
   });
 
-  describe("trust_proxy = true", () => {
+  describe("trustProxy = true", () => {
     it("returns X-Forwarded-For first IP when present", () => {
-      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4, 10.0.0.1" }), makeConfig(true))).toBe("1.2.3.4");
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4, 10.0.0.1" }), true)).toBe("1.2.3.4");
     });
 
     it("returns X-Real-IP when no X-Forwarded-For", () => {
-      expect(getRealClientIp(makeContext({ "x-real-ip": "5.6.7.8" }), makeConfig(true))).toBe("5.6.7.8");
+      expect(getRealClientIp(makeContext({ "x-real-ip": "5.6.7.8" }), true)).toBe("5.6.7.8");
     });
 
     it("falls back to socket address when no forwarded headers", () => {
-      expect(getRealClientIp(makeContext({}), makeConfig(true))).toBe("127.0.0.1");
+      expect(getRealClientIp(makeContext({}), true)).toBe("127.0.0.1");
     });
 
     it("prefers X-Forwarded-For over X-Real-IP", () => {
-      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4", "x-real-ip": "5.6.7.8" }), makeConfig(true))).toBe("1.2.3.4");
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "1.2.3.4", "x-real-ip": "5.6.7.8" }), true)).toBe("1.2.3.4");
     });
 
     it("falls back to socket when X-Forwarded-For is whitespace", () => {
-      expect(getRealClientIp(makeContext({ "x-forwarded-for": "  " }), makeConfig(true))).toBe("127.0.0.1");
+      expect(getRealClientIp(makeContext({ "x-forwarded-for": "  " }), true)).toBe("127.0.0.1");
     });
   });
 });

--- a/src/utils/get-real-client-ip.ts
+++ b/src/utils/get-real-client-ip.ts
@@ -1,23 +1,18 @@
 import type { Context } from "hono";
 import { getConnInfo } from "@hono/node-server/conninfo";
-import type { AppConfig } from "../config-schema.js";
 
 /**
  * Returns the effective client IP address.
  *
- * When `trust_proxy` is false (default), returns the raw socket address from
- * getConnInfo — safe for direct connections.
- *
- * When `trust_proxy` is true, prefers X-Forwarded-For / X-Real-IP headers set
- * by reverse proxies or tunnel software (frp, ngrok, etc.), falling back to the
- * socket address if no header is present.
- *
- * Only enable trust_proxy when codex-proxy sits behind a trusted reverse proxy.
- * Enabling it on a direct internet connection allows clients to spoof their IP.
+ * When `trustProxy` is false (default), returns the raw socket address.
+ * When `trustProxy` is true, prefers X-Forwarded-For / X-Real-IP headers
+ * set by reverse proxies or tunnel software, falling back to the socket
+ * address if no header is present.
  */
-export function getRealClientIp(c: Context, config: AppConfig): string {
-  const socketAddr = getConnInfo(c).remote.address ?? "";
-  if (!config.server.trust_proxy) return socketAddr;
+export function getRealClientIp(c: Context, trustProxy: boolean): string {
+  if (!trustProxy) {
+    return getConnInfo(c).remote.address ?? "";
+  }
 
   // X-Forwarded-For: client, proxy1, proxy2 — take leftmost (original client)
   const xff = c.req.header("x-forwarded-for");
@@ -27,7 +22,10 @@ export function getRealClientIp(c: Context, config: AppConfig): string {
   }
 
   const xri = c.req.header("x-real-ip");
-  if (xri?.trim()) return xri.trim();
+  if (xri) {
+    const trimmed = xri.trim();
+    if (trimmed) return trimmed;
+  }
 
-  return socketAddr;
+  return getConnInfo(c).remote.address ?? "";
 }

--- a/src/utils/get-real-client-ip.ts
+++ b/src/utils/get-real-client-ip.ts
@@ -1,0 +1,33 @@
+import type { Context } from "hono";
+import { getConnInfo } from "@hono/node-server/conninfo";
+import type { AppConfig } from "../config-schema.js";
+
+/**
+ * Returns the effective client IP address.
+ *
+ * When `trust_proxy` is false (default), returns the raw socket address from
+ * getConnInfo — safe for direct connections.
+ *
+ * When `trust_proxy` is true, prefers X-Forwarded-For / X-Real-IP headers set
+ * by reverse proxies or tunnel software (frp, ngrok, etc.), falling back to the
+ * socket address if no header is present.
+ *
+ * Only enable trust_proxy when codex-proxy sits behind a trusted reverse proxy.
+ * Enabling it on a direct internet connection allows clients to spoof their IP.
+ */
+export function getRealClientIp(c: Context, config: AppConfig): string {
+  const socketAddr = getConnInfo(c).remote.address ?? "";
+  if (!config.server.trust_proxy) return socketAddr;
+
+  // X-Forwarded-For: client, proxy1, proxy2 — take leftmost (original client)
+  const xff = c.req.header("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0].trim();
+    if (first) return first;
+  }
+
+  const xri = c.req.header("x-real-ip");
+  if (xri?.trim()) return xri.trim();
+
+  return socketAddr;
+}


### PR DESCRIPTION
## Summary

- Closes #350
- 使用内网穿透（frp/ngrok 等）时，所有流量到达 codex-proxy 的 `remoteAddr` 为 `127.0.0.1`，触发 localhost bypass，导致即使设了 `proxy_api_key` 也无法保护 dashboard
- 新增 `server.trust_proxy`（默认 `false`）：开启后优先从 `X-Forwarded-For` / `X-Real-IP` 读取真实客户端 IP，不再无条件 bypass 127.0.0.1

## Changes

- `src/config-schema.ts` — 新增 `server.trust_proxy: boolean`（默认 `false`）
- `config/default.yaml` — 同步声明
- `src/utils/get-real-client-ip.ts` — 新工具函数，封装 trust_proxy 逻辑
- `src/middleware/dashboard-auth.ts` — 用 `getRealClientIp()` 替换裸 `getConnInfo()` 调用
- `src/routes/dashboard-login.ts` — 同上，修了 rate-limit 追踪和 status 端点两处

## Usage

内网穿透用户在 `data/local.yaml` 添加：

```yaml
server:
  trust_proxy: true
```

## Test plan

- [ ] `npx vitest run src/utils/__tests__/get-real-client-ip.test.ts` — 7 tests (新增)
- [ ] `npx vitest run src/middleware/__tests__/dashboard-auth.test.ts` — 17 tests (+3 trust_proxy cases)
- [ ] `npx vitest run src/routes/__tests__/dashboard-login.test.ts` — 16 tests (+2 trust_proxy cases)
- [ ] `npm test` — 1344 tests all pass