### PR TITLE
test: verify Docker image builds and starts successfully

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,6 +28,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,10 +39,18 @@ jobs:
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
-            -e NODE_ENV=production \
-            codex-proxy:smoke
+          if [ "${{ matrix.port }}" = "8090" ]; then
+            docker run -d --name smoke-test \
+              -p 18090:${{ matrix.port }} \
+              -e NODE_ENV=production \
+              -e PORT=${{ matrix.port }} \
+              codex-proxy:smoke
+          else
+            docker run -d --name smoke-test \
+              -p 18080:8080 \
+              -e NODE_ENV=production \
+              codex-proxy:smoke
+          fi
           echo "Container started"
 
       - name: Wait for healthy
@@ -60,14 +71,16 @@ jobs:
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          HOST_PORT=$(( ${{ matrix.port }} + 10000 ))
+          RESPONSE=$(curl -sf http://localhost:$HOST_PORT/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
+          HOST_PORT=$(( ${{ matrix.port }} + 10000 ))
           # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$HOST_PORT/v1/models)
           echo "/v1/models status: $STATUS"
           # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
-# Read server port from config, fallback to 8080
-PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+# Read server port from environment, local override, or config, fallback to 8080
+
+if [ -z "$PORT" ]; then
+  # Check data/local.yaml first
+  PORT=$(grep -A5 '^server:' /app/data/local.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+fi
+
+if [ -z "$PORT" ]; then
+  # Fallback to config/default.yaml
+  PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+fi
+
 curl -fs "http://localhost:${PORT:-8080}/health" || exit 1


### PR DESCRIPTION
Fixes #120 by verifying the Docker image builds and starts successfully with both the default and custom ports using a matrix strategy in CI. Added logic to dynamically resolve the port in the docker healthcheck.

---
*PR created automatically by Jules for task [13846461935072594397](https://jules.google.com/task/13846461935072594397) started by @icebear0828*