### PR TITLE
fix(translation): hint upstream model to omit empty pages on Read tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Anthropic → Codex 工具 schema 转换：检测到 `name === "Read"` 时，在 `pages` 字段的 description 末尾追加 "Omit this field entirely for non-PDF files; do not pass an empty string."。上游 gpt-5.x 在生成 Read tool_use 时倾向于把可选 string 字段填成 `""` 而非省略，Claude Code harness 把 `pages: ""` 当作"已传入"走到 PDF 分支报错；改 description 是最轻量的引导（不破坏忠实转发原则、对其他工具零影响），幂等可重复调用
 - `bump-electron.yml`：checkout 时显式 `ref: master`。default branch 切到 `dev` 之后，schedule 触发的 stable bump 落到 dev 工作树，`git push origin master --follow-tags` 报 `src refspec master does not match any` 连续 fail，stable 卡在 v2.0.66（2026-04-24）补不上来。修复后下一次 16:00 UTC 自动续上
 
 ### Changed

--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -175,6 +175,29 @@ export function openAIFunctionsToCodex(
 
 // ── Anthropic → Codex ───────────────────────────────────────────
 
+// Upstream models tend to fill optional string fields with `""` rather than
+// omit them. Claude Code's Read tool then routes `pages: ""` into its PDF
+// branch and errors. Nudge the model via the property description.
+const READ_PAGES_HINT =
+  " Omit this field entirely for non-PDF files; do not pass an empty string.";
+
+function augmentReadToolSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isRecord(schema.properties)) return schema;
+  const pages = schema.properties.pages;
+  if (!isRecord(pages)) return schema;
+  const desc = typeof pages.description === "string" ? pages.description : "";
+  if (desc.endsWith(READ_PAGES_HINT)) return schema;
+  return {
+    ...schema,
+    properties: {
+      ...schema.properties,
+      pages: { ...pages, description: desc + READ_PAGES_HINT },
+    },
+  };
+}
+
 export function anthropicToolsToCodex(
   tools: NonNullable<AnthropicMessagesRequest["tools"]>,
   options?: AnthropicToolConversionOptions,
@@ -192,7 +215,10 @@ export function anthropicToolsToCodex(
       name: t.name,
     };
     if (isRecord(t) && typeof t.description === "string") def.description = t.description;
-    if (isRecord(t) && isRecord(t.input_schema)) def.parameters = normalizeSchema(t.input_schema);
+    if (isRecord(t) && isRecord(t.input_schema)) {
+      const schema = t.name === "Read" ? augmentReadToolSchema(t.input_schema) : t.input_schema;
+      def.parameters = normalizeSchema(schema);
+    }
     defs.push(def);
   }
   return defs;

--- a/tests/unit/translation/tool-format.test.ts
+++ b/tests/unit/translation/tool-format.test.ts
@@ -467,6 +467,98 @@ describe("anthropicToolsToCodex additional edge cases", () => {
     expect(result[0].parameters).toEqual({ type: "object", properties: {} });
   });
 });
+// ── Read tool `pages` field hint injection ───────────────────────
+
+describe("anthropicToolsToCodex Read tool pages hint", () => {
+  const baseRead = {
+    name: "Read",
+    description: "Reads a file",
+    input_schema: {
+      type: "object",
+      properties: {
+        file_path: { type: "string", description: "Absolute path" },
+        pages: { type: "string", description: "Page range for PDF files." },
+      },
+      required: ["file_path"],
+    },
+  };
+
+  it("appends omit-when-empty hint to Read tool's pages description", () => {
+    const result = anthropicToolsToCodex([baseRead]);
+    const params = result[0].parameters as {
+      properties: { pages: { description: string } };
+    };
+    expect(params.properties.pages.description).toBe(
+      "Page range for PDF files. Omit this field entirely for non-PDF files; do not pass an empty string.",
+    );
+  });
+
+  it("is idempotent when conversion is applied twice", () => {
+    const once = anthropicToolsToCodex([baseRead])[0].parameters as {
+      properties: { pages: { description: string } };
+    };
+    const twice = anthropicToolsToCodex([
+      {
+        name: "Read",
+        input_schema: {
+          type: "object",
+          properties: {
+            pages: { type: "string", description: once.properties.pages.description },
+          },
+        },
+      },
+    ])[0].parameters as { properties: { pages: { description: string } } };
+    expect(twice.properties.pages.description).toBe(once.properties.pages.description);
+  });
+
+  it("does not modify non-Read tools that happen to have a pages field", () => {
+    const result = anthropicToolsToCodex([
+      {
+        name: "OtherTool",
+        input_schema: {
+          type: "object",
+          properties: {
+            pages: { type: "string", description: "Some pages thing" },
+          },
+        },
+      },
+    ]);
+    const params = result[0].parameters as {
+      properties: { pages: { description: string } };
+    };
+    expect(params.properties.pages.description).toBe("Some pages thing");
+  });
+
+  it("leaves Read tool alone when pages property is absent", () => {
+    const result = anthropicToolsToCodex([
+      {
+        name: "Read",
+        input_schema: {
+          type: "object",
+          properties: { file_path: { type: "string" } },
+          required: ["file_path"],
+        },
+      },
+    ]);
+    const params = result[0].parameters as {
+      properties: Record<string, unknown>;
+    };
+    expect(params.properties).not.toHaveProperty("pages");
+  });
+
+  it("preserves other fields when augmenting", () => {
+    const result = anthropicToolsToCodex([baseRead]);
+    const params = result[0].parameters as {
+      type: string;
+      required: string[];
+      properties: { file_path: { description: string }; pages: unknown };
+    };
+    expect(params.type).toBe("object");
+    expect(params.required).toEqual(["file_path"]);
+    expect(params.properties.file_path.description).toBe("Absolute path");
+  });
+});
+
 // ── hosted web_search tool conversion ───────────────────────────────
 
 describe("hosted web_search tool conversion", () => {


### PR DESCRIPTION
## Summary

Upstream gpt-5.x tends to fill optional string fields with `""` rather than
omit them. For Claude Code's `Read` tool, that means `pages: ""` even on
non-PDF files — the harness then routes the empty string through the PDF
branch and errors out.

The proxy is otherwise pass-through for tool_use arguments, so the cleanest
nudge is to append a one-line hint to the `pages` property's description in
the schema we forward upstream. The model reads property descriptions when
deciding whether to fill a field; this is the cheapest, least invasive fix.

## Changes

- `src/translation/tool-format.ts` — new `augmentReadToolSchema` helper, called from `anthropicToolsToCodex` only when `name === "Read"`. Appends `" Omit this field entirely for non-PDF files; do not pass an empty string."` to the `pages` property description. Idempotent (won't double-append on multi-turn replays). Zero impact on other tools.
- `tests/unit/translation/tool-format.test.ts` — 5 new specs covering the augmentation, idempotency, non-Read isolation, schema with no `pages` field, and preservation of sibling fields.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry.

## Test Plan

- [x] `npx vitest run tests/unit/translation/tool-format.test.ts` — 60/60 pass
- [x] `npx vitest run` — 1654 pass, 1 skipped, 145 files
- [x] `npx tsc --noEmit` — clean

## Notes

- The test file's diff stat looks bigger than the real change because the file in HEAD has mixed CRLF/LF line endings (460 CRLF + 224 LF) — pre-existing project mess. Use `git diff --ignore-cr-at-eol tests/unit/translation/tool-format.test.ts` to see the actual delta is +93 LOC. Happy to follow up with a separate normalization PR if desired.
- This is a temporary nudge until the underlying fix happens at the harness side (treat `pages === ""` as unset). I can also file an issue against `anthropics/claude-code` if helpful.