### PR TITLE
chore: switch beta release trigger from dev push to scheduled cron

### DIFF
--- a/.github/workflows/bump-electron-beta.yml
+++ b/.github/workflows/bump-electron-beta.yml
@@ -1,13 +1,10 @@
 name: Bump beta + release (dev)
 
 on:
-  push:
-    branches: [dev]
-    paths-ignore:
-      - "CHANGELOG.md"
-      - "README.md"
-      - "docs/**"
-      - "*.md"
+  schedule:
+    # UTC 04:00 / 12:00 = 北京时间 12:00 / 20:00，每天两次聚合 dev 上的改动
+    # 错开 promote-dev-to-master (14:00 UTC) 和 bump-electron stable (16:00 UTC)
+    - cron: "0 4,12 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- `bump-electron-beta.yml` 触发改为定时 cron（每天 04:00 / 12:00 UTC，北京 12:00 / 20:00），不再随每次 dev push 即时打 beta tag。聚合多个 PR 进同一 beta，避免 beta channel 一天弹多次更新；紧急可手动 `gh workflow run bump-electron-beta.yml`
 - Ollama bridge cleanup（#403 review followups, closes #405 #406 #407）：
   - `src/ollama/bridge.ts` 不再重复实现 `normalizeHostname` / `isLoopbackHostname`，统一从 `src/utils/host.ts` 引入；`shared/utils/host.ts` 改为薄 re-export 以兼容前端的现有 import (#405)
   - `proxyOpenAIRequest` 转发头扩展到 `Content-Type` / `Accept` / `User-Agent` / `X-Request-Id` / `traceparent` / `tracestate`（#403 review #2）；`/v1/*` 路径剥离改用 `path.replace(/^\/v1/, "")` 替代 `slice(3)`


### PR DESCRIPTION
## Summary

- `bump-electron-beta.yml` 触发条件从 `push: branches: [dev]` 改为 `schedule: cron "0 4,12 * * *"`（每天 04:00 / 12:00 UTC，北京 12:00 / 20:00）
- 保留 `workflow_dispatch` 以便紧急手动发 beta
- 同步更新 `CHANGELOG.md`

## Why

每次 dev push 都会打 `vX.Y.Z-beta.SHA` tag → 触发 `release.yml`。最近 `v2.0.66` 之后短时间累积了 5 个 beta tag（每个 PR 一个），beta channel 用户一天能弹多次更新通知。

改成定时聚合后：
- beta 节奏跟 stable bump (cron 16:00 UTC) 模式一致，认知负担低
- 多个 PR 合到同一个 beta，更新通知频率可控
- 不丢任何 commit，只是延后聚合
- cron 时间故意错开 `promote-dev-to-master` (14:00 UTC) 与 `bump-electron` stable (16:00 UTC)

## Test plan

- [ ] CI smoke test 通过（workflow YAML 已用 `js-yaml` 本地验证）
- [ ] PR 合并后等下一个 cron 窗口（最近 04:00 / 12:00 UTC）观察是否成功打 beta tag
- [ ] 验证 `gh workflow run bump-electron-beta.yml` 手动触发仍然工作