### PR TITLE
ci: update docker smoke test to verify custom port

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -28,6 +28,15 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - name: default-port
+            port: 8080
+            env_args: ""
+          - name: custom-port
+            port: 8090
+            env_args: "-e PORT=8090"
     steps:
       - uses: actions/checkout@v4
 
@@ -36,17 +45,18 @@ jobs:
 
       - name: Start container
         run: |
-          docker run -d --name smoke-test \
-            -p 18080:8080 \
+          docker run -d --name smoke-test-${{ matrix.port }} \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
+            ${{ matrix.env_args }} \
             -e NODE_ENV=production \
             codex-proxy:smoke
-          echo "Container started"
+          echo "Container started on port ${{ matrix.port }}"
 
       - name: Wait for healthy
         run: |
           echo "Waiting for container to become healthy..."
           for i in $(seq 1 30); do
-            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test 2>/dev/null || echo "starting")
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' smoke-test-${{ matrix.port }} 2>/dev/null || echo "starting")
             echo "  [$i/30] status: $STATUS"
             if [ "$STATUS" = "healthy" ]; then
               echo "Container is healthy"
@@ -55,21 +65,19 @@ jobs:
             sleep 2
           done
           echo "::error::Container did not become healthy within 60s"
-          docker logs smoke-test
+          docker logs smoke-test-${{ matrix.port }}
           exit 1
 
       - name: Verify /health endpoint
         run: |
-          RESPONSE=$(curl -sf http://localhost:18080/health)
+          RESPONSE=$(curl -sf http://localhost:${{ matrix.port }}/health)
           echo "Response: $RESPONSE"
           echo "$RESPONSE" | jq -e '.status == "ok"'
 
       - name: Verify /v1/models returns valid JSON
         run: |
-          # Without auth, should return 401 or model list — either way must be valid JSON
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:18080/v1/models)
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:${{ matrix.port }}/v1/models)
           echo "/v1/models status: $STATUS"
-          # 200 (no key set) or 401 (key set) are both acceptable
           if [ "$STATUS" != "200" ] && [ "$STATUS" != "401" ]; then
             echo "::error::Unexpected status $STATUS from /v1/models"
             exit 1
@@ -78,5 +86,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker logs smoke-test 2>&1 | tail -30
-          docker rm -f smoke-test || true
+          docker logs smoke-test-${{ matrix.port }} 2>&1 | tail -30
+          docker rm -f smoke-test-${{ matrix.port }} || true


### PR DESCRIPTION
Update `ci-docker.yml` to verify Docker container health checks and functionality on both default and custom ports using a GitHub Actions matrix strategy.

---
*PR created automatically by Jules for task [12123932912036651518](https://jules.google.com/task/12123932912036651518) started by @icebear0828*