### PR TITLE
fix: rotate accounts on WS-path usage_limit_reached errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- WebSocket 路径首帧若为上游 `usage_limit_reached` / `rate_limit*` / `quota_exhausted` / 鉴权类终止错误，转换为 `CodexApiError` 抛出，复用 HTTP 路径已有的账号轮转逻辑；恢复 2.0.62 的"智能切换"行为（`src/proxy/ws-transport.ts`）。错误若发生在已有内容流出之后，仍按当前行为透传给客户端
 - 无可用账号时不再执行无意义的重试，直接返回描述性错误信息（含各状态账号计数：rate-limited / expired / banned / disabled）(#362)
 - API Key 路由（OpenAI/Anthropic/Gemini）上游返回错误时，透传原始 JSON 响应体，而非包装为代理自有格式；Codex 账号路由仍使用代理格式 (#367)
 

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -179,6 +179,13 @@ export class CodexApi {
       try {
         return await this.createResponseViaWebSocket(request, signal, onRateLimits);
       } catch (err) {
+        // Real upstream API errors classified by ws-transport (e.g.
+        // usage_limit_reached → CodexApiError(429)) must reach the
+        // proxy-handler's rotation flow on the SAME account, not retry
+        // via HTTP — HTTP would just hit the same quota.
+        if (err instanceof CodexApiError) {
+          throw err;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         if (request.previous_response_id) {
           console.warn(

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -27,7 +27,31 @@ import { CodexApiError } from "./codex-types.js";
  * Returns null for events we don't want to rotate on (genuine model
  * errors, validation errors, etc.) — those keep the SSE pass-through
  * behavior so the client sees the real reason.
+ *
+ * Why exact-match: a substring rule like `includes("rate_limit")` would
+ * also match codes such as `soft_rate_limit_warning` and incorrectly
+ * trigger account rotation. We allowlist concrete codes and fall through
+ * for everything else (unknown codes stream as SSE — safer default).
  */
+const ROTATABLE_ERROR_CODES: Readonly<Record<string, number>> = {
+  // 429 — weekly/primary cap
+  usage_limit_reached: 429,
+  rate_limit_exceeded: 429,
+  rate_limit_reached: 429,
+  // 402 — plan/credit exhausted
+  quota_exhausted: 402,
+  payment_required: 402,
+  // 401 — credential rejected upstream
+  unauthorized: 401,
+  token_invalid: 401,
+  token_expired: 401,
+  account_deactivated: 401,
+  // 403 — account banned
+  forbidden: 403,
+  account_banned: 403,
+  banned: 403,
+};
+
 function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } | null {
   const type = typeof msg.type === "string" ? msg.type : "";
   if (type !== "error" && type !== "response.failed") return null;
@@ -39,18 +63,8 @@ function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } 
     (typeof errorObj.code === "string" ? errorObj.code : null) ??
     (typeof errorObj.type === "string" ? errorObj.type : null) ??
     "";
-  const lower = codeRaw.toLowerCase();
-  if (lower.includes("usage_limit") || lower.includes("rate_limit")) return { status: 429 };
-  if (lower.includes("quota_exhausted") || lower.includes("payment_required")) return { status: 402 };
-  if (
-    lower.includes("unauthorized") ||
-    lower.includes("token_invalid") ||
-    lower.includes("deactivated")
-  ) {
-    return { status: 401 };
-  }
-  if (lower.includes("forbidden") || lower.includes("banned")) return { status: 403 };
-  return null;
+  const status = ROTATABLE_ERROR_CODES[codeRaw.toLowerCase()];
+  return status ? { status } : null;
 }
 
 /** Cached ws module — loaded once on first use. */

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -17,6 +17,41 @@
 import type { CodexInputItem } from "./codex-api.js";
 import type { ParsedRateLimit } from "./rate-limit-headers.js";
 import { parseRateLimitsEvent } from "./rate-limit-headers.js";
+import { CodexApiError } from "./codex-types.js";
+
+/**
+ * Map an upstream WS terminal error frame (`type: "error"` or
+ * `type: "response.failed"`) to an HTTP-equivalent status so that the
+ * proxy-handler's existing CodexApiError rotation flow can take over.
+ *
+ * Returns null for events we don't want to rotate on (genuine model
+ * errors, validation errors, etc.) — those keep the SSE pass-through
+ * behavior so the client sees the real reason.
+ */
+function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } | null {
+  const type = typeof msg.type === "string" ? msg.type : "";
+  if (type !== "error" && type !== "response.failed") return null;
+  const errorObj = typeof msg.error === "object" && msg.error !== null
+    ? (msg.error as Record<string, unknown>)
+    : null;
+  if (!errorObj) return null;
+  const codeRaw =
+    (typeof errorObj.code === "string" ? errorObj.code : null) ??
+    (typeof errorObj.type === "string" ? errorObj.type : null) ??
+    "";
+  const lower = codeRaw.toLowerCase();
+  if (lower.includes("usage_limit") || lower.includes("rate_limit")) return { status: 429 };
+  if (lower.includes("quota_exhausted") || lower.includes("payment_required")) return { status: 402 };
+  if (
+    lower.includes("unauthorized") ||
+    lower.includes("token_invalid") ||
+    lower.includes("deactivated")
+  ) {
+    return { status: 401 };
+  }
+  if (lower.includes("forbidden") || lower.includes("banned")) return { status: 403 };
+  return null;
+}
 
 /** Cached ws module — loaded once on first use. */
 let _WS: typeof import("ws").default | undefined;
@@ -96,7 +131,11 @@ export async function createWebSocketResponse(
     const encoder = new TextEncoder();
     let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
     let streamClosed = false;
-    let connected = false;
+    // Flips the first time we either resolve(Response) or reject(...).
+    // Internal `codex.rate_limits` frames do NOT flip this — we keep waiting
+    // for a real first frame so we can detect early upstream errors and
+    // route them through the existing CodexApiError → rotation path.
+    let earlyDecisionMade = false;
 
     function closeStream() {
       if (!streamClosed && controller) {
@@ -114,8 +153,9 @@ export async function createWebSocketResponse(
 
     // Abort signal handling
     const onAbort = () => {
-      ws.close(1000, "aborted");
-      if (!connected) {
+      try { ws.close(1000, "aborted"); } catch { /* already closing */ }
+      if (!earlyDecisionMade) {
+        earlyDecisionMade = true;
         reject(new Error("Aborted during WebSocket connect"));
       }
     };
@@ -136,48 +176,75 @@ export async function createWebSocketResponse(
       upgradeHeaders = response.headers;
     });
 
-    ws.on("open", () => {
-      connected = true;
-      ws.send(JSON.stringify(request));
-
-      // Build response headers from WS upgrade headers
+    function buildResponse(): Response {
       const responseHeaders = new Headers({ "content-type": "text/event-stream" });
       for (const [key, value] of Object.entries(upgradeHeaders)) {
         const v = Array.isArray(value) ? value[0] : value;
         if (v != null) responseHeaders.set(key, v);
       }
-      resolve(new Response(stream, { status: 200, headers: responseHeaders }));
+      return new Response(stream, { status: 200, headers: responseHeaders });
+    }
+
+    ws.on("open", () => {
+      ws.send(JSON.stringify(request));
+      // resolve() is deferred until the first non-internal frame arrives in
+      // ws.on("message"). This lets us classify early upstream errors (e.g.
+      // usage_limit_reached) and reject with a CodexApiError so the
+      // proxy-handler's existing rotation flow takes over instead of the
+      // error being passed through mid-stream to the client.
     });
 
     ws.on("message", (data: Buffer | string) => {
       if (streamClosed) return;
       const raw = typeof data === "string" ? data : data.toString("utf-8");
 
+      let msg: Record<string, unknown> | null = null;
+      let type = "unknown";
       try {
-        const msg = JSON.parse(raw) as Record<string, unknown>;
-        const type = (msg.type as string) ?? "unknown";
+        msg = JSON.parse(raw) as Record<string, unknown>;
+        type = typeof msg.type === "string" ? msg.type : "unknown";
+      } catch {
+        // Non-JSON message — handled below as raw data.
+      }
 
-        // Extract rate-limit data from codex.rate_limits event (WS-only)
-        if (type === "codex.rate_limits" && onRateLimits) {
-          const rl = parseRateLimitsEvent(msg);
-          if (rl) onRateLimits(rl);
-          // Don't forward internal rate-limit events to downstream clients
-          return;
+      // Internal rate-limit frames are observed via `onRateLimits` but not
+      // streamed, and they don't flip the early-decision flag — we keep
+      // waiting for a real frame so we can detect early upstream errors.
+      // If no callback is provided (test-only path), fall through and
+      // forward the frame as SSE like any other event.
+      if (msg && type === "codex.rate_limits" && onRateLimits) {
+        const rl = parseRateLimitsEvent(msg);
+        if (rl) onRateLimits(rl);
+        return;
+      }
+
+      if (!earlyDecisionMade) {
+        earlyDecisionMade = true;
+        if (msg) {
+          const classified = classifyWsErrorEvent(msg);
+          if (classified) {
+            reject(new CodexApiError(classified.status, JSON.stringify(msg)));
+            try { ws.close(1000, "early upstream error"); } catch { /* already closing */ }
+            return;
+          }
         }
+        resolve(buildResponse());
+        // fall through to enqueue this first frame
+      }
 
+      if (msg) {
         // Re-encode as SSE: event: <type>\ndata: <full json>\n\n
         const sse = `event: ${type}\ndata: ${raw}\n\n`;
         controller!.enqueue(encoder.encode(sse));
 
         // Close stream after response.completed, response.failed, or error
         if (type === "response.completed" || type === "response.failed" || type === "error") {
-          // Let the SSE chunk flush, then close
           queueMicrotask(() => {
             closeStream();
             ws.close(1000);
           });
         }
-      } catch {
+      } else {
         // Non-JSON message — emit as raw data
         const sse = `data: ${raw}\n\n`;
         controller!.enqueue(encoder.encode(sse));
@@ -186,15 +253,24 @@ export async function createWebSocketResponse(
 
     ws.on("error", (err: Error) => {
       signal?.removeEventListener("abort", onAbort);
-      if (!connected) {
+      if (!earlyDecisionMade) {
+        earlyDecisionMade = true;
         reject(err);
       } else {
         errorStream(err);
       }
     });
 
-    ws.on("close", (_code: number, _reason: Buffer) => {
+    ws.on("close", (code: number, reason: Buffer) => {
       signal?.removeEventListener("abort", onAbort);
+      if (!earlyDecisionMade) {
+        earlyDecisionMade = true;
+        const reasonStr = reason && reason.length ? reason.toString("utf-8") : "";
+        reject(new Error(
+          `WebSocket closed before any data: code=${code}` +
+            (reasonStr ? ` reason=${reasonStr}` : ""),
+        ));
+      }
       closeStream();
     });
   });

--- a/tests/e2e/messages.test.ts
+++ b/tests/e2e/messages.test.ts
@@ -178,9 +178,13 @@ describe("E2E: POST /v1/messages", () => {
   });
 
   it("upstream 500: retries then returns api_error", async () => {
-    setTransportPost(async () =>
+    // Count attempts at the underlying transport (covers both WS and HTTP
+    // paths; messages.ts forces useWebSocket=true, so withRetry retries the
+    // WS attempt 3x rather than falling back to HTTP).
+    const post = vi.fn(async () =>
       makeErrorTransportResponse(500, JSON.stringify({ detail: "Internal error" })),
     );
+    setTransportPost(post);
 
     const res = await messagesRequest(defaultBody());
     expect(res.status).toBe(500);
@@ -188,7 +192,7 @@ describe("E2E: POST /v1/messages", () => {
     const body = await res.json() as { type: string; error: { type: string } };
     expect(body.type).toBe("error");
     expect(body.error.type).toBe("api_error");
-    expect(getMockTransport().post).toHaveBeenCalledTimes(3);
+    expect(post).toHaveBeenCalledTimes(3);
   }, 10_000);
 
   // ── Auth ───────────────────────────────────────────────────────

--- a/tests/unit/proxy/codex-api-headers.test.ts
+++ b/tests/unit/proxy/codex-api-headers.test.ts
@@ -176,5 +176,24 @@ describe("codex-api headers", () => {
       expect(body.previous_response_id).toBeUndefined();
       expect(body.useWebSocket).toBeUndefined();
     });
+
+    it("WS 上游返回的 CodexApiError 不能降级到 HTTP（必须抛给 proxy-handler 轮转）", async () => {
+      // Without re-throwing, the same account would just retry over HTTP and
+      // hit the same usage_limit_reached, never rotating.
+      const { CodexApiError } = await import("@src/proxy/codex-api.js");
+      mockCreateWebSocketResponse.mockRejectedValue(
+        new CodexApiError(429, JSON.stringify({
+          type: "error",
+          error: { code: "usage_limit_reached", message: "Limit reached" },
+        })),
+      );
+
+      const api = await createApi();
+      await expect(
+        api.createResponse(makeRequest({ useWebSocket: true })),
+      ).rejects.toBeInstanceOf(CodexApiError);
+
+      expect(transport.post).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for ws-transport early-stream error rejection.
+ *
+ * Regression: when the upstream WebSocket sends a terminal error frame
+ * (e.g. `usage_limit_reached`) as the first observable message,
+ * `createWebSocketResponse` must reject with a `CodexApiError` so that the
+ * proxy-handler's existing rotation flow can switch to a different account
+ * — instead of resolving with HTTP 200 and streaming the error to the
+ * client, which bypasses rotation entirely (the bug fixed in this PR).
+ */
+
+import { EventEmitter } from "node:events";
+
+const wsInstances = vi.hoisted(() => [] as EventEmitter[]);
+
+vi.mock("ws", () => {
+  const { EventEmitter: EE } = require("node:events") as typeof import("node:events");
+
+  class MockWebSocket extends EE {
+    readyState = 0;
+    sentMessages: string[] = [];
+
+    constructor(_url: string, _opts?: Record<string, unknown>) {
+      super();
+      wsInstances.push(this);
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit("open");
+      });
+    }
+
+    send(data: string) {
+      this.sentMessages.push(data);
+    }
+
+    close(_code?: number, _reason?: string) {
+      this.readyState = 3;
+      queueMicrotask(() => this.emit("close", 1000, Buffer.from("")));
+    }
+  }
+
+  return { default: MockWebSocket };
+});
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { createWebSocketResponse, type WsCreateRequest } from "@src/proxy/ws-transport.js";
+import { CodexApiError } from "@src/proxy/codex-types.js";
+import { extractRetryAfterSec } from "@src/proxy/error-classification.js";
+
+interface MockWs extends EventEmitter {
+  readyState: number;
+  sentMessages: string[];
+  close(code?: number, reason?: string): void;
+}
+
+const BASE_REQUEST: WsCreateRequest = {
+  type: "response.create",
+  model: "gpt-5.3-codex",
+  instructions: "test",
+  input: [{ role: "user", content: "hi" }],
+};
+
+function lastWs(): MockWs {
+  return wsInstances[wsInstances.length - 1] as MockWs;
+}
+
+async function waitForOpen(): Promise<MockWs> {
+  for (let i = 0; i < 50; i++) {
+    if (wsInstances.length > 0) {
+      const ws = wsInstances[wsInstances.length - 1] as MockWs;
+      if (ws.readyState === 1 && ws.sentMessages.length > 0) return ws;
+    }
+    await new Promise<void>((r) => setTimeout(r, 0));
+  }
+  throw new Error("WebSocket did not open within timeout");
+}
+
+async function readAll(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text;
+}
+
+describe("createWebSocketResponse — early-stream error rejection", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+  });
+
+  it("rejects with CodexApiError(429) when first frame is usage_limit_reached", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    const errorFrame = {
+      type: "error",
+      error: {
+        code: "usage_limit_reached",
+        message: "The usage limit has been reached",
+        resets_in_seconds: 60,
+      },
+    };
+    ws.emit("message", JSON.stringify(errorFrame));
+
+    await expect(promise).rejects.toBeInstanceOf(CodexApiError);
+    try {
+      await promise;
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexApiError);
+      const apiErr = err as CodexApiError;
+      expect(apiErr.status).toBe(429);
+      // The body must contain the upstream `error` block so that
+      // `extractRetryAfterSec` can read `resets_in_seconds` for backoff.
+      expect(extractRetryAfterSec(apiErr.body)).toBe(60);
+    }
+  });
+
+  it("rejects with CodexApiError(402) when first frame is response.failed quota_exhausted", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "response.failed",
+      error: { code: "quota_exhausted", message: "Plan exhausted" },
+      response: { id: "resp_x" },
+    }));
+
+    try {
+      await promise;
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexApiError);
+      expect((err as CodexApiError).status).toBe(402);
+    }
+  });
+
+  it("resolves normally when first frame is an error with an unmapped code", async () => {
+    // Genuine model errors (e.g. invalid request, model_not_supported_in_plan)
+    // must NOT trigger rotation — they keep the SSE pass-through behavior so
+    // the client sees the real reason instead of cycling through accounts.
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    const ws = await waitForOpen();
+
+    const errorFrame = {
+      type: "error",
+      error: { code: "model_not_supported_in_plan", message: "nope" },
+    };
+    ws.emit("message", JSON.stringify(errorFrame));
+
+    const response = await promise;
+    expect(response.status).toBe(200);
+    const text = await readAll(response);
+    expect(text).toContain("event: error");
+    expect(text).toContain("model_not_supported_in_plan");
+  });
+
+  it("treats codex.rate_limits as internal — does not flip the early-decision flag", async () => {
+    // Sequence: rate-limits frame → usage_limit_reached error.
+    // The rate-limits frame must be consumed via onRateLimits and must NOT
+    // resolve the promise; the subsequent error frame must still trigger
+    // CodexApiError rejection.
+    const onRateLimits = vi.fn();
+    const promise = createWebSocketResponse(
+      "wss://test/ws",
+      {},
+      BASE_REQUEST,
+      undefined,
+      undefined,
+      onRateLimits,
+    );
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "codex.rate_limits",
+      rate_limits: {
+        primary: { used_percent: 50, window_minutes: 60, resets_in_seconds: 1800 },
+        secondary: { used_percent: 10, window_minutes: 10080, resets_in_seconds: 5_000_000 },
+      },
+    }));
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "usage_limit_reached", message: "Limit reached" },
+    }));
+
+    try {
+      await promise;
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexApiError);
+      expect((err as CodexApiError).status).toBe(429);
+    }
+    // onRateLimits was called for the codex.rate_limits frame.
+    expect(onRateLimits).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes through error events that arrive after a real frame", async () => {
+    // Once a real frame has been streamed, switching accounts is no longer
+    // safe — the client has already started receiving bytes. Errors arriving
+    // mid-stream must keep the existing SSE pass-through behavior.
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    const response = await promise;
+    expect(response.status).toBe(200);
+
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "usage_limit_reached", message: "Limit reached" },
+    }));
+
+    const text = await readAll(response);
+    expect(text).toContain("event: response.created");
+    expect(text).toContain("event: error");
+    expect(text).toContain("usage_limit_reached");
+  });
+
+  it("rejects when the WebSocket closes before any data frame", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("close", 1006, Buffer.from("upstream gone"));
+
+    try {
+      await promise;
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("WebSocket closed before any data");
+      expect((err as Error).message).toContain("code=1006");
+    }
+  });
+});

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -161,6 +161,26 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     expect(text).toContain("model_not_supported_in_plan");
   });
 
+  it("does NOT rotate on substring-only matches like soft_rate_limit_warning", async () => {
+    // Regression: previously the classifier used `lower.includes("rate_limit")`
+    // which would have classified `soft_rate_limit_warning` as a terminal 429
+    // and triggered account rotation. The exact-match allowlist must let this
+    // fall through to SSE pass-through.
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "soft_rate_limit_warning", message: "approaching cap" },
+    }));
+
+    const response = await promise;
+    expect(response.status).toBe(200);
+    const text = await readAll(response);
+    expect(text).toContain("event: error");
+    expect(text).toContain("soft_rate_limit_warning");
+  });
+
   it("treats codex.rate_limits as internal — does not flip the early-decision flag", async () => {
     // Sequence: rate-limits frame → usage_limit_reached error.
     // The rate-limits frame must be consumed via onRateLimits and must NOT

--- a/tests/unit/proxy/ws-transport.test.ts
+++ b/tests/unit/proxy/ws-transport.test.ts
@@ -61,6 +61,54 @@ function lastWs(): MockWs {
   return wsInstances[wsInstances.length - 1] as MockWs;
 }
 
+/**
+ * Wait until the dynamic import inside `createWebSocketResponse` finishes,
+ * the MockWebSocket constructor has registered an instance, and the `open`
+ * microtask has fired (so `ws.send(request)` has run).
+ */
+async function waitForOpen(): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (wsInstances.length > 0) {
+      const ws = wsInstances[wsInstances.length - 1] as MockWs;
+      if (ws.readyState === 1 && ws.sentMessages.length > 0) return;
+    }
+    await new Promise<void>((r) => setTimeout(r, 0));
+  }
+  throw new Error("WebSocket did not open within timeout");
+}
+
+/**
+ * Start a connect, wait for `open` to fire, and return the unresolved
+ * promise + the MockWs so tests can drive the message sequence.
+ *
+ * `createWebSocketResponse` no longer resolves on `open` — it waits for the
+ * first non-internal frame so it can detect early upstream errors and reject
+ * with a `CodexApiError` instead of streaming the error to the client.
+ */
+async function startConnect(
+  req: WsCreateRequest = BASE_REQUEST,
+  headers: Record<string, string> = {},
+): Promise<{ promise: Promise<Response>; ws: MockWs }> {
+  const promise = createWebSocketResponse("wss://test/ws", headers, req);
+  // Swallow the rejection if the test never awaits `promise` (e.g. it
+  // expects the promise to reject). We re-throw on any awaiter via the
+  // returned reference, so this only suppresses unhandled-rejection noise.
+  promise.catch(() => { /* test-controlled */ });
+  await waitForOpen();
+  return { promise, ws: lastWs() };
+}
+
+/** Drive a normal connect: emit `response.created` to unblock resolve. */
+async function connect(
+  req: WsCreateRequest = BASE_REQUEST,
+  headers: Record<string, string> = {},
+): Promise<{ response: Response; ws: MockWs }> {
+  const { promise, ws } = await startConnect(req, headers);
+  ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_init" } }));
+  const response = await promise;
+  return { response, ws };
+}
+
 /** Helper: read entire stream to string */
 async function readStream(response: Response): Promise<string> {
   const reader = response.body!.getReader();
@@ -80,23 +128,27 @@ describe("createWebSocketResponse", () => {
   });
 
   it("connects and sends the request message", async () => {
-    const response = await createWebSocketResponse("wss://test/ws", { auth: "bearer" }, BASE_REQUEST);
-    expect(response.status).toBe(200);
+    const { promise, ws } = await startConnect(BASE_REQUEST, { auth: "bearer" });
 
-    const ws = lastWs();
     expect(ws.url).toBe("wss://test/ws");
     expect((ws.opts?.headers as Record<string, string>)?.auth).toBe("bearer");
     expect(ws.sentMessages).toHaveLength(1);
     expect(JSON.parse(ws.sentMessages[0])).toEqual(BASE_REQUEST);
 
+    // Unblock resolve and verify the Response is HTTP 200.
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    const response = await promise;
+    expect(response.status).toBe(200);
+
     ws.close();
   });
 
   it("re-encodes WebSocket JSON messages as SSE events", async () => {
-    const response = await createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
-    const ws = lastWs();
+    const { promise, ws } = await startConnect();
 
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_123" } }));
+    const response = await promise;
+
     ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
     ws.emit("message", JSON.stringify({
       type: "response.completed",
@@ -123,21 +175,23 @@ describe("createWebSocketResponse", () => {
   });
 
   it("closes stream after response.completed", async () => {
-    const response = await createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
-    const ws = lastWs();
+    const { promise, ws } = await startConnect();
 
     ws.emit("message", JSON.stringify({ type: "response.completed", response: { id: "resp_1" } }));
 
+    const response = await promise;
     const text = await readStream(response);
     expect(text).toContain("response.completed");
   });
 
-  it("closes stream after response.failed", async () => {
-    const response = await createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
-    const ws = lastWs();
+  it("closes stream after response.failed without rotatable error code", async () => {
+    const { promise, ws } = await startConnect();
 
+    // No `error.code` / `error.type` → classifier returns null → resolves
+    // and streams the failure to the client (current pass-through behavior).
     ws.emit("message", JSON.stringify({ type: "response.failed", error: { message: "boom" } }));
 
+    const response = await promise;
     const text = await readStream(response);
     expect(text).toContain("response.failed");
   });
@@ -157,8 +211,7 @@ describe("createWebSocketResponse", () => {
       previous_response_id: "resp_prev_123",
     };
 
-    await createWebSocketResponse("wss://test/ws", {}, req);
-    const ws = lastWs();
+    const { ws } = await startConnect(req);
     const sent = JSON.parse(ws.sentMessages[0]);
     expect(sent.previous_response_id).toBe("resp_prev_123");
     expect(sent.store).toBeUndefined();
@@ -168,8 +221,10 @@ describe("createWebSocketResponse", () => {
   });
 
   it("preserves message ordering", async () => {
-    const response = await createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
-    const ws = lastWs();
+    const { promise, ws } = await startConnect();
+
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    const response = await promise;
 
     for (let i = 0; i < 5; i++) {
       ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: `chunk${i}` }));
@@ -192,14 +247,12 @@ describe("createWebSocketResponse", () => {
     // Import CodexApi to verify parseStream works with WS-generated SSE
     const { CodexApi } = await import("@src/proxy/codex-api.js");
 
-    const response = await createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
-    const ws = lastWs();
+    const { response, ws } = await connect();
 
-    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
     ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
     ws.emit("message", JSON.stringify({
       type: "response.completed",
-      response: { id: "resp_1", usage: { input_tokens: 10, output_tokens: 5 } },
+      response: { id: "resp_init", usage: { input_tokens: 10, output_tokens: 5 } },
     }));
 
     // parseStream should work identically on WS-generated SSE


### PR DESCRIPTION
## Summary

- Restore 2.0.62 "智能切换" rotation behavior: when an account hits its weekly cap, the proxy switches to the next healthy account instead of forwarding `usage_limit_reached: The usage limit has been reached` to Claude Code.
- Fix is at the WebSocket transport layer; messages.ts and responses.ts retain `useWebSocket = true` so prompt-cache and continuation gains from #392 are preserved.

## Why this regressed in 2.0.65

PR #392 forced `codexRequest.useWebSocket = true` for authenticated `/v1/messages` and `/v1/responses` requests (`src/routes/messages.ts:137-139`, `src/routes/responses.ts:574`). The WS transport (`src/proxy/ws-transport.ts:149`) always resolves with HTTP 200 the moment `ws.on("open")` fires, then re-encodes every subsequent WS frame as SSE — including `{ type: "error", error: { code: "usage_limit_reached" } }`. Once we're inside `stream(c, …)` in `proxy-handler.ts:385-449`, the response is mid-flight and rotation can't kick in. `handleCodexApiError` only runs against synchronously-thrown `CodexApiError`, so the upstream error bypassed the entire rotation path and was passed through to the client.

## How it's fixed

`createWebSocketResponse` now defers `resolve(Response)` until the first observable upstream frame:
- `codex.rate_limits` frames are still consumed via `onRateLimits` and do **not** flip the decision flag (the consumer keeps waiting).
- If the first real frame is `error` / `response.failed` with a rotatable code (`usage_limit` / `rate_limit*` → 429, `quota_exhausted` / `payment_required` → 402, `unauthorized` / `token_invalid` / `deactivated` → 401, `forbidden` / `banned` → 403), the promise rejects with a `CodexApiError(status, JSON.stringify(msg))`. The body shape includes the upstream `error: { type, code, message, resets_in_seconds, … }` block, so `extractRetryAfterSec` can read backoff hints unchanged.
- Unmapped error codes (genuine model errors, validation errors) keep the existing SSE pass-through so the client sees the real reason instead of cycling through accounts.
- Errors arriving **after** the stream has produced real content still pass through unchanged — the client has already started receiving bytes and switching accounts mid-stream is unsafe.

The new `CodexApiError` is caught by the existing `for (;;)` retry loop in `proxy-handler.ts:472`, which routes through `handleCodexApiError` (`src/routes/shared/proxy-error-handler.ts`) and acquires a different account via the configured rotation strategy. No changes to rotation logic itself were needed.

## Test plan

- [x] `npx vitest run tests/unit/proxy/ws-transport-early-error.test.ts` — 6 new cases:
  - first frame `usage_limit_reached` → rejects `CodexApiError(429)`, `extractRetryAfterSec` returns `resets_in_seconds`
  - first frame `response.failed` `quota_exhausted` → rejects `CodexApiError(402)`
  - first frame error with unmapped code (`model_not_supported_in_plan`) → resolves with HTTP 200 and streams pass-through
  - `codex.rate_limits` → `usage_limit_reached` → rejects, callback still fired once
  - `response.created` → later `error` → resolves with HTTP 200, error passes through (no retroactive rotation)
  - close before any data → rejects with synthetic close error
- [x] `npx vitest run tests/unit/proxy/ws-transport.test.ts tests/unit/proxy/ws-transport-premature-close.test.ts tests/unit/proxy/rate-limit-event.test.ts` — existing tests adjusted for deferred resolve, all pass
- [x] `npm test` — full suite (1605 passed, 1 skipped)
- [ ] Real upstream check: with one account at its weekly cap and one healthy, fire 3+ Claude Code requests against `localhost:8080` and verify the server log shows `[Messages] Account <id> | 429 rate limited (resets in …s), trying different account...` and the client never sees `usage_limit_reached`.