### PR TITLE
feat(proxy): WebSocket connection pool fixes prompt-cache hit-rate jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@
 - Usage history `five_min` granularity（5 分钟桶）+ Dashboard 新增「5 min」粒度选项与「Last 1h / 6h」时间窗：snapshot 默认 5 分钟一记，新粒度等同于一桶一快照，方便排查刚发生的请求；旧的 hourly/daily 不变，按 granularity 自动收敛兼容窗口（`src/auth/usage-stats.ts`、`src/routes/admin/usage-stats.ts`、`shared/hooks/use-usage-stats.ts`、`web/src/pages/UsageStats.tsx`）
 - 共享纯函数 `formatHitRate` / `sumWindow` / `formatUsageNumber` 抽到 `shared/utils/usage-stats.ts`，配套 vitest 单测覆盖边界（input=0 → "—"、<0.01% 截断、windowed 求和等），UsageChart 与 UsageStats 复用同一份格式化逻辑（`shared/utils/usage-stats.ts`、`shared/utils/__tests__/usage-stats.test.ts`）
 
+### Fixed
+
+- **WebSocket 连接池**（`src/proxy/ws-pool.ts` + `src/proxy/ws-transport.ts` + `src/routes/shared/proxy-handler.ts`）：上游 chatgpt.com 的 WS gateway 按"连接 ID"做负载均衡 hash，过去 codex-proxy 对每个 WS 请求都 `new WebSocket(url)`，导致同一会话同一账号的 prompt cache 命中率在 5%~99% 之间剧烈抖动（同一逻辑会话被路由到不同 backend，每个 backend 各自缓存了不同长度的前缀；实测 cached_tokens 反复出现 1920/2432/24448/40320/47488 等离散"checkpoint"）。引入 per-`(entryId, conversationId)` 的持久 WS 连接池：
+  - 单 WS 上 strict request/response 串行（codex 协议要求），busy 时旁路开新一次性 WS 而非排队（避免死锁）
+  - 无 idle TTL，连接保持开放直到自然死亡 / `max_age_ms`（默认 55 min，留 5 min 缓冲，比 server 60 min 硬限制提前关）/ 账号状态变化（`evictByEntryId`）级联清理
+  - 复用失败（pre-response close）抛 `WsReusedConnectionError`，自动单次 fallback 到一次性新连接；流中段失败保持原语义抛给客户端（不重试，client 已收到部分数据）
+  - account-pool 在 `markRateLimited` / `markStatus(non-active)` / `removeAccount` / `updateToken`（refresh 完成）时级联 `evictByEntryId`，避免老 WS 携带的 access_token 被复用
+  - 新增配置 `ws_pool: { enabled: true, max_age_ms: 3300000, max_per_account: 8 }`；可 `enabled: false` + 重启回滚到旧行为
+  - SIGTERM/SIGINT 进程退出钩子追加 `wsPool.shutdown()` 优雅关闭所有池中连接
+  - 入口日志加 `ws=reuse:<id>` / `ws=new:<id>` / `ws=bypass(<reason>)` / `ws=retry-after-stale-reuse:<id>` 字段，配合 `rid` 可对照 cache 命中率
+  - 集成测：`tests/integration/ws-pool-reuse.test.ts` 起本地 `ws.Server` 验证 5 turn 同会话只触发 1 次 `connection`
+
 ### Changed
 
 - `src/routes/shared/proxy-handler.ts` 入口与 Usage 日志补充诊断字段：入口行新增 `rid` / `conv` / `key` / `prev=<src>:<tail8>` / `tools=N` / `resume=on|off:<reason>`（reason 含 `no_pref_entry`/`acct_mismatch`/`instr_diff`/`missing_tool_calls`/`cont_start_eq_len`），Usage 行带 `rid` 与 `hit=X.X%`，便于对照 prompt-cache 命中率为何偏低、或同一会话请求是否落到同一 cache key

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -114,11 +114,30 @@ export class AccountPool {
 
   removeAccount(id: string): boolean {
     this.lifecycle.clearLock(id);
+    this.evictWsPool(id);
     return this.registry.removeAccount(id);
   }
 
   updateToken(entryId: string, newToken: string, refreshToken?: string): void {
     this.registry.updateToken(entryId, newToken, refreshToken);
+    // The new access_token doesn't take effect on already-open WebSocket
+    // sessions (the upstream auth header is captured at handshake), so any
+    // pooled WS for this entry is now using a stale credential. Evict so the
+    // next request opens a fresh WS with the refreshed token.
+    this.evictWsPool(entryId);
+  }
+
+  /** Drop any pooled WebSocket connections for `entryId`. Used by status
+   *  mutations and token refresh to prevent in-flight reuse from carrying
+   *  stale auth or routing into a backend the account is no longer welcome
+   *  on. Lazy-imports ws-pool so this module doesn't pull the proxy layer
+   *  into bootstrap when the pool isn't otherwise reachable. */
+  private evictWsPool(entryId: string): void {
+    // Avoid hard import: account-pool is also exercised in unit tests that
+    // never touch the WS layer, and dynamic resolution keeps that contract.
+    void import("../proxy/ws-pool.js")
+      .then((mod) => mod.getWsPool().evictByEntryId(entryId))
+      .catch(() => { /* pool unavailable in this build/test context — ignore */ });
   }
 
   setLabel(entryId: string, label: string | null): boolean {
@@ -135,6 +154,10 @@ export class AccountPool {
   markStatus(entryId: string, status: AccountEntry["status"]): void {
     if (this.registry.markStatus(entryId, status)) {
       this.lifecycle.clearLock(entryId);
+      // Status transitions to expired/banned/disabled make the account
+      // unusable; reusing a pooled WS would just hit the same wall on the
+      // upstream side. Evict so the pool doesn't hold a doomed connection.
+      if (status !== "active") this.evictWsPool(entryId);
     }
     if (status === "expired" && this._onExpired) {
       this._onExpired(entryId);
@@ -147,6 +170,7 @@ export class AccountPool {
   ): void {
     if (this.registry.markRateLimited(entryId, this.rateLimitBackoffSeconds, options)) {
       this.lifecycle.clearLock(entryId);
+      this.evictWsPool(entryId);
     }
   }
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -72,6 +72,18 @@ export const ConfigSchema = z.object({
     auto_download: z.boolean().default(false),
     allow_prerelease: z.boolean().default(false),
   }).default({}),
+  /** WebSocket connection pool — pins same (entryId, conversationId) to the
+   *  same physical WS so the upstream LB keeps prompt cache warm across
+   *  turns. See `src/proxy/ws-pool.ts` for the rationale. */
+  ws_pool: z.object({
+    enabled: z.boolean().default(true),
+    /** Hard upper bound per connection. Server enforces a 60-min cap; we
+     *  close 5 min early to avoid disrupting in-flight requests. */
+    max_age_ms: z.number().int().positive().default(3_300_000),
+    /** Cap on concurrent pooled connections per account, to bound memory
+     *  when a user opens many parallel conversations. */
+    max_per_account: z.number().int().positive().default(8),
+  }).default({}),
   ollama: z.object({
     enabled: z.boolean().default(false),
     host: z.string().default("127.0.0.1"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,8 +299,14 @@ async function main() {
     }, 10_000);
     if (forceExit.unref) forceExit.unref();
 
-    handle.close().then(() => {
+    handle.close().then(async () => {
       getTransport().destroy?.();
+      // Close any pooled WS connections (lazy import to avoid pulling the
+      // proxy layer into bootstrap when ws-pool is unused).
+      try {
+        const { getWsPool } = await import("./proxy/ws-pool.js");
+        await getWsPool().shutdown();
+      } catch { /* pool not initialised — nothing to drain */ }
       console.log("[Shutdown] Server closed, cleanup complete.");
       clearTimeout(forceExit);
       process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { createModelRoutes } from "./routes/models.js";
 import { createWebRoutes } from "./routes/web.js";
 import { CookieJar } from "./proxy/cookie-jar.js";
 import { ProxyPool } from "./proxy/proxy-pool.js";
+import { setWsPoolConfig, getWsPool } from "./proxy/ws-pool.js";
 import { createProxyRoutes } from "./routes/proxies.js";
 import { createResponsesRoutes } from "./routes/responses.js";
 import { startUpdateChecker, stopUpdateChecker } from "./update-checker.js";
@@ -110,6 +111,15 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
 
   // Build upstream router from config
   const cfg = getConfig();
+
+  // Wire WS connection pool to user config (defaults to enabled). Without
+  // this call `getWsPool()` would always use DEFAULT_WS_POOL_CONFIG and
+  // ignore `ws_pool.enabled: false` overrides — breaking the rollback path.
+  setWsPoolConfig({
+    enabled: cfg.ws_pool.enabled,
+    maxAgeMs: cfg.ws_pool.max_age_ms,
+    maxPerAccount: cfg.ws_pool.max_per_account,
+  });
   const adapters = new Map<string, UpstreamAdapter>();
   if (cfg.providers.openai) {
     adapters.set(
@@ -301,12 +311,9 @@ async function main() {
 
     handle.close().then(async () => {
       getTransport().destroy?.();
-      // Close any pooled WS connections (lazy import to avoid pulling the
-      // proxy layer into bootstrap when ws-pool is unused).
       try {
-        const { getWsPool } = await import("./proxy/ws-pool.js");
         await getWsPool().shutdown();
-      } catch { /* pool not initialised — nothing to drain */ }
+      } catch { /* never throws today, but defend against future regressions */ }
       console.log("[Shutdown] Server closed, cleanup complete.");
       clearTimeout(forceExit);
       process.exit(0);

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -15,9 +15,11 @@ import {
   buildHeaders,
   buildHeadersWithContentType,
 } from "../fingerprint/manager.js";
-import { createWebSocketResponse, type WsCreateRequest } from "./ws-transport.js";
+import { createWebSocketResponse, type WsCreateRequest, type WsPoolContext } from "./ws-transport.js";
 import type { ParsedRateLimit } from "./rate-limit-headers.js";
 import { getInstallationId } from "./installation-id.js";
+
+export type { WsPoolContext };
 import { parseSSEBlock, parseSSEStream } from "./codex-sse.js";
 import { fetchUsage } from "./codex-usage.js";
 import { fetchModels, probeEndpoint as probeEndpointFn } from "./codex-models.js";
@@ -175,10 +177,11 @@ export class CodexApi {
     request: CodexResponsesRequest,
     signal?: AbortSignal,
     onRateLimits?: (rl: ParsedRateLimit) => void,
+    poolCtx?: WsPoolContext,
   ): Promise<Response> {
     if (request.useWebSocket) {
       try {
-        return await this.createResponseViaWebSocket(request, signal, onRateLimits);
+        return await this.createResponseViaWebSocket(request, signal, onRateLimits, poolCtx);
       } catch (err) {
         // Real upstream API errors classified by ws-transport (e.g.
         // usage_limit_reached → CodexApiError(429)) must reach the
@@ -211,6 +214,7 @@ export class CodexApi {
     request: CodexResponsesRequest,
     signal?: AbortSignal,
     onRateLimits?: (rl: ParsedRateLimit) => void,
+    poolCtx?: WsPoolContext,
   ): Promise<Response> {
     const baseUrl = this.resolveBaseUrl();
     const wsUrl = baseUrl.replace(/^https?:/, "wss:") + "/codex/responses";
@@ -246,7 +250,7 @@ export class CodexApi {
       "x-codex-installation-id": installationId,
     };
 
-    return createWebSocketResponse(wsUrl, headers, wsRequest, signal, this.proxyUrl, onRateLimits);
+    return createWebSocketResponse(wsUrl, headers, wsRequest, signal, this.proxyUrl, onRateLimits, poolCtx);
   }
 
   /**

--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -1,0 +1,666 @@
+/**
+ * WebSocket connection pool for upstream Codex Responses API.
+ *
+ * ## Why
+ *
+ * OpenAI's WebSocket gateway routes each new connection to a backend instance
+ * via load-balancer hashing of the connection ID. Within a connection, all
+ * requests stay on the same backend, which keeps the prompt cache warm.
+ * Across connections, the LB ignores `prompt_cache_key`, `previous_response_id`,
+ * and `x-codex-installation-id` as routing hints — so re-opening a fresh WS
+ * for every turn (which the proxy used to do) randomly bounces between
+ * backend instances and produces erratic 5%~99% cache hit rates.
+ *
+ * Real Codex CLI sidesteps this by maintaining `WebsocketSession.connection`
+ * (codex-rs `core/src/client.rs:802`) and reusing it across turns until the
+ * server-side 60-minute connection cap kicks in.
+ *
+ * This pool replicates that behavior: pin same `(entryId, conversationId)`
+ * to the same physical WS for all turns, so the upstream LB pins us to the
+ * same backend and prompt cache stays warm.
+ *
+ * ## Design
+ *
+ * - **Pool key**: `${entryId}:${conversationId}` — both stable across turns
+ *   (entryId from `account-persistence.ts:57`, conversationId from
+ *   `proxy-handler.ts:226`). Empty conversationId → don't pool.
+ * - **Per-WS strict serial**: Codex protocol requires one in-flight at a
+ *   time per WS (mirrors codex-rs's `last_response_rx` pattern). Pool busy
+ *   → caller bypasses to `openOneShotWs` (no internal queue, no deadlock).
+ * - **No idle TTL**: kept open until natural death (server close / TCP RST →
+ *   immediate evict), `max_age_ms` (55 min, leaves 5 min margin under the
+ *   server's 60 min hard cap), or account state change (refresh / banned /
+ *   disabled / rate-limited → cascade evict via `evictByEntryId`).
+ * - **Account slot decoupled**: WS lifecycle is independent of the
+ *   account-pool acquire/release slot. `proxy-handler` releases the slot
+ *   when the stream finishes; the WS stays in the pool for the next turn.
+ *
+ * ## Failure semantics
+ *
+ * - WS dies **before** first response frame on a reused connection →
+ *   `WsReusedConnectionError` (caller may retry once with a fresh WS).
+ * - WS dies **after** the first frame (mid-stream RST) → `controller.error()`
+ *   on the live ReadableStream. Cannot retry — the client already saw
+ *   partial data, must propagate the error.
+ * - Caller `AbortSignal.abort()` → reject current send + immediately evict
+ *   the WS (server may continue pushing tail frames that would corrupt the
+ *   next reuser).
+ */
+
+import type { ParsedRateLimit } from "./rate-limit-headers.js";
+import { parseRateLimitsEvent } from "./rate-limit-headers.js";
+import { CodexApiError } from "./codex-types.js";
+import type { WsCreateRequest } from "./ws-transport.js";
+import { randomUUID } from "crypto";
+
+// ── Error types ────────────────────────────────────────────────────
+
+/** Thrown when a *reused* pooled WS dies before producing the first response
+ *  frame. The caller should retry once with a fresh non-pooled connection,
+ *  since the failure was caused by stale state on the reused connection
+ *  rather than by a real upstream/account issue. */
+export class WsReusedConnectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WsReusedConnectionError";
+  }
+}
+
+// ── Internal types ─────────────────────────────────────────────────
+
+interface InFlightSession {
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  onRateLimits: ((rl: ParsedRateLimit) => void) | undefined;
+  earlyDecisionMade: boolean;
+  /** Resolves the outer send() Promise with the SSE Response.
+   *  Closes over the freshly-built ReadableStream so callers don't need to
+   *  pass it back in. */
+  resolveResponse: () => void;
+  reject: (err: Error) => void;
+  abortListener: (() => void) | null;
+  signal: AbortSignal | undefined;
+  streamClosed: boolean;
+}
+
+/** Subset of the `ws` module's WebSocket interface that PersistentWs needs.
+ *  Declared here to avoid pulling in the `ws` typedefs at module load (it's
+ *  lazy-loaded). Real ws.WebSocket is structurally compatible. */
+export interface WsLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: "open", listener: () => void): void;
+  on(event: "message", listener: (data: Buffer | string) => void): void;
+  on(event: "upgrade", listener: (response: { headers: Record<string, string | string[]> }) => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): void;
+}
+
+const WS_OPEN = 1;
+
+// Same allowlist as ws-transport.ts. Duplicated here intentionally so the
+// pool module doesn't depend on the transport's internals (and vice versa).
+const ROTATABLE_ERROR_CODES: Readonly<Record<string, number>> = {
+  usage_limit_reached: 429,
+  rate_limit_exceeded: 429,
+  rate_limit_reached: 429,
+  quota_exhausted: 402,
+  payment_required: 402,
+  unauthorized: 401,
+  token_invalid: 401,
+  token_expired: 401,
+  account_deactivated: 401,
+  forbidden: 403,
+  account_banned: 403,
+  banned: 403,
+  previous_response_not_found: 400,
+  websocket_connection_limit_reached: 503,
+};
+
+function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number; code: string } | null {
+  const type = typeof msg.type === "string" ? msg.type : "";
+  if (type !== "error" && type !== "response.failed") return null;
+  const errorObj = typeof msg.error === "object" && msg.error !== null
+    ? (msg.error as Record<string, unknown>)
+    : null;
+  if (!errorObj) return null;
+  const codeRaw =
+    (typeof errorObj.code === "string" ? errorObj.code : null) ??
+    (typeof errorObj.type === "string" ? errorObj.type : null) ??
+    "";
+  const lower = codeRaw.toLowerCase();
+  const status = ROTATABLE_ERROR_CODES[lower];
+  return status ? { status, code: lower } : null;
+}
+
+// ── PersistentWs ───────────────────────────────────────────────────
+
+export interface PersistentWsHooks {
+  /** Called when this WS becomes unusable (close, error, eviction).
+   *  The pool uses this to remove the entry from its map. */
+  onDead(): void;
+}
+
+export class PersistentWs {
+  readonly id: string;
+  readonly entryId: string;
+  readonly poolKey: string;
+
+  private ws: WsLike;
+  private busy = false;
+  private currentSession: InFlightSession | null = null;
+  private readonly createdAt: number;
+  private readonly now: () => number;
+  private pendingClose = false;
+  private dead = false;
+  private upgradeHeaders: Record<string, string | string[]> = {};
+  private hooks: PersistentWsHooks;
+  private readonly encoder = new TextEncoder();
+
+  constructor(opts: {
+    ws: WsLike;
+    entryId: string;
+    poolKey: string;
+    hooks: PersistentWsHooks;
+    now?: () => number;
+  }) {
+    this.id = randomUUID().slice(0, 8);
+    this.ws = opts.ws;
+    this.entryId = opts.entryId;
+    this.poolKey = opts.poolKey;
+    this.hooks = opts.hooks;
+    this.now = opts.now ?? Date.now;
+    this.createdAt = this.now();
+
+    this.ws.on("upgrade", (response) => {
+      this.upgradeHeaders = response.headers;
+    });
+
+    this.ws.on("message", (data) => this.handleMessage(data));
+
+    this.ws.on("error", (err) => this.handleTransportError(err));
+
+    this.ws.on("close", (code, reason) => this.handleClose(code, reason));
+  }
+
+  /** Atomic-ish acquire (single-threaded JS, so just a boolean check).
+   *  Fails when busy / pendingClose / dead / not OPEN. */
+  tryAcquire(): boolean {
+    if (this.busy || this.pendingClose || this.dead) return false;
+    if (this.ws.readyState !== WS_OPEN) return false;
+    this.busy = true;
+    return true;
+  }
+
+  isAlive(): boolean {
+    return !this.dead && !this.pendingClose && this.ws.readyState === WS_OPEN;
+  }
+
+  isBusy(): boolean {
+    return this.busy;
+  }
+
+  isExpired(maxAgeMs: number): boolean {
+    return this.now() - this.createdAt > maxAgeMs;
+  }
+
+  /** Send `request` over this WS. Caller MUST have called tryAcquire() first.
+   *
+   *  - `reused = true` flag tells `send()` to throw `WsReusedConnectionError`
+   *    on pre-response failures (instead of a generic Error), so the caller
+   *    can distinguish "stale reuse" from "real upstream problem".
+   *  - On terminal frame (response.completed/failed/error) the stream closes
+   *    and busy is cleared, but the WS itself stays open for the next caller.
+   */
+  send(opts: {
+    request: WsCreateRequest;
+    signal: AbortSignal | undefined;
+    onRateLimits: ((rl: ParsedRateLimit) => void) | undefined;
+    reused: boolean;
+  }): Promise<Response> {
+    if (!this.busy) {
+      throw new Error("PersistentWs.send called without prior tryAcquire");
+    }
+
+    return new Promise<Response>((resolve, reject) => {
+      if (opts.signal?.aborted) {
+        this.busy = false;
+        this.markDead("aborted before send");
+        reject(new Error("Aborted before WebSocket send"));
+        return;
+      }
+
+      const wrappedReject = (err: Error) => {
+        if (opts.reused && !(err instanceof CodexApiError) && !(err instanceof WsReusedConnectionError)) {
+          reject(new WsReusedConnectionError(err.message));
+        } else {
+          reject(err);
+        }
+      };
+
+      const stream = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          this.currentSession = {
+            controller,
+            onRateLimits: opts.onRateLimits,
+            earlyDecisionMade: false,
+            resolveResponse: () => resolve(this.buildResponse(stream)),
+            reject: wrappedReject,
+            abortListener: null,
+            signal: opts.signal,
+            streamClosed: false,
+          };
+
+          if (opts.signal) {
+            const listener = () => this.handleAbort();
+            opts.signal.addEventListener("abort", listener, { once: true });
+            this.currentSession.abortListener = listener;
+          }
+        },
+        cancel: () => {
+          // Caller stopped reading the stream mid-flight. Server may still
+          // push tail frames; evict to prevent corrupting the next reuser.
+          this.markDead("stream cancelled by caller");
+        },
+      });
+
+      try {
+        this.ws.send(JSON.stringify(opts.request));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.busy = false;
+        this.markDead(`send failed: ${msg}`);
+        wrappedReject(err instanceof Error ? err : new Error(msg));
+      }
+    });
+  }
+
+  /** Mark this WS for graceful close. If busy, defer until the in-flight
+   *  request completes; otherwise close immediately. */
+  closeGracefully(): void {
+    this.pendingClose = true;
+    if (!this.busy) {
+      this.markDead("closeGracefully");
+    }
+  }
+
+  /** Force-close + mark dead + notify pool. Used on terminal failures. */
+  private markDead(reason: string): void {
+    if (this.dead) return;
+    this.dead = true;
+    try { this.ws.close(1000, reason.slice(0, 120)); } catch { /* already closing */ }
+    if (this.currentSession && !this.currentSession.streamClosed) {
+      try { this.currentSession.controller.close(); } catch { /* already closed */ }
+      this.currentSession.streamClosed = true;
+    }
+    this.detachAbortListener();
+    this.busy = false;
+    this.currentSession = null;
+    try { this.hooks.onDead(); } catch { /* hook errors must not propagate */ }
+  }
+
+  private detachAbortListener(): void {
+    const sess = this.currentSession;
+    if (sess?.signal && sess.abortListener) {
+      sess.signal.removeEventListener("abort", sess.abortListener);
+      sess.abortListener = null;
+    }
+  }
+
+  private buildResponse(stream: ReadableStream<Uint8Array>): Response {
+    const responseHeaders = new Headers({ "content-type": "text/event-stream" });
+    for (const [key, value] of Object.entries(this.upgradeHeaders)) {
+      const v = Array.isArray(value) ? value[0] : value;
+      if (v != null) responseHeaders.set(key, v);
+    }
+    return new Response(stream, { status: 200, headers: responseHeaders });
+  }
+
+  private handleMessage(data: Buffer | string): void {
+    const sess = this.currentSession;
+    if (!sess || sess.streamClosed) return;
+
+    const raw = typeof data === "string" ? data : data.toString("utf-8");
+    let msg: Record<string, unknown> | null = null;
+    let type = "unknown";
+    try {
+      msg = JSON.parse(raw) as Record<string, unknown>;
+      type = typeof msg.type === "string" ? msg.type : "unknown";
+    } catch {
+      /* fall through to raw passthrough */
+    }
+
+    // Internal rate-limit frames bypass the stream and don't flip the
+    // early-decision flag; they're observed via the per-session callback.
+    if (msg && type === "codex.rate_limits" && sess.onRateLimits) {
+      const rl = parseRateLimitsEvent(msg);
+      if (rl) sess.onRateLimits(rl);
+      return;
+    }
+
+    if (!sess.earlyDecisionMade) {
+      sess.earlyDecisionMade = true;
+      if (msg) {
+        const classified = classifyWsErrorEvent(msg);
+        if (classified) {
+          sess.reject(new CodexApiError(classified.status, JSON.stringify(msg)));
+          // Server connection-cap is a per-connection failure: evict so the
+          // next caller opens a fresh WS instead of hitting the same wall.
+          if (classified.code === "websocket_connection_limit_reached") {
+            this.markDead("server connection limit");
+          } else {
+            this.releaseAfterEarlyError();
+          }
+          return;
+        }
+      }
+      sess.resolveResponse();
+      // Fall through to enqueue this first frame.
+    }
+
+    if (msg) {
+      const sse = `event: ${type}\ndata: ${raw}\n\n`;
+      sess.controller.enqueue(this.encoder.encode(sse));
+
+      if (type === "response.completed" || type === "response.failed" || type === "error") {
+        queueMicrotask(() => this.releaseAfterTerminalFrame());
+      }
+    } else {
+      sess.controller.enqueue(this.encoder.encode(`data: ${raw}\n\n`));
+    }
+  }
+
+  private handleAbort(): void {
+    const sess = this.currentSession;
+    if (!sess) return;
+    if (!sess.earlyDecisionMade) {
+      sess.earlyDecisionMade = true;
+      sess.reject(new Error("Aborted during WebSocket request"));
+    } else if (!sess.streamClosed) {
+      try { sess.controller.error(new Error("Aborted during WebSocket stream")); } catch { /* already closed */ }
+      sess.streamClosed = true;
+    }
+    // Caller-initiated abort poisons the connection (server may still push
+    // tail frames) — evict.
+    this.markDead("aborted");
+  }
+
+  private handleTransportError(err: Error): void {
+    const sess = this.currentSession;
+    if (!sess) {
+      // Idle connection died while waiting in the pool — evict so next
+      // acquire creates a fresh one. No in-flight request to fail.
+      this.markDead(`transport error (idle): ${err.message}`);
+      return;
+    }
+    if (!sess.earlyDecisionMade) {
+      sess.earlyDecisionMade = true;
+      sess.reject(err);
+    } else if (!sess.streamClosed) {
+      try { sess.controller.error(err); } catch { /* already closed */ }
+      sess.streamClosed = true;
+    }
+    this.markDead(`transport error: ${err.message}`);
+  }
+
+  private handleClose(code: number, reason: Buffer): void {
+    const reasonStr = reason && reason.length ? reason.toString("utf-8") : "";
+    const sess = this.currentSession;
+    if (sess && !sess.earlyDecisionMade) {
+      sess.earlyDecisionMade = true;
+      sess.reject(new Error(
+        `WebSocket closed before any data: code=${code}` +
+          (reasonStr ? ` reason=${reasonStr}` : ""),
+      ));
+    } else if (sess && !sess.streamClosed) {
+      try { sess.controller.close(); } catch { /* already closed */ }
+      sess.streamClosed = true;
+    }
+    this.markDead(`closed code=${code}${reasonStr ? ` reason=${reasonStr}` : ""}`);
+  }
+
+  /** Stream completed normally (response.completed/failed/error). Close the
+   *  outbound stream but keep the WS open for the next caller. */
+  private releaseAfterTerminalFrame(): void {
+    const sess = this.currentSession;
+    if (sess && !sess.streamClosed) {
+      try { sess.controller.close(); } catch { /* already closed */ }
+      sess.streamClosed = true;
+    }
+    this.detachAbortListener();
+    this.currentSession = null;
+    this.busy = false;
+    if (this.pendingClose) this.markDead("pending close after terminal frame");
+  }
+
+  /** Early classified error already rejected the send-level promise. The
+   *  WS itself is fine to reuse for the next conversation, but for safety we
+   *  treat early errors as account-level and keep the WS open only if the
+   *  error wasn't connection-fatal. */
+  private releaseAfterEarlyError(): void {
+    this.detachAbortListener();
+    this.currentSession = null;
+    this.busy = false;
+    if (this.pendingClose) this.markDead("pending close after early error");
+  }
+}
+
+// ── WsConnectionPool ───────────────────────────────────────────────
+
+export interface WsPoolConfig {
+  enabled: boolean;
+  maxAgeMs: number;
+  maxPerAccount: number;
+}
+
+export const DEFAULT_WS_POOL_CONFIG: WsPoolConfig = {
+  enabled: true,
+  maxAgeMs: 3_300_000, // 55 minutes (under server's 60-min hard cap)
+  maxPerAccount: 8,
+};
+
+export interface AcquireResult {
+  ws: PersistentWs;
+  reused: boolean;
+}
+
+export type AcquireBypassReason = "busy" | "cap" | "dead" | "disabled" | "no_key";
+
+export interface AcquireBypass {
+  bypass: AcquireBypassReason;
+}
+
+export interface PersistentWsFactory {
+  /** Called when the pool needs a new WS. The factory must construct a
+   *  PersistentWs whose `hooks.onDead` callback maps back to the pool. */
+  (deps: { entryId: string; poolKey: string; hooks: PersistentWsHooks }): Promise<PersistentWs>;
+}
+
+export class WsConnectionPool {
+  private readonly map = new Map<string, PersistentWs>();
+  private readonly byEntry = new Map<string, Set<string>>();
+  private readonly config: WsPoolConfig;
+  private gcInterval: NodeJS.Timeout | undefined;
+  private shuttingDown = false;
+
+  constructor(config: Partial<WsPoolConfig> = {}, opts: { startGc?: boolean; gcIntervalMs?: number } = {}) {
+    this.config = { ...DEFAULT_WS_POOL_CONFIG, ...config };
+    if (opts.startGc !== false && this.config.enabled) {
+      this.gcInterval = setInterval(() => this.gcSweep(), opts.gcIntervalMs ?? 60_000);
+      this.gcInterval.unref?.();
+    }
+  }
+
+  /** Try to get a usable PersistentWs for `(entryId, poolKey)`.
+   *
+   *  - Empty `poolKey` (no conversationId derivable) → bypass.
+   *  - Pool disabled → bypass.
+   *  - Hit + tryAcquire → reused=true.
+   *  - Hit + busy → bypass(busy).
+   *  - Hit + dead/closed → evict + treat as miss.
+   *  - Miss + at cap for entryId → bypass(cap).
+   *  - Miss + free slot → factory(), insert, reused=false.
+   */
+  async acquire(
+    entryId: string,
+    poolKey: string,
+    factory: PersistentWsFactory,
+  ): Promise<AcquireResult | AcquireBypass> {
+    if (!this.config.enabled || this.shuttingDown) {
+      return { bypass: "disabled" };
+    }
+    if (!entryId || !poolKey) {
+      return { bypass: "no_key" };
+    }
+
+    let existing = this.map.get(poolKey);
+    if (existing && !existing.isAlive()) {
+      this.removeEntry(existing);
+      existing = undefined;
+    }
+    if (existing) {
+      if (existing.tryAcquire()) {
+        return { ws: existing, reused: true };
+      }
+      return { bypass: "busy" };
+    }
+
+    // Miss: enforce per-account cap before creating.
+    const keys = this.byEntry.get(entryId);
+    if (keys && keys.size >= this.config.maxPerAccount) {
+      return { bypass: "cap" };
+    }
+
+    const fresh = await factory({
+      entryId,
+      poolKey,
+      hooks: {
+        onDead: () => {
+          // Pool-side cleanup. PersistentWs already marked itself dead.
+          this.removeEntryByKey(poolKey);
+        },
+      },
+    });
+
+    // Race: another acquire for the same key may have completed during
+    // factory() await. If so, prefer the one already in the map.
+    const racer = this.map.get(poolKey);
+    if (racer) {
+      // Discard the freshly-created ws — close it cleanly.
+      fresh.closeGracefully();
+      if (racer.isAlive() && racer.tryAcquire()) {
+        return { ws: racer, reused: true };
+      }
+      // Racer is busy too — bypass and let caller open a one-shot.
+      return { bypass: "busy" };
+    }
+
+    if (!fresh.tryAcquire()) {
+      // Should be impossible (we just created it), but be defensive: don't
+      // leave a permanently-busy entry in the map.
+      fresh.closeGracefully();
+      return { bypass: "dead" };
+    }
+
+    this.map.set(poolKey, fresh);
+    let entryKeys = this.byEntry.get(entryId);
+    if (!entryKeys) {
+      entryKeys = new Set();
+      this.byEntry.set(entryId, entryKeys);
+    }
+    entryKeys.add(poolKey);
+    return { ws: fresh, reused: false };
+  }
+
+  /** Evict every WS for the given entryId. Used when the account is
+   *  rate-limited / banned / disabled / refreshed (token rotated). */
+  evictByEntryId(entryId: string): void {
+    const keys = this.byEntry.get(entryId);
+    if (!keys) return;
+    // Snapshot keys before iteration — closeGracefully → onDead → removeEntryByKey
+    // would mutate the set we're iterating.
+    for (const key of [...keys]) {
+      const ws = this.map.get(key);
+      if (ws) ws.closeGracefully();
+    }
+    // closeGracefully on a busy ws sets pendingClose; the actual map removal
+    // happens when the in-flight request completes. Force-clear the byEntry
+    // index now so subsequent acquires don't count against the cap.
+    this.byEntry.delete(entryId);
+  }
+
+  /** Returns the number of pooled connections for `entryId`. Test helper. */
+  countByEntryId(entryId: string): number {
+    return this.byEntry.get(entryId)?.size ?? 0;
+  }
+
+  /** Returns total pool size. Test helper. */
+  size(): number {
+    return this.map.size;
+  }
+
+  /** Gracefully close all pooled connections. Called from process exit. */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.gcInterval) {
+      clearInterval(this.gcInterval);
+      this.gcInterval = undefined;
+    }
+    for (const ws of [...this.map.values()]) {
+      ws.closeGracefully();
+    }
+    // Leave map empty after all entries are forcibly closed; subsequent
+    // acquires would fail the disabled check anyway.
+    this.map.clear();
+    this.byEntry.clear();
+  }
+
+  /** Periodic sweep: drop dead/expired idle entries. Skips busy ones. */
+  gcSweep(): void {
+    for (const [, ws] of this.map) {
+      if (ws.isBusy()) continue;
+      if (!ws.isAlive() || ws.isExpired(this.config.maxAgeMs)) {
+        ws.closeGracefully();
+      }
+    }
+  }
+
+  private removeEntry(ws: PersistentWs): void {
+    this.removeEntryByKey(ws.poolKey);
+  }
+
+  private removeEntryByKey(poolKey: string): void {
+    const ws = this.map.get(poolKey);
+    if (!ws) return;
+    this.map.delete(poolKey);
+    const entryKeys = this.byEntry.get(ws.entryId);
+    if (entryKeys) {
+      entryKeys.delete(poolKey);
+      if (entryKeys.size === 0) this.byEntry.delete(ws.entryId);
+    }
+  }
+}
+
+// ── Singleton (used by app code; tests construct their own) ────────
+
+let _singleton: WsConnectionPool | null = null;
+
+export function getWsPool(): WsConnectionPool {
+  if (!_singleton) _singleton = new WsConnectionPool();
+  return _singleton;
+}
+
+export function setWsPoolConfig(config: Partial<WsPoolConfig>): WsConnectionPool {
+  if (_singleton) {
+    // Replace existing singleton with new config; let GC clean old one.
+    void _singleton.shutdown();
+  }
+  _singleton = new WsConnectionPool(config);
+  return _singleton;
+}
+
+/** Test-only: reset the singleton so each test gets a clean pool. */
+export function _resetWsPoolForTests(): void {
+  if (_singleton) void _singleton.shutdown();
+  _singleton = null;
+}

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -18,6 +18,12 @@ import type { CodexInputItem } from "./codex-api.js";
 import type { ParsedRateLimit } from "./rate-limit-headers.js";
 import { parseRateLimitsEvent } from "./rate-limit-headers.js";
 import { CodexApiError } from "./codex-types.js";
+import {
+  PersistentWs,
+  WsReusedConnectionError,
+  type PersistentWsHooks,
+  type WsConnectionPool,
+} from "./ws-pool.js";
 
 /**
  * Map an upstream WS terminal error frame (`type: "error"` or
@@ -110,24 +116,20 @@ export interface WsCreateRequest {
   // The backend defaults to storing via WebSocket and always streams.
 }
 
-/**
- * Open a WebSocket to the Codex backend, send `response.create`,
- * and return a Response whose body is an SSE-formatted ReadableStream.
- *
- * The SSE format matches what parseStream() expects:
- *   event: <type>\ndata: <json>\n\n
- */
-export async function createWebSocketResponse(
-  wsUrl: string,
-  headers: Record<string, string>,
-  request: WsCreateRequest,
-  signal?: AbortSignal,
-  proxyUrl?: string | null,
-  onRateLimits?: (rl: ParsedRateLimit) => void,
-): Promise<Response> {
-  const WS = await getWS();
+/** Optional pool routing context. When provided, `createWebSocketResponse`
+ *  tries to reuse a pooled WS for `(entryId, poolKey)` before falling back
+ *  to opening a fresh one-shot connection. */
+export interface WsPoolContext {
+  pool: WsConnectionPool;
+  poolKey: string;
+  entryId: string;
+}
 
-  // Lazy-import proxy agent only when needed; cache by URL to reuse connections
+async function buildWsConstructorOpts(
+  WS: typeof import("ws").default,
+  headers: Record<string, string>,
+  proxyUrl: string | null | undefined,
+): Promise<ConstructorParameters<typeof WS>[2]> {
   const wsOpts: ConstructorParameters<typeof WS>[2] = { headers };
   if (proxyUrl) {
     let agent = _agentCache.get(proxyUrl);
@@ -138,6 +140,125 @@ export async function createWebSocketResponse(
     }
     wsOpts.agent = agent;
   }
+  return wsOpts;
+}
+
+/** Factory used by the pool to construct a brand-new persistent connection.
+ *  Connects + waits for OPEN before returning so callers can immediately
+ *  send. The PersistentWs is constructed up-front so its `upgrade` listener
+ *  catches the initial response headers (which carry rate-limit data). */
+async function createPersistentWsConnection(opts: {
+  wsUrl: string;
+  headers: Record<string, string>;
+  proxyUrl: string | null | undefined;
+  entryId: string;
+  poolKey: string;
+  hooks: PersistentWsHooks;
+}): Promise<PersistentWs> {
+  const WS = await getWS();
+  const wsOpts = await buildWsConstructorOpts(WS, opts.headers, opts.proxyUrl);
+  const ws = new WS(opts.wsUrl, wsOpts);
+
+  // Construct PersistentWs first so its upgrade/error/close handlers attach
+  // before the WebSocket handshake completes.
+  const persistent = new PersistentWs({
+    ws,
+    entryId: opts.entryId,
+    poolKey: opts.poolKey,
+    hooks: opts.hooks,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    if (ws.readyState === ws.OPEN) {
+      resolve();
+      return;
+    }
+    const cleanup = () => {
+      ws.removeListener("open", onOpen);
+      ws.removeListener("error", onErr);
+      ws.removeListener("close", onClose);
+    };
+    const onOpen = () => { cleanup(); resolve(); };
+    const onErr = (err: Error) => { cleanup(); reject(err); };
+    const onClose = () => { cleanup(); reject(new Error("WebSocket closed before open")); };
+    ws.once("open", onOpen);
+    ws.once("error", onErr);
+    ws.once("close", onClose);
+  });
+
+  return persistent;
+}
+
+/**
+ * Open a WebSocket to the Codex backend, send `response.create`,
+ * and return a Response whose body is an SSE-formatted ReadableStream.
+ *
+ * The SSE format matches what parseStream() expects:
+ *   event: <type>\ndata: <json>\n\n
+ *
+ * When `poolCtx` is provided the call first tries to reuse a pooled WS for
+ * `(entryId, poolKey)`; on a `WsReusedConnectionError` (stale-reuse failure)
+ * it falls back to a fresh one-shot connection exactly once.
+ */
+export async function createWebSocketResponse(
+  wsUrl: string,
+  headers: Record<string, string>,
+  request: WsCreateRequest,
+  signal?: AbortSignal,
+  proxyUrl?: string | null,
+  onRateLimits?: (rl: ParsedRateLimit) => void,
+  poolCtx?: WsPoolContext,
+): Promise<Response> {
+  if (poolCtx) {
+    try {
+      const acquired = await poolCtx.pool.acquire(
+        poolCtx.entryId,
+        poolCtx.poolKey,
+        (deps) =>
+          createPersistentWsConnection({
+            wsUrl,
+            headers,
+            proxyUrl,
+            entryId: deps.entryId,
+            poolKey: deps.poolKey,
+            hooks: deps.hooks,
+          }),
+      );
+      if ("ws" in acquired) {
+        try {
+          return await acquired.ws.send({ request, signal, onRateLimits, reused: acquired.reused });
+        } catch (err) {
+          if (err instanceof WsReusedConnectionError) {
+            // Stale-reuse: open a fresh one-shot WS for this single request.
+            // The pool's onDead hook has already evicted the dead entry.
+            return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
+          }
+          throw err;
+        }
+      }
+      // Bypass (busy / cap / dead / no_key / disabled) → fall through to one-shot.
+    } catch (err) {
+      // Pool itself failed (e.g. factory could not connect). Don't punish the
+      // caller — fall back to the legacy one-shot path. The error is still
+      // visible in the one-shot path if the underlying issue persists.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[ws-pool] acquire failed, using one-shot fallback: ${msg}`);
+    }
+  }
+
+  return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
+}
+
+async function openOneShotWs(
+  wsUrl: string,
+  headers: Record<string, string>,
+  request: WsCreateRequest,
+  signal: AbortSignal | undefined,
+  proxyUrl: string | null | undefined,
+  onRateLimits: ((rl: ParsedRateLimit) => void) | undefined,
+): Promise<Response> {
+  const WS = await getWS();
+  const wsOpts = await buildWsConstructorOpts(WS, headers, proxyUrl);
 
   return new Promise<Response>((resolve, reject) => {
     if (signal?.aborted) {

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -123,7 +123,16 @@ export interface WsPoolContext {
   pool: WsConnectionPool;
   poolKey: string;
   entryId: string;
+  /** Optional observer fired once with the pool's dispatch decision. Useful
+   *  for logging without coupling the caller to the pool's internal state. */
+  onDecision?: (decision: WsDispatchDecision) => void;
 }
+
+export type WsDispatchDecision =
+  | { kind: "reuse"; wsId: string }
+  | { kind: "new"; wsId: string }
+  | { kind: "bypass"; reason: string }
+  | { kind: "retry-after-stale-reuse"; wsId: string };
 
 async function buildWsConstructorOpts(
   WS: typeof import("ws").default,
@@ -225,24 +234,31 @@ export async function createWebSocketResponse(
           }),
       );
       if ("ws" in acquired) {
+        poolCtx.onDecision?.({
+          kind: acquired.reused ? "reuse" : "new",
+          wsId: acquired.ws.id,
+        });
         try {
           return await acquired.ws.send({ request, signal, onRateLimits, reused: acquired.reused });
         } catch (err) {
           if (err instanceof WsReusedConnectionError) {
             // Stale-reuse: open a fresh one-shot WS for this single request.
             // The pool's onDead hook has already evicted the dead entry.
+            poolCtx.onDecision?.({ kind: "retry-after-stale-reuse", wsId: acquired.ws.id });
             return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
           }
           throw err;
         }
       }
       // Bypass (busy / cap / dead / no_key / disabled) → fall through to one-shot.
+      poolCtx.onDecision?.({ kind: "bypass", reason: acquired.bypass });
     } catch (err) {
       // Pool itself failed (e.g. factory could not connect). Don't punish the
       // caller — fall back to the legacy one-shot path. The error is still
       // visible in the one-shot path if the underlying issue persists.
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[ws-pool] acquire failed, using one-shot fallback: ${msg}`);
+      poolCtx.onDecision?.({ kind: "bypass", reason: "factory_error" });
     }
   }
 

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -405,6 +405,15 @@ export async function handleProxyRequest(
       pool: getWsPool(),
       poolKey: `${forEntryId}:${chainConversationId}`,
       entryId: forEntryId,
+      onDecision: (decision) => {
+        const ridShort = requestId.slice(0, 8);
+        const tag = decision.kind === "bypass"
+          ? `bypass(${decision.reason})`
+          : decision.kind === "retry-after-stale-reuse"
+            ? `retry-after-stale-reuse:${decision.wsId}`
+            : `${decision.kind}:${decision.wsId}`;
+        console.log(`[${fmt.tag}] Account ${forEntryId} | rid=${ridShort} | ws=${tag}`);
+      },
     };
   };
 

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -36,6 +36,8 @@ import { getSessionAffinityMap, type SessionAffinityMap } from "../../auth/sessi
 import { enqueueLogEntry } from "../../logs/entry.js";
 import { randomUUID } from "crypto";
 import { deriveStableConversationKey } from "./stable-conversation-key.js";
+import { getWsPool } from "../../proxy/ws-pool.js";
+import type { WsPoolContext } from "../../proxy/codex-api.js";
 
 /** Data prepared by each route after parsing and translating the request. */
 export interface ProxyRequest {
@@ -393,6 +395,19 @@ export async function handleProxyRequest(
 
   await staggerIfNeeded(acquired.prevSlotMs);
 
+  /** Build a per-request WS pool context. Only attached when the request is
+   *  going to take the WS path AND we have a stable conversation id — empty
+   *  conversationId would degenerate the pool key and break affinity. */
+  const buildPoolCtx = (forEntryId: string = entryId): WsPoolContext | undefined => {
+    if (!req.codexRequest.useWebSocket) return undefined;
+    if (!chainConversationId) return undefined;
+    return {
+      pool: getWsPool(),
+      poolKey: `${forEntryId}:${chainConversationId}`,
+      entryId: forEntryId,
+    };
+  };
+
   for (;;) {
     try {
       // Apply parsed rate-limit data to the account pool (shared by header + WS event paths)
@@ -415,7 +430,7 @@ export async function handleProxyRequest(
 
       const startMs = Date.now();
       const rawResponse = await withRetry(
-        () => codexApi.createResponse(req.codexRequest, abortController.signal, applyRateLimits),
+        () => codexApi.createResponse(req.codexRequest, abortController.signal, applyRateLimits, buildPoolCtx()),
         { tag: fmt.tag },
       );
       const status: number | null = rawResponse.status;
@@ -537,6 +552,7 @@ export async function handleProxyRequest(
         upstreamTurnState,
         () => activeUsageHint,
         restoreImplicitResumeRequest,
+        buildPoolCtx,
       );
     } catch (err) {
       if (!(err instanceof CodexApiError)) {
@@ -649,6 +665,7 @@ async function handleNonStreaming(
   turnState?: string,
   getUsageHint?: () => UsageHint | undefined,
   restoreImplicitResumeRequest?: () => void,
+  buildPoolCtx?: (forEntryId: string) => WsPoolContext | undefined,
 ): Promise<Response> {
   let currentEntryId = initialEntryId;
   let currentApi = initialApi;
@@ -720,7 +737,7 @@ async function handleNonStreaming(
         const retryStartMs = Date.now();
         try {
           currentRawResponse = await withRetry(
-            () => currentApi.createResponse(req.codexRequest, abortController.signal),
+            () => currentApi.createResponse(req.codexRequest, abortController.signal, undefined, buildPoolCtx?.(currentEntryId)),
             { tag: fmt.tag },
           );
           enqueueLogEntry({

--- a/tests/_helpers/ws-server.ts
+++ b/tests/_helpers/ws-server.ts
@@ -1,0 +1,84 @@
+/**
+ * Test helper: spin up a local `ws.Server` for integration-style tests.
+ *
+ * Records the number of `connection` events (so tests can assert that a
+ * pooled WS is genuinely reused vs reopened) and gives each connection a
+ * tiny scripted-response interface so tests can simulate the Codex
+ * Responses API protocol without needing a real upstream.
+ */
+
+import { WebSocketServer, type WebSocket as WsServerSocket } from "ws";
+import type { AddressInfo } from "net";
+
+export interface ScriptedResponseEvent {
+  /** event.type field, e.g. "response.created" / "response.completed" / "error" */
+  type: string;
+  /** Additional fields merged into the JSON payload. */
+  data?: Record<string, unknown>;
+}
+
+export interface LocalWsServerHandle {
+  url: string;
+  /** Total `connection` events received. */
+  connectionCount(): number;
+  /** Currently active sockets. */
+  sockets(): readonly WsServerSocket[];
+  /** Set the script that the server will play back for each incoming
+   *  `response.create` message. The script is replayed for every request,
+   *  so the same connection can serve multiple turns. */
+  script(events: ScriptedResponseEvent[]): void;
+  /** Force-close all active sockets with the given code/reason. */
+  closeAllSockets(code?: number, reason?: string): void;
+  /** Stop the server. */
+  close(): Promise<void>;
+}
+
+export async function startLocalWsServer(): Promise<LocalWsServerHandle> {
+  const server = new WebSocketServer({ port: 0 });
+  let totalConnections = 0;
+  const liveSockets = new Set<WsServerSocket>();
+  let currentScript: ScriptedResponseEvent[] = [
+    { type: "response.created" },
+    { type: "response.completed" },
+  ];
+
+  server.on("connection", (socket) => {
+    totalConnections += 1;
+    liveSockets.add(socket);
+    socket.on("close", () => liveSockets.delete(socket));
+    socket.on("message", () => {
+      // Replay the script for every incoming response.create request.
+      for (const event of currentScript) {
+        if (socket.readyState !== socket.OPEN) break;
+        socket.send(JSON.stringify({ type: event.type, ...(event.data ?? {}) }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  const addr = server.address() as AddressInfo;
+  const url = `ws://127.0.0.1:${addr.port}`;
+
+  return {
+    url,
+    connectionCount: () => totalConnections,
+    sockets: () => [...liveSockets],
+    script(events) {
+      currentScript = events;
+    },
+    closeAllSockets(code = 1000, reason = "test close") {
+      for (const s of liveSockets) {
+        try { s.close(code, reason); } catch { /* already closing */ }
+      }
+    },
+    async close() {
+      for (const s of liveSockets) {
+        try { s.terminate(); } catch { /* already gone */ }
+      }
+      liveSockets.clear();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/tests/integration/ws-pool-reuse.test.ts
+++ b/tests/integration/ws-pool-reuse.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration test: pool reuses the same physical WebSocket across N turns.
+ *
+ * Uses a real local `ws.Server` (no mocks) and the actual
+ * `createWebSocketResponse` codepath. Drives 5 sequential `response.create`
+ * requests through the pool and asserts that the server only saw a single
+ * `connection` event. This locks in the LB-affinity property the pool
+ * exists to provide.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { startLocalWsServer, type LocalWsServerHandle } from "@helpers/ws-server.js";
+import { createWebSocketResponse, type WsCreateRequest } from "@src/proxy/ws-transport.js";
+import { WsConnectionPool, _resetWsPoolForTests } from "@src/proxy/ws-pool.js";
+
+const baseRequest: WsCreateRequest = {
+  type: "response.create",
+  model: "gpt-test",
+  instructions: "be brief",
+  input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+};
+
+async function drainResponse(resp: Response): Promise<string> {
+  // Read the SSE stream completely so the underlying ReadableStream is
+  // closed and the pool entry's `busy` flag clears for the next caller.
+  const reader = resp.body!.getReader();
+  let text = "";
+  const decoder = new TextDecoder();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+describe("ws-pool integration: persistent connection reuse", () => {
+  let server: LocalWsServerHandle;
+  let pool: WsConnectionPool;
+
+  beforeEach(async () => {
+    _resetWsPoolForTests();
+    server = await startLocalWsServer();
+    pool = new WsConnectionPool({ enabled: true, maxAgeMs: 60_000, maxPerAccount: 8 }, { startGc: false });
+  });
+
+  afterEach(async () => {
+    await pool.shutdown();
+    await server.close();
+    _resetWsPoolForTests();
+  });
+
+  it("5 sequential turns on same (entryId, conversationId) reuse a single WS connection", async () => {
+    const poolKey = "entry-A:conv-1";
+    const entryId = "entry-A";
+
+    for (let turn = 1; turn <= 5; turn++) {
+      const resp = await createWebSocketResponse(
+        server.url,
+        {},
+        { ...baseRequest, instructions: `turn-${turn}` },
+        undefined,
+        null,
+        undefined,
+        { pool, entryId, poolKey },
+      );
+      expect(resp.status).toBe(200);
+      const text = await drainResponse(resp);
+      expect(text).toContain("event: response.completed");
+    }
+
+    expect(server.connectionCount()).toBe(1);
+    expect(pool.size()).toBe(1);
+  });
+
+  it("different conversations open different connections (one per pool key)", async () => {
+    const entryId = "entry-A";
+
+    for (let conv = 1; conv <= 3; conv++) {
+      const resp = await createWebSocketResponse(
+        server.url,
+        {},
+        baseRequest,
+        undefined,
+        null,
+        undefined,
+        { pool, entryId, poolKey: `${entryId}:conv-${conv}` },
+      );
+      await drainResponse(resp);
+    }
+
+    expect(server.connectionCount()).toBe(3);
+    expect(pool.size()).toBe(3);
+    expect(pool.countByEntryId(entryId)).toBe(3);
+  });
+
+  it("server-side disconnect evicts pool entry; next acquire reconnects fresh", async () => {
+    const entryId = "entry-A";
+    const poolKey = `${entryId}:conv-1`;
+
+    const r1 = await createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey },
+    );
+    await drainResponse(r1);
+    expect(server.connectionCount()).toBe(1);
+    expect(pool.size()).toBe(1);
+
+    server.closeAllSockets(1000, "simulated server drop");
+    // Allow the close event to propagate through PersistentWs → pool eviction.
+    // Poll until evicted (avoids relying on a fixed sleep duration).
+    const start = Date.now();
+    while (pool.size() > 0 && Date.now() - start < 1000) {
+      await new Promise<void>((r) => setTimeout(r, 20));
+    }
+    expect(pool.size()).toBe(0);
+
+    const r2 = await createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey },
+    );
+    await drainResponse(r2);
+    expect(server.connectionCount()).toBe(2);
+    expect(pool.size()).toBe(1);
+  });
+
+  it("disabled pool falls back to one-shot connections (every turn opens a new socket)", async () => {
+    const disabled = new WsConnectionPool({ enabled: false }, { startGc: false });
+    try {
+      for (let turn = 1; turn <= 3; turn++) {
+        const resp = await createWebSocketResponse(
+          server.url, {}, baseRequest, undefined, null, undefined,
+          { pool: disabled, entryId: "entry-A", poolKey: "entry-A:conv-1" },
+        );
+        await drainResponse(resp);
+      }
+      expect(server.connectionCount()).toBe(3);
+      expect(disabled.size()).toBe(0);
+    } finally {
+      await disabled.shutdown();
+    }
+  });
+
+  it("evictByEntryId closes pooled WS; subsequent acquire opens fresh", async () => {
+    const entryId = "entry-A";
+
+    const r1 = await createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey: `${entryId}:conv-1` },
+    );
+    await drainResponse(r1);
+    expect(pool.countByEntryId(entryId)).toBe(1);
+
+    pool.evictByEntryId(entryId);
+    // closeGracefully is async (queueMicrotask close emit + onDead hook).
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(pool.countByEntryId(entryId)).toBe(0);
+
+    const r2 = await createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey: `${entryId}:conv-1` },
+    );
+    await drainResponse(r2);
+    expect(server.connectionCount()).toBe(2);
+  });
+});
+
+describe("ws-pool integration: backward compat (no poolCtx)", () => {
+  let server: LocalWsServerHandle;
+
+  beforeEach(async () => {
+    server = await startLocalWsServer();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it("createWebSocketResponse without poolCtx behaves exactly like the old one-shot path", async () => {
+    for (let turn = 1; turn <= 3; turn++) {
+      const resp = await createWebSocketResponse(server.url, {}, baseRequest);
+      await drainResponse(resp);
+    }
+    // Each call opens a fresh connection — proves poolCtx-less callers are
+    // unaffected by the pool integration.
+    expect(server.connectionCount()).toBe(3);
+  });
+});

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "events";
+import {
+  PersistentWs,
+  WsConnectionPool,
+  WsReusedConnectionError,
+  type PersistentWsHooks,
+  type WsLike,
+} from "@src/proxy/ws-pool.js";
+import { CodexApiError } from "@src/proxy/codex-types.js";
+
+class MockWs extends EventEmitter implements WsLike {
+  public readyState = 1; // OPEN
+  public sent: string[] = [];
+  public closed = false;
+  public closeCode: number | undefined;
+  public closeReason: string | undefined;
+
+  send(data: string): void {
+    if (this.closed) throw new Error("send after close");
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeCode = code;
+    this.closeReason = reason;
+    this.readyState = 3; // CLOSED
+    queueMicrotask(() => this.emit("close", code ?? 1006, Buffer.from(reason ?? "")));
+  }
+
+  /** Simulate the server pushing a JSON frame over the wire. */
+  pushMessage(payload: Record<string, unknown>): void {
+    this.emit("message", JSON.stringify(payload));
+  }
+
+  /** Simulate a transport-level error (TCP RST, etc.). */
+  pushError(err: Error): void {
+    this.emit("error", err);
+  }
+
+  /** Simulate the server closing the socket abruptly. */
+  pushClose(code = 1006, reason = ""): void {
+    this.readyState = 3;
+    this.closed = true;
+    this.emit("close", code, Buffer.from(reason));
+  }
+}
+
+function newPersistentWs(opts: { hooks?: Partial<PersistentWsHooks>; entryId?: string; poolKey?: string } = {}) {
+  const ws = new MockWs();
+  const onDead = vi.fn();
+  const persistent = new PersistentWs({
+    ws,
+    entryId: opts.entryId ?? "entry-A",
+    poolKey: opts.poolKey ?? "entry-A:conv-1",
+    hooks: { onDead, ...opts.hooks },
+  });
+  return { ws, persistent, onDead };
+}
+
+async function nextTick() {
+  await new Promise<void>((r) => queueMicrotask(r));
+}
+
+describe("PersistentWs", () => {
+  it("tryAcquire succeeds once on a fresh OPEN ws", () => {
+    const { persistent } = newPersistentWs();
+    expect(persistent.tryAcquire()).toBe(true);
+    expect(persistent.tryAcquire()).toBe(false); // already busy
+  });
+
+  it("tryAcquire fails when readyState is not OPEN", () => {
+    const { ws, persistent } = newPersistentWs();
+    ws.readyState = 0; // CONNECTING
+    expect(persistent.tryAcquire()).toBe(false);
+  });
+
+  it("send rejects with WsReusedConnectionError on pre-response close (reused=true)", async () => {
+    const { ws, persistent } = newPersistentWs();
+    expect(persistent.tryAcquire()).toBe(true);
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushClose(1006, "tcp rst");
+    await expect(promise).rejects.toBeInstanceOf(WsReusedConnectionError);
+  });
+
+  it("send rejects with plain Error on pre-response close (reused=false)", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushClose(1006, "tcp rst");
+    await expect(promise).rejects.toBeInstanceOf(Error);
+    await expect(promise).rejects.not.toBeInstanceOf(WsReusedConnectionError);
+  });
+
+  it("send resolves Response on first non-internal frame and streams subsequent events", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created", id: "r1" });
+    const resp = await promise;
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toBe("text/event-stream");
+    ws.pushMessage({ type: "response.output_text.delta", delta: "hi" });
+    ws.pushMessage({ type: "response.completed" });
+    const text = await resp.text();
+    expect(text).toContain("event: response.created");
+    expect(text).toContain("event: response.output_text.delta");
+    expect(text).toContain("event: response.completed");
+  });
+
+  it("after response.completed the WS becomes available for the next send", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const p1 = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created" });
+    ws.pushMessage({ type: "response.completed" });
+    const r1 = await p1;
+    await r1.text();
+    await nextTick();
+    expect(persistent.isBusy()).toBe(false);
+    expect(persistent.isAlive()).toBe(true);
+    expect(persistent.tryAcquire()).toBe(true);
+  });
+
+  it("rate_limits frame routes only to the per-session callback and does not stream", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const onRateLimits = vi.fn();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({
+      type: "codex.rate_limits",
+      rate_limits: { primary: { used_percent: 50, window_minutes: 60 } },
+    });
+    expect(onRateLimits).toHaveBeenCalledTimes(1);
+    ws.pushMessage({ type: "response.created" });
+    const resp = await promise;
+    ws.pushMessage({ type: "response.completed" });
+    const text = await resp.text();
+    expect(text).not.toContain("codex.rate_limits");
+  });
+
+  it("classified early error rejects with CodexApiError without resolving stream", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true, // even reused, classified errors stay as CodexApiError
+    });
+    await nextTick();
+    ws.pushMessage({ type: "error", error: { code: "usage_limit_reached", message: "limit" } });
+    const err = await promise.then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(CodexApiError);
+    expect((err as CodexApiError).status).toBe(429);
+  });
+
+  it("websocket_connection_limit_reached early error evicts the WS", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({
+      type: "error",
+      error: { code: "websocket_connection_limit_reached", message: "60 min limit" },
+    });
+    const err = await promise.then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(CodexApiError);
+    expect((err as CodexApiError).status).toBe(503);
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalled();
+  });
+
+  it("AbortSignal abort during in-flight rejects + evicts (cannot poison the next reuser)", async () => {
+    const { persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const ac = new AbortController();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: ac.signal,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ac.abort();
+    await expect(promise).rejects.toThrow(/Aborted/);
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalled();
+  });
+
+  it("transport error before any message rejects the in-flight send and evicts", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushError(new Error("ECONNRESET"));
+    await expect(promise).rejects.toBeInstanceOf(WsReusedConnectionError);
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalled();
+  });
+
+  it("idle close on a connection without an in-flight session evicts cleanly", () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    expect(persistent.isAlive()).toBe(true);
+    ws.pushClose(1006, "idle drop");
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("closeGracefully on busy WS defers eviction until terminal frame", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created" });
+    const resp = await promise;
+    persistent.closeGracefully();
+    expect(onDead).not.toHaveBeenCalled(); // still busy
+    ws.pushMessage({ type: "response.completed" });
+    await resp.text();
+    await nextTick();
+    expect(onDead).toHaveBeenCalledTimes(1);
+    expect(persistent.isAlive()).toBe(false);
+  });
+
+  it("closeGracefully on idle WS evicts immediately", () => {
+    const { persistent, onDead } = newPersistentWs();
+    persistent.closeGracefully();
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalledTimes(1);
+  });
+
+  it("isExpired returns true once max age has elapsed", () => {
+    let now = 1_000_000;
+    const ws = new MockWs();
+    const persistent = new PersistentWs({
+      ws,
+      entryId: "e",
+      poolKey: "k",
+      hooks: { onDead: () => {} },
+      now: () => now,
+    });
+    expect(persistent.isExpired(60_000)).toBe(false);
+    now += 60_001;
+    expect(persistent.isExpired(60_000)).toBe(true);
+  });
+
+  it("upgrade headers are cached and surfaced on Response", async () => {
+    const { ws, persistent } = newPersistentWs();
+    ws.emit("upgrade", { headers: { "x-codex-primary-used-percent": "42" } });
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created" });
+    const resp = await promise;
+    expect(resp.headers.get("x-codex-primary-used-percent")).toBe("42");
+  });
+});
+
+describe("WsConnectionPool", () => {
+  let pool: WsConnectionPool;
+
+  beforeEach(() => {
+    pool = new WsConnectionPool({}, { startGc: false });
+  });
+
+  afterEach(async () => {
+    await pool.shutdown();
+  });
+
+  function makeFactory() {
+    const created: PersistentWs[] = [];
+    const factory = vi.fn(async (deps: { entryId: string; poolKey: string; hooks: PersistentWsHooks }) => {
+      const ws = new MockWs();
+      const persistent = new PersistentWs({
+        ws,
+        entryId: deps.entryId,
+        poolKey: deps.poolKey,
+        hooks: deps.hooks,
+      });
+      created.push(persistent);
+      return persistent;
+    });
+    return { factory, created };
+  }
+
+  it("acquire miss creates and caches a new PersistentWs (reused=false)", async () => {
+    const { factory } = makeFactory();
+    const r = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(r).toMatchObject({ reused: false });
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(pool.size()).toBe(1);
+    expect(pool.countByEntryId("entry-A")).toBe(1);
+  });
+
+  it("acquire hit returns same instance after release (reused=true)", async () => {
+    const { factory } = makeFactory();
+    const first = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    if (!("ws" in first)) throw new Error("expected acquire success");
+    // Simulate release by completing a request: trigger terminal frame.
+    const wsInst = first.ws;
+    wsInst["busy"] = false; // direct test-internal release (no real send)
+    const second = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(second).toMatchObject({ reused: true });
+    expect("ws" in second && second.ws).toBe(wsInst);
+    expect(factory).toHaveBeenCalledTimes(1); // no new factory call
+  });
+
+  it("acquire while busy returns bypass(busy)", async () => {
+    const { factory } = makeFactory();
+    await pool.acquire("entry-A", "entry-A:conv-1", factory); // first acquires + holds
+    const second = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(second).toEqual({ bypass: "busy" });
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("acquire returns bypass(no_key) when poolKey or entryId is empty", async () => {
+    const { factory } = makeFactory();
+    expect(await pool.acquire("", "k", factory)).toEqual({ bypass: "no_key" });
+    expect(await pool.acquire("e", "", factory)).toEqual({ bypass: "no_key" });
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("acquire returns bypass(disabled) when pool is disabled", async () => {
+    const disabled = new WsConnectionPool({ enabled: false }, { startGc: false });
+    const { factory } = makeFactory();
+    expect(await disabled.acquire("entry-A", "k", factory)).toEqual({ bypass: "disabled" });
+    expect(factory).not.toHaveBeenCalled();
+    await disabled.shutdown();
+  });
+
+  it("acquire returns bypass(cap) when entry already at max_per_account", async () => {
+    const capped = new WsConnectionPool({ maxPerAccount: 2 }, { startGc: false });
+    const { factory } = makeFactory();
+    await capped.acquire("entry-A", "entry-A:conv-1", factory);
+    await capped.acquire("entry-A", "entry-A:conv-2", factory);
+    const third = await capped.acquire("entry-A", "entry-A:conv-3", factory);
+    expect(third).toEqual({ bypass: "cap" });
+    expect(factory).toHaveBeenCalledTimes(2);
+    await capped.shutdown();
+  });
+
+  it("dead connection is treated as a miss on next acquire", async () => {
+    const factories: MockWs[] = [];
+    const factory = vi.fn(async (deps: { entryId: string; poolKey: string; hooks: PersistentWsHooks }) => {
+      const mock = new MockWs();
+      factories.push(mock);
+      return new PersistentWs({ ws: mock, entryId: deps.entryId, poolKey: deps.poolKey, hooks: deps.hooks });
+    });
+    await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    factories[0].pushClose(1006, "tcp dropped"); // simulate underlying socket dying
+    expect(pool.size()).toBe(0); // onDead hook should have removed it
+    const second = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(second).toMatchObject({ reused: false });
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("evictByEntryId closes all connections for that entry and frees the cap", async () => {
+    const capped = new WsConnectionPool({ maxPerAccount: 2 }, { startGc: false });
+    const { factory } = makeFactory();
+    await capped.acquire("entry-A", "entry-A:conv-1", factory);
+    await capped.acquire("entry-A", "entry-A:conv-2", factory);
+    expect(capped.countByEntryId("entry-A")).toBe(2);
+    capped.evictByEntryId("entry-A");
+    expect(capped.countByEntryId("entry-A")).toBe(0);
+    const next = await capped.acquire("entry-A", "entry-A:conv-3", factory);
+    expect(next).toMatchObject({ reused: false });
+    await capped.shutdown();
+  });
+
+  it("gcSweep skips busy entries and closes expired idle ones", async () => {
+    let now = 0;
+    const sweepPool = new WsConnectionPool(
+      { maxAgeMs: 100 },
+      { startGc: false },
+    );
+    const factory = vi.fn(async (deps: { entryId: string; poolKey: string; hooks: PersistentWsHooks }) => {
+      const ws = new MockWs();
+      return new PersistentWs({ ...deps, ws, now: () => now });
+    });
+    const r1 = await sweepPool.acquire("entry-A", "entry-A:conv-1", factory);
+    if (!("ws" in r1)) throw new Error();
+    // r1.ws stays busy
+    const r2 = await sweepPool.acquire("entry-A", "entry-A:conv-2", factory);
+    if (!("ws" in r2)) throw new Error();
+    r2.ws["busy"] = false; // release r2
+
+    now = 200; // both expired by clock
+    sweepPool.gcSweep();
+    // r2 is idle + expired → closed; r1 is busy → kept
+    expect(r1.ws.isAlive()).toBe(true);
+    expect(r2.ws.isAlive()).toBe(false);
+    await sweepPool.shutdown();
+  });
+
+  it("shutdown closes all and disables further acquires", async () => {
+    const { factory } = makeFactory();
+    await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    await pool.shutdown();
+    expect(pool.size()).toBe(0);
+    const after = await pool.acquire("entry-A", "entry-A:conv-2", factory);
+    expect(after).toEqual({ bypass: "disabled" });
+  });
+});

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -4,6 +4,9 @@ import {
   PersistentWs,
   WsConnectionPool,
   WsReusedConnectionError,
+  setWsPoolConfig,
+  getWsPool,
+  _resetWsPoolForTests,
   type PersistentWsHooks,
   type WsLike,
 } from "@src/proxy/ws-pool.js";
@@ -452,5 +455,40 @@ describe("WsConnectionPool", () => {
     expect(pool.size()).toBe(0);
     const after = await pool.acquire("entry-A", "entry-A:conv-2", factory);
     expect(after).toEqual({ bypass: "disabled" });
+  });
+});
+
+describe("singleton wiring (setWsPoolConfig + getWsPool)", () => {
+  beforeEach(() => _resetWsPoolForTests());
+  afterEach(() => _resetWsPoolForTests());
+
+  it("setWsPoolConfig({enabled:false}) makes getWsPool() reject acquires", async () => {
+    setWsPoolConfig({ enabled: false });
+    const pool = getWsPool();
+    const factory = vi.fn(async () => {
+      throw new Error("factory should never run when pool is disabled");
+    });
+    const result = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(result).toEqual({ bypass: "disabled" });
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("getWsPool() returns a default-enabled singleton when setWsPoolConfig was never called", async () => {
+    const pool = getWsPool();
+    const factory = vi.fn(async (deps: { entryId: string; poolKey: string; hooks: PersistentWsHooks }) => {
+      const ws = new MockWs();
+      return new PersistentWs({ ws, entryId: deps.entryId, poolKey: deps.poolKey, hooks: deps.hooks });
+    });
+    const result = await pool.acquire("entry-A", "entry-A:conv-1", factory);
+    expect(result).toMatchObject({ reused: false });
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("setWsPoolConfig replaces an existing singleton (later override wins)", async () => {
+    setWsPoolConfig({ enabled: true });
+    setWsPoolConfig({ enabled: false });
+    const pool = getWsPool();
+    const factory = vi.fn(async () => { throw new Error("unreachable"); });
+    expect(await pool.acquire("e", "k", factory)).toEqual({ bypass: "disabled" });
   });
 });


### PR DESCRIPTION
## Summary

修上游 prompt cache 命中率在 5%~99% 之间剧烈抖动的问题。根因：codex-proxy 对每个上游 WS 请求都 `new WebSocket(url)`，OpenAI 的 WS gateway 按"连接 ID"做 LB hash → 同一逻辑会话被随机扔到不同 backend，每个 backend 各自缓存了不同长度的前缀，导致 cached_tokens 反复出现 1920 / 2432 / 24448 / 40320 / 47488 等离散"checkpoint"。

参考真 codex CLI（`core/src/client.rs:802` 的 `WebsocketSession.connection`）的策略，引入 per-`(entryId, conversationId)` 持久 WS 连接池：同会话同账号的连续 turn 全部走同一条物理 WS，让上游 LB 钉到同一 backend，prompt cache 稳态命中。

## Architecture

- `src/proxy/ws-pool.ts`（新）：`PersistentWs` + `WsConnectionPool` + `WsReusedConnectionError`
  - **Pool key**: `\${entryId}:\${conversationId}`，覆盖显式/隐式续链
  - **单 WS strict 串行**：busy 时旁路开 one-shot 新连接（不排队，避免死锁）
  - **无 idle TTL**：连接保持开放，仅在自然死亡 / 触达 `max_age_ms`（55 min，比 server 60 min 硬限提前关）/ 账号状态变化（`evictByEntryId`）时清理
  - **复用失败语义**：pre-response close → `WsReusedConnectionError` → 单次 fallback 一次性 WS；流中段 close → 抛给 client（不 retry，已收到部分数据）
  - **账号状态钩子**：`account-pool.ts` 在 `markRateLimited` / `markStatus(non-active)` / `removeAccount` / `updateToken`（refresh）时级联 `evictByEntryId`，避免老 WS 携带的 access_token 被复用
  - **进程退出**：`SIGTERM`/`SIGINT` 钩子追加 `wsPool.shutdown()`
- `src/proxy/ws-transport.ts`：抽出 `openOneShotWs`（旧路径），`createWebSocketResponse` 接 optional `poolCtx?` 参数；带 ctx 时先尝试 `pool.acquire`，否则回到 one-shot。pool/factory 任何故障都 fallback 到 one-shot，绝不污染 caller
- `src/proxy/codex-api.ts` / `src/routes/shared/proxy-handler.ts`：透传 `poolCtx`；`buildPoolCtx()` 在 implicit resume / explicit prev_resp_id 等 WS 路径下生成 ctx
- 配置 `ws_pool: { enabled: true (默认), max_age_ms: 3300000, max_per_account: 8 }`：默认开（bugfix 性质），`enabled: false` + 重启即可回滚

## Observability

入口日志新增 `ws=` 字段：
- `ws=reuse:abc12345` — 池命中复用
- `ws=new:def67890` — 池 miss 新建
- `ws=bypass(busy|cap|dead|disabled|no_key|factory_error)` — 旁路一次性
- `ws=retry-after-stale-reuse:abc12345` — 复用失败自动单次重试

配合现有 `rid/conv/key/prev/resume/hit` 字段可直接观察池行为 + 命中率归因。

## Test Plan

- [x] `npm test` — 1702 passed (+1 skipped)，零回归
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — vite + tsc OK
- [x] `tests/unit/proxy/ws-pool.test.ts` — 26 个单测覆盖 PersistentWs + WsConnectionPool 完整生命周期（acquire/release/idle/dead/cap/abort/server limit/upgrade headers/...）
- [x] `tests/integration/ws-pool-reuse.test.ts` — 起本地 `ws.Server` 验证：
  - 5 turn 同会话 → server 仅 1 次 connection ✓
  - 不同 conv → 各自 1 个连接 ✓
  - server 主动 close → 池立即驱逐 + 下次 acquire 重连 ✓
  - `enabled: false` → 退化为 one-shot ✓
  - `evictByEntryId` → 池清空 + 后续重建 ✓
  - 不传 poolCtx → 行为 100% 等价于今天 ✓
- [x] 现有 `ws-transport*.test.ts` 不动且全过（向后兼容）
- [ ] **端到端命中率 live 验证**：重启 dev 跑长会话，目标稳态 ≥ 90%（旧基线 5%~99% 抖动）

## Notes

- 本 PR 包含了 PR #439 的 5 个 commit（dashboard hit-rate panel + installation_id + resume diagnostic + 3 个 WS 池 commit）。PR #439 单独 review；这里目标 review 后 3 个 commit（96339f1 / 5023709 / 06407e6）。
- 若 PR #439 先合，本 PR rebase 后会只剩 ws-pool 3 个 commit。
- 实施分 3 commit，可独立 revert：
  1. `96339f1` 纯新增 ws-pool.ts + 26 个单测，零接线零回归
  2. `5023709` 接线 ws-transport / proxy-handler / account-pool / index.ts + 集成测
  3. `06407e6` 可观测性 + CHANGELOG