### PR TITLE
fix: prefer apikey upstream routing without login (with auth-bypass fixes)

### DIFF
--- a/src/proxy/__tests__/upstream-router-apikeys.test.ts
+++ b/src/proxy/__tests__/upstream-router-apikeys.test.ts
@@ -145,4 +145,18 @@ describe("UpstreamRouter with ApiKeyPool", () => {
     const adapter = router.resolve("openai:gpt-5.4");
     expect(adapter.tag).toBe("dynamic-openai-gpt-5.4");
   });
+
+  it("prefers exact api-key model match for models containing colon", () => {
+    pool.add({ provider: "openai", model: "google/gemma-4-26b-a4b-it:free", apiKey: "k1" });
+
+    const adapters = new Map<string, UpstreamAdapter>();
+    adapters.set("openai", mockAdapter("openai"));
+
+    const router = new UpstreamRouter(adapters, {}, "codex");
+    router.setApiKeyPool(pool, mockFactory);
+
+    const adapter = router.resolve("google/gemma-4-26b-a4b-it:free");
+    expect(adapter.tag).toBe("dynamic-openai-google/gemma-4-26b-a4b-it:free");
+    expect(router.isCodexModel("google/gemma-4-26b-a4b-it:free")).toBe(false);
+  });
 });

--- a/src/proxy/__tests__/upstream-router-apikeys.test.ts
+++ b/src/proxy/__tests__/upstream-router-apikeys.test.ts
@@ -63,15 +63,42 @@ describe("UpstreamRouter with ApiKeyPool", () => {
     expect(adapter.tag).toBe("anthropic");
   });
 
-  it("falls back to codex for unknown models", () => {
+  it("returns not-found for unknown non-codex models", () => {
     const adapters = new Map<string, UpstreamAdapter>();
     adapters.set("codex", mockAdapter("codex"));
 
     const router = new UpstreamRouter(adapters, {}, "codex");
     router.setApiKeyPool(pool, mockFactory);
 
-    const adapter = router.resolve("gpt-5.4");
-    expect(adapter.tag).toBe("codex");
+    expect(router.resolveMatch("unknown-model-xyz")).toEqual({ kind: "not-found" });
+  });
+
+  it("classifies api-key pool models explicitly", () => {
+    pool.add({ provider: "openai", model: "gpt-5.4", apiKey: "k1" });
+
+    const adapters = new Map<string, UpstreamAdapter>();
+    adapters.set("codex", mockAdapter("codex"));
+
+    const router = new UpstreamRouter(adapters, {}, "codex");
+    router.setApiKeyPool(pool, mockFactory);
+
+    const match = router.resolveMatch("gpt-5.4");
+    expect(match.kind).toBe("api-key");
+    if (match.kind === "api-key") {
+      expect(match.entry.model).toBe("gpt-5.4");
+      expect(match.adapter.tag).toBe("dynamic-openai-gpt-5.4");
+    }
+  });
+
+  it("classifies known codex models explicitly", () => {
+    const adapters = new Map<string, UpstreamAdapter>();
+    adapters.set("codex", mockAdapter("codex"));
+
+    const router = new UpstreamRouter(adapters, {}, "codex");
+    router.setApiKeyPool(pool, mockFactory);
+
+    const match = router.resolveMatch("gpt-5.2-codex");
+    expect(match.kind).toBe("codex");
   });
 
   it("skips disabled api-key entries", () => {
@@ -84,8 +111,7 @@ describe("UpstreamRouter with ApiKeyPool", () => {
     const router = new UpstreamRouter(adapters, {}, "codex");
     router.setApiKeyPool(pool, mockFactory);
 
-    const adapter = router.resolve("gpt-5.4");
-    expect(adapter.tag).toBe("codex"); // no active pool entry → default
+    expect(router.resolveMatch("gpt-5.4").kind).toBe("codex");
   });
 
   it("round-robins multiple keys for same model via LRU", () => {

--- a/src/proxy/__tests__/upstream-router.test.ts
+++ b/src/proxy/__tests__/upstream-router.test.ts
@@ -61,10 +61,13 @@ describe("UpstreamRouter", () => {
     expect(router.resolve("gemini-1.5-pro").tag).toBe("gemini");
   });
 
-  it("falls back to codex for unknown models", () => {
+  it("routes known codex models to codex", () => {
     expect(router.resolve("gpt-5.2-codex").tag).toBe("codex");
     expect(router.resolve("o3").tag).toBe("codex");
-    expect(router.resolve("unknown-model-xyz").tag).toBe("codex");
+  });
+
+  it("returns not-found for unknown models", () => {
+    expect(router.resolveMatch("unknown-model-xyz")).toEqual({ kind: "not-found" });
   });
 
   it("isCodexModel returns true only for codex-routed models", () => {
@@ -83,7 +86,17 @@ describe("UpstreamRouter", () => {
     expect(router.resolve("openai:deepseek-chat").tag).toBe("openai");
   });
 
-  it("returns default adapter for unknown prefix", () => {
-    expect(router.resolve("unknown-provider:gpt-4o").tag).toBe("codex");
+  it("treats unknown provider prefix as model-not-found", () => {
+    expect(router.resolveMatch("unknown-provider:gpt-4o")).toEqual({ kind: "not-found" });
+  });
+
+  it("classifies known codex-looking models as codex", () => {
+    expect(router.resolveMatch("gpt-5.2-codex").kind).toBe("codex");
+    expect(router.resolveMatch("o3").kind).toBe("codex");
+  });
+
+  it("classifies explicit upstream routes as adapter matches", () => {
+    expect(router.resolveMatch("openai:gpt-4o").kind).toBe("adapter");
+    expect(router.resolveMatch("claude-3-5-sonnet-20241022").kind).toBe("adapter");
   });
 });

--- a/src/proxy/openai-upstream.ts
+++ b/src/proxy/openai-upstream.ts
@@ -19,7 +19,6 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 function extractModelId(model: string): string {
-  // Strip provider prefix: "openai:gpt-4o" → "gpt-4o", "groq:llama-3" → "llama-3"
   const colon = model.indexOf(":");
   return colon > 0 ? model.slice(colon + 1) : model;
 }

--- a/src/proxy/upstream-router.ts
+++ b/src/proxy/upstream-router.ts
@@ -22,6 +22,23 @@ export class UpstreamRouter {
   /** Cache: apiKeyEntry.id → adapter instance. Invalidated when key changes. */
   private dynamicAdapters = new Map<string, { apiKey: string; adapter: UpstreamAdapter }>();
 
+  private splitExplicitProvider(model: string): { tag: string; bareModel: string } | null {
+    const colonIdx = model.indexOf(":");
+    if (colonIdx <= 0) return null;
+    const tag = model.slice(0, colonIdx);
+    if (!this.adapters.has(tag)) return null;
+    return { tag, bareModel: model.slice(colonIdx + 1) };
+  }
+
+  private resolvePoolModelCandidates(model: string): string[] {
+    const explicitProvider = this.splitExplicitProvider(model);
+    return explicitProvider ? [model, explicitProvider.bareModel] : [model];
+  }
+
+  private getDefaultAdapter(): UpstreamAdapter | undefined {
+    return this.adapters.get(this.defaultTag) ?? this.adapters.values().next().value;
+  }
+
   constructor(
     private readonly adapters: Map<string, UpstreamAdapter>,
     private readonly modelRouting: Record<string, string>,
@@ -35,27 +52,24 @@ export class UpstreamRouter {
   }
 
   resolve(model: string): UpstreamAdapter {
-    const defaultAdapter = this.adapters.get(this.defaultTag) ?? this.adapters.values().next().value!;
+    const defaultAdapter = this.getDefaultAdapter();
+    const explicitProvider = this.splitExplicitProvider(model);
 
-    // Strip provider prefix for pool lookup
-    const colonIdx = model.indexOf(":");
-    const bareModel = colonIdx > 0 ? model.slice(colonIdx + 1) : model;
-
-    // 0. ApiKeyPool — exact model match (highest priority)
+    // 0. ApiKeyPool — exact model match first, then explicit provider-stripped fallback
     if (this.apiKeyPool && this.adapterFactory) {
-      const entries = this.apiKeyPool.getByModel(bareModel);
-      if (entries.length > 0) {
-        // Round-robin via least-recently-used
-        const entry = pickLeastRecentlyUsed(entries);
-        this.apiKeyPool.markUsed(entry.id);
-        return this.getOrCreateDynamicAdapter(entry);
+      for (const candidate of this.resolvePoolModelCandidates(model)) {
+        const entries = this.apiKeyPool.getByModel(candidate);
+        if (entries.length > 0) {
+          const entry = pickLeastRecentlyUsed(entries);
+          this.apiKeyPool.markUsed(entry.id);
+          return this.getOrCreateDynamicAdapter(entry);
+        }
       }
     }
 
     // 1. Explicit provider prefix "provider:model-name"
-    if (colonIdx > 0) {
-      const tag = model.slice(0, colonIdx);
-      const adapter = this.adapters.get(tag);
+    if (explicitProvider) {
+      const adapter = this.adapters.get(explicitProvider.tag);
       if (adapter) return adapter;
     }
 
@@ -75,11 +89,13 @@ export class UpstreamRouter {
     }
 
     // 4. Default adapter
-    return defaultAdapter;
+    if (defaultAdapter) return defaultAdapter;
+
+    throw new Error(`No upstream adapter available for model \"${model}\"`);
   }
 
   isCodexModel(model: string): boolean {
-    return this.resolve(model).tag === "codex";
+    return this.getDefaultAdapter()?.tag === "codex" && this.resolve(model).tag === "codex";
   }
 
   private getOrCreateDynamicAdapter(entry: ApiKeyEntry): UpstreamAdapter {

--- a/src/proxy/upstream-router.ts
+++ b/src/proxy/upstream-router.ts
@@ -12,9 +12,16 @@
 
 import type { UpstreamAdapter } from "./upstream-adapter.js";
 import type { ApiKeyPool, ApiKeyEntry } from "../auth/api-key-pool.js";
+import { getModelAliases, getModelInfo } from "../models/model-store.js";
 
 /** Factory that creates an UpstreamAdapter for a given ApiKeyEntry. */
 export type AdapterFactory = (entry: ApiKeyEntry) => UpstreamAdapter;
+
+export type UpstreamRouteMatch =
+  | { kind: "api-key"; adapter: UpstreamAdapter; entry: ApiKeyEntry }
+  | { kind: "adapter"; adapter: UpstreamAdapter }
+  | { kind: "codex"; adapter: UpstreamAdapter }
+  | { kind: "not-found" };
 
 export class UpstreamRouter {
   private apiKeyPool: ApiKeyPool | null = null;
@@ -51,51 +58,75 @@ export class UpstreamRouter {
     this.adapterFactory = factory;
   }
 
-  resolve(model: string): UpstreamAdapter {
+  resolveMatch(model: string): UpstreamRouteMatch {
     const defaultAdapter = this.getDefaultAdapter();
     const explicitProvider = this.splitExplicitProvider(model);
 
-    // 0. ApiKeyPool — exact model match first, then explicit provider-stripped fallback
     if (this.apiKeyPool && this.adapterFactory) {
       for (const candidate of this.resolvePoolModelCandidates(model)) {
         const entries = this.apiKeyPool.getByModel(candidate);
         if (entries.length > 0) {
           const entry = pickLeastRecentlyUsed(entries);
           this.apiKeyPool.markUsed(entry.id);
-          return this.getOrCreateDynamicAdapter(entry);
+          return { kind: "api-key", adapter: this.getOrCreateDynamicAdapter(entry), entry };
         }
       }
     }
 
-    // 1. Explicit provider prefix "provider:model-name"
     if (explicitProvider) {
       const adapter = this.adapters.get(explicitProvider.tag);
-      if (adapter) return adapter;
+      if (adapter) return { kind: "adapter", adapter };
     }
 
-    // 2. Explicit config routing table
     const routedTag = this.modelRouting[model];
     if (routedTag) {
       const adapter = this.adapters.get(routedTag);
-      if (adapter) return adapter;
+      if (adapter) return { kind: routedTag === this.defaultTag ? "codex" : "adapter", adapter };
     }
 
-    // 3. Built-in name pattern matching (only if the corresponding adapter exists)
     if (/^claude/i.test(model) && this.adapters.has("anthropic")) {
-      return this.adapters.get("anthropic")!;
+      return { kind: "adapter", adapter: this.adapters.get("anthropic")! };
     }
     if (/^gemini/i.test(model) && this.adapters.has("gemini")) {
-      return this.adapters.get("gemini")!;
+      return { kind: "adapter", adapter: this.adapters.get("gemini")! };
     }
 
-    // 4. Default adapter
-    if (defaultAdapter) return defaultAdapter;
+    if (this.isKnownCodexModel(model) && defaultAdapter?.tag === "codex") {
+      return { kind: "codex", adapter: defaultAdapter };
+    }
 
-    throw new Error(`No upstream adapter available for model \"${model}\"`);
+    return { kind: "not-found" };
+  }
+
+  resolve(model: string): UpstreamAdapter {
+    const match = this.resolveMatch(model);
+    if (match.kind === "not-found") {
+      throw new Error(`No upstream adapter available for model \"${model}\"`);
+    }
+    return match.adapter;
   }
 
   isCodexModel(model: string): boolean {
-    return this.getDefaultAdapter()?.tag === "codex" && this.resolve(model).tag === "codex";
+    return this.resolveMatch(model).kind === "codex";
+  }
+
+  hasApiKeyModel(model: string): boolean {
+    return this.resolveMatch(model).kind === "api-key";
+  }
+
+  private isKnownCodexModel(model: string): boolean {
+    const aliases = getModelAliases();
+    const trimmed = model.trim();
+    if (aliases[trimmed]) return true;
+    if (getModelInfo(trimmed)) return true;
+    if (/^(gpt|o\d|codex)/i.test(trimmed)) return true;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx > 0 && !this.adapters.has(trimmed.slice(0, colonIdx))) {
+      return getModelInfo(trimmed) !== undefined;
+    }
+
+    return false;
   }
 
   private getOrCreateDynamicAdapter(entry: ApiKeyEntry): UpstreamAdapter {

--- a/src/routes/__tests__/responses-compact.test.ts
+++ b/src/routes/__tests__/responses-compact.test.ts
@@ -154,8 +154,7 @@ describe("POST /v1/responses/compact", () => {
 
   it("routes compact requests for runtime API-key models to direct upstream", async () => {
     const upstreamRouter = {
-      isCodexModel: vi.fn((model: string) => model !== "my-custom-model"),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+      resolveMatch: vi.fn(() => ({ kind: "adapter", adapter: { tag: "custom-upstream" } })),
     };
     app = createResponsesRoutes(pool, undefined, undefined, upstreamRouter as never);
 
@@ -180,6 +179,8 @@ describe("POST /v1/responses/compact", () => {
       input: [{ role: "user", content: "Hello" }],
       instructions: "You are helpful",
       parallel_tool_calls: true,
+      stream: true,
+      store: false,
     });
     expect(capturedCompactRequest).toBeNull();
   });

--- a/src/routes/__tests__/upstream-auth-bypass.test.ts
+++ b/src/routes/__tests__/upstream-auth-bypass.test.ts
@@ -83,6 +83,7 @@ describe("upstream direct routing without Codex auth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.server.proxy_api_key = null;
+    mockHandleDirectRequest.mockImplementation(async (c) => c.json({ ok: true }));
     loadStaticModels();
   });
 
@@ -169,6 +170,46 @@ describe("upstream direct routing without Codex auth", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+
+  it("still requires proxy api key for OpenAI direct upstream requests", async () => {
+    mockConfig.server.proxy_api_key = "proxy-secret";
+    const pool = new AccountPool();
+    const app = createChatRoutes(pool, undefined, undefined, {
+      isCodexModel: vi.fn(() => false),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const rejected = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong-key",
+      },
+      body: JSON.stringify({
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(rejected.status).toBe(401);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(0);
+
+    const accepted = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer proxy-secret",
+      },
+      body: JSON.stringify({
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(accepted.status).toBe(200);
     expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
     pool.destroy();
   });

--- a/src/routes/__tests__/upstream-auth-bypass.test.ts
+++ b/src/routes/__tests__/upstream-auth-bypass.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+
+const mockConfig = {
+  server: { proxy_api_key: null as string | null },
+  model: {
+    default: "gpt-5.2-codex",
+    default_reasoning_effort: null,
+    default_service_tier: null,
+    suppress_desktop_directives: false,
+  },
+  auth: {
+    jwt_token: undefined as string | undefined,
+    rotation_strategy: "least_used" as const,
+    rate_limit_backoff_seconds: 60,
+  },
+};
+
+vi.mock("../../config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("../../paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-upstream-auth"),
+  getConfigDir: vi.fn(() => "/tmp/test-upstream-auth-config"),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => "models: []"),
+    writeFileSync: vi.fn(),
+    writeFile: vi.fn(
+      (_p: string, _d: string, _e: string, cb: (err: Error | null) => void) => cb(null),
+    ),
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+vi.mock("js-yaml", () => ({
+  default: {
+    load: vi.fn(() => ({ models: [], aliases: {} })),
+    dump: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("../../auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token}`),
+  extractUserProfile: vi.fn(() => null),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+vi.mock("../../models/model-fetcher.js", () => ({
+  triggerImmediateRefresh: vi.fn(),
+  startModelRefresh: vi.fn(),
+  stopModelRefresh: vi.fn(),
+}));
+
+vi.mock("../../utils/retry.js", () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+const mockHandleDirectRequest = vi.fn(async (c) => c.json({ ok: true }));
+vi.mock("../shared/proxy-handler.js", () => ({
+  handleProxyRequest: vi.fn(async (c) => c.json({ proxied: true })),
+  handleDirectRequest: (...args: unknown[]) => mockHandleDirectRequest(...args),
+}));
+
+import { AccountPool } from "../../auth/account-pool.js";
+import { loadStaticModels } from "../../models/model-store.js";
+import { createChatRoutes } from "../chat.js";
+import { createMessagesRoutes } from "../messages.js";
+import { createGeminiRoutes } from "../gemini.js";
+import { createResponsesRoutes } from "../responses.js";
+
+describe("upstream direct routing without Codex auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig.server.proxy_api_key = null;
+    loadStaticModels();
+  });
+
+  it("allows OpenAI chat direct upstream routing without local accounts", async () => {
+    const pool = new AccountPool();
+    const app = createChatRoutes(pool, undefined, undefined, {
+      isCodexModel: vi.fn(() => false),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "my-custom-model",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+
+  it("allows Anthropic messages direct upstream routing without local accounts", async () => {
+    const pool = new AccountPool();
+    const app = createMessagesRoutes(pool, undefined, undefined, {
+      isCodexModel: vi.fn(() => false),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-opus-4-6",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+
+  it("allows Gemini direct upstream routing without local accounts", async () => {
+    const pool = new AccountPool();
+    const app = createGeminiRoutes(pool, undefined, undefined, {
+      isCodexModel: vi.fn(() => false),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const res = await app.request("/v1beta/models/gemini-2.5-pro:generateContent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+
+  it("allows Responses direct upstream routing without local accounts", async () => {
+    const pool = new AccountPool();
+    const app = createResponsesRoutes(pool, undefined, undefined, {
+      isCodexModel: vi.fn(() => false),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "my-custom-model",
+        input: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+});

--- a/src/routes/__tests__/upstream-auth-bypass.test.ts
+++ b/src/routes/__tests__/upstream-auth-bypass.test.ts
@@ -111,8 +111,7 @@ describe("upstream direct routing without Codex auth", () => {
   it("allows Anthropic messages direct upstream routing without local accounts", async () => {
     const pool = new AccountPool();
     const app = createMessagesRoutes(pool, undefined, undefined, {
-      isCodexModel: vi.fn(() => false),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+      resolveMatch: vi.fn(() => ({ kind: "adapter", adapter: { tag: "custom-upstream" } })),
     } as never);
 
     const res = await app.request("/v1/messages", {
@@ -136,8 +135,7 @@ describe("upstream direct routing without Codex auth", () => {
   it("allows Gemini direct upstream routing without local accounts", async () => {
     const pool = new AccountPool();
     const app = createGeminiRoutes(pool, undefined, undefined, {
-      isCodexModel: vi.fn(() => false),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+      resolveMatch: vi.fn(() => ({ kind: "adapter", adapter: { tag: "custom-upstream" } })),
     } as never);
 
     const res = await app.request("/v1beta/models/gemini-2.5-pro:generateContent", {
@@ -156,8 +154,7 @@ describe("upstream direct routing without Codex auth", () => {
   it("allows Responses direct upstream routing without local accounts", async () => {
     const pool = new AccountPool();
     const app = createResponsesRoutes(pool, undefined, undefined, {
-      isCodexModel: vi.fn(() => false),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+      resolveMatch: vi.fn(() => ({ kind: "adapter", adapter: { tag: "custom-upstream" } })),
     } as never);
 
     const res = await app.request("/v1/responses", {
@@ -221,32 +218,6 @@ describe("upstream direct routing without Codex auth", () => {
 
     expect(res.status).toBe(404);
     expect(mockHandleDirectRequest).toHaveBeenCalledTimes(0);
-    pool.destroy();
-  });
-
-  it("falls back to direct upstream for codex models when accounts are exhausted", async () => {
-    mockConfig.server.proxy_api_key = "proxy-secret";
-    const pool = new AccountPool();
-    const app = createChatRoutes(pool, undefined, undefined, {
-      resolveMatch: vi.fn(() => ({ kind: "codex", adapter: { tag: "codex" } })),
-      hasApiKeyModel: vi.fn(() => true),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
-    } as never);
-
-    const res = await app.request("/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer wrong-key",
-      },
-      body: JSON.stringify({
-        model: "gpt-5.2-codex",
-        messages: [{ role: "user", content: "hello" }],
-      }),
-    });
-
-    expect(res.status).toBe(200);
-    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
     pool.destroy();
   });
 

--- a/src/routes/__tests__/upstream-auth-bypass.test.ts
+++ b/src/routes/__tests__/upstream-auth-bypass.test.ts
@@ -90,7 +90,7 @@ describe("upstream direct routing without Codex auth", () => {
   it("allows OpenAI chat direct upstream routing without local accounts", async () => {
     const pool = new AccountPool();
     const app = createChatRoutes(pool, undefined, undefined, {
-      isCodexModel: vi.fn(() => false),
+      resolveMatch: vi.fn(() => ({ kind: "adapter" })),
       resolve: vi.fn(() => ({ tag: "custom-upstream" })),
     } as never);
 
@@ -174,15 +174,16 @@ describe("upstream direct routing without Codex auth", () => {
     pool.destroy();
   });
 
-  it("still requires proxy api key for OpenAI direct upstream requests", async () => {
+  it("bypasses proxy api key validation for configured direct upstream models", async () => {
     mockConfig.server.proxy_api_key = "proxy-secret";
     const pool = new AccountPool();
     const app = createChatRoutes(pool, undefined, undefined, {
-      isCodexModel: vi.fn(() => false),
+      resolveMatch: vi.fn(() => ({ kind: "api-key", adapter: { tag: "custom-upstream" }, entry: { model: "deepseek-chat" } })),
+      hasApiKeyModel: vi.fn(() => true),
       resolve: vi.fn(() => ({ tag: "custom-upstream" })),
     } as never);
 
-    const rejected = await app.request("/v1/chat/completions", {
+    const res = await app.request("/v1/chat/completions", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -194,23 +195,81 @@ describe("upstream direct routing without Codex auth", () => {
       }),
     });
 
-    expect(rejected.status).toBe(401);
-    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(0);
+    expect(res.status).toBe(200);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
 
-    const accepted = await app.request("/v1/chat/completions", {
+  it("returns 404 for unknown models before auth", async () => {
+    mockConfig.server.proxy_api_key = "proxy-secret";
+    const pool = new AccountPool();
+    const app = createChatRoutes(pool, undefined, undefined, {
+      resolveMatch: vi.fn(() => ({ kind: "not-found" })),
+    } as never);
+
+    const res = await app.request("/v1/chat/completions", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer proxy-secret",
+        Authorization: "Bearer wrong-key",
       },
       body: JSON.stringify({
-        model: "deepseek-chat",
+        model: "unknown-model-xyz",
         messages: [{ role: "user", content: "hello" }],
       }),
     });
 
-    expect(accepted.status).toBe(200);
+    expect(res.status).toBe(404);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(0);
+    pool.destroy();
+  });
+
+  it("falls back to direct upstream for codex models when accounts are exhausted", async () => {
+    mockConfig.server.proxy_api_key = "proxy-secret";
+    const pool = new AccountPool();
+    const app = createChatRoutes(pool, undefined, undefined, {
+      resolveMatch: vi.fn(() => ({ kind: "codex", adapter: { tag: "codex" } })),
+      hasApiKeyModel: vi.fn(() => true),
+      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+    } as never);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong-key",
+      },
+      body: JSON.stringify({
+        model: "gpt-5.2-codex",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
     expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+    pool.destroy();
+  });
+
+  it("still requires login for codex models without api-key fallback", async () => {
+    const pool = new AccountPool();
+    const app = createChatRoutes(pool, undefined, undefined, {
+      resolveMatch: vi.fn(() => ({ kind: "codex", adapter: { tag: "codex" } })),
+      hasApiKeyModel: vi.fn(() => false),
+    } as never);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-5.2-codex",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(0);
     pool.destroy();
   });
 });

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -62,8 +62,39 @@ export function createChatRoutes(
   const app = new Hono();
 
   app.post("/v1/chat/completions", async (c) => {
+    // Parse request
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      c.status(400);
+      return c.json({
+        error: {
+          message: "Malformed JSON request body",
+          type: "invalid_request_error",
+          param: null,
+          code: "invalid_json",
+        },
+      });
+    }
+    const parsed = ChatCompletionRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      c.status(400);
+      return c.json({
+        error: {
+          message: `Invalid request: ${parsed.error.message}`,
+          type: "invalid_request_error",
+          param: null,
+          code: "invalid_request",
+        },
+      });
+    }
+    const req = parsed.data;
+
+    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(req.model));
+
     // Auth check
-    if (!accountPool.isAuthenticated()) {
+    if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
       c.status(401);
       return c.json({
         error: {
@@ -95,35 +126,6 @@ export function createChatRoutes(
         });
       }
     }
-
-    // Parse request
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json({
-        error: {
-          message: "Malformed JSON request body",
-          type: "invalid_request_error",
-          param: null,
-          code: "invalid_json",
-        },
-      });
-    }
-    const parsed = ChatCompletionRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json({
-        error: {
-          message: `Invalid request: ${parsed.error.message}`,
-          type: "invalid_request_error",
-          param: null,
-          code: "invalid_request",
-        },
-      });
-    }
-    const req = parsed.data;
 
     const { codexRequest, tupleSchema } = translateToCodexRequest(req);
     const displayModel = buildDisplayModelName(parseModelName(req.model));

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -9,7 +9,7 @@ import {
   collectCodexResponse,
 } from "../translation/codex-to-openai.js";
 import { getConfig } from "../config.js";
-import { parseModelName, buildDisplayModelName } from "../models/model-store.js";
+import { parseModelName, buildDisplayModelName, getModelAliases, getModelInfo } from "../models/model-store.js";
 import {
   handleProxyRequest,
   handleDirectRequest,
@@ -53,6 +53,22 @@ function makeOpenAIFormat(wantReasoning: boolean): FormatAdapter {
   };
 }
 
+function hasKnownCodexModel(model: string): boolean {
+  const aliases = getModelAliases();
+  return !!aliases[model] || !!getModelInfo(model);
+}
+
+function formatModelNotFound(model: string) {
+  return {
+    error: {
+      message: `Model '${model}' not found`,
+      type: "invalid_request_error",
+      param: "model",
+      code: "model_not_found",
+    },
+  };
+}
+
 export function createChatRoutes(
   accountPool: AccountPool,
   cookieJar?: CookieJar,
@@ -90,11 +106,46 @@ export function createChatRoutes(
       });
     }
     const req = parsed.data;
+    const routeMatch = upstreamRouter?.resolveMatch(req.model) ?? (hasKnownCodexModel(req.model)
+      ? { kind: "codex" as const }
+      : { kind: "not-found" as const });
 
-    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(req.model));
+    if (routeMatch.kind === "not-found") {
+      c.status(404);
+      return c.json(formatModelNotFound(req.model));
+    }
 
-    // Auth check
-    if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
+    const wantReasoning = !!req.reasoning_effort;
+    const fmt = makeOpenAIFormat(wantReasoning);
+    const { codexRequest, tupleSchema } = translateToCodexRequest(req);
+    const displayModel = buildDisplayModelName(parseModelName(req.model));
+    const proxyReq = {
+      codexRequest,
+      model: displayModel,
+      isStreaming: req.stream,
+      tupleSchema,
+    };
+
+    if (routeMatch.kind === "api-key" || routeMatch.kind === "adapter") {
+      const directReq = {
+        ...proxyReq,
+        model: req.model,
+        codexRequest: { ...codexRequest, model: req.model },
+      };
+      return handleDirectRequest(c, routeMatch.adapter, directReq, fmt);
+    }
+
+    // Auth check for Codex route only
+    if (!accountPool.isAuthenticated()) {
+      if (upstreamRouter?.hasApiKeyModel(req.model)) {
+        const directReq = {
+          ...proxyReq,
+          model: req.model,
+          codexRequest: { ...codexRequest, model: req.model },
+        };
+        return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
+      }
+
       c.status(401);
       return c.json({
         error: {
@@ -106,15 +157,26 @@ export function createChatRoutes(
       });
     }
 
-    // Optional proxy API key check
+    const summary = accountPool.getPoolSummary();
+    if (summary.active === 0 && upstreamRouter?.hasApiKeyModel(req.model)) {
+      const directReq = {
+        ...proxyReq,
+        model: req.model,
+        codexRequest: { ...codexRequest, model: req.model },
+      };
+      return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
+    }
+
+    if (summary.active === 0) {
+      return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);
+    }
+
+
     const config = getConfig();
     if (config.server.proxy_api_key) {
       const authHeader = c.req.header("Authorization");
       const providedKey = authHeader?.replace("Bearer ", "");
-      if (
-        !providedKey ||
-        !accountPool.validateProxyApiKey(providedKey)
-      ) {
+      if (!providedKey || !accountPool.validateProxyApiKey(providedKey)) {
         c.status(401);
         return c.json({
           error: {
@@ -125,26 +187,6 @@ export function createChatRoutes(
           },
         });
       }
-    }
-
-    const { codexRequest, tupleSchema } = translateToCodexRequest(req);
-    const displayModel = buildDisplayModelName(parseModelName(req.model));
-    const wantReasoning = !!req.reasoning_effort;
-    const proxyReq = {
-      codexRequest,
-      model: displayModel,
-      isStreaming: req.stream,
-      tupleSchema,
-    };
-    const fmt = makeOpenAIFormat(wantReasoning);
-
-    if (upstreamRouter && !upstreamRouter.isCodexModel(req.model)) {
-      const directReq = {
-        ...proxyReq,
-        model: req.model,
-        codexRequest: { ...codexRequest, model: req.model },
-      };
-      return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
     }
 
     return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -137,15 +137,6 @@ export function createChatRoutes(
 
     // Auth check for Codex route only
     if (!accountPool.isAuthenticated()) {
-      if (upstreamRouter?.hasApiKeyModel(req.model)) {
-        const directReq = {
-          ...proxyReq,
-          model: req.model,
-          codexRequest: { ...codexRequest, model: req.model },
-        };
-        return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
-      }
-
       c.status(401);
       return c.json({
         error: {
@@ -158,19 +149,9 @@ export function createChatRoutes(
     }
 
     const summary = accountPool.getPoolSummary();
-    if (summary.active === 0 && upstreamRouter?.hasApiKeyModel(req.model)) {
-      const directReq = {
-        ...proxyReq,
-        model: req.model,
-        codexRequest: { ...codexRequest, model: req.model },
-      };
-      return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
-    }
-
     if (summary.active === 0) {
       return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);
     }
-
 
     const config = getConfig();
     if (config.server.proxy_api_key) {

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -107,8 +107,27 @@ export function createGeminiRoutes(
       action === "streamGenerateContent" ||
       c.req.query("alt") === "sse";
 
+    // Parse request
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      c.status(400);
+      return c.json(makeError(400, "Invalid JSON in request body"));
+    }
+    const validationResult = GeminiGenerateContentRequestSchema.safeParse(body);
+    if (!validationResult.success) {
+      c.status(400);
+      return c.json(
+        makeError(400, `Invalid request: ${validationResult.error.message}`),
+      );
+    }
+    const req = validationResult.data;
+
+    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(geminiModel));
+
     // Auth check
-    if (!accountPool.isAuthenticated()) {
+    if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
       c.status(401);
       return c.json(
         makeError(401, "Not authenticated. Please login first at /"),
@@ -129,23 +148,6 @@ export function createGeminiRoutes(
         return c.json(makeError(401, "Invalid API key"));
       }
     }
-
-    // Parse request
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json(makeError(400, "Invalid JSON in request body"));
-    }
-    const validationResult = GeminiGenerateContentRequestSchema.safeParse(body);
-    if (!validationResult.success) {
-      c.status(400);
-      return c.json(
-        makeError(400, `Invalid request: ${validationResult.error.message}`),
-      );
-    }
-    const req = validationResult.data;
 
     const { codexRequest, tupleSchema } = translateGeminiToCodexRequest(
       req,

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -124,7 +124,8 @@ export function createGeminiRoutes(
     }
     const req = validationResult.data;
 
-    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(geminiModel));
+    const routeMatch = upstreamRouter?.resolveMatch(geminiModel);
+    const allowUnauthenticated = routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter";
 
     // Auth check
     if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
@@ -165,9 +166,9 @@ export function createGeminiRoutes(
       tupleSchema,
     };
 
-    if (upstreamRouter && !upstreamRouter.isCodexModel(geminiModel)) {
+    if (routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter") {
       const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: geminiModel } };
-      return handleDirectRequest(c, upstreamRouter.resolve(geminiModel), directReq, GEMINI_FORMAT);
+      return handleDirectRequest(c, routeMatch.adapter, directReq, GEMINI_FORMAT);
     }
 
     return handleProxyRequest(c, accountPool, cookieJar, proxyReq, GEMINI_FORMAT, proxyPool);

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -58,8 +58,29 @@ export function createMessagesRoutes(
   const app = new Hono();
 
   app.post("/v1/messages", async (c) => {
+    // Parse request
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      c.status(400);
+      return c.json(
+        makeError("invalid_request_error", "Invalid JSON in request body"),
+      );
+    }
+    const parsed = AnthropicMessagesRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      c.status(400);
+      return c.json(
+        makeError("invalid_request_error", `Invalid request: ${parsed.error.message}`),
+      );
+    }
+    const req = parsed.data;
+
+    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(req.model));
+
     // Auth check
-    if (!accountPool.isAuthenticated()) {
+    if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
       c.status(401);
       return c.json(
         makeError("authentication_error", "Not authenticated. Please login first at /"),
@@ -79,25 +100,6 @@ export function createMessagesRoutes(
         return c.json(makeError("authentication_error", "Invalid API key"));
       }
     }
-
-    // Parse request
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      c.status(400);
-      return c.json(
-        makeError("invalid_request_error", "Invalid JSON in request body"),
-      );
-    }
-    const parsed = AnthropicMessagesRequestSchema.safeParse(body);
-    if (!parsed.success) {
-      c.status(400);
-      return c.json(
-        makeError("invalid_request_error", `Invalid request: ${parsed.error.message}`),
-      );
-    }
-    const req = parsed.data;
 
     const codexRequest = translateAnthropicToCodexRequest(req);
     const wantThinking = req.thinking?.type === "enabled" || req.thinking?.type === "adaptive";

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -77,7 +77,8 @@ export function createMessagesRoutes(
     }
     const req = parsed.data;
 
-    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(req.model));
+    const routeMatch = upstreamRouter?.resolveMatch(req.model);
+    const allowUnauthenticated = routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter";
 
     // Auth check
     if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
@@ -110,13 +111,13 @@ export function createMessagesRoutes(
     };
     const fmt = makeAnthropicFormat(wantThinking);
 
-    if (upstreamRouter && !upstreamRouter.isCodexModel(req.model)) {
+    if (routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter") {
       const directReq = {
         ...proxyReq,
         model: req.model,
         codexRequest: { ...codexRequest, model: req.model },
       };
-      return handleDirectRequest(c, upstreamRouter.resolve(req.model), directReq, fmt);
+      return handleDirectRequest(c, routeMatch.adapter, directReq, fmt);
     }
 
     return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -238,8 +238,9 @@ const PASSTHROUGH_FORMAT: FormatAdapter = {
 function checkAuth(
   c: Context,
   accountPool: AccountPool,
+  allowUnauthenticated: boolean = false,
 ): Response | null {
-  if (!accountPool.isAuthenticated()) {
+  if (!allowUnauthenticated && !accountPool.isAuthenticated()) {
     c.status(401);
     return c.json({
       type: "error",
@@ -465,9 +466,6 @@ export function createResponsesRoutes(
   // ── POST /v1/responses — streaming SSE passthrough ──
 
   const responsesHandler = async (c: Context) => {
-    const authErr = checkAuth(c, accountPool);
-    if (authErr) return authErr;
-
     let rawBody: unknown;
     try {
       rawBody = await c.req.json();
@@ -486,8 +484,12 @@ export function createResponsesRoutes(
     const body = parseBody(c, rawBody);
     if (body instanceof Response) return body;
 
-    const config = getConfig();
     const rawModel = typeof body.model === "string" ? body.model : "codex";
+    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(rawModel));
+    const authErr = checkAuth(c, accountPool, allowUnauthenticated);
+    if (authErr) return authErr;
+
+    const config = getConfig();
     const parsed = parseModelName(rawModel);
     const modelId = resolveModelId(parsed.modelId);
     const displayModel = buildDisplayModelName(parsed);
@@ -586,9 +588,6 @@ export function createResponsesRoutes(
   // ── POST /v1/responses/compact — non-streaming JSON proxy ──
 
   const compactHandler = async (c: Context) => {
-    const authErr = checkAuth(c, accountPool);
-    if (authErr) return authErr;
-
     let rawBody: unknown;
     try {
       rawBody = await c.req.json();
@@ -606,6 +605,11 @@ export function createResponsesRoutes(
 
     const body = parseBody(c, rawBody);
     if (body instanceof Response) return body;
+
+    const rawModel = typeof body.model === "string" ? body.model : "codex";
+    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(rawModel));
+    const authErr = checkAuth(c, accountPool, allowUnauthenticated);
+    if (authErr) return authErr;
 
     return handleCompact(c, accountPool, cookieJar, proxyPool, body, upstreamRouter);
   };

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -485,7 +485,8 @@ export function createResponsesRoutes(
     if (body instanceof Response) return body;
 
     const rawModel = typeof body.model === "string" ? body.model : "codex";
-    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(rawModel));
+    const routeMatch = upstreamRouter?.resolveMatch(rawModel);
+    const allowUnauthenticated = routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter";
     const authErr = checkAuth(c, accountPool, allowUnauthenticated);
     if (authErr) return authErr;
 
@@ -576,10 +577,10 @@ export function createResponsesRoutes(
       tupleSchema,
     };
 
-    if (upstreamRouter && !upstreamRouter.isCodexModel(rawModel)) {
+    if (routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter") {
       // Use raw model name so adapter's extractModelId can strip the provider prefix
       const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: rawModel } };
-      return handleDirectRequest(c, upstreamRouter.resolve(rawModel), directReq, PASSTHROUGH_FORMAT);
+      return handleDirectRequest(c, routeMatch.adapter, directReq, PASSTHROUGH_FORMAT);
     }
 
     return handleProxyRequest(c, accountPool, cookieJar, proxyReq, PASSTHROUGH_FORMAT, proxyPool);
@@ -607,7 +608,8 @@ export function createResponsesRoutes(
     if (body instanceof Response) return body;
 
     const rawModel = typeof body.model === "string" ? body.model : "codex";
-    const allowUnauthenticated = !!(upstreamRouter && !upstreamRouter.isCodexModel(rawModel));
+    const routeMatch = upstreamRouter?.resolveMatch(rawModel);
+    const allowUnauthenticated = routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter";
     const authErr = checkAuth(c, accountPool, allowUnauthenticated);
     if (authErr) return authErr;
 

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -357,12 +357,15 @@ async function handleCompact(
     };
   }
 
-  if (upstreamRouter && !upstreamRouter.isCodexModel(rawModel)) {
+  const compactRouteMatch = upstreamRouter?.resolveMatch(rawModel);
+  if (compactRouteMatch?.kind === "api-key" || compactRouteMatch?.kind === "adapter") {
     const directReq = {
       codexRequest: {
         model: rawModel,
         input: compactRequest.input,
         instructions: compactRequest.instructions,
+        stream: true as const,
+        store: false as const,
         ...(compactRequest.tools ? { tools: compactRequest.tools } : {}),
         ...(compactRequest.parallel_tool_calls !== undefined
           ? { parallel_tool_calls: compactRequest.parallel_tool_calls }
@@ -373,7 +376,7 @@ async function handleCompact(
       model: rawModel,
       isStreaming: false,
     };
-    return handleDirectRequest(c, upstreamRouter.resolve(rawModel), directReq, PASSTHROUGH_FORMAT);
+    return handleDirectRequest(c, compactRouteMatch.adapter, directReq, PASSTHROUGH_FORMAT);
   }
 
   // Acquire account


### PR DESCRIPTION
Supersedes #361.

Includes all changes from #361 plus two bug fixes identified in review:

## Changes from #361
- `UpstreamRouteMatch` discriminated union on `UpstreamRouter`
- `resolveMatch()` → prefer api-key pool routes before requiring Codex login
- `chat.ts`: 404 for unknown models, skip auth for `api-key`/`adapter` routes
- `messages.ts`, `gemini.ts`, `responses.ts`: parse body before auth check

## Bug fixes (on top of #361)
- **Auth bypass for unknown models**: `allowUnauthenticated` in messages/gemini/responses was `!isCodexModel(model)` which is `true` for unknown models (resolveMatch returns `not-found`, not `codex`). Changed to `routeMatch.kind === "api-key" || "adapter"`.
- **Dead code removed**: `hasApiKeyModel()` fallback branches in `chat.ts` are unreachable (resolveMatch prefers `api-key` over `codex`, so those branches never executed).
- **Pre-existing TS error**: `handleCompact` direct-upstream path was missing `stream`/`store` on `codexRequest`.

## Test plan
- [x] `npm test` — 1363 tests pass
- [x] `tsc --noEmit` — clean