### PR TITLE
docs: inline Authorization in Codex config.toml example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- README / README_EN 的 Codex CLI + Codex Desktop 两节示例从 `env_key = "PROXY_API_KEY"` 改成 `[model_providers.proxy_codex.http_headers]` 内嵌 `Authorization = "Bearer ..."`：原写法在 GUI 客户端启动时会因为 macOS / Windows GUI 进程不继承 shell rc 的环境变量而报 `Missing environment variable: PROXY_API_KEY`，普通用户得额外学 `launchctl setenv` 或 LaunchAgent 才能让 Codex Desktop 看到环境变量；http_headers 把 key 直接写在 config 文件里，重启 Codex 即用。`env_key` 写法作为「需要密钥从配置文件解耦」（多人共享 / 仓库提交）场景的备选保留在文档说明里
+
 ### Fixed
 
 - `promote-dev-to-master.yml` 与 `bump-electron.yml` 末尾各补一步 `gh workflow run docker-publish.yml --ref master`：GitHub Actions 安全策略禁止默认 `GITHUB_TOKEN` 触发的 push 事件再触发其他 workflow（防递归），导致 promote 把 dev fast-forward 到 master、bump 提交版本号 commit + tag 之后，`docker-publish.yml` 的 `on: push: branches: [master]` 全部静默不跑——表象就是 ghcr.io 上的 `:latest` / `:vX.Y.Z` 长期停留在最后一次"人手 push master"的时刻（最近一次是 2026-04-30，期间 master 已经吃下 4 天的 promote）。`workflow_dispatch` 是 GITHUB_TOKEN 允许触发的少数事件之一，所以两条管道收尾各 dispatch 一次即可衔接；docker-publish 已有 `concurrency: cancel-in-progress: true`，promote + bump 两次 dispatch 在窗口期重叠时后者直接接管，最终镜像反映 bump 后的新版本号。配套把 promote 的 `permissions: actions` 从 `read` 升到 `write`（dispatch 需要）

--- a/README.md
+++ b/README.md
@@ -283,17 +283,17 @@ claude
 name = "Codex Proxy"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
-env_key = "PROXY_API_KEY"
+
+# 直接把 API Key 写进 config（推荐：本地单用户场景）
+[model_providers.proxy_codex.http_headers]
+Authorization = "Bearer your-api-key"
 
 [profiles.default]
 model = "gpt-5.4"
 model_provider = "proxy_codex"
 ```
 
-```bash
-export PROXY_API_KEY=your-api-key
-codex
-```
+> 💡 也可以改用环境变量：把 `[model_providers.proxy_codex.http_headers]` 这两行删掉，换成 `env_key = "PROXY_API_KEY"`，然后 `export PROXY_API_KEY=your-api-key && codex`。需要避免密钥落到 config 文件（多人共享 / 开源仓库）时用这个。
 
 ### Claude Desktop
 
@@ -335,14 +335,18 @@ codex
 name = "Codex Proxy"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
-env_key = "PROXY_API_KEY"
+
+[model_providers.proxy_codex.http_headers]
+Authorization = "Bearer your-api-key"
 
 [profiles.default]
 model = "gpt-5.4"
 model_provider = "proxy_codex"
 ```
 
-> ⚠️ 如果你是通过“登录 ChatGPT 账号”方式使用的，客户端可能会忽略此配置。建议在环境变量中设置 `PROXY_API_KEY` 后启动。
+> 💡 **为什么不用 `env_key`？** macOS / Windows 的 GUI 应用不读 shell 的 `~/.zshrc` / `.bashrc`，光 `export PROXY_API_KEY=...` 在终端里 GUI 进程根本看不到，启动会直接报 `Missing environment variable`。`http_headers` 把 Authorization 写在 config 里，重启 Codex 就能用，不用折腾 `launchctl setenv` 或 LaunchAgent。需要密钥从配置文件解耦时（共享机器 / 仓库提交）再换回 `env_key = "PROXY_API_KEY"` 走环境变量。
+>
+> ⚠️ 如果你是通过"登录 ChatGPT 账号"方式使用的，客户端可能会忽略此配置——只要 `[model_providers.proxy_codex]` 配上、`profiles.default.model_provider = "proxy_codex"`，新会话就会走 proxy；登录会话仍可能直接走官方上游。
 
 ### Claude for VSCode / JetBrains
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -252,17 +252,17 @@ claude
 name = "Codex Proxy"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
-env_key = "PROXY_API_KEY"
+
+# Inline the API Key (recommended for local single-user setups)
+[model_providers.proxy_codex.http_headers]
+Authorization = "Bearer your-api-key"
 
 [profiles.default]
 model = "gpt-5.4"
 model_provider = "proxy_codex"
 ```
 
-```bash
-export PROXY_API_KEY=your-api-key
-codex
-```
+> 💡 To keep the key out of the config file (shared machine / open-source repo), drop the `http_headers` block and use `env_key = "PROXY_API_KEY"` instead, then `export PROXY_API_KEY=your-api-key && codex`.
 
 ### Claude Desktop
 
@@ -302,14 +302,18 @@ The official client shares configuration with the CLI. Restart the app after edi
 name = "Codex Proxy"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
-env_key = "PROXY_API_KEY"
+
+[model_providers.proxy_codex.http_headers]
+Authorization = "Bearer your-api-key"
 
 [profiles.default]
 model = "gpt-5.4"
 model_provider = "proxy_codex"
 ```
 
-> ⚠️ If you are logged in via "ChatGPT account", the client might ignore this config. Launching with `PROXY_API_KEY` environment variable set is recommended.
+> 💡 **Why not `env_key`?** macOS/Windows GUI apps do not inherit env vars from your shell rc files — `export PROXY_API_KEY=...` in your terminal is invisible to the GUI process and Codex Desktop will fail with `Missing environment variable`. Inlining `Authorization` via `http_headers` avoids `launchctl setenv` / LaunchAgent gymnastics. Switch back to `env_key = "PROXY_API_KEY"` only when you need the key out of the config file.
+>
+> ⚠️ When logged in via "ChatGPT account", existing sessions might bypass this config and hit the official upstream directly. New sessions started after `[model_providers.proxy_codex]` is wired up + `profiles.default.model_provider = "proxy_codex"` will route through the proxy.
 
 ### Claude for VSCode / JetBrains
 


### PR DESCRIPTION
## Summary

Switches the canonical Codex CLI / Codex Desktop config example in both READMEs from `env_key = "PROXY_API_KEY"` to `[model_providers.proxy_codex.http_headers]` with a literal `Authorization = "Bearer ..."`.

## Why

The previous wording was technically correct but routinely broken in practice:

- **macOS GUI apps** launched from Dock / Spotlight do not inherit env vars from `~/.zshrc` / `~/.bash_profile`. `export PROXY_API_KEY=...` in a terminal is invisible to Codex Desktop, which then aborts with `Missing environment variable: PROXY_API_KEY`.
- The fix (`launchctl setenv` for the current login session, or a LaunchAgent plist for persistence) is documented nowhere in the README and surprises everyone who follows the quickstart.
- **Windows GUI apps** have the analogous issue — env vars set in CMD do not propagate to GUI processes spawned outside that shell.

For the dominant use case (single user, localhost, key is whatever the user picked in `data/local.yaml`), inlining `Authorization` in the TOML eliminates the launch-environment plumbing entirely. Restart Codex → it works.

## Changes

- `README.md` and `README_EN.md`, both **Codex CLI** and **Codex Desktop (官方应用 / Official App)** sections:
  - Provider block now uses `[model_providers.proxy_codex.http_headers]` with inline `Authorization`. Removed the `env_key` line.
  - Removed the `export PROXY_API_KEY=... && codex` shell snippet (no longer needed).
  - Added a callout explaining the macOS/Windows GUI-env-var pitfall, why `http_headers` avoids it, and when to switch back to `env_key` (shared machines / open-source repos where the key shouldn't live in the config file).
  - Tightened the existing "ChatGPT account login may bypass" warning to mention that *new* sessions after wiring `model_provider = "proxy_codex"` will route through the proxy.
- `CHANGELOG.md` — `[Unreleased] / Changed` entry summarizing the rationale.

## Test plan

- [x] Both READMEs render the new TOML block correctly (eyeballed in editor).
- [x] Locally verified the new config form: `~/.codex/config.toml` with `http_headers.Authorization = "Bearer pwd"` + `model_provider = "proxy_codex"` boots Codex Desktop without `Missing environment variable` and the dropdown lists upstream models from `localhost:8080/v1/models`.
- No code changed; no test suite to run.