### PR TITLE
fix: least_used rotation thundering herd on cold start

### DIFF
--- a/src/auth/rotation-strategy.ts
+++ b/src/auth/rotation-strategy.ts
@@ -16,8 +16,8 @@ export interface RotationStrategy {
 }
 
 const leastUsed: RotationStrategy = {
-  select(candidates) {
-    const sorted = [...candidates].sort((a, b) => {
+  select(candidates, state) {
+    const cmp = (a: AccountEntry, b: AccountEntry): number => {
       // Primary: deprioritize quota-exhausted accounts
       const aExhausted = a.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
       const bExhausted = b.cachedQuota?.rate_limit?.limit_reached ? 1 : 0;
@@ -36,8 +36,16 @@ const leastUsed: RotationStrategy = {
       const aTime = a.usage.last_used ? new Date(a.usage.last_used).getTime() : 0;
       const bTime = b.usage.last_used ? new Date(b.usage.last_used).getTime() : 0;
       return aTime - bTime;
-    });
-    return sorted[0];
+    };
+    const sorted = [...candidates].sort(cmp);
+    // Rotate among tied front-runners to avoid thundering herd on cold start
+    let tiedCount = 1;
+    while (tiedCount < sorted.length && cmp(sorted[0], sorted[tiedCount]) === 0) {
+      tiedCount++;
+    }
+    const pick = state.roundRobinIndex % tiedCount;
+    state.roundRobinIndex++;
+    return sorted[pick];
   },
 };
 

--- a/tests/unit/auth/rotation-strategy.test.ts
+++ b/tests/unit/auth/rotation-strategy.test.ts
@@ -122,6 +122,15 @@ describe("rotation-strategy", () => {
       expect(strategy.select([a, b], state).id).toBe("b");
     });
 
+    it("disperses across tied candidates on cold start (thundering herd)", () => {
+      const freshState: RotationState = { roundRobinIndex: 0 };
+      const candidates = [makeEntry("a"), makeEntry("b"), makeEntry("c")];
+      const picks = Array.from({ length: 6 }, () =>
+        strategy.select(candidates, freshState).id,
+      );
+      expect(picks).toEqual(["a", "b", "c", "a", "b", "c"]);
+    });
+
     it("treats accounts without cached quota as non-exhausted", () => {
       const noQuota = makeEntry("noQuota", { request_count: 2, window_reset_at: Date.now() + 7 * 86400_000 });
       const exhausted = makeEntry(


### PR DESCRIPTION
## Summary
- On cold start, all accounts have identical sort keys → stable sort always picks the first one → concurrent requests all hit the same account
- Fix: count tied front-runners after sort, rotate among them using `roundRobinIndex`
- Normal operation unaffected (tiedCount=1 when usage has diverged)

Closes #375

## Test plan
- [x] New test: 6 consecutive selections with 3 identical candidates → `["a","b","c","a","b","c"]`
- [x] All 15 rotation-strategy tests pass
- [x] Full regression: 126 files, 1460 passed, 2 skipped