### PR TITLE
ci: add dev branch + beta channel auto-promotion

### DIFF
--- a/.github/workflows/bump-electron-beta.yml
+++ b/.github/workflows/bump-electron-beta.yml
@@ -1,0 +1,86 @@
+name: Bump beta + release (dev)
+
+on:
+  push:
+    branches: [dev]
+    paths-ignore:
+      - "CHANGELOG.md"
+      - "README.md"
+      - "docs/**"
+      - "*.md"
+  workflow_dispatch:
+
+concurrency:
+  group: bump-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  bump-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: dev
+
+      - name: Decide whether to release a beta
+        id: check
+        run: |
+          # Find latest stable tag (excludes prerelease suffixes)
+          LAST_STABLE=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "")
+          if [ -z "$LAST_STABLE" ]; then
+            echo "No stable tag yet, skipping beta"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Only count meaningful commits since last stable (mirror bump-electron.yml filter)
+          NEW_COMMITS=$(git log "${LAST_STABLE}..HEAD" --no-merges \
+            --pretty=format:"%s" | grep -cvE "^(chore|docs|ci|test|refactor|style)" || true)
+          if [ "$NEW_COMMITS" -eq 0 ]; then
+            echo "No meaningful commits since $LAST_STABLE, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Next patch + short SHA suffix (semver prerelease)
+          CURRENT="${LAST_STABLE#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEXT_PATCH=$((PATCH + 1))
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          NEW_TAG="v${MAJOR}.${MINOR}.${NEXT_PATCH}-beta.${SHORT_SHA}"
+
+          # SHA suffix makes collisions impossible unless we redo the same commit
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Tag $NEW_TAG already exists (re-run on same commit), skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Will tag $NEW_TAG (commits since stable: $NEW_COMMITS)"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and push
+        id: tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          NEW_TAG="${{ steps.check.outputs.new_tag }}"
+          git tag -a "$NEW_TAG" -m "Beta release $NEW_TAG"
+          git push origin "$NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger release workflow
+        if: steps.tag.outputs.new_tag
+        run: |
+          echo "Dispatching release for $NEW_TAG"
+          gh workflow run release.yml -f tag="$NEW_TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}

--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -29,11 +29,12 @@ jobs:
           IFS='.' read -r PKG_MAJOR PKG_MINOR _PKG_PATCH <<< "$PKG_VERSION"
           SERIES="${PKG_MAJOR}.${PKG_MINOR}"
 
-          # Find latest tag in this series (e.g. v2.0.x)
-          LAST_TAG=$(git tag --sort=-v:refname | grep "^v${SERIES}\." | head -1 || echo "")
+          # Find latest stable tag in this series (e.g. v2.0.x). Excludes
+          # prerelease tags like v2.0.67-beta.SHA produced by bump-electron-beta.yml.
+          LAST_TAG=$(git tag --sort=-v:refname | grep -E "^v${SERIES}\.[0-9]+$" | head -1 || echo "")
           if [ -z "$LAST_TAG" ]; then
-            # First release in this series — use any previous tag for commit check
-            LAST_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1 || echo "")
+            # First release in this series — use any previous stable tag for commit check
+            LAST_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "")
             if [ -z "$LAST_TAG" ]; then
               echo "No previous tag, skipping"
               echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -121,6 +121,23 @@ jobs:
           echo "::error::Push failed after 3 attempts"
           exit 1
 
+      - name: Sync bump commit back to dev (FF)
+        if: steps.bump.outputs.new_tag
+        # Without this, every stable bump leaves dev behind master by one commit.
+        # The next promote run would then fail FF check ("manual rebase needed")
+        # and stay stuck until someone manually rebases dev.
+        run: |
+          if ! git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+            echo "dev branch does not exist, skipping sync"
+            exit 0
+          fi
+          git fetch origin dev:refs/remotes/origin/dev
+          if git push origin master:dev; then
+            echo "Synced master ($(git rev-parse master)) to dev (FF)"
+          else
+            echo "::warning::FF push master:dev refused (dev moved during bump window). Manual sync needed."
+          fi
+
       - name: Trigger release workflow
         if: steps.bump.outputs.new_tag
         run: |

--- a/.github/workflows/promote-dev-to-master.yml
+++ b/.github/workflows/promote-dev-to-master.yml
@@ -22,13 +22,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Guard — dev branch must exist
+        id: dev_exists
+        run: |
+          if git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::dev branch does not exist yet, nothing to promote"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch master and dev
+        if: steps.dev_exists.outputs.ok == 'true'
         run: |
           git fetch origin master:refs/remotes/origin/master --tags
           git fetch origin dev:refs/remotes/origin/dev
 
       - name: Check ahead-count
         id: ahead
+        if: steps.dev_exists.outputs.ok == 'true'
         run: |
           AHEAD=$(git rev-list --count origin/master..origin/dev)
           echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
@@ -75,11 +87,12 @@ jobs:
           DEV_SHA=$(git rev-parse origin/dev)
           echo "Checking check-runs for $DEV_SHA"
 
-          # Exclude this workflow's own checks (promote-dev) and bump workflows from the gate
+          # Exclude this workflow's own checks (promote-dev) and bump workflows from the gate.
+          # (?i) makes the regex case-insensitive so we catch "promote"/"Promote", "bump-beta"/etc.
           STATUS=$(gh api "repos/${{ github.repository }}/commits/${DEV_SHA}/check-runs" \
             --jq '
               [.check_runs[]
-               | select(.name | test("Promote|bump-beta|Bump|Bump version") | not)
+               | select(.name | test("(?i)promote|bump") | not)
               ] as $relevant
               | if ($relevant | length) == 0
                 then "no-checks"

--- a/.github/workflows/promote-dev-to-master.yml
+++ b/.github/workflows/promote-dev-to-master.yml
@@ -1,0 +1,111 @@
+name: Promote dev → master
+
+on:
+  schedule:
+    - cron: "0 14 * * *"   # UTC 14:00 = PRC 22:00 (2h before bump-electron stable run)
+  workflow_dispatch:
+
+concurrency:
+  group: promote-dev
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: read
+  checks: read
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch master and dev
+        run: |
+          git fetch origin master:refs/remotes/origin/master --tags
+          git fetch origin dev:refs/remotes/origin/dev
+
+      - name: Check ahead-count
+        id: ahead
+        run: |
+          AHEAD=$(git rev-list --count origin/master..origin/dev)
+          echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "::notice::dev is not ahead of master, nothing to promote"
+          else
+            echo "dev is $AHEAD commit(s) ahead of master"
+          fi
+
+      - name: Check fast-forward possible
+        id: ff
+        if: steps.ahead.outputs.ahead != '0'
+        run: |
+          if git merge-base --is-ancestor origin/master origin/dev; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::master has commits not in dev — manual rebase needed (likely a hotfix landed directly on master)"
+          fi
+
+      - name: Check soak (>= 24h since latest dev commit)
+        id: soak
+        if: steps.ff.outputs.ok == 'true'
+        run: |
+          DEV_TS=$(git log -1 origin/dev --format=%ct)
+          NOW=$(date +%s)
+          AGE=$(( NOW - DEV_TS ))
+          MIN_AGE=86400
+          echo "dev HEAD age: ${AGE}s (need >= ${MIN_AGE}s)"
+          if [ "$AGE" -lt "$MIN_AGE" ]; then
+            REMAIN=$(( MIN_AGE - AGE ))
+            echo "::notice::Soak: ${REMAIN}s remaining before dev is eligible for promotion"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CI status on dev HEAD
+        id: ci
+        if: steps.soak.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEV_SHA=$(git rev-parse origin/dev)
+          echo "Checking check-runs for $DEV_SHA"
+
+          # Exclude this workflow's own checks (promote-dev) and bump workflows from the gate
+          STATUS=$(gh api "repos/${{ github.repository }}/commits/${DEV_SHA}/check-runs" \
+            --jq '
+              [.check_runs[]
+               | select(.name | test("Promote|bump-beta|Bump|Bump version") | not)
+              ] as $relevant
+              | if ($relevant | length) == 0
+                then "no-checks"
+                else
+                  if all($relevant[]; .conclusion == "success" or .conclusion == "skipped")
+                  then "green"
+                  else "not-green"
+                  end
+                end
+            ')
+
+          echo "status=$STATUS"
+          if [ "$STATUS" = "green" ] || [ "$STATUS" = "no-checks" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::CI on dev is not green (status=$STATUS), skipping promotion"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fast-forward push dev → master
+        if: steps.ci.outputs.ok == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEV_SHA="${{ steps.ci.outputs.dev_sha }}"
+          echo "Promoting $DEV_SHA to master"
+          git push origin "${DEV_SHA}:refs/heads/master"
+          echo "::notice::Promoted dev ($DEV_SHA) to master. bump-electron.yml will pick it up on the next 16:00 UTC tick."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- 发版流程引入 `dev` 分支 + beta channel：`bump-electron-beta.yml` 在 dev push 时打 `vX.Y.Z-beta.SHA` tag 出预发布包；`promote-dev-to-master.yml` 每天 14:00 UTC 检查 dev soak ≥24h + CI 绿后 fast-forward 到 master，再由现有 `bump-electron.yml` 出 stable tag (`.github/workflows/`)
+- `update.allow_prerelease` 配置项（默认 `false`）：开启后本地 Electron 通过 electron-updater 接收 beta channel 推送的预发布版本，便于自己的安装实测 dev 改动 (`src/config-schema.ts`、`packages/electron/electron/auto-updater.ts`、`config/default.yaml`)
 - `config/models.yaml`: `gpt-5.5` (Plus-only general-purpose chat) and `gpt-image-2` (Plus-only image-generation backend) entered the static catalog
 - `CodexModelInfo.outputModalities` optional field on the model catalog interface to flag image-gen models apart from chat models (`src/models/model-store.ts`, `BackendModelEntry.output_modalities` also added for backend passthrough). `/v1/models/catalog` defaults missing values to `["text"]` so API output matches the documented contract.
 - README 新增图像生成小节 + 模型表 Output 列；`API.md` / `API_CN.md` 补 `image_generation` 工具参数矩阵、事件流、编辑模式文档

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -54,6 +54,7 @@ quota:
   skip_exhausted: true
 update:
   auto_update: true
+  # allow_prerelease: false  # set true to receive beta builds (vX.Y.Z-beta.SHA) from the dev branch
 ollama:
   enabled: false
   host: 127.0.0.1

--- a/packages/electron/electron/auto-updater.ts
+++ b/packages/electron/electron/auto-updater.ts
@@ -25,6 +25,7 @@ interface AutoUpdaterOptions {
   rebuildTrayMenu: () => void;
   autoUpdate?: boolean;
   autoDownload?: boolean;
+  allowPrerelease?: boolean;
 }
 
 const state: AutoUpdateState = {
@@ -58,7 +59,10 @@ export function initAutoUpdater(options: AutoUpdaterOptions): void {
   // macOS always false — ad-hoc signed zips can't be auto-installed
   autoUpdater.autoDownload = isAutoDownload;
   autoUpdater.autoInstallOnAppQuit = !IS_MAC;
-  autoUpdater.allowPrerelease = false;
+  // Beta channel opt-in via config.update.allow_prerelease (default false).
+  // electron-builder writes beta-mac.yml / beta.yml for tags like vX.Y.Z-beta.SHA;
+  // setting allowPrerelease=true makes electron-updater consume that channel.
+  autoUpdater.allowPrerelease = options.allowPrerelease ?? false;
 
   autoUpdater.on("checking-for-update", () => {
     state.checking = true;

--- a/packages/electron/electron/main.ts
+++ b/packages/electron/electron/main.ts
@@ -156,16 +156,19 @@ app.on("ready", async () => {
     if (app.isPackaged) {
       let autoUpdate = true;
       let autoDownload = false;
+      let allowPrerelease = false;
       try {
         const updateCfg = getConfig().update;
         autoUpdate = updateCfg.auto_update;
         autoDownload = updateCfg.auto_download;
+        allowPrerelease = updateCfg.allow_prerelease;
       } catch { /* use defaults */ }
       initAutoUpdater({
         getMainWindow: () => mainWindow,
         rebuildTrayMenu,
         autoUpdate,
         autoDownload,
+        allowPrerelease,
       });
     }
   } catch (err) {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -70,6 +70,7 @@ export const ConfigSchema = z.object({
   update: z.object({
     auto_update: z.boolean().default(true),
     auto_download: z.boolean().default(false),
+    allow_prerelease: z.boolean().default(false),
   }).default({}),
   ollama: z.object({
     enabled: z.boolean().default(false),

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -43,6 +43,7 @@ describe("ConfigSchema", () => {
     expect(result.quota.warning_thresholds.primary).toEqual([80, 90]);
     expect(result.quota.skip_exhausted).toBe(true);
     expect(result.update.auto_update).toBe(true);
+    expect(result.update.allow_prerelease).toBe(false);
     expect(result.session.ttl_minutes).toBe(1440);
     expect(result.ollama).toEqual({
       enabled: false,
@@ -63,7 +64,7 @@ describe("ConfigSchema", () => {
       session: { ttl_minutes: 120 },
       tls: { force_http11: true },
       quota: { skip_exhausted: false },
-      update: { auto_update: false },
+      update: { auto_update: false, allow_prerelease: true },
       ollama: {
         enabled: true,
         host: "0.0.0.0",
@@ -83,6 +84,7 @@ describe("ConfigSchema", () => {
     expect(result.tls.force_http11).toBe(true);
     expect(result.quota.skip_exhausted).toBe(false);
     expect(result.update.auto_update).toBe(false);
+    expect(result.update.allow_prerelease).toBe(true);
     expect(result.ollama).toEqual({
       enabled: true,
       host: "0.0.0.0",


### PR DESCRIPTION
## Summary

引入 `dev` 分支做 soak 缓冲 + beta channel 自动晋升流程。目标：dev 上的改动有 ≥24h 真实安装实测时间才能进 stable，但**不需要手动切 master 上传**——CI 完全接管。

## 新链路

```
feature/* ──PR──▶ dev ──[push]──▶ bump-electron-beta.yml ──tag vX.Y.Z-beta.SHA──▶ release.yml ──▶ beta channel
                  │
                  ▼ [daily cron 14:00 UTC]
            promote-dev-to-master.yml
            （soak ≥24h + CI 绿 + FF 可行 → push dev:master）
                  │
                  ▼
              master ──[16:00 UTC bump-electron.yml]──tag vX.Y.Z──▶ release.yml ──▶ stable channel
```

## 改动

**新增 workflow**
- `.github/workflows/bump-electron-beta.yml` — dev push 触发，复用 `bump-electron.yml` 的 commit 类型过滤（chore/docs/ci/test/refactor/style 不出 beta），不写回 `package.json`，tag 格式 `vX.Y.Z-beta.<short_sha>`
- `.github/workflows/promote-dev-to-master.yml` — cron 14:00 UTC + workflow_dispatch；任一检查失败 `exit 0` 不强推；按顺序检查：dev 是否 ahead → FF 可行（无 master-only 提交）→ soak ≥24h → CI 全绿（排除 promote/bump 自身的 check）→ `git push dev:master`

**修改**
- `.github/workflows/bump-electron.yml` — tag grep 加 `[0-9]+$` 锚定，排除 beta 后缀避免污染 `last stable tag` 查询
- `src/config-schema.ts` — `update.allow_prerelease: boolean`（默认 `false`）
- `packages/electron/electron/auto-updater.ts` — 移除 hardcoded `allowPrerelease = false`，改从 `initAutoUpdater` options 读
- `packages/electron/electron/main.ts` — 把 config 的 `allow_prerelease` 传进去
- `config/default.yaml` — 注释提示 beta 开关
- `CHANGELOG.md` — `[Unreleased]` 加 Added 条目

## 用户 / 维护者影响

- 普通用户：**零影响**——`allowPrerelease` 默认 false，stable channel 不受 beta tag 影响（electron-builder 自动写 `beta.yml` 而非 `latest.yml`）
- 维护者本地：在 `local.yaml` 加 `update: { allow_prerelease: true }` 即可让自己的 Electron 自动收 dev 的 beta 包

## PR 合并后还要做

1. 在 GitHub 创建 `dev` 分支（从 master 起）
2. Settings → Branches → 把 default branch 改成 `dev`（让新 PR 默认 base 是 dev）
3. master 加 branch protection：require linear history、restrict pushes（只允许 GitHub Actions 推）

## Test plan

- [x] `npx vitest run` — 142 文件 / 1607 用例全过（含新增 `update.allow_prerelease` 的默认值 + override 测试）
- [x] `npm run build` — vite + tsc 干净
- [x] `packages/electron` esbuild + tsc --noEmit 干净
- [x] 3 个 workflow YAML 用 js-yaml 解析无错
- [ ] PR 合并 + dev 分支建立后，第一个 dev push 验证 beta 包出包路径（`v*-beta.SHA` tag 出现 + GitHub Releases 显示 Pre-release + `beta-mac.yml` manifest 存在）
- [ ] 24h 后等 promote workflow 自动 FF 到 master，验证 `bump-electron.yml` 后续仍能正确算 patch 号（不被 beta tag 误导）