### PR TITLE
fix: recover from previous_response_not_found instead of passing it through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 
 ### Fixed
 
+- 上游返回 `previous_response_not_found`（response 由别的账号创建 / `SessionAffinityMap` 过期或重启丢失 / 跨账号轮转）时端到端恢复：
+  - `ws-transport.ts:36` `ROTATABLE_ERROR_CODES` 增补 `previous_response_not_found: 400`，让 WS 首帧 in-stream error 转成 `CodexApiError` reject —— 之前因为不在白名单里直接被流式透传到客户端，绕过了 catch
+  - `proxy-handler.ts` catch 块新增 strip-and-retry：剥掉 `previous_response_id` + `turnState`，在同一账号上重试一次，并把 ID 从 affinity map 清掉防止后续请求继续命中错路由；重试仍失败时降级返回原错误
+  - 隐式续链场景通过已有的 `restoreImplicitResumeRequest()` 路径回放完整 input，无损恢复；显式续链（客户端传 `previous_response_id`）会丢服务端历史，但请求仍能完成
+  - 新增分类器 `isPreviousResponseNotFoundError` + `SessionAffinityMap.forget()`（`src/proxy/error-classification.ts`、`src/auth/session-affinity.ts`、`src/routes/shared/proxy-handler.ts`、`src/proxy/ws-transport.ts`）
 - `release.yml` 让 electron-builder 用 tag 名当版本（`--config.extraMetadata.version="${TAG#v}"`），不再依赖 `package.json`。修复 `bump-electron-beta.yml` 故意不写 `package.json` 时 beta 包被跳过上传的问题（"existing type not compatible with publishing type"）；同步在 `release` job 给 prerelease tag 兜底 `--prerelease` flag (#413)
 - `release.yml` 的 `Pack` 步骤强制 `shell: bash`，让 Windows runner（默认 pwsh）正确解析 bash 多行续行符 `\` (#414)
 - WebSocket 路径首帧若为上游 `usage_limit_reached` / `rate_limit*` / `quota_exhausted` / 鉴权类终止错误，转换为 `CodexApiError` 抛出，复用 HTTP 路径已有的账号轮转逻辑；恢复 2.0.62 的"智能切换"行为（`src/proxy/ws-transport.ts`）。错误若发生在已有内容流出之后，仍按当前行为透传给客户端

--- a/src/auth/session-affinity.ts
+++ b/src/auth/session-affinity.ts
@@ -106,6 +106,11 @@ export class SessionAffinityMap {
     return entry?.functionCallIds ? [...entry.functionCallIds] : [];
   }
 
+  /** Drop a response ID — called after upstream rejects it as not-found. */
+  forget(responseId: string): void {
+    this.map.delete(responseId);
+  }
+
   private getEntry(responseId: string): AffinityEntry | null {
     const entry = this.map.get(responseId);
     if (!entry) return null;

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -57,6 +57,29 @@ export function isTokenInvalidError(err: unknown): boolean {
   return err.status === 401;
 }
 
+/**
+ * Check if an error indicates the upstream account does not recognize the
+ * `previous_response_id` referenced in the request (response was created by
+ * a different account, expired upstream, or the local affinity map was lost).
+ *
+ * Detects either:
+ *  - structured `code: "previous_response_not_found"` in the error body, or
+ *  - the human-readable "Previous response with id ... not found" message.
+ */
+export function isPreviousResponseNotFoundError(err: unknown): boolean {
+  if (!isCodexLike(err)) return false;
+  try {
+    const parsed = JSON.parse(err.body) as Record<string, unknown>;
+    const error = parsed.error as Record<string, unknown> | undefined;
+    if (error && typeof error.code === "string" && error.code === "previous_response_not_found") {
+      return true;
+    }
+  } catch { /* fall through to message check */ }
+  const lower = (err.body + " " + err.message).toLowerCase();
+  return lower.includes("previous_response_not_found")
+    || (lower.includes("previous response with id") && lower.includes("not found"));
+}
+
 /** Check if a CodexApiError indicates the model is not supported on the account's plan. */
 export function isModelNotSupportedError(err: CodexLikeError): boolean {
   if (err.status < 400 || err.status >= 500 || err.status === 429) return false;

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -50,6 +50,9 @@ const ROTATABLE_ERROR_CODES: Readonly<Record<string, number>> = {
   forbidden: 403,
   account_banned: 403,
   banned: 403,
+  // 400 — stale previous_response_id (account doesn't recognise it; let
+  // proxy-handler strip the ID and retry on the same account)
+  previous_response_not_found: 400,
 };
 
 function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } | null {

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -26,6 +26,7 @@ import type { ProxyPool } from "../../proxy/proxy-pool.js";
 import { withRetry } from "../../utils/retry.js";
 import { acquireAccount, releaseAccount } from "./account-acquisition.js";
 import { handleCodexApiError, toErrorStatus } from "./proxy-error-handler.js";
+import { isPreviousResponseNotFoundError } from "../../proxy/error-classification.js";
 import { streamResponse } from "./response-processor.js";
 import type { UsageInfo } from "../../translation/codex-event-extractor.js";
 import { parseRateLimitHeaders, rateLimitToQuota, type ParsedRateLimit } from "../../proxy/rate-limit-headers.js";
@@ -251,6 +252,7 @@ export async function handleProxyRequest(
   let codexApi = buildCodexApi(acquired.token, acquired.accountId, cookieJar, entryId, proxyPool);
   const triedEntryIds: string[] = [entryId];
   let modelRetried = false;
+  let prevRespNotFoundRetried = false;
   let usageInfo: UsageInfo | undefined;
   let capturedResponseId: string | null = null;
   const responseFunctionCallIds = new Set<string>();
@@ -480,6 +482,24 @@ export async function handleProxyRequest(
           `[${fmt.tag}] 隐式续链 WebSocket 失败，回退为完整历史重放：${err.causeMessage}`,
         );
         restoreImplicitResumeRequest();
+        continue;
+      }
+
+      // previous_response_id stale (account doesn't recognise it / map lost on
+      // restart / cross-account routing): drop the ID and retry once on the
+      // same account. For implicit-resume requests this also restores the
+      // full input history; for explicit ones the client's own input is sent
+      // verbatim (server-side history is lost but the request still completes).
+      if (!prevRespNotFoundRetried && isPreviousResponseNotFoundError(err)) {
+        prevRespNotFoundRetried = true;
+        const staleId = req.codexRequest.previous_response_id;
+        console.warn(
+          `[${fmt.tag}] Account ${entryId} | previous_response_not_found (id=${staleId ?? "?"}), stripping and retrying same account`,
+        );
+        if (staleId) affinityMap.forget(staleId);
+        restoreImplicitResumeRequest();
+        req.codexRequest.previous_response_id = undefined;
+        req.codexRequest.turnState = undefined;
         continue;
       }
 

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -636,7 +636,91 @@ describe("proxy-handler integration", () => {
     expect(message).toContain("2 rate-limited");
   });
 
-  // 16. 403 ban with mixed pool states → descriptive error
+  // 17. previous_response_not_found: should strip previous_response_id and retry
+  // Reproduces the bug: when upstream returns previous_response_not_found
+  // (because the response was created on a different account or is unknown to
+  // this account), the proxy currently passes the error straight through with
+  // no recovery. Desired behavior: strip previous_response_id and replay.
+  it("recovers from previous_response_not_found by stripping ID and retrying", async () => {
+    const notFoundBody = JSON.stringify({
+      error: {
+        type: "invalid_request_error",
+        code: "previous_response_not_found",
+        message: "Previous response with id 'resp_0e2e6e7917486cfd0069eec8532d988194a3da6379c70abe68' not found.",
+      },
+    });
+
+    let createCount = 0;
+    const seenPrevIds: Array<string | undefined> = [];
+    mockCreateResponse = () => {
+      // The mock-CodexApi instance receives the *current* codexRequest by
+      // reference. We capture the previous_response_id at the moment of call.
+      createCount++;
+      if (createCount === 1) return Promise.reject(new CodexApiError(400, notFoundBody));
+      return Promise.resolve(new Response("data: {}\n\n"));
+    };
+
+    // Wrap createResponse to capture the previous_response_id seen on each call.
+    // (Re-mock CodexApi inline so we can observe the request mutation.)
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const req: ProxyRequest = {
+      ...createDefaultRequest(),
+      codexRequest: {
+        ...createDefaultRequest().codexRequest,
+        previous_response_id: "resp_0e2e6e7917486cfd0069eec8532d988194a3da6379c70abe68",
+      },
+    };
+
+    // Spy: snapshot previous_response_id before the upstream is called.
+    const origMock = mockCreateResponse;
+    mockCreateResponse = () => {
+      seenPrevIds.push(req.codexRequest.previous_response_id);
+      return origMock!();
+    };
+
+    const { app } = buildTestApp({ accountPool, fmt, req });
+    const res = await app.request("/test", { method: "POST" });
+
+    // Desired: proxy retries after stripping previous_response_id, returns 200
+    expect(res.status).toBe(200);
+    // Desired: 2 upstream calls — first with the stale ID, second without it
+    expect(createCount).toBe(2);
+    expect(seenPrevIds[0]).toBe("resp_0e2e6e7917486cfd0069eec8532d988194a3da6379c70abe68");
+    expect(seenPrevIds[1]).toBeUndefined();
+  });
+
+  // 17b. previous_response_not_found loop guard — only retry once
+  it("does not loop forever when previous_response_not_found persists after strip", async () => {
+    const notFoundBody = JSON.stringify({
+      error: { type: "invalid_request_error", code: "previous_response_not_found",
+        message: "Previous response with id 'resp_xxx' not found." },
+    });
+    let createCount = 0;
+    mockCreateResponse = () => {
+      createCount++;
+      return Promise.reject(new CodexApiError(400, notFoundBody));
+    };
+
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const req: ProxyRequest = {
+      ...createDefaultRequest(),
+      codexRequest: {
+        ...createDefaultRequest().codexRequest,
+        previous_response_id: "resp_xxx",
+      },
+    };
+    const { app } = buildTestApp({ accountPool, fmt, req });
+
+    const res = await app.request("/test", { method: "POST" });
+    // After the strip+retry attempt also fails, fall through to generic error
+    expect(res.status).toBe(400);
+    // Exactly 2 upstream calls — strip-retry happens once, no further retries
+    expect(createCount).toBe(2);
+  });
+
+  // 18. 403 ban with mixed pool states → descriptive error
   it("returns descriptive error when banned and remaining accounts disabled/expired", async () => {
     mockCreateResponse = () =>
       Promise.reject(new CodexApiError(403, '{"detail": "Account suspended"}'));

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -121,6 +121,34 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     }
   });
 
+  it("rejects with CodexApiError(400) when first frame is previous_response_not_found", async () => {
+    // The proxy maintains a per-response affinity map in memory. When the map
+    // is lost (process restart, 4h TTL expiry) or a request is forced onto a
+    // different account (rate-limit / ban / quota), the upstream rejects with
+    // `previous_response_not_found`. We treat this as rotatable so the
+    // proxy-handler can strip the stale ID and retry.
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: {
+        code: "previous_response_not_found",
+        message: "Previous response with id 'resp_xxx' not found.",
+      },
+    }));
+
+    try {
+      await promise;
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CodexApiError);
+      expect((err as CodexApiError).status).toBe(400);
+      expect((err as CodexApiError).body).toContain("previous_response_not_found");
+    }
+  });
+
   it("rejects with CodexApiError(402) when first frame is response.failed quota_exhausted", async () => {
     const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
     promise.catch(() => { /* asserted below */ });


### PR DESCRIPTION
## Summary

- 上游返回 `previous_response_not_found`（response 由别的账号创建 / `SessionAffinityMap` 过期或重启丢失 / 跨账号轮转）时，proxy 自动剥掉 `previous_response_id` + `turnState`，在同一账号上重试一次，并把这条 ID 从 affinity map 清掉
- 修复需要两半：先让 WS 首帧错误转成 `CodexApiError` reject（`ws-transport.ts` `ROTATABLE_ERROR_CODES` 增补），再在 catch 里 strip + retry（`proxy-handler.ts`）
- 隐式续链场景通过已有 `restoreImplicitResumeRequest()` 路径回放完整 input，无损恢复；显式续链丢服务端历史但请求仍能完成

## Why

之前这个错误从 chatgpt.com 以 in-stream WS 错误帧到达，不在 `ROTATABLE_ERROR_CODES` 白名单里 → 直接被流式翻译器格式化成 `[Error] previous_response_not_found:` 透传给客户端。proxy-handler 的 catch 块根本没触发。客户端（Codex CLI / Claude Code 等）没法 graceful 处理这个错误，整个对话上下文丢失就挂了。

## Changes

- `src/proxy/error-classification.ts` — 新增 `isPreviousResponseNotFoundError`，按 body code + message 兜底两路识别
- `src/proxy/ws-transport.ts` — `ROTATABLE_ERROR_CODES` 增补 `previous_response_not_found: 400`
- `src/auth/session-affinity.ts` — 新增 `forget(responseId)` 方法
- `src/routes/shared/proxy-handler.ts` — catch 块新增 strip-and-retry，复用 `restoreImplicitResumeRequest()`，loop guard 防死循环
- `tests/unit/proxy/ws-transport-early-error.test.ts` — WS 首帧 `previous_response_not_found` → `CodexApiError(400)`
- `tests/integration/proxy-handler.test.ts` — strip-retry 恢复路径 + loop guard

## Test plan

- [x] `npm test` — 1619 tests pass (143 files)
- [x] `npx tsc --noEmit` — 干净
- [x] **真实 chatgpt.com E2E**：3/3 连续成功恢复
  - 日志证实 `affinity=miss` → `previous_response_not_found` → `stripping and retrying same account` → 200 OK
  - 测试用 Plus 账号通过 `/v1/responses` + 已知 stale `previous_response_id` 触发
- [x] 反向验证：白名单加入前 ws-transport 测试失败、proxy-handler 测试失败 — 加入后通过，证明两半都必需