### PR TITLE
[codex] Accept suffixed chat model names and stabilize tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ public-desktop/
 data/
 public/
 docs/
-bin/
+bin/*
+!bin/README.md
 .env
 *.log
 .asar-out/

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,4 @@
+This directory is reserved for runtime helper binaries.
+
+Electron packaging and path resolution expect `bin/` to exist at the repo root,
+even in source checkouts where the actual binaries are provided separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.41",
+  "version": "2.0.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.41",
+      "version": "2.0.64",
       "workspaces": [
         "packages/*"
       ],
@@ -27,6 +27,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "electron-to-chromium": "^1.5.302",
         "js-beautify": "^1.15.0",
+        "preact": "^10.29.1",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
         "vitest": "^3.2.4"
@@ -5681,6 +5682,17 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -7349,7 +7361,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.41",
+      "version": "2.0.64",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "electron-to-chromium": "^1.5.302",
     "js-beautify": "^1.15.0",
+    "preact": "^10.29.1",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
     "vitest": "^3.2.4"

--- a/packages/electron/__tests__/build.test.ts
+++ b/packages/electron/__tests__/build.test.ts
@@ -5,15 +5,22 @@
  * with the expected exports.
  */
 
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { existsSync, rmSync, statSync } from "fs";
 import { resolve } from "path";
 import { execFileSync } from "child_process";
+import { acquireElectronTestLock } from "./test-lock.js";
 
 const PKG_DIR = resolve(import.meta.dirname, "..");
 const DIST = resolve(PKG_DIR, "dist-electron");
 
 describe("electron build (esbuild)", () => {
+  let releaseLock: (() => void) | null = null;
+
+  beforeAll(async () => {
+    releaseLock = await acquireElectronTestLock();
+  });
+
   // Build once for all tests in this suite
   const buildOnce = (() => {
     let built = false;
@@ -32,6 +39,7 @@ describe("electron build (esbuild)", () => {
     if (existsSync(DIST)) {
       rmSync(DIST, { recursive: true });
     }
+    releaseLock?.();
   });
 
   it("produces main.cjs (Electron main process)", () => {

--- a/packages/electron/__tests__/prepare-pack.test.ts
+++ b/packages/electron/__tests__/prepare-pack.test.ts
@@ -6,10 +6,11 @@
  * up afterward.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { execFileSync } from "child_process";
+import { acquireElectronTestLock } from "./test-lock.js";
 
 const PKG_DIR = resolve(import.meta.dirname, "..");
 const ROOT_DIR = resolve(PKG_DIR, "..", "..");
@@ -19,6 +20,12 @@ const SCRIPT = resolve(PKG_DIR, "electron", "prepare-pack.mjs");
 const DIRS = ["config", "public", "bin"];
 
 describe("prepare-pack.mjs", () => {
+  let releaseLock: (() => void) | null = null;
+
+  beforeAll(async () => {
+    releaseLock = await acquireElectronTestLock();
+  });
+
   // Clean up any leftover copies before/after each test
   function cleanCopies(): void {
     for (const dir of DIRS) {
@@ -32,6 +39,9 @@ describe("prepare-pack.mjs", () => {
 
   beforeEach(cleanCopies);
   afterEach(cleanCopies);
+  afterAll(() => {
+    releaseLock?.();
+  });
 
   it("copies root directories into packages/electron/", () => {
     execFileSync("node", [SCRIPT], { cwd: PKG_DIR });

--- a/packages/electron/__tests__/release-pipeline.test.ts
+++ b/packages/electron/__tests__/release-pipeline.test.ts
@@ -6,16 +6,23 @@
  * Tests the sequence: core build → desktop build → esbuild → prepare-pack.
  */
 
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { existsSync, rmSync, readFileSync, statSync } from "fs";
 import { resolve } from "path";
 import { execFileSync } from "child_process";
+import { acquireElectronTestLock } from "./test-lock.js";
 
 const PKG_DIR = resolve(import.meta.dirname, "..");
 const ROOT_DIR = resolve(PKG_DIR, "..", "..");
 const DIST_ELECTRON = resolve(PKG_DIR, "dist-electron");
 
 describe("release pipeline", () => {
+  let releaseLock: (() => void) | null = null;
+
+  beforeAll(async () => {
+    releaseLock = await acquireElectronTestLock();
+  });
+
   afterAll(() => {
     // Clean up build artifacts
     if (existsSync(DIST_ELECTRON)) rmSync(DIST_ELECTRON, { recursive: true });
@@ -25,6 +32,7 @@ describe("release pipeline", () => {
         cwd: PKG_DIR,
       });
     } catch { /* ignore */ }
+    releaseLock?.();
   });
 
   it("core build produces web assets", () => {

--- a/packages/electron/__tests__/test-lock.ts
+++ b/packages/electron/__tests__/test-lock.ts
@@ -1,0 +1,22 @@
+import { mkdirSync, rmSync } from "fs";
+import { resolve } from "path";
+
+const LOCK_DIR = resolve(import.meta.dirname, ".electron-test-lock");
+const RETRY_MS = 50;
+
+export async function acquireElectronTestLock(): Promise<() => void> {
+  for (;;) {
+    try {
+      mkdirSync(LOCK_DIR);
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw err;
+      await new Promise((resolveRetry) => setTimeout(resolveRetry, RETRY_MS));
+    }
+  }
+
+  return () => {
+    rmSync(LOCK_DIR, { recursive: true, force: true });
+  };
+}

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -87,6 +87,34 @@ interface NormalizedModelWithMeta extends CodexModelInfo {
 const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
 const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 
+function stripKnownModelSuffixes(input: string): {
+  modelName: string;
+  serviceTier: string | null;
+  reasoningEffort: string | null;
+} {
+  let remaining = input.trim();
+  let serviceTier: string | null = null;
+  let reasoningEffort: string | null = null;
+
+  for (const tier of SERVICE_TIER_SUFFIXES) {
+    if (remaining.endsWith(`-${tier}`)) {
+      serviceTier = tier;
+      remaining = remaining.slice(0, -(tier.length + 1));
+      break;
+    }
+  }
+
+  for (const effort of EFFORT_SUFFIXES) {
+    if (remaining.endsWith(`-${effort}`)) {
+      reasoningEffort = effort;
+      remaining = remaining.slice(0, -(effort.length + 1));
+      break;
+    }
+  }
+
+  return { modelName: remaining, serviceTier, reasoningEffort };
+}
+
 // ── Class ────────────────────────────────────────────────────────────
 
 export class ModelStore {
@@ -225,6 +253,26 @@ export class ModelStore {
     return this.defaultModelFn();
   }
 
+  isRecognizedModelName(input: string): boolean {
+    const trimmed = input.trim();
+    if (!trimmed) return false;
+
+    if (this.aliases[trimmed] || this.catalog.some((m) => m.id === trimmed)) {
+      return true;
+    }
+
+    const stripped = stripKnownModelSuffixes(trimmed);
+    if (
+      stripped.modelName === trimmed
+      || (!stripped.serviceTier && !stripped.reasoningEffort)
+    ) {
+      return false;
+    }
+
+    return !!this.aliases[stripped.modelName]
+      || this.catalog.some((m) => m.id === stripped.modelName);
+  }
+
   parseModelName(input: string): ParsedModelName {
     const trimmed = input.trim();
 
@@ -232,27 +280,9 @@ export class ModelStore {
       return { modelId: this.resolveModelId(trimmed), serviceTier: null, reasoningEffort: null };
     }
 
-    let remaining = trimmed;
-    let serviceTier: string | null = null;
-    let reasoningEffort: string | null = null;
-
-    for (const tier of SERVICE_TIER_SUFFIXES) {
-      if (remaining.endsWith(`-${tier}`)) {
-        serviceTier = tier;
-        remaining = remaining.slice(0, -(tier.length + 1));
-        break;
-      }
-    }
-
-    for (const effort of EFFORT_SUFFIXES) {
-      if (remaining.endsWith(`-${effort}`)) {
-        reasoningEffort = effort;
-        remaining = remaining.slice(0, -(effort.length + 1));
-        break;
-      }
-    }
-
-    const modelId = this.resolveModelId(remaining);
+    const stripped = stripKnownModelSuffixes(trimmed);
+    const modelId = this.resolveModelId(stripped.modelName);
+    const { serviceTier, reasoningEffort } = stripped;
     return { modelId, serviceTier, reasoningEffort };
   }
 
@@ -420,6 +450,10 @@ export function isPlanFetched(planType: string): boolean {
 
 export function resolveModelId(input: string): string {
   return _instance.resolveModelId(input);
+}
+
+export function isRecognizedModelName(input: string): boolean {
+  return _instance.isRecognizedModelName(input);
 }
 
 export function parseModelName(input: string): ParsedModelName {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -9,7 +9,11 @@ import {
   collectCodexResponse,
 } from "../translation/codex-to-openai.js";
 import { getConfig } from "../config.js";
-import { parseModelName, buildDisplayModelName, getModelAliases, getModelInfo } from "../models/model-store.js";
+import {
+  parseModelName,
+  buildDisplayModelName,
+  isRecognizedModelName,
+} from "../models/model-store.js";
 import { enqueueLogEntry } from "../logs/entry.js";
 import { getRealClientIp } from "../utils/get-real-client-ip.js";
 import { randomUUID } from "crypto";
@@ -55,11 +59,6 @@ function makeOpenAIFormat(wantReasoning: boolean): FormatAdapter {
     collectTranslator: (api, response, model, tupleSchema) =>
       collectCodexResponse(api, response, model, wantReasoning, tupleSchema),
   };
-}
-
-function hasKnownCodexModel(model: string): boolean {
-  const aliases = getModelAliases();
-  return !!aliases[model] || !!getModelInfo(model);
 }
 
 function formatModelNotFound(model: string) {
@@ -110,7 +109,7 @@ export function createChatRoutes(
       });
     }
     const req = parsed.data;
-    const routeMatch = upstreamRouter?.resolveMatch(req.model) ?? (hasKnownCodexModel(req.model)
+    const routeMatch = upstreamRouter?.resolveMatch(req.model) ?? (isRecognizedModelName(req.model)
       ? { kind: "codex" as const }
       : { kind: "not-found" as const });
 

--- a/tests/_helpers/e2e-setup.ts
+++ b/tests/_helpers/e2e-setup.ts
@@ -115,6 +115,29 @@ vi.mock("@src/tls/transport.js", () => ({
   getTransport: vi.fn(() => mockTransport),
 }));
 
+vi.mock("@src/proxy/ws-transport.js", () => ({
+  createWebSocketResponse: vi.fn(async (
+    wsUrl: string,
+    headers: Record<string, string>,
+    request: unknown,
+    signal?: AbortSignal,
+    proxyUrl?: string | null,
+  ) => {
+    const body = JSON.stringify(request);
+    _lastTransportBody = body;
+    const result = await _transportPost(wsUrl, headers, body, signal, undefined, proxyUrl);
+    if (result.status < 200 || result.status >= 300) {
+      const errorBody = await new Response(result.body as BodyInit).text();
+      const { CodexApiError } = await import("@src/proxy/codex-types.js");
+      throw new CodexApiError(result.status, errorBody);
+    }
+    return new Response(result.body as BodyInit, {
+      status: result.status,
+      headers: result.headers,
+    });
+  }),
+}));
+
 vi.mock("@src/tls/curl-binary.js", () => ({
   initProxy: vi.fn(async () => {}),
   getCurlBinary: vi.fn(() => null),

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -314,16 +314,29 @@ describe("E2E: POST /v1/chat/completions", () => {
 
   // ── Model suffix ──────────────────────────────────────────────
 
-  // TODO: alias "codex" doesn't resolve suffix — codex-high returns 404
-  it.skip("model suffix: codex-high resolves reasoning effort", async () => {
+  it("model suffix: gpt-5.4-low resolves reasoning effort", async () => {
     setTransportPost(async () =>
       makeTransportResponse(buildTextStreamChunks("resp_chat_sfx", "Suffix!")),
+    );
+
+    const res = await chatRequest(defaultBody({ model: "gpt-5.4-low" }));
+    expect(res.status).toBe(200);
+
+    const sentBody = JSON.parse(getLastTransportBody()!);
+    expect(sentBody.model).toBe("gpt-5.4");
+    expect(sentBody.reasoning?.effort).toBe("low");
+  });
+
+  it("model suffix: codex-high resolves reasoning effort", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(buildTextStreamChunks("resp_chat_alias_sfx", "Alias suffix!")),
     );
 
     const res = await chatRequest(defaultBody({ model: "codex-high" }));
     expect(res.status).toBe(200);
 
     const sentBody = JSON.parse(getLastTransportBody()!);
+    expect(sentBody.model).toBe("gpt-5.4");
     expect(sentBody.reasoning?.effort).toBe("high");
   });
 });

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -37,6 +37,7 @@ import { readFileSync as realReadFileSync } from "fs";
 
 import {
   loadStaticModels,
+  isRecognizedModelName,
   parseModelName,
   resolveModelId,
   getModelInfo,
@@ -222,6 +223,24 @@ describe("ModelStore", () => {
       expect(result.modelId).toBe("gpt-5.4");
       expect(result.serviceTier).toBe("flex");
       expect(result.reasoningEffort).toBe("low");
+    });
+  });
+
+  describe("isRecognizedModelName", () => {
+    it("accepts known model IDs with suffixes", () => {
+      expect(isRecognizedModelName("gpt-5.4-low")).toBe(true);
+      expect(isRecognizedModelName("gpt-5.4-high-fast")).toBe(true);
+    });
+
+    it("accepts aliases with suffixes", () => {
+      expect(isRecognizedModelName("codex-high")).toBe(true);
+      expect(isRecognizedModelName("codex-fast")).toBe(true);
+    });
+
+    it("rejects unknown model names even with valid-looking suffixes", () => {
+      expect(isRecognizedModelName("totally-unknown")).toBe(false);
+      expect(isRecognizedModelName("totally-unknown-low")).toBe(false);
+      expect(isRecognizedModelName("totally-unknown-high-fast")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

This PR fixes `/v1/chat/completions` so suffixed model names like `gpt-5.4-low`, `codex-high`, and `gpt-5.4-high-fast` are accepted by the route's model validation and reach the existing suffix parser.

It also stabilizes the test suite around this change by fixing websocket e2e mocks, adding a root-level `preact` test dependency, serializing Electron tests that mutate shared build state, and committing a placeholder `bin/` entry required by Electron packaging tests.

## Root Cause

`/v1/chat/completions` performed an early model existence check against only exact model IDs and aliases. That rejected virtual suffixed names before `parseModelName()` could strip reasoning/service-tier suffixes and resolve the real model.

In parallel, the repository had a few unrelated test regressions that masked validation work:

- websocket transport paths were not mocked consistently in e2e tests
- root-level `shared/i18n` tests could not resolve `preact`
- multiple Electron test files raced on shared packaging state
- Electron packaging tests expected a committed root `bin/` directory

## What Changed

- add explicit recognition for known model names and aliases with supported suffix combinations
- update chat route validation to use the new recognition helper before rejecting requests
- cover suffixed chat models in unit and e2e tests
- align websocket transport mocking with the actual transport path and error behavior
- add the missing root dev dependency and serialize shared-state Electron tests
- commit a tracked `bin/README.md` so packaging tests have the expected directory

## Impact

OpenAI-compatible chat clients can now select reasoning effort and service-tier variants through suffixed model names without being blocked by `model_not_found` on `/v1/chat/completions`.

The full Vitest suite is green again, which makes it easier to validate future proxy changes without chasing unrelated red tests.

## Validation

- `npm test`
