### PR TITLE
fix(self-update): guard against non-master branch and dirty tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Self-update 双重安全护栏（`src/self-update.ts`）：`applyProxySelfUpdate` 之前会无条件 `git checkout -- .` + `git pull origin master`，导致 ① 工作目录任何未提交改动被静默丢弃；② 在 `dev` 等非 master 分支上把 master 合进来，破坏 dev→master promote 流程。本地 dev 服跑着的时候每次 tsx watch 重启都会触发：新进程启动 → 10s 后 update check → `auto_update: true` → 把开发者刚保存的代码当垃圾扫掉。修复：进入 `applyProxySelfUpdate` 先校验 ① 当前分支必须是 `master`/`main`，② `git status --porcelain` 必须为空；任一失败立刻 abort 并返回错误，**不再调用** `git checkout -- .`
 - Anthropic → Codex 工具 schema 转换：检测到 `name === "Read"` 时，在 `pages` 字段的 description 末尾追加 "Omit this field entirely for non-PDF files; do not pass an empty string."。上游 gpt-5.x 在生成 Read tool_use 时倾向于把可选 string 字段填成 `""` 而非省略，Claude Code harness 把 `pages: ""` 当作"已传入"走到 PDF 分支报错；改 description 是最轻量的引导（不破坏忠实转发原则、对其他工具零影响），幂等可重复调用
 - `bump-electron.yml`：checkout 时显式 `ref: master`。default branch 切到 `dev` 之后，schedule 触发的 stable bump 落到 dev 工作树，`git push origin master --follow-tags` 报 `src refspec master does not match any` 连续 fail，stable 卡在 v2.0.66（2026-04-24）补不上来。修复后下一次 16:00 UTC 自动续上
 

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -453,9 +453,35 @@ export async function applyProxySelfUpdate(
   const report = onProgress ?? (() => {});
 
   try {
+    // Safety: refuse to auto-update on a non-master branch. Pulling master
+    // into dev (or any other branch) corrupts the branch model and breaks
+    // the dev→master promote workflow.
+    const { stdout: branchOut } = await execFileAsync(
+      "git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 },
+    );
+    const currentBranch = branchOut.trim();
+    if (currentBranch !== "master" && currentBranch !== "main") {
+      _proxyUpdateInProgress = false;
+      const msg = `Refusing to auto-update on branch '${currentBranch}' — only master/main are eligible. Switch branches or update manually.`;
+      console.warn(`[SelfUpdate] ${msg}`);
+      return { started: false, error: msg };
+    }
+
+    // Safety: refuse to overwrite uncommitted local changes. The previous
+    // implementation ran `git checkout -- .` which silently discarded them;
+    // that destroyed in-flight edits whenever the dev server restarted.
+    const { stdout: statusOut } = await execFileAsync(
+      "git", ["status", "--porcelain"], { cwd, timeout: 5000 },
+    );
+    if (statusOut.trim()) {
+      _proxyUpdateInProgress = false;
+      const msg = "Refusing to auto-update with uncommitted changes in working tree. Commit, stash, or discard them first.";
+      console.warn(`[SelfUpdate] ${msg}`);
+      return { started: false, error: msg };
+    }
+
     report("pull", "running");
     console.log("[SelfUpdate] Pulling latest code...");
-    await execFileAsync("git", ["checkout", "--", "."], { cwd, timeout: 10000 }).catch(() => {});
     await execFileAsync("git", ["pull", "origin", "master"], { cwd, timeout: 60000 });
     report("pull", "done");
 

--- a/tests/e2e/self-update.test.ts
+++ b/tests/e2e/self-update.test.ts
@@ -357,7 +357,11 @@ describe("E2E: self-update routes", () => {
 
   describe("POST /admin/apply-update", () => {
     it("streams SSE progress: pull → install → build → restart", async () => {
-      _execFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+      _execFileAsync.mockReset();
+      _execFileAsync
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" }) // branch
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })          // clean tree
+        .mockResolvedValue({ stdout: "", stderr: "" });
 
       const app = await buildApp();
       const res = await app.request("/admin/apply-update", { method: "POST" });
@@ -387,9 +391,11 @@ describe("E2E: self-update routes", () => {
     });
 
     it("reports error when git pull fails", async () => {
+      _execFileAsync.mockReset();
       _execFileAsync
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })    // git checkout -- .
-        .mockRejectedValueOnce(new Error("git pull failed")); // git pull
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" }) // branch
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })          // clean tree
+        .mockRejectedValueOnce(new Error("git pull failed"));       // git pull
 
       const app = await buildApp();
       const res = await app.request("/admin/apply-update", { method: "POST" });
@@ -403,10 +409,12 @@ describe("E2E: self-update routes", () => {
     });
 
     it("reports error when npm install fails", async () => {
+      _execFileAsync.mockReset();
       _execFileAsync
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })        // git checkout
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })        // git pull
-        .mockRejectedValueOnce(new Error("npm ERR! ERESOLVE"));   // npm install
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" }) // branch
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })          // clean tree
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })          // git pull
+        .mockRejectedValueOnce(new Error("npm ERR! ERESOLVE"));     // npm install
 
       const app = await buildApp();
       const res = await app.request("/admin/apply-update", { method: "POST" });
@@ -425,11 +433,13 @@ describe("E2E: self-update routes", () => {
     });
 
     it("reports error when build fails", async () => {
+      _execFileAsync.mockReset();
       _execFileAsync
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })             // git checkout
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })             // git pull
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })             // npm install
-        .mockRejectedValueOnce(new Error("tsc: error TS2345"));        // npm run build
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" })     // branch
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })              // clean tree
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })              // git pull
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })              // npm install
+        .mockRejectedValueOnce(new Error("tsc: error TS2345"));         // npm run build
 
       const app = await buildApp();
       const res = await app.request("/admin/apply-update", { method: "POST" });
@@ -450,7 +460,11 @@ describe("E2E: self-update routes", () => {
       _spawn.mockClear();
       exitSpy.mockClear();
 
-      _execFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+      _execFileAsync.mockReset();
+      _execFileAsync
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" })
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
+        .mockResolvedValue({ stdout: "", stderr: "" });
 
       const app = await buildApp();
       await app.request("/admin/apply-update", { method: "POST" });

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -354,24 +354,78 @@ describe("self-update", () => {
   // ── applyProxySelfUpdate ──────────────────────────────────────────
 
   describe("applyProxySelfUpdate", () => {
-    it("runs git checkout + git pull + npm install + npm run build", async () => {
-      _execFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+    // Default mock for the happy path: branch=master, clean tree, then any
+    // subsequent git/npm calls succeed silently.
+    function mockCleanMaster(): void {
+      _execFileAsync.mockReset();
+      _execFileAsync
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" }) // rev-parse --abbrev-ref HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })          // status --porcelain
+        .mockResolvedValue({ stdout: "", stderr: "" });             // remaining steps
+    }
+
+    it("runs git pull + npm install + npm run build on clean master", async () => {
+      mockCleanMaster();
 
       const { applyProxySelfUpdate } = await importFresh();
       const result = await applyProxySelfUpdate();
       expect(result.started).toBe(true);
       expect(result.error).toBeUndefined();
 
-      // 4 sequential calls: git checkout -- ., git pull, npm install, npm run build
-      expect(_execFileAsync).toHaveBeenCalledTimes(4);
+      // 5 sequential calls: rev-parse, status, git pull, npm install, npm run build
+      expect(_execFileAsync).toHaveBeenCalledTimes(5);
+      // Critically: no `git checkout -- .` should be invoked
+      const checkoutCalls = _execFileAsync.mock.calls.filter(
+        (c) => c[0] === "git" && Array.isArray(c[1]) && c[1][0] === "checkout",
+      );
+      expect(checkoutCalls).toHaveLength(0);
     });
 
-    it("returns error when step fails", async () => {
-      // First call is "git checkout -- ." which has .catch(() => {}), so it swallows errors.
-      // Reject the second call (git pull) to trigger the error path.
+    it("refuses to update when on a non-master branch", async () => {
+      _execFileAsync.mockReset();
+      _execFileAsync.mockResolvedValueOnce({ stdout: "dev\n", stderr: "" }); // branch=dev
+
+      const { applyProxySelfUpdate } = await importFresh();
+      const result = await applyProxySelfUpdate();
+      expect(result.started).toBe(false);
+      expect(result.error).toContain("dev");
+      expect(result.error).toContain("master/main");
+      // Only the branch check should have run — no destructive ops attempted
+      expect(_execFileAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts 'main' as well as 'master'", async () => {
+      _execFileAsync.mockReset();
       _execFileAsync
-        .mockResolvedValueOnce({ stdout: "", stderr: "" })   // git checkout -- .
-        .mockRejectedValueOnce(new Error("git pull failed")); // git pull
+        .mockResolvedValueOnce({ stdout: "main\n", stderr: "" }) // branch=main
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })        // clean tree
+        .mockResolvedValue({ stdout: "", stderr: "" });
+
+      const { applyProxySelfUpdate } = await importFresh();
+      const result = await applyProxySelfUpdate();
+      expect(result.started).toBe(true);
+    });
+
+    it("refuses to update when working tree has uncommitted changes", async () => {
+      _execFileAsync.mockReset();
+      _execFileAsync
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" })          // branch=master
+        .mockResolvedValueOnce({ stdout: " M src/foo.ts\n", stderr: "" });  // dirty
+
+      const { applyProxySelfUpdate } = await importFresh();
+      const result = await applyProxySelfUpdate();
+      expect(result.started).toBe(false);
+      expect(result.error).toContain("uncommitted changes");
+      // Branch + status checks only — no pull attempted
+      expect(_execFileAsync).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns error when git pull fails", async () => {
+      _execFileAsync.mockReset();
+      _execFileAsync
+        .mockResolvedValueOnce({ stdout: "master\n", stderr: "" })
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
+        .mockRejectedValueOnce(new Error("git pull failed"));
 
       const { applyProxySelfUpdate } = await importFresh();
       const result = await applyProxySelfUpdate();
@@ -380,27 +434,24 @@ describe("self-update", () => {
     });
 
     it("returns error when already in progress", async () => {
-      // Make first call hang
+      // Make the first call (rev-parse) hang so the in-progress guard trips.
       let resolveFirst: (() => void) | undefined;
       _execFileAsync.mockImplementationOnce(
         () => new Promise<{ stdout: string; stderr: string }>((resolve) => {
-          resolveFirst = () => resolve({ stdout: "", stderr: "" });
+          resolveFirst = () => resolve({ stdout: "master\n", stderr: "" });
         }),
       );
 
       const { applyProxySelfUpdate } = await importFresh();
 
-      // Start first update (will hang on git pull)
       const first = applyProxySelfUpdate();
-
-      // Second call while first is in progress
       const second = await applyProxySelfUpdate();
       expect(second.started).toBe(false);
       expect(second.error).toContain("already in progress");
 
-      // Cleanup: resolve the hanging promise
+      // Resolving the hung call doesn't matter for this assertion — cleanup
       resolveFirst?.();
-      await first;
+      await first.catch(() => {});
     });
   });
 });


### PR DESCRIPTION
## Summary

`applyProxySelfUpdate` 之前会无条件 `git checkout -- .` + `git pull origin master`。两个真实后果：dev 服跑着改代码时，tsx watch 每次重启触发 10s update check，开发者刚保存的改动会在 ~12s 内被 `git checkout -- .` 静默吞掉；并且即使在 `dev` 等非 master 分支上也照样把 master 合进来，破坏 dev→master promote 流程。本 PR 加双重护栏 + 移除危险的 checkout 调用。

## Changes

- `src/self-update.ts`：`applyProxySelfUpdate` 进入即先校验
  - 当前分支必须是 `master` / `main`，否则 abort 返回错误
  - `git status --porcelain` 必须为空，否则 abort 返回错误
  - **删除** 原本的 `git checkout -- .`；干净 master 上的 `git pull` 已足够
- `tests/unit/self-update.test.ts`：4 条新 case（干净 master 走完整流程并断言无 checkout 调用、dev 分支被拒、main 分支被接受、脏树被拒）
- `tests/e2e/self-update.test.ts`：5 条 mock 序列改为 `[branch, status, ...]` 适配新调用顺序
- `CHANGELOG.md`：`[Unreleased] → Fixed` 第一条

## Test Plan

- [x] `npx vitest run tests/unit/self-update.test.ts` — 28 通过
- [x] `npx vitest run tests/e2e/self-update.test.ts` — 15 通过 + 1 skipped
- [x] `npm test` — 1657 通过 + 1 skipped
- [x] `npx tsc --noEmit` — 无报错
- [x] pre-push hook — 通过

## Notes

发现路径有点意思：起初是排查"开 dev server 改代码会被神秘覆盖"，靠 `sudo fs_usage` 抓到 `git.<pid>` 在写源码文件，回溯到 `src/self-update.ts:458` 的 `git checkout -- .`。所有跑在 dev 分支并启用 `auto_update: true` 的开发者都会中招。