### PR TITLE
feat: implicit resume via effectiveConversationId for chat/gemini routes

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -122,10 +122,11 @@ export function createChatRoutes(
     const fmt = makeOpenAIFormat(wantReasoning);
     const { codexRequest, tupleSchema } = translateToCodexRequest(req);
     const displayModel = buildDisplayModelName(parseModelName(req.model));
-    const proxyReq = {
+    const proxyReq: ProxyRequest = {
       codexRequest,
       model: displayModel,
-      isStreaming: req.stream,
+      isStreaming: req.stream ?? false,
+      clientConversationId: req.user,
       tupleSchema,
     };
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -21,6 +21,7 @@ import {
   handleProxyRequest,
   handleDirectRequest,
   type FormatAdapter,
+  type ProxyRequest,
 } from "./shared/proxy-handler.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
 import { summarizeRequestForLog } from "../logs/request-summary.js";

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -159,10 +159,11 @@ export function createGeminiRoutes(
       `[Gemini] Model: ${geminiModel} → ${codexRequest.model}`,
     );
 
-    const proxyReq = {
+    const proxyReq: ProxyRequest = {
       codexRequest,
       model: geminiModel,
       isStreaming,
+      clientConversationId: c.req.header("x-conversation-id") || c.req.header("x-session-id"),
       tupleSchema,
     };
 

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -25,6 +25,7 @@ import {
   handleProxyRequest,
   handleDirectRequest,
   type FormatAdapter,
+  type ProxyRequest,
 } from "./shared/proxy-handler.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
 

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -222,7 +222,7 @@ export async function handleProxyRequest(
   const continuationInputStart = explicitPrevRespId ? 0 : getContinuationInputStartIndex(req.codexRequest.input);
   const explicitConversationId = explicitPrevRespId ? affinityMap.lookupConversationId(explicitPrevRespId) : null;
   // effectiveConversationId: client explicit ID > content hash derived ID > promptCacheKey
-  const effectiveConversationId = req.clientConversationId ?? derivedConversationId ?? promptCacheKey;
+  const effectiveConversationId = req.clientConversationId || derivedConversationId || promptCacheKey;
   const chainConversationId = explicitConversationId ?? effectiveConversationId;
   const implicitPrevRespId =
     !explicitPrevRespId &&

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -221,12 +221,14 @@ export async function handleProxyRequest(
   const promptCacheKey = derivedConversationId ?? req.clientConversationId ?? crypto.randomUUID();
   const continuationInputStart = explicitPrevRespId ? 0 : getContinuationInputStartIndex(req.codexRequest.input);
   const explicitConversationId = explicitPrevRespId ? affinityMap.lookupConversationId(explicitPrevRespId) : null;
-  const chainConversationId = explicitConversationId ?? req.clientConversationId ?? promptCacheKey;
+  // effectiveConversationId: client explicit ID > content hash derived ID > promptCacheKey
+  const effectiveConversationId = req.clientConversationId ?? derivedConversationId ?? promptCacheKey;
+  const chainConversationId = explicitConversationId ?? effectiveConversationId;
   const implicitPrevRespId =
     !explicitPrevRespId &&
     continuationInputStart > 0 &&
-    req.clientConversationId
-      ? affinityMap.lookupLatestResponseIdByConversationId(req.clientConversationId)
+    effectiveConversationId
+      ? affinityMap.lookupLatestResponseIdByConversationId(effectiveConversationId)
       : null;
   const prevRespId = explicitPrevRespId ?? implicitPrevRespId;
   const implicitStoredInstructions = implicitPrevRespId

--- a/tests/unit/routes/implicit-resume-from-derived-key.test.ts
+++ b/tests/unit/routes/implicit-resume-from-derived-key.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+
+// ── Mocks ───────────────────────────────────────────────
+const mockConfig = {
+  server: { proxy_api_key: null as string | null },
+  model: {
+    default: "gpt-5.3-codex",
+    default_reasoning_effort: null,
+    default_service_tier: null,
+    suppress_desktop_directives: false,
+  },
+  auth: {
+    jwt_token: undefined as string | undefined,
+    rotation_strategy: "least_used" as const,
+    rate_limit_backoff_seconds: 60,
+    request_interval_ms: 0,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-compact"),
+  getConfigDir: vi.fn(() => "/tmp/test-compact-config"),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => "models: []"),
+    writeFileSync: vi.fn(),
+    writeFile: vi.fn((_p: string, _d: string, _e: string, cb: (err: Error | null) => void) => cb(null)),
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+vi.mock("@src/models/model-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@src/models/model-store.js")>();
+  return {
+    ...actual,
+    loadStaticModels: vi.fn(),
+    isRecognizedModelName: vi.fn(() => true),
+    getModelCatalog: vi.fn(() => []),
+  };
+});
+vi.mock("js-yaml", () => ({
+  default: {
+    load: vi.fn(() => ({ models: [], aliases: {} })),
+    dump: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("@src/auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({ exp: Math.floor(Date.now() / 1000) + 3600 })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token}`),
+  extractUserProfile: vi.fn(() => null),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+vi.mock("@src/models/model-fetcher.js", () => ({
+  triggerImmediateRefresh: vi.fn(),
+  startModelRefresh: vi.fn(),
+  stopModelRefresh: vi.fn(),
+}));
+
+vi.mock("@src/utils/retry.js", () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+// Capture upstream requests
+let capturedCodexRequest: any = null;
+
+vi.mock("@src/proxy/codex-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@src/proxy/codex-api.js")>();
+  return {
+    ...actual,
+    CodexApi: vi.fn().mockImplementation(() => ({
+      createResponse: vi.fn(async (req: any) => {
+        capturedCodexRequest = JSON.parse(JSON.stringify(req));
+        return {
+          status: 200,
+          headers: new Headers({ "x-codex-turn-state": "turn-123" }),
+        };
+      }),
+    })),
+  };
+});
+
+// Use global to pass state into hoisted mocks safely
+globalThis.__mockResponseIdCount = 0;
+
+vi.mock("@src/translation/codex-to-openai.js", () => ({
+  streamCodexToOpenAI: vi.fn(),
+  collectCodexResponse: vi.fn(async (_api, _resp, _model, _wantReasoning, _tuple, usageHint, onMetadata) => {
+    (globalThis as any).__mockResponseIdCount++;
+    const id = `resp-${(globalThis as any).__mockResponseIdCount}`;
+    return {
+      response: { id, choices: [{ message: { role: "assistant", content: "ok" } }] },
+      usage: { input_tokens: 10, output_tokens: 5 },
+      responseId: id,
+    };
+  }),
+}));
+
+vi.mock("@src/translation/codex-to-gemini.js", () => ({
+  streamCodexToGemini: vi.fn(),
+  collectCodexToGeminiResponse: vi.fn(async (_api, _resp, _model, _tuple) => {
+    (globalThis as any).__mockResponseIdCount++;
+    const id = `resp-${(globalThis as any).__mockResponseIdCount}`;
+    return {
+      response: { candidates: [{ content: { parts: [{ text: "ok" }] } }] },
+      usage: { input_tokens: 10, output_tokens: 5 },
+      responseId: id,
+    };
+  }),
+}));
+
+
+// No mock for session-affinity.js, we test the real implementation.
+
+// ── Imports ─────────────────────────────────────────────────────────
+import { AccountPool } from "@src/auth/account-pool.js";
+import { createChatRoutes } from "@src/routes/chat.js";
+import { createGeminiRoutes } from "@src/routes/gemini.js";
+import { getSessionAffinityMap } from "@src/auth/session-affinity.js";
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("Implicit Resume from Derived Key", () => {
+  let pool: AccountPool;
+  let chatApp: Hono;
+  let geminiApp: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCodexRequest = null;
+    (globalThis as any).__mockResponseIdCount = 0;
+    delete process.env.CODEX_JWT_TOKEN; // Prevent AccountPool from loading multiple accounts
+    pool = new AccountPool();
+    pool.addAccount("test-token-1");
+    chatApp = createChatRoutes(pool);
+    geminiApp = createGeminiRoutes(pool);
+  });
+
+  afterEach(() => {
+    pool?.destroy();
+    getSessionAffinityMap().dispose();
+  });
+
+  it("Test 1 & 2: Chat endpoint uses derived key and triggers implicit resume on multi-turn", async () => {
+    // Turn 1
+    const t1Input = [{ role: "user", content: "First message" }];
+    const req1 = await chatApp.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: t1Input,
+      }),
+    });
+    
+    expect(capturedCodexRequest).toBeDefined();
+    expect(capturedCodexRequest.previous_response_id).toBeUndefined(); // First turn, no implicit resume
+    const derivedKeyT1 = capturedCodexRequest.prompt_cache_key;
+    expect(derivedKeyT1).toBeDefined();
+    
+    // Turn 2
+    // Client sends the history
+    const t2Input = [
+      ...t1Input,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "Hello again" },
+    ];
+    
+    const req2 = await chatApp.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: t2Input,
+      }),
+    });
+    
+    // T2 should have triggered implicit resume
+    expect(capturedCodexRequest.previous_response_id).toBe("resp-1");
+    expect(capturedCodexRequest.input).toEqual([{ role: "user", content: "Hello again" }]);
+  });
+
+  it("Test 1 & 2b: Chat endpoint uses client session via 'user' field if provided", async () => {
+    const explicitUserId = "client-provided-session-uuid";
+    const req1 = await chatApp.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "Hi" }],
+        user: explicitUserId,
+      }),
+    });
+    expect(req1.status).toBe(200);
+    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
+    
+    // The chainConversationId used for affinity should be the client ID
+    const affinityMap = getSessionAffinityMap();
+    expect(affinityMap.lookupConversationId("resp-1")).toBe(explicitUserId);
+  });
+
+  it("Test 3: Gemini route extracts session ID from headers", async () => {
+    const req1 = await geminiApp.request("/v1beta/models/gemini-1.5-pro:generateContent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-session-id": "gemini-test-session-id",
+      },
+      body: JSON.stringify({
+        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+      }),
+    });
+    expect(req1.status).toBe(200);
+    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
+
+    const affinityMap = getSessionAffinityMap();
+    expect(affinityMap.lookupConversationId("resp-1")).toBe("gemini-test-session-id");
+  });
+
+  it("Test 4: Empty requests do not crash and fallback to random UUID promptCacheKey", async () => {
+    const req1 = await chatApp.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "" }],
+      }),
+    });
+    expect(req1.status).toBe(200);
+
+    // Derived key will be null for empty request, so promptCacheKey will be UUID
+    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
+    expect(capturedCodexRequest.prompt_cache_key.length).toBeGreaterThan(16); // UUID
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `effectiveConversationId` fallback chain (`clientConversationId` → `derivedConversationId` → `promptCacheKey`) in `proxy-handler.ts`.
- Uses `effectiveConversationId` for both `chainConversationId` and the `implicitPrevRespId` lookup condition to ensure seamless implicit resume even without explicit client-provided session IDs.
- Forwards `req.user` from the OpenAI schema as `clientConversationId` in `chat.ts`.
- Extracts `x-conversation-id` and `x-session-id` headers as `clientConversationId` in `gemini.ts`.
- Adds a comprehensive test suite `implicit-resume-from-derived-key.test.ts` to validate multi-turn session affinity logic.

## Test plan
- [x] Run `npx vitest run tests/unit/routes/implicit-resume-from-derived-key.test.ts` (all 4 tests pass)
- [x] Run the full test suite `npx vitest run` (1649 tests pass)