### PR TITLE
refactor: add hasActiveModel() to ApiKeyPool for efficient model lookup

### DIFF
--- a/src/auth/__tests__/api-key-pool.test.ts
+++ b/src/auth/__tests__/api-key-pool.test.ts
@@ -97,6 +97,17 @@ describe("ApiKeyPool", () => {
     expect(results).toHaveLength(2);
   });
 
+  it("hasActiveModel returns true for active entry", () => {
+    pool.add({ provider: "openai", model: "gpt-5.4", apiKey: "k1" });
+    expect(pool.hasActiveModel("gpt-5.4")).toBe(true);
+  });
+
+  it("hasActiveModel returns false for disabled entry", () => {
+    const entry = pool.add({ provider: "openai", model: "gpt-5.4", apiKey: "k1" });
+    pool.setStatus(entry.id, "disabled");
+    expect(pool.hasActiveModel("gpt-5.4")).toBe(false);
+  });
+
   // ── Remove ────────────────────────────────────────────────────
 
   it("remove deletes the entry", () => {

--- a/src/auth/api-key-pool.ts
+++ b/src/auth/api-key-pool.ts
@@ -115,6 +115,11 @@ export class ApiKeyPool {
     return [...new Set(this.entries.filter((e) => e.status === "active").map((e) => e.model))];
   }
 
+  /** Returns true if any active entry matches the given model ID. */
+  hasActiveModel(modelId: string): boolean {
+    return this.entries.some((e) => e.status === "active" && e.model === modelId);
+  }
+
   // ── Mutations ──────────────────────────────────────────────────
 
   add(input: {

--- a/src/routes/models.ts
+++ b/src/routes/models.ts
@@ -79,7 +79,7 @@ export function createModelRoutes(apiKeyPool?: ApiKeyPool): Hono {
       return c.json(toRuntimeOpenAIModel(modelId));
     }
 
-    if (apiKeyPool?.getActiveModels().includes(modelId)) {
+    if (apiKeyPool?.hasActiveModel(modelId)) {
       return c.json(toRuntimeOpenAIModel(modelId));
     }
 


### PR DESCRIPTION
## Summary
- Add `hasActiveModel(modelId: string): boolean` to `ApiKeyPool` using a single-pass `.some()` check
- Replace `getActiveModels().includes(modelId)` in `/:modelId` handler — removes redundant filter+map+Set+spread allocation
- Add 2 unit tests covering active and disabled entry cases

Closes #357