### PR TITLE
fix: forward upstream error body for API-key routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - 无可用账号时不再执行无意义的重试，直接返回描述性错误信息（含各状态账号计数：rate-limited / expired / banned / disabled）(#362)
+- API Key 路由（OpenAI/Anthropic/Gemini）上游返回错误时，透传原始 JSON 响应体，而非包装为代理自有格式；Codex 账号路由仍使用代理格式 (#367)
 
 - `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
 

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -22,7 +22,7 @@ export function toErrorStatus(status: number): StatusCode {
 }
 
 export type ErrorAction =
-  | { action: "respond"; status: number; message: string }
+  | { action: "respond"; status: number; message: string; errorBody?: string }
   | {
       action: "retry";
       releaseBeforeRetry?: boolean;
@@ -127,7 +127,7 @@ export function handleCodexApiError(
     return { action: "retry", status: 401, message: err.message };
   }
 
-  // 6. Generic error — return to client
+  // 6. Generic error — return to client (preserve original body for passthrough)
   const status = toErrorStatus(err.status);
-  return { action: "respond", status, message: err.message };
+  return { action: "respond", status, message: err.message, errorBody: err.body };
 }

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -425,15 +425,24 @@ export async function handleDirectRequest(
   try {
     rawResponse = await upstream.createResponse(req.codexRequest, abortController.signal);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Upstream request failed";
-    const status = err instanceof CodexApiError ? err.status : 502;
-    if (status === 429) {
-      c.status(429);
-      return c.json(fmt.format429(msg));
+    if (err instanceof CodexApiError) {
+      const code = toErrorStatus(err.status) as StatusCode;
+      c.status(code);
+      // For API-key upstreams, forward the raw upstream error body transparently
+      try {
+        const parsed: unknown = JSON.parse(err.body);
+        if (parsed && typeof parsed === "object") {
+          return c.json(parsed);
+        }
+      } catch { /* non-JSON body — fall through */ }
+      if (code === 429) {
+        return c.json(fmt.format429(err.message));
+      }
+      return c.json(fmt.formatError(code, err.message));
     }
-    const code = toErrorStatus(status) as StatusCode;
-    c.status(code);
-    return c.json(fmt.formatError(code, msg));
+    const msg = err instanceof Error ? err.message : "Upstream request failed";
+    c.status(502);
+    return c.json(fmt.formatError(502, msg));
   }
 
   if (req.isStreaming) {

--- a/tests/unit/routes/shared/error-forwarding.test.ts
+++ b/tests/unit/routes/shared/error-forwarding.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for upstream error forwarding in handleDirectRequest and handleProxyRequest.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import type { ProxyRequest } from "@src/routes/shared/proxy-handler.js";
+import { createMockFormatAdapter } from "@helpers/format-adapter.js";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+let mockUpstreamCreate: (() => Promise<Response>) | null = null;
+let mockCodexCreate: (() => Promise<Response>) | null = null;
+
+vi.mock("@src/proxy/codex-api.js", () => {
+  class CodexApiError extends Error {
+    status: number;
+    body: string;
+    constructor(status: number, body: string) {
+      let detail: string;
+      try {
+        const parsed = JSON.parse(body);
+        detail = parsed.detail ?? parsed.error?.message ?? body;
+      } catch {
+        detail = body;
+      }
+      super(`Codex API error (${status}): ${detail}`);
+      this.status = status;
+      this.body = body;
+    }
+  }
+
+  const CodexApi = vi.fn().mockImplementation(() => ({
+    createResponse: vi.fn((): Promise<Response> => {
+      if (mockCodexCreate) return mockCodexCreate();
+      return Promise.resolve(new Response("data: {}\n\n"));
+    }),
+  }));
+
+  return { CodexApi, CodexApiError };
+});
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => ({ auth: { request_interval_ms: 0 } })),
+}));
+
+vi.mock("@src/utils/jitter.js", () => ({
+  jitterInt: vi.fn((val: number) => val),
+}));
+
+vi.mock("@src/utils/retry.js", () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock("@src/translation/codex-event-extractor.js", () => {
+  class EmptyResponseError extends Error {
+    usage: { input_tokens: number; output_tokens: number } | undefined;
+    responseId: string | null;
+    constructor(
+      responseId: string | null = null,
+      usage?: { input_tokens: number; output_tokens: number },
+    ) {
+      super("Codex returned an empty response");
+      this.name = "EmptyResponseError";
+      this.responseId = responseId;
+      this.usage = usage;
+    }
+  }
+  return { EmptyResponseError };
+});
+
+import { handleDirectRequest, handleProxyRequest } from "@src/routes/shared/proxy-handler.js";
+// Both imported — handleDirectRequest for passthrough tests, handleProxyRequest for non-passthrough verification
+import { CodexApiError } from "@src/proxy/codex-api.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createDefaultRequest(): ProxyRequest {
+  return {
+    codexRequest: {
+      model: "gpt-4o",
+      instructions: "You are helpful",
+      input: [{ role: "user" as const, content: "Hello" }],
+      stream: true as const,
+      store: false as const,
+    },
+    model: "gpt-4o",
+    isStreaming: false,
+  };
+}
+
+function createMockUpstream(overrides?: Record<string, unknown>) {
+  return {
+    createResponse: vi.fn((): Promise<Response> => {
+      if (mockUpstreamCreate) return mockUpstreamCreate();
+      return Promise.resolve(new Response("data: {}\n\n"));
+    }),
+    ...overrides,
+  };
+}
+
+function createMockAccountPool(overrides: Record<string, unknown> = {}) {
+  return {
+    acquire: vi.fn(() => ({ entryId: "e1", token: "tok", accountId: "acc1" })),
+    release: vi.fn(),
+    markRateLimited: vi.fn(),
+    markStatus: vi.fn(),
+    getEntry: vi.fn(() => ({ email: "test@test.com" })),
+    recordEmptyResponse: vi.fn(),
+    hasAvailableAccounts: vi.fn(() => true),
+    getPoolSummary: vi.fn(() => ({
+      total: 1, active: 0, expired: 0, quota_exhausted: 0,
+      rate_limited: 0, refreshing: 0, disabled: 0, banned: 0,
+    })),
+    ...overrides,
+  };
+}
+
+// ── handleDirectRequest error forwarding ─────────────────────────────
+
+describe("handleDirectRequest error forwarding", () => {
+  beforeEach(() => {
+    mockUpstreamCreate = null;
+    vi.clearAllMocks();
+  });
+
+  it("forwards upstream JSON error body transparently", async () => {
+    const upstreamError = {
+      error: {
+        message: "Invalid model: gpt-4o-nonexist",
+        type: "invalid_request_error",
+        param: "model",
+        code: "model_not_found",
+      },
+    };
+    mockUpstreamCreate = () =>
+      Promise.reject(new CodexApiError(404, JSON.stringify(upstreamError)));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(404);
+
+    const body = await res.json();
+    // Should forward the original upstream error, not the proxy-wrapped version
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.param).toBe("model");
+    expect(body.error.code).toBe("model_not_found");
+    // formatError should NOT have been called
+    expect(fmt.formatError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to formatError for non-JSON error body", async () => {
+    mockUpstreamCreate = () =>
+      Promise.reject(new CodexApiError(502, "Bad Gateway"));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body.error).toBe("api_error");
+    expect(fmt.formatError).toHaveBeenCalled();
+  });
+
+  it("forwards upstream 429 JSON body transparently", async () => {
+    const upstreamError = {
+      error: {
+        message: "Rate limit exceeded",
+        type: "rate_limit_error",
+        code: "rate_limit_exceeded",
+      },
+    };
+    mockUpstreamCreate = () =>
+      Promise.reject(new CodexApiError(429, JSON.stringify(upstreamError)));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.error.type).toBe("rate_limit_error");
+    expect(fmt.format429).not.toHaveBeenCalled();
+  });
+
+  it("falls back to format429 for non-JSON 429", async () => {
+    mockUpstreamCreate = () =>
+      Promise.reject(new CodexApiError(429, "Too Many Requests"));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(fmt.format429).toHaveBeenCalled();
+  });
+
+  it("forwards Anthropic-style error body", async () => {
+    const anthropicError = {
+      type: "error",
+      error: { type: "invalid_request_error", message: "max_tokens required" },
+    };
+    mockUpstreamCreate = () =>
+      Promise.reject(new CodexApiError(400, JSON.stringify(anthropicError)));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it("uses formatError for non-CodexApiError exceptions", async () => {
+    mockUpstreamCreate = () =>
+      Promise.reject(new TypeError("network failure"));
+
+    const app = new Hono();
+    const upstream = createMockUpstream();
+    const req = createDefaultRequest();
+    const fmt = createMockFormatAdapter();
+
+    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body.error).toBe("api_error");
+    expect(fmt.formatError).toHaveBeenCalled();
+  });
+});
+
+// ── handleProxyRequest does NOT forward — Codex routes use proxy format ──
+
+describe("handleProxyRequest uses proxy error format (no passthrough)", () => {
+  beforeEach(() => {
+    mockCodexCreate = null;
+    vi.clearAllMocks();
+  });
+
+  it("wraps upstream error in proxy format, not transparent passthrough", async () => {
+    const upstreamError = { detail: "Internal error" };
+    mockCodexCreate = () =>
+      Promise.reject(new CodexApiError(500, JSON.stringify(upstreamError)));
+
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const req = createDefaultRequest();
+
+    const app = new Hono();
+    app.post("/test", (c) =>
+      handleProxyRequest(c, accountPool as never, undefined, req, fmt),
+    );
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    // Should use proxy error format, NOT forward upstream body
+    expect(body.error).toBe("api_error");
+    expect(fmt.formatError).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/routes/shared/proxy-error-handler.test.ts
+++ b/tests/unit/routes/shared/proxy-error-handler.test.ts
@@ -208,6 +208,16 @@ describe("handleCodexApiError", () => {
       expect(result.action).toBe("respond");
       expect(result.status).toBe(502);
     });
+
+    it("includes errorBody from upstream in respond action", () => {
+      const upstreamBody = JSON.stringify({ error: { message: "invalid param", type: "invalid_request_error" } });
+      const err = new CodexApiError(422, upstreamBody);
+
+      const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      expect(result.action).toBe("respond");
+      expect(result.errorBody).toBe(upstreamBody);
+    });
   });
 
   // ── ErrorAction shape ──
@@ -234,6 +244,20 @@ describe("handleCodexApiError", () => {
       // Includes fallback info for when no retry account is available
       expect(result.status).toBe(429);
       expect(result.useFormat429).toBe(true);
+    });
+
+    it("retry actions do NOT include errorBody", () => {
+      const cases = [
+        new CodexApiError(429, JSON.stringify({ error: { resets_in_seconds: 30 } })),
+        new CodexApiError(402, JSON.stringify({ detail: "Payment required" })),
+        new CodexApiError(403, JSON.stringify({ error: { message: "banned" } })),
+        new CodexApiError(401, "token revoked"),
+      ];
+      for (const err of cases) {
+        const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
+        expect(result.action).toBe("retry");
+        expect("errorBody" in result).toBe(false);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- API Key 路由（handleDirectRequest）捕获到 `CodexApiError` 时，尝试解析 `err.body` 为 JSON 并直接透传给客户端
- 非 JSON body 回退到 `formatError` / `format429` 包装
- Codex 账号路由（handleProxyRequest）不变，仍用代理自有格式（避免泄露 ChatGPT 内部错误细节）
- `ErrorAction` respond variant 新增 `errorBody` 字段（预留扩展）

Closes #367

## Test plan
- [x] `tests/unit/routes/shared/error-forwarding.test.ts` — 7 个 case 验证 JSON/non-JSON 透传与回退
- [x] `tests/unit/routes/shared/proxy-error-handler.test.ts` — 2 个新 case 验证 errorBody 有无
- [x] `npm test` 全量回归通过（127 files, 1469 tests）