### PR TITLE
test: add CI smoke tests for Docker, Electron, and Web

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,64 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker Image
+        run: docker build -t codex-proxy-test .
+
+      - name: Test Default Port (8080)
+        run: |
+          docker run -d --name codex-proxy-8080 -p 8080:8080 codex-proxy-test
+          # Wait up to 30s for the healthcheck to pass
+          for i in {1..15}; do
+            STATUS=$(docker inspect --format='{{json .State.Health.Status}}' codex-proxy-8080)
+            if [ "$STATUS" = '"healthy"' ]; then
+              break
+            fi
+            sleep 2
+          done
+          STATUS=$(docker inspect --format='{{json .State.Health.Status}}' codex-proxy-8080)
+          if [ "$STATUS" != '"healthy"' ]; then
+            docker logs codex-proxy-8080
+            exit 1
+          fi
+          # Verify the endpoint
+          curl -f http://localhost:8080/health
+
+      - name: Cleanup Default Port Container
+        run: docker rm -f codex-proxy-8080
+
+      - name: Test Custom Port (8090)
+        run: |
+          # Create a modified config
+          mkdir -p test-config
+          cp -r config/* test-config/
+          sed -i 's/port: 8080/port: 8090/' test-config/default.yaml
+
+          docker run -d --name codex-proxy-8090 -p 8090:8090 -v ${{ github.workspace }}/test-config:/app/config codex-proxy-test
+
+          # Wait up to 30s for the healthcheck to pass
+          for i in {1..15}; do
+            STATUS=$(docker inspect --format='{{json .State.Health.Status}}' codex-proxy-8090)
+            if [ "$STATUS" = '"healthy"' ]; then
+              break
+            fi
+            sleep 2
+          done
+          STATUS=$(docker inspect --format='{{json .State.Health.Status}}' codex-proxy-8090)
+          if [ "$STATUS" != '"healthy"' ]; then
+            docker logs codex-proxy-8090
+            exit 1
+          fi
+          # Verify the endpoint
+          curl -f http://localhost:8090/health

--- a/.github/workflows/electron-smoke-test.yml
+++ b/.github/workflows/electron-smoke-test.yml
@@ -1,0 +1,47 @@
+name: Electron Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/electron/**'
+  pull_request:
+    paths:
+      - 'packages/electron/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Root (Backend + Web)
+        run: npm run build
+
+      - name: Build Electron Workspace
+        run: cd packages/electron && npm run build
+
+      - name: Prepare Electron Package
+        run: cd packages/electron && node electron/prepare-pack.mjs
+
+      - name: Package Electron
+        run: cd packages/electron && npx electron-builder --linux --dir
+
+      - name: Install Chromium for Playwright
+        run: |
+          cd packages/electron
+          npx playwright install --with-deps chromium
+
+      - name: Run Smoke Test
+        run: xvfb-run -a npm run test -- packages/electron/__tests__/launch/smoke.test.ts

--- a/.github/workflows/web-smoke-test.yml
+++ b/.github/workflows/web-smoke-test.yml
@@ -1,0 +1,29 @@
+name: Web Smoke Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Run Web Smoke Test
+        run: npm test -- src/__tests__/web-smoke.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.41",
+  "version": "2.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.41",
+      "version": "2.0.55",
       "workspaces": [
         "packages/*"
       ],
@@ -1218,6 +1218,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5607,6 +5623,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -7349,14 +7412,16 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.41",
+      "version": "2.0.55",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "electron": "^35.7.5",
         "electron-builder": "^26.0.0",
-        "esbuild": "^0.25.12"
+        "esbuild": "^0.25.12",
+        "playwright": "^1.59.1"
       }
     },
     "packages/electron/node_modules/@esbuild/aix-ppc64": {

--- a/packages/electron/__tests__/launch/smoke.test.ts
+++ b/packages/electron/__tests__/launch/smoke.test.ts
@@ -1,0 +1,53 @@
+import { _electron as electron } from "playwright";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+describe.runIf(process.env.CI || process.env.RUN_E2E_SMOKE)("Electron Launch Smoke Test", () => {
+  let app: Awaited<ReturnType<typeof electron.launch>>;
+
+  beforeAll(async () => {
+    const platform = os.platform();
+    let executablePath = "";
+
+    // Resolve unpack directory dynamically based on platform
+    if (platform === "linux") {
+      executablePath = path.join(import.meta.dirname, "../../release/linux-unpacked/@codex-proxyelectron");
+    } else if (platform === "darwin") {
+      executablePath = path.join(import.meta.dirname, "../../release/mac/Codex Proxy.app/Contents/MacOS/Codex Proxy");
+    } else if (platform === "win32") {
+      executablePath = path.join(import.meta.dirname, "../../release/win-unpacked/Codex Proxy.exe");
+    } else {
+      throw new Error(`Unsupported platform: ${platform}`);
+    }
+
+    if (!fs.existsSync(executablePath)) {
+      throw new Error(`Executable not found at ${executablePath}. Did you run 'npm run pack:linux' (or win/mac) first?`);
+    }
+
+    // Set environment variable to enable logging for debugging native startup crashes
+    process.env.ELECTRON_ENABLE_LOGGING = "1";
+
+    app = await electron.launch({
+      executablePath,
+      args: ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    });
+
+    app.process().stdout?.on("data", (data) => console.log(`[Electron STDOUT] ${data.toString()}`));
+    app.process().stderr?.on("data", (data) => console.error(`[Electron STDERR] ${data.toString()}`));
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it("should open the main window", async () => {
+    const window = await app.firstWindow();
+    expect(window).not.toBeNull();
+    const title = await window.title();
+    expect(title).toContain("Codex Proxy");
+  });
+});

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,8 +19,10 @@
     "electron-updater": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "electron": "^35.7.5",
     "electron-builder": "^26.0.0",
-    "esbuild": "^0.25.12"
+    "esbuild": "^0.25.12",
+    "playwright": "^1.59.1"
   }
 }

--- a/src/__tests__/web-smoke.test.ts
+++ b/src/__tests__/web-smoke.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, ChildProcess } from "child_process";
+import fs from "fs";
+import path from "path";
+import http from "http";
+
+describe("Web Smoke Test", () => {
+  let serverProcess: ChildProcess;
+  const PORT = 8081;
+
+  beforeAll(async () => {
+    // Start the server
+    serverProcess = spawn("node", ["dist/index.js"], {
+      env: {
+        ...process.env,
+        PORT: PORT.toString(),
+        DISABLE_NATIVE_TRANSPORT: "1",
+      },
+    });
+
+    // Wait for the server to fully start
+    await new Promise<void>((resolve, reject) => {
+      let output = "";
+      serverProcess.stdout?.on("data", (data) => {
+        output += data.toString();
+        if (output.includes("Listen:")) {
+          resolve();
+        }
+      });
+
+      serverProcess.stderr?.on("data", (data) => {
+        console.error(`[Server STDERR]: ${data.toString()}`);
+      });
+
+      serverProcess.on("error", reject);
+
+      // Safety timeout
+      setTimeout(() => reject(new Error("Timeout waiting for server to start")), 10000);
+    });
+  });
+
+  afterAll(() => {
+    if (serverProcess) {
+      serverProcess.kill();
+    }
+  });
+
+  it("should contain CSS files with dark mode rules in public/assets/", () => {
+    const assetsDir = path.join(import.meta.dirname, "../../public/assets");
+    const files = fs.readdirSync(assetsDir);
+    const cssFiles = files.filter(f => f.endsWith(".css"));
+
+    expect(cssFiles.length).toBeGreaterThan(0);
+
+    let hasDarkTheme = false;
+    for (const file of cssFiles) {
+      const content = fs.readFileSync(path.join(assetsDir, file), "utf-8");
+      if (content.includes(".dark") || content.includes("color-scheme")) {
+        hasDarkTheme = true;
+        break;
+      }
+    }
+
+    expect(hasDarkTheme).toBe(true);
+  });
+
+  it("should serve the web app on the root endpoint", async () => {
+    const html = await new Promise<string>((resolve, reject) => {
+      http.get(`http://localhost:${PORT}/`, (res) => {
+        let data = "";
+        res.on("data", (chunk) => data += chunk);
+        res.on("end", () => resolve(data));
+      }).on("error", reject);
+    });
+
+    expect(html).toContain('<div id="app"></div>');
+  });
+});


### PR DESCRIPTION
Resolves #133, #134, #135 by adding CI smoke test workflows and accompanying test suites to verify project functionality across different distributions (Docker, Electron, Web).

---
*PR created automatically by Jules for task [17226201106457996265](https://jules.google.com/task/17226201106457996265) started by @icebear0828*