### PR TITLE
ci: switch version bump to daily cron + manual dispatch

### DIFF
--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -1,11 +1,8 @@
 name: Bump version + release
 
 on:
-  push:
-    branches: [master]
-    paths-ignore:
-      - "packages/electron/package.json"
-      - "*.md"
+  schedule:
+    - cron: "0 16 * * *"   # UTC 16:00 = 北京时间 00:00，每天最多一个版本
   workflow_dispatch:
 
 concurrency:
@@ -50,9 +47,9 @@ jobs:
             exit 0
           fi
 
-          # Count non-merge, non-chore commits since last tag
+          # Count commits that affect runtime behavior (skip chore/docs/ci/test/refactor/style)
           NEW_COMMITS=$(git log "${LAST_TAG}..HEAD" --no-merges \
-            --pretty=format:"%s" | grep -cvE "^(chore|docs|ci)" || true)
+            --pretty=format:"%s" | grep -cvE "^(chore|docs|ci|test|refactor|style)" || true)
           if [ "$NEW_COMMITS" -eq 0 ]; then
             echo "No meaningful commits since $LAST_TAG, skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Replace per-push auto-bump with daily cron (UTC 16:00 / 北京 00:00)
- Keep `workflow_dispatch` for urgent manual releases
- Expand skip filter to exclude `test:`, `refactor:`, `style:` commits from triggering version bump

## Why
Every merge to master was triggering a version bump + Docker publish + Electron release. Tech debt PRs (test refactoring, CI changes) don't need releases. Daily cron batches all changes into at most one version per day.

## Test plan
- [x] Verify cron syntax is valid
- [ ] Wait for first cron trigger (or manual dispatch) to confirm the workflow runs correctly