### PR TITLE
fix(translation): preserve OpenAI function tool strict

### DIFF
--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -131,6 +131,7 @@ export function openAIToolsToCodex(
     const def: CodexToolDefinition = {
       type: "function",
       name: t.function.name,
+      strict: t.function.strict ?? false,
     };
     if (t.function.description) def.description = t.function.description;
     if (t.function.parameters) def.parameters = normalizeSchema(t.function.parameters);
@@ -166,6 +167,7 @@ export function openAIFunctionsToCodex(
     const def: CodexToolDefinition = {
       type: "function",
       name: f.name,
+      strict: f.strict ?? false,
     };
     if (f.description) def.description = f.description;
     if (f.parameters) def.parameters = normalizeSchema(f.parameters);

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -55,6 +55,7 @@ export const ChatCompletionRequestSchema = z.object({
         name: z.string(),
         description: z.string().optional(),
         parameters: z.record(z.unknown()).optional(),
+        strict: z.boolean().optional(),
       }),
     }),
     z.object({
@@ -83,6 +84,7 @@ export const ChatCompletionRequestSchema = z.object({
     name: z.string(),
     description: z.string().optional(),
     parameters: z.record(z.unknown()).optional(),
+    strict: z.boolean().optional(),
   })).optional(),
   function_call: z.union([
     z.enum(["none", "auto"]),

--- a/tests/unit/translation/tool-format.test.ts
+++ b/tests/unit/translation/tool-format.test.ts
@@ -33,6 +33,7 @@ describe("openAIToolsToCodex", () => {
       {
         type: "function",
         name: "get_weather",
+        strict: false,
         description: "Get the weather",
         parameters: {
           type: "object",
@@ -48,6 +49,7 @@ describe("openAIToolsToCodex", () => {
     ]);
     expect(result[0]).not.toHaveProperty("description");
     expect(result[0].name).toBe("noop");
+    expect(result[0].strict).toBe(false);
   });
 
   it("omits parameters when not provided", () => {
@@ -55,6 +57,18 @@ describe("openAIToolsToCodex", () => {
       { type: "function", function: { name: "ping", description: "Ping" } },
     ]);
     expect(result[0]).not.toHaveProperty("parameters");
+    expect(result[0].strict).toBe(false);
+  });
+
+  it("preserves explicit strict mode on function tools", () => {
+    const result = openAIToolsToCodex([
+      { type: "function", function: { name: "strict_tool", strict: true } },
+    ]);
+    expect(result[0]).toMatchObject({
+      type: "function",
+      name: "strict_tool",
+      strict: true,
+    });
   });
 
   it("normalizes object schema without properties", () => {
@@ -136,6 +150,7 @@ describe("openAIFunctionsToCodex", () => {
       {
         type: "function",
         name: "search",
+        strict: false,
         description: "Search the web",
         parameters: {
           type: "object",
@@ -147,9 +162,14 @@ describe("openAIFunctionsToCodex", () => {
 
   it("omits description and parameters when absent", () => {
     const result = openAIFunctionsToCodex([{ name: "bare" }]);
-    expect(result[0]).toEqual({ type: "function", name: "bare" });
+    expect(result[0]).toEqual({ type: "function", name: "bare", strict: false });
     expect(result[0]).not.toHaveProperty("description");
     expect(result[0]).not.toHaveProperty("parameters");
+  });
+
+  it("preserves explicit strict mode on legacy functions", () => {
+    const result = openAIFunctionsToCodex([{ name: "legacy_strict", strict: true }]);
+    expect(result[0]).toEqual({ type: "function", name: "legacy_strict", strict: true });
   });
 
   it("normalizes object schema without properties", () => {
@@ -587,6 +607,7 @@ describe("hosted web_search tool conversion", () => {
       {
         type: "function",
         name: "lookup",
+        strict: false,
         parameters: { type: "object", properties: {} },
       },
     ]);


### PR DESCRIPTION
## Summary
- Accept and preserve `strict` on OpenAI-compatible function tool definitions.
- Default translated OpenAI function tools and legacy `functions` to `strict: false` when the client does not specify it.
- Add unit coverage for default non-strict behavior and explicit `strict: true` preservation.

## Why
OpenAI Responses-style tool handling can normalize omitted `strict` into strict schema behavior. That can make previously optional tool schema properties mandatory, which breaks MCP-style tools that intentionally use optional fields or mutually exclusive request modes.

This keeps strict mode available for clients that explicitly request it, while preserving non-strict compatibility for OpenAI chat/function tools by default.

## Test plan
- `npm test -- tests/unit/translation/tool-format.test.ts`