### PR TITLE
chore: remove retired OpenAI models

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -9,7 +9,7 @@ client:
   arch: arm64
   chromium_version: "144"
 model:
-  default: gpt-5.2-codex
+  default: gpt-5.3-codex
   default_reasoning_effort: null
   default_service_tier: null
   inject_desktop_context: false

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -7,7 +7,7 @@
 # Dynamic fetch merges with static; backend entries win for shared IDs.
 # Models endpoint now requires ?client_version= query parameter.
 #
-# Last updated: 2026-03-22 (gpt-5.4 family restored to backend)
+# Last updated: 2026-04-15 (removed retired models: gpt-5.2-codex, gpt-5.1 family, gpt-5)
 
 models:
   # ── GPT-5.4 family (current flagship) ───────────────────────────────
@@ -43,21 +43,6 @@ models:
   - id: gpt-5.3-codex
     displayName: GPT-5.3 Codex
     description: Frontier Codex-optimized agentic coding model
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: low,    description: "Fast responses with lighter reasoning" }
-      - { reasoningEffort: medium, description: "Balances speed and reasoning depth" }
-      - { reasoningEffort: high,   description: "Greater reasoning depth for complex problems" }
-      - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
-    defaultReasoningEffort: medium
-    inputModalities: [text, image]
-    supportsPersonality: false
-    upgrade: null
-
-  # ── GPT-5.2 Codex ──────────────────────────────────────────────────
-  - id: gpt-5.2-codex
-    displayName: GPT-5.2 Codex
-    description: Frontier agentic coding model
     isDefault: true
     supportedReasoningEfforts:
       - { reasoningEffort: low,    description: "Fast responses with lighter reasoning" }
@@ -66,7 +51,7 @@ models:
       - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
-    supportsPersonality: true
+    supportsPersonality: false
     upgrade: null
 
   # ── GPT-5.2 (general-purpose) ────────────────────────────────────────
@@ -84,59 +69,6 @@ models:
     supportsPersonality: true
     upgrade: null
 
-  # ── GPT-5.1 Codex family ──────────────────────────────────────────
-  - id: gpt-5.1-codex-max
-    displayName: GPT-5.1 Codex Max
-    description: GPT-5.1 Codex — extended context / deepest reasoning
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: low,    description: "Fast responses" }
-      - { reasoningEffort: medium, description: "Balanced speed and quality" }
-      - { reasoningEffort: high,   description: "Deepest reasoning" }
-      - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
-    defaultReasoningEffort: medium
-    inputModalities: [text, image]
-    supportsPersonality: false
-    upgrade: null
-
-  - id: gpt-5.1-codex
-    displayName: GPT-5.1 Codex
-    description: GPT-5.1 Codex
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: low,    description: "Fastest responses" }
-      - { reasoningEffort: medium, description: "Balanced speed and quality" }
-      - { reasoningEffort: high,   description: "Deepest reasoning" }
-    defaultReasoningEffort: medium
-    inputModalities: [text, image]
-    supportsPersonality: false
-    upgrade: null
-
-  - id: gpt-5.1
-    displayName: GPT-5.1
-    description: General-purpose GPT-5.1
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: low,    description: "Fastest responses" }
-      - { reasoningEffort: medium, description: "Balanced speed and quality" }
-      - { reasoningEffort: high,   description: "Deepest reasoning" }
-    defaultReasoningEffort: medium
-    inputModalities: [text, image]
-    supportsPersonality: false
-    upgrade: null
-
-  - id: gpt-5.1-codex-mini
-    displayName: GPT-5.1 Codex Mini
-    description: GPT-5.1 Codex Mini — lightweight, low-latency
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: medium, description: "Balanced" }
-      - { reasoningEffort: high,   description: "Greater reasoning" }
-    defaultReasoningEffort: medium
-    inputModalities: [text]
-    supportsPersonality: false
-    upgrade: null
-
   # ── GPT-5 Codex family ──────────────────────────────────────────────
   - id: gpt-5-codex
     displayName: GPT-5 Codex
@@ -146,20 +78,6 @@ models:
       - { reasoningEffort: low,    description: "Fastest responses" }
       - { reasoningEffort: medium, description: "Balanced speed and quality" }
       - { reasoningEffort: high,   description: "Deepest reasoning" }
-    defaultReasoningEffort: medium
-    inputModalities: [text, image]
-    supportsPersonality: false
-    upgrade: null
-
-  - id: gpt-5
-    displayName: GPT-5
-    description: General-purpose GPT-5
-    isDefault: false
-    supportedReasoningEfforts:
-      - { reasoningEffort: minimal, description: "Fastest responses with limited reasoning" }
-      - { reasoningEffort: low,     description: "Fast responses" }
-      - { reasoningEffort: medium,  description: "Balanced" }
-      - { reasoningEffort: high,    description: "Deepest reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
     supportsPersonality: false
@@ -205,4 +123,4 @@ models:
     upgrade: null
 
 aliases:
-  codex: "gpt-5.2-codex"
+  codex: "gpt-5.3-codex"

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -16,7 +16,7 @@ export const ConfigSchema = z.object({
     chromium_version: z.string().default("136"),
   }),
   model: z.object({
-    default: z.string().default("gpt-5.2-codex"),
+    default: z.string().default("gpt-5.3-codex"),
     default_reasoning_effort: z.string().nullable().default(null),
     default_service_tier: z.string().nullable().default(null),
     inject_desktop_context: z.boolean().default(false),

--- a/tests/_helpers/config.ts
+++ b/tests/_helpers/config.ts
@@ -37,7 +37,7 @@ export function createMockConfig(overrides?: MockConfigOverrides): AppConfig {
       chromium_version: "136",
     },
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
       inject_desktop_context: false,

--- a/tests/bench/concurrency-bench.ts
+++ b/tests/bench/concurrency-bench.ts
@@ -11,7 +11,7 @@
 const N = parseInt(process.argv[2] || "3", 10);
 const BASE_URL = process.argv[3] || "http://localhost:8080";
 const API_KEY = "pwd";
-const MODEL = "gpt-5.2-codex";
+const MODEL = "gpt-5.3-codex";
 const TIMEOUT_MS = 120_000;
 
 interface TimingResult {

--- a/tests/bench/overhead-bench.ts
+++ b/tests/bench/overhead-bench.ts
@@ -63,7 +63,7 @@ bench("buildHeadersWithContentType()", () => {
 
 bench("JSON.stringify (request body)", () => {
   JSON.stringify({
-    model: "gpt-5.2-codex",
+    model: "gpt-5.3-codex",
     instructions: "",
     input: [{ role: "user", content: "Say hi" }],
     stream: true,

--- a/tests/integration/account-routing.test.ts
+++ b/tests/integration/account-routing.test.ts
@@ -31,7 +31,7 @@ vi.mock("@src/config.js", () => ({
       rate_limit_backoff_seconds: 60,
     },
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
     },
@@ -72,7 +72,7 @@ describe("account-routing integration", () => {
         rate_limit_backoff_seconds: 60,
       },
       model: {
-        default: "gpt-5.2-codex",
+        default: "gpt-5.3-codex",
         default_reasoning_effort: null,
         default_service_tier: null,
       },
@@ -123,7 +123,7 @@ describe("account-routing integration", () => {
     vi.mocked(getModelPlanTypes).mockReturnValue([]);
 
     // When no plan constraint, any account is a candidate
-    const acquired = pool.acquire({ model: "gpt-5.2-codex" });
+    const acquired = pool.acquire({ model: "gpt-5.3-codex" });
     expect(acquired).not.toBeNull();
   });
 
@@ -165,7 +165,7 @@ describe("account-routing integration", () => {
         rate_limit_backoff_seconds: 60,
       },
       model: {
-        default: "gpt-5.2-codex",
+        default: "gpt-5.3-codex",
         default_reasoning_effort: null,
         default_service_tier: null,
       },

--- a/tests/integration/usage-passthrough.test.ts
+++ b/tests/integration/usage-passthrough.test.ts
@@ -79,7 +79,7 @@ describe("usage passthrough", () => {
   describe("OpenAI format", () => {
     it("cached_tokens in prompt_tokens_details", async () => {
       mockEvents = createUsageEvents({ cached_tokens: 30 });
-      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.2-codex");
+      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.3-codex");
 
       expect(response.usage.prompt_tokens).toBe(100);
       expect(response.usage.completion_tokens).toBe(50);
@@ -90,7 +90,7 @@ describe("usage passthrough", () => {
 
     it("reasoning_tokens in completion_tokens_details", async () => {
       mockEvents = createUsageEvents({ reasoning_tokens: 20 });
-      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.2-codex");
+      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.3-codex");
 
       expect(response.usage.completion_tokens_details).toBeDefined();
       expect(response.usage.completion_tokens_details!.reasoning_tokens).toBe(20);
@@ -98,7 +98,7 @@ describe("usage passthrough", () => {
 
     it("both cached and reasoning tokens together", async () => {
       mockEvents = createUsageEvents({ cached_tokens: 30, reasoning_tokens: 20 });
-      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.2-codex");
+      const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.3-codex");
 
       expect(response.usage.prompt_tokens_details!.cached_tokens).toBe(30);
       expect(response.usage.completion_tokens_details!.reasoning_tokens).toBe(20);
@@ -109,7 +109,7 @@ describe("usage passthrough", () => {
     it("cache_read_input_tokens from cached_tokens", async () => {
       mockEvents = createUsageEvents({ cached_tokens: 30 });
       const { response } = await collectCodexToAnthropicResponse(
-        fakeCodexApi, fakeResponse, "gpt-5.2-codex",
+        fakeCodexApi, fakeResponse, "gpt-5.3-codex",
       );
 
       expect(response.usage.input_tokens).toBe(100);
@@ -122,7 +122,7 @@ describe("usage passthrough", () => {
     it("cachedContentTokenCount from cached_tokens", async () => {
       mockEvents = createUsageEvents({ cached_tokens: 30 });
       const { response } = await collectCodexToGeminiResponse(
-        fakeCodexApi, fakeResponse, "gpt-5.2-codex",
+        fakeCodexApi, fakeResponse, "gpt-5.3-codex",
       );
 
       expect(response.usageMetadata).toBeDefined();
@@ -138,7 +138,7 @@ describe("usage passthrough", () => {
       mockEvents = createUsageEvents({ cached_tokens: 30, reasoning_tokens: 20 });
       const chunks: string[] = [];
 
-      for await (const chunk of streamCodexToOpenAI(fakeCodexApi, fakeResponse, "gpt-5.2-codex")) {
+      for await (const chunk of streamCodexToOpenAI(fakeCodexApi, fakeResponse, "gpt-5.3-codex")) {
         chunks.push(chunk);
       }
 
@@ -166,13 +166,13 @@ describe("usage passthrough", () => {
       // Non-streaming
       mockEvents = [...events];
       const { response: collectResult } = await collectCodexResponse(
-        fakeCodexApi, fakeResponse, "gpt-5.2-codex",
+        fakeCodexApi, fakeResponse, "gpt-5.3-codex",
       );
 
       // Streaming
       mockEvents = [...events];
       const chunks: string[] = [];
-      for await (const chunk of streamCodexToOpenAI(fakeCodexApi, fakeResponse, "gpt-5.2-codex")) {
+      for await (const chunk of streamCodexToOpenAI(fakeCodexApi, fakeResponse, "gpt-5.3-codex")) {
         chunks.push(chunk);
       }
 

--- a/tests/real/free-model-access.test.ts
+++ b/tests/real/free-model-access.test.ts
@@ -88,12 +88,12 @@ async function sendCodexRequest(
 }
 
 describe("free account model access", () => {
-  it("free + gpt-5.2-codex (should succeed)", async () => {
+  it("free + gpt-5.3-codex (should succeed)", async () => {
     if (!ready || !freeAccount) return; // skip gracefully
-    const { status, body } = await sendCodexRequest(freeAccount, "gpt-5.2-codex");
-    console.log("[free + gpt-5.2-codex] status:", status, "body:", body.slice(0, 300));
+    const { status, body } = await sendCodexRequest(freeAccount, "gpt-5.3-codex");
+    console.log("[free + gpt-5.3-codex] status:", status, "body:", body.slice(0, 300));
     if (status === 401) {
-      console.warn("[free + gpt-5.2-codex] token expired, skipping");
+      console.warn("[free + gpt-5.3-codex] token expired, skipping");
       return;
     }
     expect(status).toBe(200);
@@ -120,10 +120,10 @@ describe("team account model access", () => {
     expect(status).toBe(200);
   }, 60_000);
 
-  it("team + gpt-5.2-codex (should succeed)", async () => {
+  it("team + gpt-5.3-codex (should succeed)", async () => {
     if (!ready || !teamAccount) return;
-    const { status, body } = await sendCodexRequest(teamAccount, "gpt-5.2-codex");
-    console.log("[team + gpt-5.2-codex] status:", status, "body:", body.slice(0, 300));
+    const { status, body } = await sendCodexRequest(teamAccount, "gpt-5.3-codex");
+    console.log("[team + gpt-5.3-codex] status:", status, "body:", body.slice(0, 300));
     expect(status).toBe(200);
   }, 60_000);
 });

--- a/tests/scripts/stress-test.ts
+++ b/tests/scripts/stress-test.ts
@@ -47,7 +47,7 @@ interface AccountDiff {
 const CONCURRENCY = parseInt(process.argv[2] || "10", 10);
 const BASE_URL = process.argv[3] || "http://localhost:8080";
 const API_KEY = "pwd";
-const MODEL = "gpt-5.2-codex";
+const MODEL = "gpt-5.3-codex";
 const TIMEOUT_MS = 120_000;
 
 // ── Helpers ────────────────────────────────────────────────────────

--- a/tests/scripts/test-account.ts
+++ b/tests/scripts/test-account.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   npx tsx tests/test-account.ts user@example.com
- *   npx tsx tests/test-account.ts user@example.com gpt-5.2-codex
+ *   npx tsx tests/test-account.ts user@example.com gpt-5.3-codex
  *   npx tsx tests/test-account.ts --all              # test all accounts
  *   npx tsx tests/test-account.ts --all --parallel 5  # 5 concurrent
  */
@@ -43,7 +43,7 @@ const TIMEOUT_MS = 30_000;
 
 function parseArgs(): { emails: string[]; model: string; all: boolean; parallel: number } {
   const args = process.argv.slice(2);
-  let model = "gpt-5.2-codex";
+  let model = "gpt-5.3-codex";
   let all = false;
   let parallel = 3;
   const emails: string[] = [];

--- a/tests/unit/auth/account-pool.test.ts
+++ b/tests/unit/auth/account-pool.test.ts
@@ -243,10 +243,10 @@ describe("AccountPool", () => {
       it("acquires normally for models available to free", () => {
         pool.addAccount("token-free-1");
 
-        // gpt-5.2-codex available for free
+        // gpt-5.3-codex available for free
         vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
 
-        const acquired = pool.acquire({ model: "gpt-5.2-codex" });
+        const acquired = pool.acquire({ model: "gpt-5.3-codex" });
         expect(acquired).not.toBeNull();
         expect(acquired!.token).toBe("token-free-1");
       });
@@ -277,7 +277,7 @@ describe("AccountPool", () => {
 
         vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
 
-        const acquired = pool.acquire({ model: "gpt-5.2-codex" });
+        const acquired = pool.acquire({ model: "gpt-5.3-codex" });
         expect(acquired).not.toBeNull();
       });
     });
@@ -299,7 +299,7 @@ describe("AccountPool", () => {
       it("can use either account for shared models", () => {
         vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
 
-        const acquired = pool.acquire({ model: "gpt-5.2-codex" });
+        const acquired = pool.acquire({ model: "gpt-5.3-codex" });
         expect(acquired).not.toBeNull();
         // Both are eligible, least_used picks one
       });
@@ -335,7 +335,7 @@ describe("AccountPool", () => {
 
         // Now request a shared model — free should serve it
         vi.mocked(getModelPlanTypes).mockReturnValue(["free", "team"]);
-        const free = pool.acquire({ model: "gpt-5.2-codex" });
+        const free = pool.acquire({ model: "gpt-5.3-codex" });
         expect(free).not.toBeNull();
         expect(free!.token).toBe("token-free-x");
       });
@@ -374,7 +374,7 @@ describe("AccountPool", () => {
 
         const tokens: string[] = [];
         for (let i = 0; i < 3; i++) {
-          const a = pool.acquire({ model: "gpt-5.2-codex" })!;
+          const a = pool.acquire({ model: "gpt-5.3-codex" })!;
           tokens.push(a.token);
           pool.release(a.entryId);
         }

--- a/tests/unit/auth/ban-detection.test.ts
+++ b/tests/unit/auth/ban-detection.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     server: {},
-    model: { default: "gpt-5.2-codex" },
+    model: { default: "gpt-5.3-codex" },
     api: { base_url: "https://chatgpt.com/backend-api" },
     client: { app_version: "1.0.0" },
     auth: { refresh_margin_seconds: 300 },

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -36,7 +36,7 @@ describe("ConfigSchema", () => {
     expect(result.auth.refresh_concurrency).toBe(2);
     expect(result.auth.max_concurrent_per_account).toBe(3);
     expect(result.auth.request_interval_ms).toBe(50);
-    expect(result.model.default).toBe("gpt-5.2-codex");
+    expect(result.model.default).toBe("gpt-5.3-codex");
     expect(result.model.default_reasoning_effort).toBeNull();
     expect(result.tls.force_http11).toBe(false);
     expect(result.quota.refresh_interval_minutes).toBe(5);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -36,7 +36,7 @@ client:
   arch: "arm64"
   chromium_version: "136"
 model:
-  default: "gpt-5.2-codex"
+  default: "gpt-5.3-codex"
   default_reasoning_effort: null
   default_service_tier: null
   suppress_desktop_directives: true
@@ -92,7 +92,7 @@ describe("config", () => {
     const config = loadConfig("/tmp/test-config");
     expect(config.api.base_url).toBe("https://chatgpt.com/backend-api");
     expect(config.server.port).toBe(8080);
-    expect(config.model.default).toBe("gpt-5.2-codex");
+    expect(config.model.default).toBe("gpt-5.3-codex");
   });
 
   it("loads fingerprint config", async () => {

--- a/tests/unit/models/model-cache.test.ts
+++ b/tests/unit/models/model-cache.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     server: {},
-    model: { default: "gpt-5.2-codex" },
+    model: { default: "gpt-5.3-codex" },
     api: { base_url: "https://chatgpt.com/backend-api" },
     client: { app_version: "1.0.0" },
   })),

--- a/tests/unit/models/model-fetcher-retry.test.ts
+++ b/tests/unit/models/model-fetcher-retry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
-    model: { default: "gpt-5.2-codex" },
+    model: { default: "gpt-5.3-codex" },
   })),
 }));
 

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -21,7 +21,7 @@ vi.mock("@src/paths.js", () => ({
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
     },
@@ -131,7 +131,7 @@ describe("ModelStore", () => {
     });
 
     it("falls back to config default for unknown model", () => {
-      expect(resolveModelId("unknown-model")).toBe("gpt-5.2-codex");
+      expect(resolveModelId("unknown-model")).toBe("gpt-5.3-codex");
     });
   });
 
@@ -184,7 +184,7 @@ describe("ModelStore", () => {
 
     it("falls back to config default for fully unknown name", () => {
       const result = parseModelName("totally-unknown");
-      expect(result.modelId).toBe("gpt-5.2-codex");
+      expect(result.modelId).toBe("gpt-5.3-codex");
     });
 
     it("strips -xhigh suffix as reasoning_effort", () => {

--- a/tests/unit/models/plan-routing.test.ts
+++ b/tests/unit/models/plan-routing.test.ts
@@ -58,21 +58,21 @@ describe("plan-based model routing", () => {
 
   it("applyBackendModelsForPlan registers models for a plan", () => {
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
 
-    expect(getModelPlanTypes("gpt-5.2-codex")).toContain("free");
+    expect(getModelPlanTypes("gpt-5.3-codex")).toContain("free");
     expect(getModelPlanTypes("gpt-5.4")).toContain("free");
   });
 
   it("models available in both plans return both plan types", () => {
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
     applyBackendModelsForPlan("team", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
       makeModel("gpt-5.4-mini"),
     ]);
@@ -81,17 +81,17 @@ describe("plan-based model routing", () => {
     expect(plans54).toContain("free");
     expect(plans54).toContain("team");
 
-    const plansCodex = getModelPlanTypes("gpt-5.2-codex");
+    const plansCodex = getModelPlanTypes("gpt-5.3-codex");
     expect(plansCodex).toContain("free");
     expect(plansCodex).toContain("team");
   });
 
   it("model only in team plan does not include free", () => {
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
     applyBackendModelsForPlan("team", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
 
@@ -102,31 +102,31 @@ describe("plan-based model routing", () => {
 
   it("replacing a plan's models updates the index", () => {
     // Initially free doesn't have gpt-5.4
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
     expect(getModelPlanTypes("gpt-5.4")).not.toContain("free");
 
     // Backend now returns gpt-5.4 for free → re-fetch
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
     expect(getModelPlanTypes("gpt-5.4")).toContain("free");
   });
 
   it("unknown model returns empty plan list", () => {
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
     expect(getModelPlanTypes("nonexistent-model")).toEqual([]);
   });
 
   it("all backend model slugs are admitted (no client-side filtering)", () => {
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("research"),
       makeModel("gpt-5-2"),
       makeModel("some-internal-slug"),
     ]);
 
-    expect(getModelPlanTypes("gpt-5.2-codex")).toContain("free");
+    expect(getModelPlanTypes("gpt-5.3-codex")).toContain("free");
     expect(getModelPlanTypes("research")).toContain("free");
     expect(getModelPlanTypes("gpt-5-2")).toContain("free");
     expect(getModelPlanTypes("some-internal-slug")).toContain("free");
@@ -144,7 +144,7 @@ describe("plan-based model routing", () => {
 
   it("planMap in store info reflects current state", () => {
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
     applyBackendModelsForPlan("team", [
@@ -152,9 +152,9 @@ describe("plan-based model routing", () => {
     ]);
 
     const info = getModelStoreDebug();
-    expect(info.planMap.free).toContain("gpt-5.2-codex");
+    expect(info.planMap.free).toContain("gpt-5.3-codex");
     expect(info.planMap.free).toContain("gpt-5.4");
     expect(info.planMap.team).toContain("gpt-5.4");
-    expect(info.planMap.team).not.toContain("gpt-5.2-codex");
+    expect(info.planMap.team).not.toContain("gpt-5.3-codex");
   });
 });

--- a/tests/unit/proxy/codex-models.test.ts
+++ b/tests/unit/proxy/codex-models.test.ts
@@ -30,7 +30,7 @@ describe("fetchModels", () => {
   it("returns models from first successful endpoint", async () => {
     const transport = createMockTransport(vi.fn(async () => ({
       status: 200,
-      body: JSON.stringify({ models: [{ slug: "gpt-5.4" }, { slug: "gpt-5.2-codex" }] }),
+      body: JSON.stringify({ models: [{ slug: "gpt-5.4" }, { slug: "gpt-5.3-codex" }] }),
     })));
 
     const result = await fetchModels({ ...headers }, null, apiConfig, transport);
@@ -72,7 +72,7 @@ describe("fetchModels", () => {
           },
           {
             category: "code",
-            models: [{ slug: "gpt-5.2-codex" }],
+            models: [{ slug: "gpt-5.3-codex" }],
           },
         ],
       }),
@@ -80,7 +80,7 @@ describe("fetchModels", () => {
 
     const result = await fetchModels({ ...headers }, null, apiConfig, transport);
     expect(result).toHaveLength(3);
-    expect(result!.map((m) => m.slug)).toEqual(["gpt-5.4", "gpt-5.2", "gpt-5.2-codex"]);
+    expect(result!.map((m) => m.slug)).toEqual(["gpt-5.4", "gpt-5.2", "gpt-5.3-codex"]);
   });
 
   it("handles sentinel/chat-requirements format", async () => {

--- a/tests/unit/proxy/upstream-router-apikeys.test.ts
+++ b/tests/unit/proxy/upstream-router-apikeys.test.ts
@@ -97,7 +97,7 @@ describe("UpstreamRouter with ApiKeyPool", () => {
     const router = new UpstreamRouter(adapters, {}, "codex");
     router.setApiKeyPool(pool, mockFactory);
 
-    const match = router.resolveMatch("gpt-5.2-codex");
+    const match = router.resolveMatch("gpt-5.3-codex");
     expect(match.kind).toBe("codex");
   });
 

--- a/tests/unit/proxy/upstream-router.test.ts
+++ b/tests/unit/proxy/upstream-router.test.ts
@@ -62,7 +62,7 @@ describe("UpstreamRouter", () => {
   });
 
   it("routes known codex models to codex", () => {
-    expect(router.resolveMatch("gpt-5.2-codex").kind).toBe("codex");
+    expect(router.resolveMatch("gpt-5.3-codex").kind).toBe("codex");
     expect(router.resolveMatch("o3").kind).toBe("codex");
   });
 
@@ -71,7 +71,7 @@ describe("UpstreamRouter", () => {
   });
 
   it("isCodexModel returns true only for codex-routed models", () => {
-    expect(router.isCodexModel("gpt-5.2-codex")).toBe(true);
+    expect(router.isCodexModel("gpt-5.3-codex")).toBe(true);
     expect(router.isCodexModel("claude-3-5-sonnet-20241022")).toBe(false);
     expect(router.isCodexModel("openai:gpt-4o")).toBe(false);
   });
@@ -91,7 +91,7 @@ describe("UpstreamRouter", () => {
   });
 
   it("classifies known codex-looking models as codex", () => {
-    expect(router.resolveMatch("gpt-5.2-codex").kind).toBe("codex");
+    expect(router.resolveMatch("gpt-5.3-codex").kind).toBe("codex");
     expect(router.resolveMatch("o3").kind).toBe("codex");
   });
 

--- a/tests/unit/proxy/ws-transport.test.ts
+++ b/tests/unit/proxy/ws-transport.test.ts
@@ -52,7 +52,7 @@ interface MockWs extends EventEmitter {
 
 const BASE_REQUEST: WsCreateRequest = {
   type: "response.create",
-  model: "gpt-5.2-codex",
+  model: "gpt-5.3-codex",
   instructions: "test",
   input: [{ role: "user", content: "hello" }],
 };

--- a/tests/unit/routes/general-settings.test.ts
+++ b/tests/unit/routes/general-settings.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockConfig = {
   server: { port: 8080, proxy_api_key: null as string | null },
   tls: { proxy_url: null as string | null, force_http11: false },
-  model: { default: "gpt-5.2-codex", default_reasoning_effort: null as string | null, inject_desktop_context: false, suppress_desktop_directives: true },
+  model: { default: "gpt-5.3-codex", default_reasoning_effort: null as string | null, inject_desktop_context: false, suppress_desktop_directives: true },
   quota: {
     refresh_interval_minutes: 5,
     warning_thresholds: { primary: [80, 90], secondary: [80, 90] },
@@ -113,7 +113,7 @@ describe("GET /admin/general-settings", () => {
       force_http11: false,
       inject_desktop_context: false,
       suppress_desktop_directives: true,
-      default_model: "gpt-5.2-codex",
+      default_model: "gpt-5.3-codex",
       default_reasoning_effort: null,
       refresh_enabled: true,
       refresh_margin_seconds: 300,

--- a/tests/unit/routes/plan-routing-integration.test.ts
+++ b/tests/unit/routes/plan-routing-integration.test.ts
@@ -14,7 +14,7 @@ import { Hono } from "hono";
 
 const mockConfig = {
   server: { proxy_api_key: null as string | null },
-  model: { default: "gpt-5.2-codex" },
+  model: { default: "gpt-5.3-codex" },
   auth: {
     jwt_token: undefined as string | undefined,
     rotation_strategy: "least_used" as const,
@@ -194,9 +194,9 @@ describe("plan routing through proxy handler", () => {
     pool.addAccount("free-token-1");
     applyBackendModelsForPlan("team", [
       makeModel("gpt-5.4"),
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
 
     const app = new Hono();
     app.post("/test", (c) =>
@@ -219,11 +219,11 @@ describe("plan routing through proxy handler", () => {
     pool.addAccount("free-token-1");
     applyBackendModelsForPlan("free", [
       makeModel("gpt-5.4"),
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
     applyBackendModelsForPlan("team", [
       makeModel("gpt-5.4"),
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
 
     const app = new Hono();
@@ -244,7 +244,7 @@ describe("plan routing through proxy handler", () => {
   it("plan map update → previously blocked request now succeeds", async () => {
     pool.addAccount("free-token-1");
     applyBackendModelsForPlan("team", [makeModel("gpt-5.4")]);
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
 
     const app = new Hono();
     app.post("/test", (c) =>
@@ -263,7 +263,7 @@ describe("plan routing through proxy handler", () => {
 
     // Backend refresh: free now has gpt-5.4
     applyBackendModelsForPlan("free", [
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
       makeModel("gpt-5.4"),
     ]);
 
@@ -276,9 +276,9 @@ describe("plan routing through proxy handler", () => {
     pool.addAccount("team-token-1");
     applyBackendModelsForPlan("team", [
       makeModel("gpt-5.4"),
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
 
     const app = new Hono();
     app.post("/test", (c) =>
@@ -300,9 +300,9 @@ describe("plan routing through proxy handler", () => {
     pool.addAccount("team-token-1");
     applyBackendModelsForPlan("team", [
       makeModel("gpt-5.4"),
-      makeModel("gpt-5.2-codex"),
+      makeModel("gpt-5.3-codex"),
     ]);
-    applyBackendModelsForPlan("free", [makeModel("gpt-5.2-codex")]);
+    applyBackendModelsForPlan("free", [makeModel("gpt-5.3-codex")]);
 
     const app = new Hono();
     app.post("/test", (c) =>

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -14,7 +14,7 @@ import { Hono } from "hono";
 const mockConfig = {
   server: { proxy_api_key: null as string | null },
   model: {
-    default: "gpt-5.2-codex",
+    default: "gpt-5.3-codex",
     default_reasoning_effort: null,
     default_service_tier: null,
     suppress_desktop_directives: false,
@@ -210,7 +210,7 @@ describe("POST /v1/responses/compact", () => {
     expect(req).not.toHaveProperty("previous_response_id");
 
     // Must have compact fields
-    expect(req.model).toBe("gpt-5.2-codex");
+    expect(req.model).toBe("gpt-5.3-codex");
     expect(req.instructions).toBe("Be concise");
     expect(req.input).toEqual([{ role: "user", content: "Hello" }]);
     expect(req.tools).toEqual([{ type: "function", function: { name: "read_file" } }]);

--- a/tests/unit/routes/responses-optional-instructions.test.ts
+++ b/tests/unit/routes/responses-optional-instructions.test.ts
@@ -11,7 +11,7 @@ import { Hono } from "hono";
 const mockConfig = {
   server: { proxy_api_key: null as string | null },
   model: {
-    default: "gpt-5.2-codex",
+    default: "gpt-5.3-codex",
     default_reasoning_effort: null,
     default_service_tier: null,
     suppress_desktop_directives: false,

--- a/tests/unit/routes/responses-premature-close.test.ts
+++ b/tests/unit/routes/responses-premature-close.test.ts
@@ -11,7 +11,7 @@ vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     server: { proxy_api_key: null },
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
       suppress_desktop_directives: false,

--- a/tests/unit/routes/upstream-auth-bypass.test.ts
+++ b/tests/unit/routes/upstream-auth-bypass.test.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 const mockConfig = {
   server: { proxy_api_key: null as string | null },
   model: {
-    default: "gpt-5.2-codex",
+    default: "gpt-5.3-codex",
     default_reasoning_effort: null,
     default_service_tier: null,
     suppress_desktop_directives: false,
@@ -234,7 +234,7 @@ describe("upstream direct routing without Codex auth", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-5.2-codex",
+        model: "gpt-5.3-codex",
         messages: [{ role: "user", content: "hello" }],
       }),
     });

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
       suppress_desktop_directives: false,

--- a/tests/unit/translation/gemini-to-codex.test.ts
+++ b/tests/unit/translation/gemini-to-codex.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
       suppress_desktop_directives: false,

--- a/tests/unit/translation/openai-to-codex.test.ts
+++ b/tests/unit/translation/openai-to-codex.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@src/config.js", () => ({
   getConfig: vi.fn(() => ({
     model: {
-      default: "gpt-5.2-codex",
+      default: "gpt-5.3-codex",
       default_reasoning_effort: null,
       default_service_tier: null,
       suppress_desktop_directives: false,


### PR DESCRIPTION
## Summary
- Remove 6 models delisted by OpenAI: `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gpt-5.1-codex-mini`, `gpt-5`
- Update default model and `codex` alias from `gpt-5.2-codex` → `gpt-5.3-codex`
- Sync all test fixtures and config schemas to new default

## Test plan
- [x] `npm test` — 126 files, 1460 tests passed
- [ ] Verify `/v1/models` endpoint no longer lists retired models
- [ ] Confirm `codex` alias resolves to `gpt-5.3-codex`