### PR TITLE
fix: skip pointless retry when no accounts available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- 无可用账号时不再执行无意义的重试，直接返回描述性错误信息（含各状态账号计数：rate-limited / expired / banned / disabled）(#362)
+
 - `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
 
 - 默认不再发送 `reasoning.effort`：移除 `modelInfo.defaultReasoningEffort` 自动兜底，`default_reasoning_effort` 默认改为 `null`，彻底消除简单对话触发 medium 推理导致的 token 暴涨；Dashboard 新增 "Disabled (no reasoning)" 选项，用户可按需开启

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -80,6 +80,11 @@ export class AccountPool {
     this.lifecycle.releaseWithoutCounting(entryId);
   }
 
+  /** Fast check: is there at least one active account not in the exclude list? */
+  hasAvailableAccounts(excludeIds?: string[]): boolean {
+    return this.registry.hasAvailableAccounts(excludeIds);
+  }
+
   setRotationStrategy(name: "least_used" | "round_robin" | "sticky"): void {
     this.lifecycle.setRotationStrategy(name);
   }

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -245,6 +245,19 @@ export class AccountRegistry {
     return false;
   }
 
+  /** Fast check: is there at least one active account not in the exclude list? */
+  hasAvailableAccounts(excludeIds?: string[]): boolean {
+    const now = new Date();
+    const excludeSet = excludeIds?.length ? new Set(excludeIds) : null;
+    for (const entry of this.accounts.values()) {
+      this.refreshStatus(entry, now);
+      if (entry.status === "active" && (!excludeSet || !excludeSet.has(entry.id))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   getUserInfo(): { email?: string; accountId?: string; planType?: string } | null {
     const first = [...this.accounts.values()].find((a) => a.status === "active");
     if (!first) return null;

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -268,11 +268,10 @@ export async function handleProxyRequest(
         modelRetried = true;
       }
 
-      // Early exit: skip acquire overhead when no active accounts remain
+      // Early exit: skip acquire overhead when no active accounts remain.
+      // Lock already cleared by handleCodexApiError (markRateLimited/markStatus
+      // → clearLock), so no releaseAccount call needed — matches existing !retry path.
       if (!accountPool.hasAvailableAccounts(triedEntryIds)) {
-        if (!decision.releaseBeforeRetry) {
-          releaseAccount(accountPool, entryId, undefined, released);
-        }
         const summary = accountPool.getPoolSummary();
         const parts: string[] = [];
         if (summary.rate_limited) parts.push(`${summary.rate_limited} rate-limited`);

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -268,6 +268,30 @@ export async function handleProxyRequest(
         modelRetried = true;
       }
 
+      // Early exit: skip acquire overhead when no active accounts remain
+      if (!accountPool.hasAvailableAccounts(triedEntryIds)) {
+        if (!decision.releaseBeforeRetry) {
+          releaseAccount(accountPool, entryId, undefined, released);
+        }
+        const summary = accountPool.getPoolSummary();
+        const parts: string[] = [];
+        if (summary.rate_limited) parts.push(`${summary.rate_limited} rate-limited`);
+        if (summary.expired) parts.push(`${summary.expired} expired`);
+        if (summary.banned) parts.push(`${summary.banned} banned`);
+        if (summary.disabled) parts.push(`${summary.disabled} disabled`);
+        if (summary.quota_exhausted) parts.push(`${summary.quota_exhausted} quota-exhausted`);
+        if (summary.refreshing) parts.push(`${summary.refreshing} refreshing`);
+        const detail = parts.length
+          ? `All accounts exhausted (${parts.join(", ")}). ${decision.message}`
+          : `No accounts available. ${decision.message}`;
+        const status = decision.status as StatusCode;
+        c.status(status);
+        if (decision.useFormat429) {
+          return c.json(fmt.format429(detail));
+        }
+        return c.json(fmt.formatError(status, detail));
+      }
+
       const retry = acquireAccount(accountPool, req.codexRequest.model, triedEntryIds, fmt.tag);
       if (!retry) {
         const status = decision.status as StatusCode;

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -86,6 +86,11 @@ function createMockAccountPool(overrides: Record<string, unknown> = {}) {
     markStatus: vi.fn(),
     getEntry: vi.fn(() => ({ email: "test@test.com" })),
     recordEmptyResponse: vi.fn(),
+    hasAvailableAccounts: vi.fn(() => true),
+    getPoolSummary: vi.fn(() => ({
+      total: 1, active: 0, expired: 0, quota_exhausted: 0,
+      rate_limited: 0, refreshing: 0, disabled: 0, banned: 0,
+    })),
     ...overrides,
   };
 }
@@ -598,5 +603,64 @@ describe("proxy-handler integration", () => {
 
     expect(accountPool.markStatus).toHaveBeenCalledWith("e1", "expired");
     expect(accountPool.release).not.toHaveBeenCalled();
+  });
+
+  // 15. 429 with no available accounts → descriptive "all accounts exhausted" error
+  it("returns descriptive error when 429 and no accounts available for retry", async () => {
+    const body429 = JSON.stringify({
+      error: { type: "usage_limit_reached", message: "Limit reached" },
+    });
+    mockCreateResponse = () =>
+      Promise.reject(new CodexApiError(429, body429));
+
+    const accountPool = createMockAccountPool({
+      acquire: vi.fn()
+        .mockReturnValueOnce({ entryId: "e1", token: "tok", accountId: "acc1" }),
+      hasAvailableAccounts: vi.fn(() => false),
+      getPoolSummary: vi.fn(() => ({
+        total: 2, active: 0, expired: 0, quota_exhausted: 0,
+        rate_limited: 2, refreshing: 0, disabled: 0, banned: 0,
+      })),
+    });
+    const fmt = createMockFormatAdapter();
+    const { app } = buildTestApp({ accountPool, fmt });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    // format429 is used for 429 errors
+    expect(fmt.format429).toHaveBeenCalled();
+    const message = fmt.format429.mock.calls[0][0] as string;
+    expect(message).toContain("All accounts exhausted");
+    expect(message).toContain("2 rate-limited");
+  });
+
+  // 16. 403 ban with mixed pool states → descriptive error
+  it("returns descriptive error when banned and remaining accounts disabled/expired", async () => {
+    mockCreateResponse = () =>
+      Promise.reject(new CodexApiError(403, '{"detail": "Account suspended"}'));
+
+    const accountPool = createMockAccountPool({
+      acquire: vi.fn()
+        .mockReturnValueOnce({ entryId: "e1", token: "tok", accountId: "acc1" }),
+      hasAvailableAccounts: vi.fn(() => false),
+      getPoolSummary: vi.fn(() => ({
+        total: 3, active: 0, expired: 1, quota_exhausted: 0,
+        rate_limited: 0, refreshing: 0, disabled: 1, banned: 1,
+      })),
+    });
+    const fmt = createMockFormatAdapter();
+    const { app } = buildTestApp({ accountPool, fmt });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(403);
+
+    const body = await res.json();
+    expect(body.error).toBe("api_error");
+    expect(body.message).toContain("All accounts exhausted");
+    expect(body.message).toContain("1 expired");
+    expect(body.message).toContain("1 disabled");
+    expect(body.message).toContain("1 banned");
   });
 });

--- a/tests/unit/auth/account-pool-has-available.test.ts
+++ b/tests/unit/auth/account-pool-has-available.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for AccountPool.hasAvailableAccounts() — quick check for available accounts
+ * without the full acquire overhead.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-data"),
+  getConfigDir: vi.fn(() => "/tmp/test-config"),
+}));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => ({
+    auth: {
+      jwt_token: null,
+      rotation_strategy: "least_used",
+      rate_limit_backoff_seconds: 60,
+      max_concurrent_per_account: 3,
+    },
+  })),
+}));
+
+vi.mock("@src/auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token.slice(0, 8)}`),
+  extractUserProfile: vi.fn(() => ({
+    email: "test@test.com",
+    chatgpt_plan_type: "free",
+  })),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+vi.mock("@src/utils/jitter.js", () => ({
+  jitter: vi.fn((val: number) => val),
+}));
+
+vi.mock("@src/models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+  isPlanFetched: vi.fn(() => true),
+}));
+
+import { AccountPool } from "@src/auth/account-pool.js";
+import { isTokenExpired } from "@src/auth/jwt-utils.js";
+
+describe("AccountPool.hasAvailableAccounts", () => {
+  let pool: AccountPool;
+
+  beforeEach(() => {
+    vi.mocked(isTokenExpired).mockReturnValue(false);
+    pool = new AccountPool({ rotationStrategy: "least_used" });
+  });
+
+  it("returns false for empty pool", () => {
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns true when an active account exists", () => {
+    pool.addAccount("token-a");
+    expect(pool.hasAvailableAccounts()).toBe(true);
+  });
+
+  it("returns false when all accounts are rate-limited", () => {
+    const id = pool.addAccount("token-a");
+    pool.markRateLimited(id, {});
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns false when all accounts are disabled", () => {
+    const id = pool.addAccount("token-a");
+    pool.markStatus(id, "disabled");
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns false when all accounts are banned", () => {
+    const id = pool.addAccount("token-a");
+    pool.markStatus(id, "banned");
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns true when mix of statuses includes at least one active", () => {
+    const id1 = pool.addAccount("token-a");
+    pool.addAccount("token-b");
+    pool.markStatus(id1, "banned");
+    expect(pool.hasAvailableAccounts()).toBe(true);
+  });
+
+  it("excludes specified entry IDs", () => {
+    const id = pool.addAccount("token-a");
+    expect(pool.hasAvailableAccounts([id])).toBe(false);
+  });
+
+  it("returns true when excluded IDs leave other active accounts", () => {
+    const id1 = pool.addAccount("token-a");
+    pool.addAccount("token-b");
+    expect(pool.hasAvailableAccounts([id1])).toBe(true);
+  });
+
+  it("returns false when all active accounts are excluded", () => {
+    const id1 = pool.addAccount("token-a");
+    const id2 = pool.addAccount("token-b");
+    expect(pool.hasAvailableAccounts([id1, id2])).toBe(false);
+  });
+
+  it("refreshes rate_limit_until and counts expired accounts correctly", () => {
+    const id = pool.addAccount("token-a");
+    // Mark rate-limited with a past timestamp so refreshStatus will flip to active
+    pool.markRateLimited(id, { retryAfterSec: -1 });
+    // Despite being marked rate_limited, refreshStatus should recover it
+    expect(pool.hasAvailableAccounts()).toBe(true);
+  });
+
+  it("detects expired tokens via refreshStatus", () => {
+    pool.addAccount("token-a");
+    vi.mocked(isTokenExpired).mockReturnValue(true);
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `AccountPool.hasAvailableAccounts()` 快速检查，避免无可用账号时执行完整的 `acquire()` 遍历
- retry 分支在 `acquireAccount()` 前短路，返回描述性错误信息（含各状态账号计数）
- 用户不再看到裸的上游错误（如 "rate limit reached"），而是 "All accounts exhausted (2 rate-limited, 1 banned)"

Closes #362

## Test plan
- [x] `tests/unit/auth/account-pool-has-available.test.ts` — 11 个 case 覆盖各状态组合
- [x] `tests/integration/proxy-handler.test.ts` — 2 个新 case 验证描述性错误消息
- [x] `npm test` 全量回归通过（127 files, 1469 tests）