### PR TITLE
test: verify Docker image builds and starts successfully

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,6 +28,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        port: [8080, 8090]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,8 +39,9 @@ jobs:
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
+          docker run -d --name smoke-test-${{ matrix.port }} \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
+            -e PORT=${{ matrix.port }} \
             -e NODE_ENV=production \
             codex-proxy:smoke
           echo "Container started"
@@ -46,7 +50,7 @@ jobs:
         run: |
           echo "Waiting for container to become healthy..."
           for i in $(seq 1 30); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-${{ matrix.port }} 2>/dev/null || echo "starting")
             echo "  [$i/30] status: $STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Container is healthy"
@@ -55,19 +59,19 @@ jobs:
             sleep 2
           done
           echo "::error::Container did not become healthy within 60s"
-          docker logs smoke-test
+          docker logs smoke-test-${{ matrix.port }}
           exit 1
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          RESPONSE=$(curl -sf http://localhost:${{ matrix.port }}/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
           # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${{ matrix.port }}/v1/models)
           echo "/v1/models status: $STATUS"
           # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then
@@ -78,5 +82,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
-          docker rm -f smoke-test || true
+          docker logs smoke-test-${{ matrix.port }} 2>&1 | tail -30
+          docker rm -f smoke-test-${{ matrix.port }} || true

--- a/docker-healthcheck.sh
+++ b/docker-healthcheck.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
-# Read server port from config, fallback to 8080
-PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
-curl -fs "http://localhost:${PORT:-8080}/health" || exit 1
+
+RESOLVED_PORT=""
+if [ -n "$PORT" ]; then
+  RESOLVED_PORT="$PORT"
+fi
+
+if [ -z "$RESOLVED_PORT" ] && [ -f /app/data/local.yaml ]; then
+  RESOLVED_PORT=$(grep -A5 '^server:' /app/data/local.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+fi
+
+if [ -z "$RESOLVED_PORT" ] && [ -f /app/config/default.yaml ]; then
+  RESOLVED_PORT=$(grep -A5 '^server:' /app/config/default.yaml 2>/dev/null | grep 'port:' | head -1 | awk '{print $2}')
+fi
+
+if [ -z "$RESOLVED_PORT" ]; then
+  RESOLVED_PORT=8080
+fi
+
+curl -fs "http://localhost:${RESOLVED_PORT}/health" || exit 1


### PR DESCRIPTION
This commit updates the GitHub Action workflow `ci-docker.yml` to utilize a matrix strategy to smoke test the Docker image over both port `8080` (default) and `8090` (custom override via env var `PORT`).
Additionally, it enhances `docker-healthcheck.sh` to correctly check for configurations overridden in environment variable `PORT`, `/app/data/local.yaml`, or `/app/config/default.yaml` securely before defaulting to `8080`.

---
*PR created automatically by Jules for task [9278626766797036186](https://jules.google.com/task/9278626766797036186) started by @icebear0828*