### PR TITLE
docs: clarify custom API Keys support / 文档：补充自定义 API Keys 兼容性说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ curl http://localhost:8080/v1/chat/completions \
 - 自动完成 Chat Completions / Anthropic / Gemini ↔ Codex Responses API 双向协议转换
 - **Structured Outputs** — `response_format`（`json_object` / `json_schema`）和 Gemini `responseMimeType`
 - **Function Calling** — 原生 `function_call` / `tool_calls` 支持（所有协议）
+- 若使用自定义 API Keys，则仅兼容 OpenAI（`/v1/chat/completions`）格式。
 
 ### 🔐 账号管理与智能轮换
 - **OAuth PKCE 登录** — 浏览器一键授权，无需手动复制 Token

--- a/README_EN.md
+++ b/README_EN.md
@@ -115,6 +115,7 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 - Automatic bidirectional translation between all protocols and Codex Responses API
 - **Structured Outputs** — `response_format` (`json_object` / `json_schema`) and Gemini `responseMimeType`
 - **Function Calling** — native `function_call` / `tool_calls` across all protocols
+- If using custom API Keys, only the OpenAI (`/v1/chat/completions`) format is supported.
 
 ### 2. 🔐 Account Management & Smart Rotation
 - **OAuth PKCE login** — one-click browser auth


### PR DESCRIPTION
## Summary / 变更说明
- clarify in README.md that custom API Keys only support the OpenAI `/v1/chat/completions` format
- 在 README.md 中补充说明：自定义 API Keys 仅兼容 OpenAI `/v1/chat/completions` 格式
- add the same note to README_EN.md under the core protocol compatibility section
- 在 README_EN.md 的 core protocol compatibility 部分同步补充相同说明

## Test plan / 验证
- [x] Verify the new note appears in the core features protocol compatibility section in Chinese README
- [x] 验证中文 README 的“核心功能 / 全协议兼容”部分已出现该说明
- [x] Verify the new note appears in the core features protocol compatibility section in English README
- [x] 验证英文 README 的 "Full Protocol Compatibility" 部分已出现该说明