### PR TITLE
fix: codex models return 404 when upstream providers are configured

### DIFF
--- a/src/proxy/__tests__/upstream-router.test.ts
+++ b/src/proxy/__tests__/upstream-router.test.ts
@@ -62,8 +62,8 @@ describe("UpstreamRouter", () => {
   });
 
   it("routes known codex models to codex", () => {
-    expect(router.resolve("gpt-5.2-codex").tag).toBe("codex");
-    expect(router.resolve("o3").tag).toBe("codex");
+    expect(router.resolveMatch("gpt-5.2-codex").kind).toBe("codex");
+    expect(router.resolveMatch("o3").kind).toBe("codex");
   });
 
   it("returns not-found for unknown models", () => {

--- a/src/proxy/upstream-router.ts
+++ b/src/proxy/upstream-router.ts
@@ -20,7 +20,7 @@ export type AdapterFactory = (entry: ApiKeyEntry) => UpstreamAdapter;
 export type UpstreamRouteMatch =
   | { kind: "api-key"; adapter: UpstreamAdapter; entry: ApiKeyEntry }
   | { kind: "adapter"; adapter: UpstreamAdapter }
-  | { kind: "codex"; adapter: UpstreamAdapter }
+  | { kind: "codex"; adapter?: UpstreamAdapter }
   | { kind: "not-found" };
 
 export class UpstreamRouter {
@@ -91,8 +91,8 @@ export class UpstreamRouter {
       return { kind: "adapter", adapter: this.adapters.get("gemini")! };
     }
 
-    if (this.isKnownCodexModel(model) && defaultAdapter?.tag === "codex") {
-      return { kind: "codex", adapter: defaultAdapter };
+    if (this.isKnownCodexModel(model)) {
+      return { kind: "codex" };
     }
 
     return { kind: "not-found" };
@@ -100,7 +100,7 @@ export class UpstreamRouter {
 
   resolve(model: string): UpstreamAdapter {
     const match = this.resolveMatch(model);
-    if (match.kind === "not-found") {
+    if (match.kind === "not-found" || !match.adapter) {
       throw new Error(`No upstream adapter available for model \"${model}\"`);
     }
     return match.adapter;

--- a/src/proxy/upstream-router.ts
+++ b/src/proxy/upstream-router.ts
@@ -42,10 +42,6 @@ export class UpstreamRouter {
     return explicitProvider ? [model, explicitProvider.bareModel] : [model];
   }
 
-  private getDefaultAdapter(): UpstreamAdapter | undefined {
-    return this.adapters.get(this.defaultTag) ?? this.adapters.values().next().value;
-  }
-
   constructor(
     private readonly adapters: Map<string, UpstreamAdapter>,
     private readonly modelRouting: Record<string, string>,
@@ -59,7 +55,6 @@ export class UpstreamRouter {
   }
 
   resolveMatch(model: string): UpstreamRouteMatch {
-    const defaultAdapter = this.getDefaultAdapter();
     const explicitProvider = this.splitExplicitProvider(model);
 
     if (this.apiKeyPool && this.adapterFactory) {


### PR DESCRIPTION
## Summary

- Fix `UpstreamRouter.resolveMatch()` incorrectly returning `not-found` for codex-native models (gpt-5.4, o3, etc.) when any upstream provider is configured
- The root cause was `defaultAdapter?.tag === "codex"` always failing because the adapters map never contains a `"codex"` key
- Make `kind: "codex"` adapter optional since codex models route to the built-in chatgpt.com backend

Fixes #368

## Test plan

- [x] `upstream-router.test.ts` — 14 tests pass (codex routing no longer depends on adapter tag)
- [x] `upstream-router-apikeys.test.ts` — 10 tests pass (API key pool routing unaffected)
- [x] Full test suite — 1363/1363 pass, no regressions