### PR TITLE
fix: correct Ollama context metadata for GPT-5.5 and GPT-5.4 models

### DIFF
--- a/src/ollama/bridge.ts
+++ b/src/ollama/bridge.ts
@@ -51,8 +51,11 @@ class OllamaBridgeError extends Error {
 }
 
 const CONTEXT_WINDOW_OVERRIDES = new Map<string, number>([
-  ["gpt-5.4", 272000],
-  ["gpt-5.4-mini", 272000],
+  ["gpt-5.5", 400000],
+  ["gpt-5.4", 400000],
+  ["gpt-5.4-pro", 400000],
+  ["gpt-5.4-mini", 400000],
+  ["gpt-5.4-nano", 400000],
   ["gpt-5.3-codex", 272000],
   ["gpt-5.3-codex-spark", 272000],
   ["gpt-5.2", 272000],
@@ -117,6 +120,7 @@ function responseHeaders(init: HeadersInit, request?: Request): Headers {
 
 function inferFamily(modelId: string): string {
   const normalized = modelId.toLowerCase();
+  if (normalized.startsWith("gpt-5.5")) return "gpt-5.5";
   if (normalized.startsWith("gpt-5.4")) return "gpt-5.4";
   if (normalized.startsWith("gpt-5.3")) return "gpt-5.3";
   if (normalized.startsWith("gpt-5.2")) return "gpt-5.2";

--- a/tests/unit/ollama/bridge.test.ts
+++ b/tests/unit/ollama/bridge.test.ts
@@ -105,36 +105,40 @@ describe("Ollama bridge routes", () => {
     expect(body.models[0].digest).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it("returns model show metadata and can suppress vision capability", async () => {
-    fetchMock.mockResolvedValueOnce(json({
-      id: "gpt-5.4-mini",
-      displayName: "GPT 5.4 mini",
-      inputModalities: ["text", "image"],
-      supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
-      defaultReasoningEffort: "medium",
-    }));
-    const app = createApp(true);
+  it.each(["gpt-5.5", "gpt-5.4-mini"])(
+    "returns 400k context metadata for %s and can suppress vision capability",
+    async (model) => {
+      fetchMock.mockResolvedValueOnce(json({
+        id: model,
+        displayName: model,
+        inputModalities: ["text", "image"],
+        supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+        defaultReasoningEffort: "medium",
+      }));
+      const app = createApp(true);
 
-    const res = await app.request("/api/show", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: "gpt-5.4-mini" }),
-    });
+      const res = await app.request("/api/show", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model }),
+      });
 
-    expect(res.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://upstream.test/v1/models/gpt-5.4-mini/info",
-      expect.any(Object),
-    );
-    const body = await res.json() as Record<string, unknown>;
-    expect(body.capabilities).toEqual(["completion", "tools", "thinking"]);
-    expect(body.parameters).toBe("num_ctx 272000\nreasoning medium");
-    expect(body.model_info).toMatchObject({
-      "gpt-5.4.context_length": 272000,
-      upstream_id: "gpt-5.4-mini",
-      input_modalities: ["text", "image"],
+      expect(res.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `http://upstream.test/v1/models/${model}/info`,
+        expect.any(Object),
+      );
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.capabilities).toEqual(["completion", "tools", "thinking"]);
+      expect(body.parameters).toBe("num_ctx 400000\nreasoning medium");
+      const architecture = model.startsWith("gpt-5.4") ? "gpt-5.4" : model;
+      expect(body.model_info).toMatchObject({
+        [`${architecture}.context_length`]: 400000,
+        context_length: 400000,
+        upstream_id: model,
+        input_modalities: ["text", "image"],
+      });
     });
-  });
 
   it("converts non-streaming Ollama chat requests and responses", async () => {
     fetchMock.mockResolvedValueOnce(json({


### PR DESCRIPTION
## Summary

Fixes the Ollama bridge metadata for current GPT-5.5 / GPT-5.4 models so `/api/show` reports a 400k effective context window instead of smaller stale fallback values.

This updates the bridge context override table for:

- `gpt-5.5`
- `gpt-5.4`
- `gpt-5.4-pro`
- `gpt-5.4-mini`
- `gpt-5.4-nano`

It also adds GPT-5.5 family detection so Ollama `model_info` uses `gpt-5.5.context_length` instead of falling back to the generic `gpt.context_length` key.

Fixes #419.

## Why this is hardcoded for now

I checked the current Codex model info endpoint exposed by the proxy (`/v1/models/gpt-5.5/info` and `/v1/models/gpt-5.4/info`). The returned model metadata includes reasoning efforts and modalities, but does not include a context-window field such as `context_window`, `contextLength`, or `context_length`.

Because the upstream model info does not currently provide context length, the Ollama bridge has no dynamic source to sync from. This PR therefore keeps the existing override-table approach and updates that table to the current 400k effective context size for the GPT-5.5 / GPT-5.4 family.

## Root cause

`gpt-5.5` was not present in `CONTEXT_WINDOW_OVERRIDES`, so it fell back to `131072`. GPT-5.4-family entries were still set to `272000`.

## Validation

- `npx vitest run tests/unit/ollama/bridge.test.ts`
- `npx vitest run tests/unit/models/model-store.test.ts tests/unit/ollama/bridge.test.ts`
- `npx vitest run tests/unit`
- `npm run build`