### PR TITLE
ci(docker): dispatch docker-publish from promote and bump workflows

### DIFF
--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -147,3 +147,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+
+      - name: Trigger docker publish
+        # GITHUB_TOKEN-driven pushes do not fire downstream workflows, so the bump
+        # commit + tag won't trip docker-publish.yml's push trigger on its own.
+        # Dispatching workflow_run here ensures ghcr.io/.../codex-proxy:vX.Y.Z
+        # exists for the version we just tagged.
+        if: steps.bump.outputs.new_tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run docker-publish.yml --ref master

--- a/.github/workflows/promote-dev-to-master.yml
+++ b/.github/workflows/promote-dev-to-master.yml
@@ -16,7 +16,10 @@ concurrency:
 
 permissions:
   contents: write
-  actions: read
+  # `actions: write` is required by the final step's `gh workflow run docker-publish.yml`
+  # dispatch; the earlier CI status read needs only `actions: read`, but the
+  # broader scope subsumes it.
+  actions: write
   checks: read
 
 jobs:
@@ -130,3 +133,13 @@ jobs:
           echo "Promoting $DEV_SHA to master"
           git push origin "${DEV_SHA}:refs/heads/master"
           echo "::notice::Promoted dev ($DEV_SHA) to master. bump-electron.yml will pick it up on the next 16:00 UTC tick."
+
+      - name: Trigger docker publish
+        # GITHUB_TOKEN-driven pushes do not fire downstream workflows (anti-recursion
+        # guard), so docker-publish.yml's `on: push: branches: [master]` would
+        # otherwise stay silent after every promotion. workflow_dispatch is one of
+        # the few events GITHUB_TOKEN is allowed to trigger.
+        if: steps.ci.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run docker-publish.yml --ref master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `promote-dev-to-master.yml` 与 `bump-electron.yml` 末尾各补一步 `gh workflow run docker-publish.yml --ref master`：GitHub Actions 安全策略禁止默认 `GITHUB_TOKEN` 触发的 push 事件再触发其他 workflow（防递归），导致 promote 把 dev fast-forward 到 master、bump 提交版本号 commit + tag 之后，`docker-publish.yml` 的 `on: push: branches: [master]` 全部静默不跑——表象就是 ghcr.io 上的 `:latest` / `:vX.Y.Z` 长期停留在最后一次"人手 push master"的时刻（最近一次是 2026-04-30，期间 master 已经吃下 4 天的 promote）。`workflow_dispatch` 是 GITHUB_TOKEN 允许触发的少数事件之一，所以两条管道收尾各 dispatch 一次即可衔接；docker-publish 已有 `concurrency: cancel-in-progress: true`，promote + bump 两次 dispatch 在窗口期重叠时后者直接接管，最终镜像反映 bump 后的新版本号。配套把 promote 的 `permissions: actions` 从 `read` 升到 `write`（dispatch 需要）
+
 ### Added
 
 - Dashboard 用量页新增「时段命中率（Range Hit Rate）」卡片：基于当前选中时间窗口聚合 `cached_tokens / input_tokens`，与原本的全局累计「Cache Hit Rate」卡并列，方便对比近窗口与历史命中率（`web/src/pages/UsageStats.tsx`、`shared/i18n/translations.ts`）


### PR DESCRIPTION
## Summary

- Closes the gap where ghcr.io images stop tracking master. Last successful `Publish Docker Image` run on master was **2026-04-30**, even though `promote-dev-to-master.yml` has merged dev tip onto master multiple times since (5/3, 5/5) and `bump-electron.yml` has tagged `v2.0.69`.
- Root cause: GitHub Actions does not let pushes authored by the default `GITHUB_TOKEN` trigger further workflows (anti-recursion guard). Both promote (FF push to master) and bump (commit + tag push to master) use the default token, so `docker-publish.yml`'s `on: push: branches: [master]` stays silent.
- `workflow_dispatch` **is** allowed for the default token, so each pipeline now ends with an explicit `gh workflow run docker-publish.yml --ref master`.

## Changes

- `.github/workflows/promote-dev-to-master.yml`
  - New step `Trigger docker publish` after `Fast-forward push dev → master`, gated on the same `steps.ci.outputs.ok == 'true'`.
  - `permissions.actions` raised `read` → `write` (required for `gh workflow run`).
- `.github/workflows/bump-electron.yml`
  - New step `Trigger docker publish` after `Trigger release workflow`, gated on `steps.bump.outputs.new_tag` (only when a real bump happened).
  - `permissions: actions: write` was already present.

## Behavior after merge

- Promote (14:00 UTC daily) successfully FF's master → dispatches docker-publish → ghcr image updated within ~7 min.
- Bump (16:00 UTC daily, 2h later) tags new version + dispatches docker-publish again → image labels reflect the new `v2.0.69`-style tag.
- Two dispatches in the same 2h window are safe: docker-publish.yml has `concurrency: cancel-in-progress: true`, so the bump-triggered run cancels the still-running promote-triggered one (or just supersedes it).

## Test plan

- [x] Both YAML files parse cleanly (`npx js-yaml`).
- [ ] After merge: confirm next `promote-dev-to-master` schedule (or manual dispatch) triggers a fresh `Publish Docker Image` run on master.
- [ ] After merge: confirm next `bump-electron` (manual or scheduled) does the same.

## Out of scope

- Switching to a GitHub App / PAT to make the original push-triggered flow Just Work. That's the cleanest fix but requires secret management; deferred until we need it for other reasons.
- Retroactive backfill: I'll dispatch `docker-publish.yml --ref master` manually once after merge to bring `:latest` up to current master.