### PR TITLE
fix(ci): force bash shell on Pack steps for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,9 @@ jobs:
 
       - name: Pack (${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }})
         working-directory: packages/electron
+        # shell: bash needed so the Windows runner uses Git Bash instead of pwsh
+        # (pwsh doesn't handle backslash line continuations the same way).
+        shell: bash
         run: |
           # Drive electron-builder version from the tag, not package.json. Required
           # so beta tags (vX.Y.Z-beta.SHA, where bump-electron-beta.yml deliberately
@@ -194,6 +197,7 @@ jobs:
 
       - name: Pack (mac-x64)
         working-directory: packages/electron
+        shell: bash
         run: |
           TAG="${{ inputs.tag || github.ref_name }}"
           VERSION="${TAG#v}"


### PR DESCRIPTION
PR #413 的多行 bash 脚本在 Windows runner（默认 pwsh）跑挂：
\`\`\`
ParserError: Missing expression after unary operator '--'.
   9 |   --win  \\
\`\`\`
加 \`shell: bash\` 让 Windows runner 用 Git Bash（GitHub-hosted runner 都有）。