### PR TITLE
feat: add auth.tier_priority for account selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- `auth.tier_priority` 配置项：按 plan 类型排序账号选择优先级（如 `["plus", "pro", "team", "free"]`），高优先级 tier 的账号在有可用时始终优先选择；默认 `null`（不启用），与所有轮转策略兼容 (#348)
+
 - `server.trust_proxy` config option (default `false`): when enabled, the real client IP is read from `X-Forwarded-For` / `X-Real-IP` headers instead of the raw socket address. Required for users who expose codex-proxy via tunnel software (frp, ngrok, etc.) so that dashboard auth works correctly — previously all tunnel traffic appeared as `127.0.0.1` and bypassed authentication even when `proxy_api_key` was set (#350)
 
 ### Fixed

--- a/src/auth/account-lifecycle.ts
+++ b/src/auth/account-lifecycle.ts
@@ -100,6 +100,22 @@ export class AccountLifecycle {
       }
     }
 
+    // Tier-based filtering: when configured, restrict to the highest available tier
+    const tierPriority = getConfig().auth.tier_priority;
+    if (tierPriority && tierPriority.length > 0) {
+      const tierOrder = new Map(tierPriority.map((t, i) => [t, i]));
+      let bestIdx = Infinity;
+      for (const c of candidates) {
+        const idx = c.planType != null ? (tierOrder.get(c.planType) ?? Infinity) : Infinity;
+        if (idx < bestIdx) bestIdx = idx;
+      }
+      if (bestIdx < Infinity) {
+        const bestTier = tierPriority[bestIdx];
+        const tierFiltered = candidates.filter((c) => c.planType === bestTier);
+        if (tierFiltered.length > 0) candidates = tierFiltered;
+      }
+    }
+
     // Session affinity: prefer the account that owns the conversation
     let selected: AccountEntry;
     if (options?.preferredEntryId) {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -31,6 +31,8 @@ export const ConfigSchema = z.object({
     max_concurrent_per_account: z.number().int().min(1).nullable().default(3),
     request_interval_ms: z.number().int().min(0).nullable().default(50),
     rotation_strategy: z.enum(ROTATION_STRATEGIES).default("least_used"),
+    /** Preferred plan-type ordering for account selection (e.g. ["plus","team","free"]). */
+    tier_priority: z.array(z.string()).nullable().default(null),
     rate_limit_backoff_seconds: z.number().min(1).default(60),
     oauth_client_id: z.string().default("app_EMoamEEZ73f0CkXaXp7hrann"),
     oauth_auth_endpoint: z.string().default("https://auth.openai.com/oauth/authorize"),

--- a/tests/unit/auth/tier-priority.test.ts
+++ b/tests/unit/auth/tier-priority.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for tier_priority — account selection prefers higher-tier plan types.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(() => { throw new Error("ENOENT"); }),
+  writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-data"),
+  getConfigDir: vi.fn(() => "/tmp/test-config"),
+}));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => ({
+    auth: {
+      jwt_token: null,
+      rotation_strategy: "least_used",
+      rate_limit_backoff_seconds: 60,
+      max_concurrent_per_account: 3,
+      tier_priority: null,
+    },
+  })),
+}));
+
+vi.mock("@src/auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token.slice(0, 8)}`),
+  extractUserProfile: vi.fn((token: string) => {
+    let plan = "free";
+    if (token.includes("plus")) plan = "plus";
+    else if (token.includes("team")) plan = "team";
+    else if (token.includes("pro")) plan = "pro";
+    return { email: `${token}@test.com`, chatgpt_plan_type: plan };
+  }),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+vi.mock("@src/utils/jitter.js", () => ({
+  jitter: vi.fn((val: number) => val),
+}));
+
+vi.mock("@src/models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+  isPlanFetched: vi.fn(() => true),
+}));
+
+import { AccountPool } from "@src/auth/account-pool.js";
+import { getConfig } from "@src/config.js";
+import { extractUserProfile } from "@src/auth/jwt-utils.js";
+
+describe("tier_priority", () => {
+  let pool: AccountPool;
+
+  function setupPool(tierPriority: string[] | null): void {
+    vi.mocked(getConfig).mockReturnValue({
+      auth: {
+        jwt_token: null,
+        rotation_strategy: "least_used",
+        rate_limit_backoff_seconds: 60,
+        max_concurrent_per_account: 3,
+        tier_priority: tierPriority,
+      },
+    } as ReturnType<typeof getConfig>);
+    pool = new AccountPool({ rotationStrategy: "least_used" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("without tier_priority, uses default least_used ordering", () => {
+    setupPool(null);
+    // Add free first, then plus — with least_used, both have 0 requests
+    pool.addAccount("free-token-1");
+    pool.addAccount("plus-token-1");
+
+    // With no tier priority, the order is determined by least_used (both equal → round robin)
+    const first = pool.acquire();
+    expect(first).not.toBeNull();
+    // Just verify acquire works — order is not tier-based
+  });
+
+  it("plus is preferred over free when tier_priority is set", () => {
+    setupPool(["plus", "team", "free"]);
+    pool.addAccount("free-token-1");
+    pool.addAccount("plus-token-1");
+
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    // Verify it picked the plus account
+    const entry = pool.getEntry(acquired!.entryId);
+    expect(entry?.planType).toBe("plus");
+  });
+
+  it("team is preferred over free but not plus", () => {
+    setupPool(["plus", "team", "free"]);
+    pool.addAccount("free-token-1");
+    pool.addAccount("team-token-1");
+
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    const entry = pool.getEntry(acquired!.entryId);
+    expect(entry?.planType).toBe("team");
+  });
+
+  it("within same tier, only that tier is offered to the strategy", () => {
+    setupPool(["plus", "free"]);
+    pool.addAccount("plus-token-a");
+    pool.addAccount("plus-token-b");
+    pool.addAccount("free-token-1");
+
+    // Tier filter should restrict candidates to plus accounts only,
+    // so free account is never chosen while a plus is available
+    for (let i = 0; i < 6; i++) {
+      const acq = pool.acquire();
+      expect(acq).not.toBeNull();
+      const entry = pool.getEntry(acq!.entryId);
+      expect(entry?.planType).toBe("plus");
+      pool.release(acq!.entryId, { input_tokens: 10, output_tokens: 5 });
+    }
+  });
+
+  it("accounts with null planType sort after all listed tiers", () => {
+    setupPool(["plus", "free"]);
+    // Create an account with null planType
+    vi.mocked(extractUserProfile).mockReturnValueOnce({
+      email: "null@test.com",
+      chatgpt_plan_type: null,
+    } as ReturnType<typeof extractUserProfile>);
+    pool.addAccount("null-plan-token");
+    pool.addAccount("free-token-1");
+
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    const entry = pool.getEntry(acquired!.entryId);
+    // free is in the priority list, null is not — free should be preferred
+    expect(entry?.planType).toBe("free");
+  });
+
+  it("accounts with planType not in list sort after listed tiers", () => {
+    setupPool(["plus"]);
+    pool.addAccount("free-token-1"); // "free" not in priority list
+    pool.addAccount("plus-token-1");
+
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    const entry = pool.getEntry(acquired!.entryId);
+    expect(entry?.planType).toBe("plus");
+  });
+
+  it("falls through to lower tier when higher tier accounts are busy", () => {
+    vi.mocked(getConfig).mockReturnValue({
+      auth: {
+        jwt_token: null,
+        rotation_strategy: "least_used",
+        rate_limit_backoff_seconds: 60,
+        max_concurrent_per_account: 1, // Only 1 concurrent per account
+        tier_priority: ["plus", "free"],
+      },
+    } as ReturnType<typeof getConfig>);
+    pool = new AccountPool({ rotationStrategy: "least_used" });
+    pool.addAccount("plus-token-1");
+    pool.addAccount("free-token-1");
+
+    // First acquire takes the plus account
+    const first = pool.acquire();
+    expect(pool.getEntry(first!.entryId)?.planType).toBe("plus");
+
+    // Second acquire — plus is at capacity, falls to free
+    const second = pool.acquire();
+    expect(second).not.toBeNull();
+    expect(pool.getEntry(second!.entryId)?.planType).toBe("free");
+  });
+
+  it("works with round_robin strategy", () => {
+    setupPool(["plus", "free"]);
+    pool.setRotationStrategy("round_robin");
+    pool.addAccount("free-token-1");
+    pool.addAccount("plus-token-1");
+
+    // With tier priority, plus should come first regardless of round_robin order
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    const entry = pool.getEntry(acquired!.entryId);
+    expect(entry?.planType).toBe("plus");
+  });
+
+  it("works with sticky strategy", () => {
+    setupPool(["plus", "free"]);
+    pool.setRotationStrategy("sticky");
+    pool.addAccount("free-token-1");
+    pool.addAccount("plus-token-1");
+
+    const acquired = pool.acquire();
+    expect(acquired).not.toBeNull();
+    const entry = pool.getEntry(acquired!.entryId);
+    expect(entry?.planType).toBe("plus");
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 `auth.tier_priority` 配置（如 `["plus", "pro", "team", "free"]`）
- `AccountLifecycle.acquire()` 在候选人数组计算后、传入策略前，按 tier 过滤到最高可用层级
- 高优先级 tier 账号全部占满时自动降级到下一 tier
- 与所有轮转策略兼容（least_used / round_robin / sticky）
- 默认 `null`（不启用），向后兼容

Closes #348

## Test plan
- [x] `tests/unit/auth/tier-priority.test.ts` — 9 个 case 覆盖优先级、同 tier 内策略、null planType、策略兼容性
- [x] `npm test` 全量回归通过（127 files, 1469 tests）