### PR TITLE
fix(ci): drive electron-builder version from tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,17 @@ jobs:
 
       - name: Pack (${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }})
         working-directory: packages/electron
-        run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} ${{ matrix.arch && format('--{0}', matrix.arch) || '' }} --publish always
+        run: |
+          # Drive electron-builder version from the tag, not package.json. Required
+          # so beta tags (vX.Y.Z-beta.SHA, where bump-electron-beta.yml deliberately
+          # does NOT touch package.json) publish to the correct GitHub release and
+          # are detected as prerelease by electron-builder's semver suffix check.
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          npx electron-builder --config electron-builder.yml \
+            --${{ matrix.platform }} ${{ matrix.arch && format('--{0}', matrix.arch) || '' }} \
+            --config.extraMetadata.version="$VERSION" \
+            --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -184,7 +194,13 @@ jobs:
 
       - name: Pack (mac-x64)
         working-directory: packages/electron
-        run: npx electron-builder --config electron-builder.yml --mac --x64 --publish never
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          npx electron-builder --config electron-builder.yml \
+            --mac --x64 \
+            --config.extraMetadata.version="$VERSION" \
+            --publish never
 
       - name: Upload x64 artifacts to release
         run: |
@@ -255,7 +271,14 @@ jobs:
             fi
           fi
           echo "$BODY" > /tmp/release-notes.md
-          gh release edit "$TAG" --draft=false --notes-file /tmp/release-notes.md 2>/dev/null || \
-            gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md
+
+          # Tag like v1.2.3-beta.SHA → mark as prerelease (semver convention).
+          # Defensive: electron-builder normally does this, but the create fallback
+          # below would miss it when electron-builder's draft creation didn't fire.
+          PRERELEASE_FLAG=""
+          case "$TAG" in *-*) PRERELEASE_FLAG="--prerelease" ;; esac
+
+          gh release edit "$TAG" --draft=false $PRERELEASE_FLAG --notes-file /tmp/release-notes.md 2>/dev/null || \
+            gh release create "$TAG" --title "$TAG" $PRERELEASE_FLAG --notes-file /tmp/release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

第一次真实跑 beta channel 暴露的 bug：`bump-electron-beta.yml` 故意不写 `package.json`，导致 `release.yml` 让 electron-builder 用 `2.0.66`（package.json 旧值）发包，撞到现有 v2.0.66 release，全部跳过上传。最后 `release` job 创建了一个空的 v2.0.67-beta.SHA release，没标 prerelease。

实际错误日志（来自失败的 run [#24957499114](https://github.com/icebear0828/codex-proxy/actions/runs/24957499114)）：
```
publishing publisher=Github (owner: icebear0828, project: codex-proxy, version: 2.0.66)
GitHub release not created  reason=existing type not compatible with publishing type
  tag=v2.0.66 version=2.0.66 existingType=release publishingType=draft
skipped publishing  file=latest-linux.yml ...
```

## 改动

`release.yml`:
- 两处 `electron-builder` 调用加 `--config.extraMetadata.version="${TAG#v}"`，从 tag 名取版本，**不再依赖 package.json**
- `release` job 的 `gh release create/edit` 在 tag 带 semver prerelease 后缀（`vX.Y.Z-foo`）时加 `--prerelease`，作为 electron-builder 漏设时的兜底

## 影响

- **stable 不变**：`bump-electron.yml` 仍然写 package.json 再 tag，TAG 和 package.json 永远一致
- **beta 修好**：tag `v2.0.67-beta.b9ebb6d` → electron-builder 使用 `2.0.67-beta.b9ebb6d` 当版本 → 自动 prerelease 检测、artifact 文件名带 `-beta.SHA` 后缀、上传到正确 release

## Test plan

- [x] release.yml YAML 语法验证
- [ ] PR 合并后 dispatch `bump-electron-beta.yml`，验证：
  - tag `v2.0.67-beta.<sha>` 创建
  - `release.yml` 全部 5 个 job success
  - GitHub Release 标 "Pre-release" badge
  - assets 包含 `Codex-Proxy-2.0.67-beta.<sha>-mac-arm64.dmg` 等 4 个平台 + `beta-mac.yml` / `beta.yml` manifest