### PR TITLE
fix: preserve direct upstream routing for API key models

### DIFF
--- a/src/routes/__tests__/responses-compact.test.ts
+++ b/src/routes/__tests__/responses-compact.test.ts
@@ -77,9 +77,11 @@ vi.mock("../../utils/retry.js", () => ({
   withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
-// Mock handleProxyRequest (used by regular /v1/responses, not compact)
+// Mock shared proxy handler
+const mockHandleDirectRequest = vi.fn(async (c) => c.json({ ok: true }));
 vi.mock("../shared/proxy-handler.js", () => ({
   handleProxyRequest: vi.fn(async (c) => c.json({ ok: true })),
+  handleDirectRequest: (...args: unknown[]) => mockHandleDirectRequest(...args),
   staggerIfNeeded: vi.fn(async () => {}),
 }));
 
@@ -123,6 +125,7 @@ describe("POST /v1/responses/compact", () => {
     mockCompactResponse = { output: [{ role: "user", content: "compacted" }] };
     mockCompactThrow = null;
     mockConfig.server.proxy_api_key = null;
+    mockHandleDirectRequest.mockImplementation(async (c) => c.json({ ok: true }));
     loadStaticModels();
     pool = new AccountPool();
     pool.addAccount("test-token-1");
@@ -147,6 +150,38 @@ describe("POST /v1/responses/compact", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ output: [{ role: "user", content: "compacted" }] });
+  });
+
+  it("routes compact requests for runtime API-key models to direct upstream", async () => {
+    const upstreamRouter = {
+      isCodexModel: vi.fn((model: string) => model !== "my-custom-model"),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    };
+    app = createResponsesRoutes(pool, undefined, undefined, upstreamRouter as never);
+
+    const res = await app.request("/v1/responses/compact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "my-custom-model",
+        input: [{ role: "user", content: "Hello" }],
+        instructions: "You are helpful",
+        parallel_tool_calls: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    const [, , directReq] = mockHandleDirectRequest.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(directReq.model).toBe("my-custom-model");
+    expect(directReq.isStreaming).toBe(false);
+    expect(directReq.codexRequest).toEqual({
+      model: "my-custom-model",
+      input: [{ role: "user", content: "Hello" }],
+      instructions: "You are helpful",
+      parallel_tool_calls: true,
+    });
+    expect(capturedCompactRequest).toBeNull();
   });
 
   it("sends correct CompactRequest format (no stream/store)", async () => {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -137,7 +137,11 @@ export function createChatRoutes(
     const fmt = makeOpenAIFormat(wantReasoning);
 
     if (upstreamRouter && !upstreamRouter.isCodexModel(req.model)) {
-      const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: req.model } };
+      const directReq = {
+        ...proxyReq,
+        model: req.model,
+        codexRequest: { ...codexRequest, model: req.model },
+      };
       return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
     }
 

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -109,7 +109,11 @@ export function createMessagesRoutes(
     const fmt = makeAnthropicFormat(wantThinking);
 
     if (upstreamRouter && !upstreamRouter.isCodexModel(req.model)) {
-      const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: req.model } };
+      const directReq = {
+        ...proxyReq,
+        model: req.model,
+        codexRequest: { ...codexRequest, model: req.model },
+      };
       return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
     }
 

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -317,6 +317,7 @@ async function handleCompact(
   cookieJar: CookieJar | undefined,
   proxyPool: ProxyPool | undefined,
   body: Record<string, unknown>,
+  upstreamRouter?: UpstreamRouter,
 ): Promise<Response> {
   const rawModel = typeof body.model === "string" ? body.model : "codex";
   const parsed = parseModelName(rawModel);
@@ -353,6 +354,25 @@ async function handleCompact(
         ...(typeof body.text.format.strict === "boolean" ? { strict: body.text.format.strict } : {}),
       },
     };
+  }
+
+  if (upstreamRouter && !upstreamRouter.isCodexModel(rawModel)) {
+    const directReq = {
+      codexRequest: {
+        model: rawModel,
+        input: compactRequest.input,
+        instructions: compactRequest.instructions,
+        ...(compactRequest.tools ? { tools: compactRequest.tools } : {}),
+        ...(compactRequest.parallel_tool_calls !== undefined
+          ? { parallel_tool_calls: compactRequest.parallel_tool_calls }
+          : {}),
+        ...(compactRequest.reasoning ? { reasoning: compactRequest.reasoning } : {}),
+        ...(compactRequest.text ? { text: compactRequest.text } : {}),
+      },
+      model: rawModel,
+      isStreaming: false,
+    };
+    return handleDirectRequest(c, upstreamRouter.resolve(rawModel), directReq, PASSTHROUGH_FORMAT);
   }
 
   // Acquire account
@@ -585,7 +605,7 @@ export function createResponsesRoutes(
     const body = parseBody(c, rawBody);
     if (body instanceof Response) return body;
 
-    return handleCompact(c, accountPool, cookieJar, proxyPool, body);
+    return handleCompact(c, accountPool, cookieJar, proxyPool, body, upstreamRouter);
   };
 
   app.post("/v1/responses", responsesHandler);


### PR DESCRIPTION
## Summary
- preserve the original requested model name when chat and messages requests are routed to direct API-key upstreams
- route `/v1/responses/compact` requests for runtime API-key models through the direct upstream path as well
- add a regression test covering compact requests for custom API-key models

## Test plan
- [x] npm test -- --run \"src/routes/__tests__/responses-compact.test.ts\" \"src/proxy/__tests__/upstream-router-apikeys.test.ts\" \"src/proxy/__tests__/upstream-router.test.ts\"

Closes #354.