### PR TITLE
fix(ci): checkout master in bump-electron.yml

### DIFF
--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: master
 
       - name: Check for new commits since last tag
         id: check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `bump-electron.yml`：checkout 时显式 `ref: master`。default branch 切到 `dev` 之后，schedule 触发的 stable bump 落到 dev 工作树，`git push origin master --follow-tags` 报 `src refspec master does not match any` 连续 fail，stable 卡在 v2.0.66（2026-04-24）补不上来。修复后下一次 16:00 UTC 自动续上
+
 ### Changed
 
 - `bump-electron-beta.yml` 触发改为定时 cron（每天 04:00 / 12:00 UTC，北京 12:00 / 20:00），不再随每次 dev push 即时打 beta tag。聚合多个 PR 进同一 beta，避免 beta channel 一天弹多次更新；紧急可手动 `gh workflow run bump-electron-beta.yml`


### PR DESCRIPTION
## Summary

- `bump-electron.yml` 的 checkout 没指定 ref，schedule 触发时落到 default branch (`dev`) 的工作树
- 脚本最后 `git push origin master --follow-tags` 在 dev worktree 上报 `src refspec master does not match any`
- 自 2026-04-26 起每天 16:00 UTC 跑都失败，stable 停在 v2.0.66
- 显式 `ref: master` 让 checkout 落在 master 上，bump commit + tag 推回 master

## Test plan

- [x] `git diff` 只有一行 `ref: master` + CHANGELOG
- [ ] `gh workflow run bump-electron.yml --ref fix/bump-electron-checkout-master` 跑通，发出 v2.0.67
- [ ] 合并后下一个 16:00 UTC schedule tick 不再 fail