### PR TITLE
fix: expose API key models in /v1/models

### DIFF
--- a/src/auth/api-key-pool.ts
+++ b/src/auth/api-key-pool.ts
@@ -110,6 +110,11 @@ export class ApiKeyPool {
     return this.entries.filter((e) => e.provider === provider && e.status === "active");
   }
 
+  /** Get unique active model IDs from runtime-managed API keys. */
+  getActiveModels(): string[] {
+    return [...new Set(this.entries.filter((e) => e.status === "active").map((e) => e.model))];
+  }
+
   // ── Mutations ──────────────────────────────────────────────────
 
   add(input: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   app.route("/", geminiRoutes);
   app.route("/", responsesRoutes);
   app.route("/", proxyRoutes);
-  app.route("/", createModelRoutes());
+  app.route("/", createModelRoutes(apiKeyPool));
   app.route("/", webRoutes);
 
   // Start server

--- a/src/routes/__tests__/plan-routing-integration.test.ts
+++ b/src/routes/__tests__/plan-routing-integration.test.ts
@@ -99,6 +99,8 @@ import {
   applyBackendModelsForPlan,
 } from "../../models/model-store.js";
 import { extractUserProfile } from "../../auth/jwt-utils.js";
+import { ApiKeyPool } from "../../auth/api-key-pool.js";
+import type { ApiKeyPersistence, ApiKeyEntry } from "../../auth/api-key-pool.js";
 import {
   handleProxyRequest,
   type FormatAdapter,
@@ -107,6 +109,14 @@ import {
 import type { StatusCode } from "hono/utils/http-status";
 import { createModelRoutes } from "../models.js";
 import { triggerImmediateRefresh } from "../../models/model-fetcher.js";
+
+function createApiKeyMemoryPersistence(): ApiKeyPersistence {
+  let stored: ApiKeyEntry[] = [];
+  return {
+    load: () => [...stored],
+    save: (keys) => { stored = [...keys]; },
+  };
+}
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -309,6 +319,52 @@ describe("plan routing through proxy handler", () => {
     expect(res.status).toBe(200);
     // Team account is used (only plan supporting gpt-5.4)
     expect(mockCreateResponse).toHaveBeenCalledOnce();
+  });
+});
+
+describe("GET /v1/models with runtime API keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadStaticModels();
+  });
+
+  it("includes active API key models in /v1/models", async () => {
+    const pool = new ApiKeyPool(createApiKeyMemoryPersistence());
+    pool.add({ provider: "openai", model: "gpt-5.4", apiKey: "k1" });
+    pool.add({ provider: "custom", model: "my-runtime-model", apiKey: "k2", baseUrl: "https://example.com/v1" });
+
+    const app = createModelRoutes(pool);
+    const res = await app.request("/v1/models");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.data.some((m: { id: string }) => m.id === "my-runtime-model")).toBe(true);
+    expect(body.data.some((m: { id: string }) => m.id === "gpt-5.4")).toBe(true);
+  });
+
+  it("excludes disabled API key models from /v1/models", async () => {
+    const pool = new ApiKeyPool(createApiKeyMemoryPersistence());
+    const added = pool.add({ provider: "custom", model: "disabled-runtime-model", apiKey: "k1", baseUrl: "https://example.com/v1" });
+    pool.setStatus(added.id, "disabled");
+
+    const app = createModelRoutes(pool);
+    const res = await app.request("/v1/models");
+    const body = await res.json();
+
+    expect(body.data.some((m: { id: string }) => m.id === "disabled-runtime-model")).toBe(false);
+  });
+
+  it("returns runtime API key model from /v1/models/:modelId", async () => {
+    const pool = new ApiKeyPool(createApiKeyMemoryPersistence());
+    pool.add({ provider: "custom", model: "my-runtime-model", apiKey: "k1", baseUrl: "https://example.com/v1" });
+
+    const app = createModelRoutes(pool);
+    const res = await app.request("/v1/models/my-runtime-model");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.id).toBe("my-runtime-model");
+    expect(body.object).toBe("model");
   });
 });
 

--- a/src/routes/models.ts
+++ b/src/routes/models.ts
@@ -13,6 +13,7 @@ import {
 } from "../models/model-store.js";
 import { triggerImmediateRefresh } from "../models/model-fetcher.js";
 import { getConfig } from "../config.js";
+import type { ApiKeyPool } from "../auth/api-key-pool.js";
 
 // --- Routes ---
 
@@ -28,24 +29,34 @@ function toOpenAIModel(info: CodexModelInfo): OpenAIModel {
   };
 }
 
-export function createModelRoutes(): Hono {
+function toRuntimeOpenAIModel(id: string): OpenAIModel {
+  return {
+    id,
+    object: "model",
+    created: MODEL_CREATED_TIMESTAMP,
+    owned_by: "openai",
+  };
+}
+
+export function createModelRoutes(apiKeyPool?: ApiKeyPool): Hono {
   const app = new Hono();
 
   app.get("/v1/models", (c) => {
     const catalog = getModelCatalog();
     const aliases = getModelAliases();
+    const modelsById = new Map<string, OpenAIModel>();
 
-    // Include catalog models + aliases as separate entries
-    const models: OpenAIModel[] = catalog.map(toOpenAIModel);
-    for (const alias of Object.keys(aliases)) {
-      models.push({
-        id: alias,
-        object: "model",
-        created: MODEL_CREATED_TIMESTAMP,
-        owned_by: "openai",
-      });
+    for (const model of catalog) {
+      modelsById.set(model.id, toOpenAIModel(model));
     }
-    const response: OpenAIModelList = { object: "list", data: models };
+    for (const alias of Object.keys(aliases)) {
+      modelsById.set(alias, toRuntimeOpenAIModel(alias));
+    }
+    for (const modelId of apiKeyPool?.getActiveModels() ?? []) {
+      modelsById.set(modelId, toRuntimeOpenAIModel(modelId));
+    }
+
+    const response: OpenAIModelList = { object: "list", data: [...modelsById.values()] };
     return c.json(response);
   });
 
@@ -60,19 +71,16 @@ export function createModelRoutes(): Hono {
     const catalog = getModelCatalog();
     const aliases = getModelAliases();
 
-    // Try direct match
     const info = catalog.find((m) => m.id === modelId);
     if (info) return c.json(toOpenAIModel(info));
 
-    // Try alias
     const resolved = aliases[modelId];
     if (resolved) {
-      return c.json({
-        id: modelId,
-        object: "model",
-        created: MODEL_CREATED_TIMESTAMP,
-        owned_by: "openai",
-      });
+      return c.json(toRuntimeOpenAIModel(modelId));
+    }
+
+    if (apiKeyPool?.getActiveModels().includes(modelId)) {
+      return c.json(toRuntimeOpenAIModel(modelId));
     }
 
     c.status(404);


### PR DESCRIPTION
## Summary
- include active runtime API key models in `/v1/models`
- allow `/v1/models/:modelId` to resolve models added via API Keys
- add coverage for active, disabled, and direct lookup cases

## Test plan
- [x] `npm test -- src/routes/__tests__/plan-routing-integration.test.ts src/auth/__tests__/api-key-pool.test.ts`