### PR TITLE
fix(proxy): close implicit-resume reverse mismatch + surface 4xx errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 隐式续链反向校验缺失导致客户端持续看到上游 `invalid_request_error: No tool output found for function call call_X`：`evaluateImplicitResume` 此前只做 forward 检查（新输入里的 `function_call_output.call_id` 必须命中上一轮 stored function_call），漏了反向（上一轮 stored function_call 必须在新输入里有 output）。当上一轮模型并发吐 N 个 tool_use、客户端只回 N-1 个 tool_result 时，proxy 仍然 resume + `previous_response_id` 发出去，上游存的 context 里那个未回复的 function_call 触发 400。新增反向检查 → 走完整重放（`reason: "unanswered_tool_calls"`），同时 `error-classification.ts` 加 `isUnansweredFunctionCallError`，proxy-handler catch 块兜底：strip `previous_response_id` + 完整历史重放 + 同账号重试一次（与 `previous_response_not_found` 同款），避免 ws/sse 路径上的 400 静默吞掉变成 502
+- `codex-to-anthropic.ts` / `codex-to-openai.ts` / `codex-to-gemini.ts` 非流式 collect 路径里把上游错误事件抛成 `new Error(...)`，丢失 status 信息，handleNonStreaming 的 collectErr 再通过正则匹配 `HTTP/X.X NNN` 状态码必然失败 → 一律 502 兜底，客户端拿到的是模糊的 502 而不是上游真实的 400/429。改为统一 `codexApiErrorFromEvent(evt.error)` 抛 `CodexApiError(status, body)`，按 error code 映射到 400/401/402/403/429（默认 502）；handleNonStreaming 的 collectErr 也加一条 `instanceof CodexApiError` 分支直接透传 status，不再走正则降级
+- `streamResponse` 流式路径里上游错误此前只往 SSE 写一条 `stream_error` 事件、零日志，客户端能看到错误但 proxy `dev-YYYY-MM-DD.log` 里完全没记录，排查时无证据链。catch 块加 `console.warn` 打 `status / msg / body`，留下 call_id 等关键现场
+
 ### Changed
 
 - README / README_EN 的 Codex CLI + Codex Desktop 两节示例从 `env_key = "PROXY_API_KEY"` 改成 `[model_providers.proxy_codex.http_headers]` 内嵌 `Authorization = "Bearer ..."`：原写法在 GUI 客户端启动时会因为 macOS / Windows GUI 进程不继承 shell rc 的环境变量而报 `Missing environment variable: PROXY_API_KEY`，普通用户得额外学 `launchctl setenv` 或 LaunchAgent 才能让 Codex Desktop 看到环境变量；http_headers 把 key 直接写在 config 文件里，重启 Codex 即用。`env_key` 写法作为「需要密钥从配置文件解耦」（多人共享 / 仓库提交）场景的备选保留在文档说明里

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -80,6 +80,21 @@ export function isPreviousResponseNotFoundError(err: unknown): boolean {
     || (lower.includes("previous response with id") && lower.includes("not found"));
 }
 
+/**
+ * Check if an error indicates a stored function_call from the previous response
+ * was not answered with a function_call_output in the current request. Upstream
+ * surfaces this as 400 with message "No tool output found for function call call_X".
+ *
+ * Recovered the same way as previous_response_not_found: drop previous_response_id,
+ * resend full input history, retry on the same account.
+ */
+export function isUnansweredFunctionCallError(err: unknown): boolean {
+  if (!isCodexLike(err)) return false;
+  if (err.status !== 400) return false;
+  const haystack = (err.body + " " + err.message).toLowerCase();
+  return haystack.includes("no tool output found for function call");
+}
+
 /** Check if a CodexApiError indicates the model is not supported on the account's plan. */
 export function isModelNotSupportedError(err: CodexLikeError): boolean {
   if (err.status < 400 || err.status >= 500 || err.status === 429) return false;

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -306,7 +306,7 @@ export async function handleProxyRequest(
   let codexApi = buildCodexApi(acquired.token, acquired.accountId, cookieJar, entryId, proxyPool);
   const triedEntryIds: string[] = [entryId];
   let modelRetried = false;
-  let prevRespNotFoundRetried = false;
+  let stripAndRetryDone = false;
   let usageInfo: UsageInfo | undefined;
   let capturedResponseId: string | null = null;
   const responseFunctionCallIds = new Set<string>();
@@ -600,8 +600,8 @@ export async function handleProxyRequest(
       // same account. For implicit-resume requests this also restores the
       // full input history; for explicit ones the client's own input is sent
       // verbatim (server-side history is lost but the request still completes).
-      if (!prevRespNotFoundRetried && isPreviousResponseNotFoundError(err)) {
-        prevRespNotFoundRetried = true;
+      if (!stripAndRetryDone && isPreviousResponseNotFoundError(err)) {
+        stripAndRetryDone = true;
         const staleId = req.codexRequest.previous_response_id;
         console.warn(
           `[${fmt.tag}] Account ${entryId} | previous_response_not_found (id=${staleId ?? "?"}), stripping and retrying same account`,
@@ -617,8 +617,8 @@ export async function handleProxyRequest(
       // response was not answered with a function_call_output. Recovery is the
       // same as previous_response_not_found: drop previous_response_id, replay
       // full history, retry once on the same account.
-      if (!prevRespNotFoundRetried && isUnansweredFunctionCallError(err)) {
-        prevRespNotFoundRetried = true;
+      if (!stripAndRetryDone && isUnansweredFunctionCallError(err)) {
+        stripAndRetryDone = true;
         const staleId = req.codexRequest.previous_response_id;
         console.warn(
           `[${fmt.tag}] Account ${entryId} | unanswered_function_call (id=${staleId ?? "?"}): ${err.message.slice(0, 200)}, stripping and retrying same account`,
@@ -840,15 +840,15 @@ async function handleNonStreaming(
         c.status(502);
         return c.json(fmt.formatError(502, "Codex returned empty responses across all available accounts"));
       }
-      // Surface upstream HTTP errors with their actual status so the caller
-      // sees a structured 4xx instead of an opaque 502 fallback.
+      // Mid-SSE upstream errors (e.g. "No tool output found for function call",
+      // "previous_response_not_found") need the same strip+retry recovery as
+      // HTTP-time errors. Rethrow so the outer handleProxyRequest catch runs
+      // its unified classification once, instead of duplicating logic here.
       if (collectErr instanceof CodexApiError) {
-        const code = toErrorStatus(collectErr.status);
         console.warn(
           `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${collectErr.message.slice(0, 200)}`,
         );
-        c.status(code);
-        return c.json(fmt.formatError(code, collectErr.message));
+        throw collectErr;
       }
       const msg = collectErr instanceof Error ? collectErr.message : "Unknown error";
       const statusMatch = msg.match(/HTTP\/[\d.]+ (\d{3})/);

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -830,6 +830,20 @@ async function handleNonStreaming(
         continue;
       }
 
+      // Mid-SSE upstream errors (e.g. "No tool output found for function call",
+      // "previous_response_not_found") need the same strip+retry recovery as
+      // HTTP-time errors. Rethrow so the outer handleProxyRequest catch runs
+      // its unified classification once. Critically, do NOT release the slot
+      // here — outer catch's strip+retry continues on the same entryId and
+      // would race another acquirer if we released early. Outer catch is
+      // responsible for the release on the final respond/retry decision (the
+      // released Set guards against double-release on terminal paths).
+      if (collectErr instanceof CodexApiError) {
+        console.warn(
+          `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${collectErr.message.slice(0, 200)}`,
+        );
+        throw collectErr;
+      }
       releaseAccount(accountPool, currentEntryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
       if (collectErr instanceof EmptyResponseError) {
         const email = accountPool.getEntry(currentEntryId)?.email ?? "?";
@@ -839,16 +853,6 @@ async function handleNonStreaming(
         accountPool.recordEmptyResponse(currentEntryId);
         c.status(502);
         return c.json(fmt.formatError(502, "Codex returned empty responses across all available accounts"));
-      }
-      // Mid-SSE upstream errors (e.g. "No tool output found for function call",
-      // "previous_response_not_found") need the same strip+retry recovery as
-      // HTTP-time errors. Rethrow so the outer handleProxyRequest catch runs
-      // its unified classification once, instead of duplicating logic here.
-      if (collectErr instanceof CodexApiError) {
-        console.warn(
-          `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${collectErr.message.slice(0, 200)}`,
-        );
-        throw collectErr;
       }
       const msg = collectErr instanceof Error ? collectErr.message : "Unknown error";
       const statusMatch = msg.match(/HTTP\/[\d.]+ (\d{3})/);

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -26,7 +26,7 @@ import type { ProxyPool } from "../../proxy/proxy-pool.js";
 import { withRetry } from "../../utils/retry.js";
 import { acquireAccount, releaseAccount } from "./account-acquisition.js";
 import { handleCodexApiError, toErrorStatus } from "./proxy-error-handler.js";
-import { isPreviousResponseNotFoundError } from "../../proxy/error-classification.js";
+import { isPreviousResponseNotFoundError, isUnansweredFunctionCallError } from "../../proxy/error-classification.js";
 import { streamResponse } from "./response-processor.js";
 import type { UsageInfo } from "../../translation/codex-event-extractor.js";
 import { parseRateLimitHeaders, rateLimitToQuota, type ParsedRateLimit } from "../../proxy/rate-limit-headers.js";
@@ -155,6 +155,14 @@ export function evaluateImplicitResume(opts: ImplicitResumeOpts):
   if (!requiredFunctionCallOutputIds.every((callId) => storedFunctionCallIds.has(callId))) {
     return { active: false, reason: "missing_tool_calls" };
   }
+  // Reverse check: every stored function_call must be answered in this continuation.
+  // Otherwise upstream rejects with "No tool output found for function call call_X".
+  const requiredSet = new Set(requiredFunctionCallOutputIds);
+  for (const callId of storedFunctionCallIds) {
+    if (!requiredSet.has(callId)) {
+      return { active: false, reason: "unanswered_tool_calls" };
+    }
+  }
   return { active: true, reason: null };
 }
 
@@ -260,6 +268,10 @@ export async function handleProxyRequest(
   const missingFunctionCallOutputIds = requiredFunctionCallOutputIds.filter(
     (callId) => !implicitStoredFunctionCallIds.includes(callId),
   );
+  const requiredOutputIdSet = new Set(requiredFunctionCallOutputIds);
+  const unansweredStoredCallIds = implicitPrevRespId
+    ? implicitStoredFunctionCallIds.filter((id) => !requiredOutputIdSet.has(id))
+    : [];
 
   // Session affinity: prefer the account that created the previous response
   const preferredEntryId =
@@ -307,6 +319,12 @@ export async function handleProxyRequest(
     console.warn(
       `[${fmt.tag}] 隐式续链跳过：上一轮 response 未记录 tool_result 对应的 call_id=` +
       missingFunctionCallOutputIds.slice(0, 3).join(","),
+    );
+  }
+  if (implicitPrevRespId && unansweredStoredCallIds.length > 0) {
+    console.warn(
+      `[${fmt.tag}] 隐式续链跳过：上一轮 function_call 未被全部回复，缺 call_id=` +
+      unansweredStoredCallIds.slice(0, 3).join(","),
     );
   }
 
@@ -595,6 +613,23 @@ export async function handleProxyRequest(
         continue;
       }
 
+      // Upstream rejected because a stored function_call from the previous
+      // response was not answered with a function_call_output. Recovery is the
+      // same as previous_response_not_found: drop previous_response_id, replay
+      // full history, retry once on the same account.
+      if (!prevRespNotFoundRetried && isUnansweredFunctionCallError(err)) {
+        prevRespNotFoundRetried = true;
+        const staleId = req.codexRequest.previous_response_id;
+        console.warn(
+          `[${fmt.tag}] Account ${entryId} | unanswered_function_call (id=${staleId ?? "?"}): ${err.message.slice(0, 200)}, stripping and retrying same account`,
+        );
+        if (staleId) affinityMap.forget(staleId);
+        restoreImplicitResumeRequest();
+        req.codexRequest.previous_response_id = undefined;
+        req.codexRequest.turnState = undefined;
+        continue;
+      }
+
       const decision = handleCodexApiError(
         err, accountPool, entryId, req.codexRequest.model, fmt.tag, modelRetried,
       );
@@ -804,6 +839,16 @@ async function handleNonStreaming(
         accountPool.recordEmptyResponse(currentEntryId);
         c.status(502);
         return c.json(fmt.formatError(502, "Codex returned empty responses across all available accounts"));
+      }
+      // Surface upstream HTTP errors with their actual status so the caller
+      // sees a structured 4xx instead of an opaque 502 fallback.
+      if (collectErr instanceof CodexApiError) {
+        const code = toErrorStatus(collectErr.status);
+        console.warn(
+          `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${collectErr.message.slice(0, 200)}`,
+        );
+        c.status(code);
+        return c.json(fmt.formatError(code, collectErr.message));
       }
       const msg = collectErr instanceof Error ? collectErr.message : "Unknown error";
       const statusMatch = msg.match(/HTTP\/[\d.]+ (\d{3})/);

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -101,6 +101,12 @@ function normalizeInstructions(instructions: string | null | undefined): string 
   return instructions ?? "";
 }
 
+/** Strip CodexApiError's "Codex API error (NNN): " prefix so log warns that
+ *  already include status= don't duplicate it inside the message body. */
+function stripCodexErrorPrefix(msg: string): string {
+  return msg.replace(/^Codex API error \(\d+\): /, "");
+}
+
 /** Annotate a usage payload with image_generation attempt outcome before
  *  releasing the account, so `recordUsage` can split it into success vs failed
  *  counters. Synthesizes a usage object when the failure path has none. */
@@ -135,10 +141,14 @@ export interface ImplicitResumeOpts {
 
 /** Reason why implicit resume was rejected, or null if it would activate.
  *  Returns "no_implicit_prev" when there's no candidate at all (caller can
- *  treat this as "not applicable"). */
+ *  treat this as "not applicable").
+ *
+ *  When rejected with `missing_tool_calls` or `unanswered_tool_calls`, also
+ *  returns the offending call_ids so the caller can surface them in logs
+ *  without recomputing the same set difference. */
 export function evaluateImplicitResume(opts: ImplicitResumeOpts):
   | { active: true; reason: null }
-  | { active: false; reason: string } {
+  | { active: false; reason: string; missingCallIds?: string[]; unansweredCallIds?: string[] } {
   if (!opts.implicitPrevRespId) return { active: false, reason: "no_implicit_prev" };
   if (opts.continuationInputStart >= opts.inputLength) {
     return { active: false, reason: "cont_start_eq_len" };
@@ -152,16 +162,16 @@ export function evaluateImplicitResume(opts: ImplicitResumeOpts):
   }
   const storedFunctionCallIds = new Set(opts.storedFunctionCallIds ?? []);
   const requiredFunctionCallOutputIds = opts.requiredFunctionCallOutputIds ?? [];
-  if (!requiredFunctionCallOutputIds.every((callId) => storedFunctionCallIds.has(callId))) {
-    return { active: false, reason: "missing_tool_calls" };
+  const missingCallIds = requiredFunctionCallOutputIds.filter((id) => !storedFunctionCallIds.has(id));
+  if (missingCallIds.length > 0) {
+    return { active: false, reason: "missing_tool_calls", missingCallIds };
   }
   // Reverse check: every stored function_call must be answered in this continuation.
   // Otherwise upstream rejects with "No tool output found for function call call_X".
   const requiredSet = new Set(requiredFunctionCallOutputIds);
-  for (const callId of storedFunctionCallIds) {
-    if (!requiredSet.has(callId)) {
-      return { active: false, reason: "unanswered_tool_calls" };
-    }
+  const unansweredCallIds = [...storedFunctionCallIds].filter((id) => !requiredSet.has(id));
+  if (unansweredCallIds.length > 0) {
+    return { active: false, reason: "unanswered_tool_calls", unansweredCallIds };
   }
   return { active: true, reason: null };
 }
@@ -265,14 +275,6 @@ export async function handleProxyRequest(
   const implicitStoredFunctionCallIds = implicitPrevRespId
     ? affinityMap.lookupFunctionCallIds(implicitPrevRespId)
     : [];
-  const missingFunctionCallOutputIds = requiredFunctionCallOutputIds.filter(
-    (callId) => !implicitStoredFunctionCallIds.includes(callId),
-  );
-  const requiredOutputIdSet = new Set(requiredFunctionCallOutputIds);
-  const unansweredStoredCallIds = implicitPrevRespId
-    ? implicitStoredFunctionCallIds.filter((id) => !requiredOutputIdSet.has(id))
-    : [];
-
   // Session affinity: prefer the account that created the previous response
   const preferredEntryId =
     explicitPrevRespId
@@ -315,19 +317,6 @@ export async function handleProxyRequest(
   // Idempotent-release guard: prevents double-release across retry branches
   const released = new Set<string>();
 
-  if (implicitPrevRespId && missingFunctionCallOutputIds.length > 0) {
-    console.warn(
-      `[${fmt.tag}] 隐式续链跳过：上一轮 response 未记录 tool_result 对应的 call_id=` +
-      missingFunctionCallOutputIds.slice(0, 3).join(","),
-    );
-  }
-  if (implicitPrevRespId && unansweredStoredCallIds.length > 0) {
-    console.warn(
-      `[${fmt.tag}] 隐式续链跳过：上一轮 function_call 未被全部回复，缺 call_id=` +
-      unansweredStoredCallIds.slice(0, 3).join(","),
-    );
-  }
-
   const resumeEval = evaluateImplicitResume({
     implicitPrevRespId,
     continuationInputStart,
@@ -339,6 +328,18 @@ export async function handleProxyRequest(
     requiredFunctionCallOutputIds,
     storedFunctionCallIds: implicitStoredFunctionCallIds,
   });
+  if (!resumeEval.active && resumeEval.missingCallIds && resumeEval.missingCallIds.length > 0) {
+    console.warn(
+      `[${fmt.tag}] 隐式续链跳过：上一轮 response 未记录 tool_result 对应的 call_id=` +
+      resumeEval.missingCallIds.slice(0, 3).join(","),
+    );
+  }
+  if (!resumeEval.active && resumeEval.unansweredCallIds && resumeEval.unansweredCallIds.length > 0) {
+    console.warn(
+      `[${fmt.tag}] 隐式续链跳过：上一轮 function_call 未被全部回复，缺 call_id=` +
+      resumeEval.unansweredCallIds.slice(0, 3).join(","),
+    );
+  }
   if (resumeEval.active) {
     req.codexRequest.previous_response_id = implicitPrevRespId!;
     req.codexRequest.useWebSocket = true;
@@ -621,7 +622,7 @@ export async function handleProxyRequest(
         stripAndRetryDone = true;
         const staleId = req.codexRequest.previous_response_id;
         console.warn(
-          `[${fmt.tag}] Account ${entryId} | unanswered_function_call (id=${staleId ?? "?"}): ${err.message.slice(0, 200)}, stripping and retrying same account`,
+          `[${fmt.tag}] Account ${entryId} | unanswered_function_call (id=${staleId ?? "?"}): ${stripCodexErrorPrefix(err.message).slice(0, 200)}, stripping and retrying same account`,
         );
         if (staleId) affinityMap.forget(staleId);
         restoreImplicitResumeRequest();
@@ -840,7 +841,7 @@ async function handleNonStreaming(
       // released Set guards against double-release on terminal paths).
       if (collectErr instanceof CodexApiError) {
         console.warn(
-          `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${collectErr.message.slice(0, 200)}`,
+          `[${fmt.tag}] Account ${currentEntryId} | upstream ${collectErr.status} during collect: ${stripCodexErrorPrefix(collectErr.message).slice(0, 200)}`,
         );
         throw collectErr;
       }

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -581,6 +581,11 @@ export async function handleProxyRequest(
         () => activeUsageHint,
         restoreImplicitResumeRequest,
         buildPoolCtx,
+        (nextEntryId, nextApi) => {
+          entryId = nextEntryId;
+          codexApi = nextApi;
+          if (!triedEntryIds.includes(nextEntryId)) triedEntryIds.push(nextEntryId);
+        },
       );
     } catch (err) {
       if (!(err instanceof CodexApiError)) {
@@ -711,6 +716,7 @@ async function handleNonStreaming(
   getUsageHint?: () => UsageHint | undefined,
   restoreImplicitResumeRequest?: () => void,
   buildPoolCtx?: (forEntryId: string) => WsPoolContext | undefined,
+  setActiveAccount?: (entryId: string, api: CodexApi) => void,
 ): Promise<Response> {
   let currentEntryId = initialEntryId;
   let currentApi = initialApi;
@@ -779,6 +785,7 @@ async function handleNonStreaming(
 
         currentEntryId = newAcquired.entryId;
         currentApi = buildCodexApi(newAcquired.token, newAcquired.accountId, cookieJar, newAcquired.entryId, proxyPool);
+        setActiveAccount?.(currentEntryId, currentApi);
         const retryStartMs = Date.now();
         try {
           currentRawResponse = await withRetry(

--- a/src/routes/shared/response-processor.ts
+++ b/src/routes/shared/response-processor.ts
@@ -51,9 +51,15 @@ export async function streamResponse(
       }
     }
   } catch (err) {
+    const errMsg = err instanceof Error ? err.message : "Stream interrupted";
+    const errBody = (err as { body?: unknown })?.body;
+    const errStatus = (err as { status?: unknown })?.status;
+    console.warn(
+      `[stream-error] status=${errStatus ?? "?"} msg=${errMsg}` +
+        (typeof errBody === "string" ? ` body=${errBody.slice(0, 1000)}` : ""),
+    );
     // Send error SSE event to client before closing
     try {
-      const errMsg = err instanceof Error ? err.message : "Stream interrupted";
       await s.write(
         `data: ${JSON.stringify({ error: { message: errMsg, type: "stream_error" } })}\n\n`,
       );

--- a/src/routes/shared/response-processor.ts
+++ b/src/routes/shared/response-processor.ts
@@ -5,6 +5,7 @@
  */
 
 import type { UpstreamAdapter } from "../../proxy/upstream-adapter.js";
+import { CodexApiError } from "../../proxy/codex-types.js";
 import type { FormatAdapter, ResponseMetadata, UsageHint } from "./proxy-handler.js";
 import type { UsageInfo } from "../../translation/codex-event-extractor.js";
 
@@ -52,11 +53,11 @@ export async function streamResponse(
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : "Stream interrupted";
-    const errBody = (err as { body?: unknown })?.body;
-    const errStatus = (err as { status?: unknown })?.status;
+    const errStatus = err instanceof CodexApiError ? err.status : "?";
+    const errBody = err instanceof CodexApiError ? err.body : undefined;
     console.warn(
-      `[stream-error] status=${errStatus ?? "?"} msg=${errMsg}` +
-        (typeof errBody === "string" ? ` body=${errBody.slice(0, 1000)}` : ""),
+      `[stream-error] status=${errStatus} msg=${errMsg}` +
+        (errBody ? ` body=${errBody.slice(0, 1000)}` : ""),
     );
     // Send error SSE event to client before closing
     try {

--- a/src/translation/codex-api-error-from-event.ts
+++ b/src/translation/codex-api-error-from-event.ts
@@ -1,0 +1,27 @@
+import { CodexApiError } from "../proxy/codex-types.js";
+
+/**
+ * Convert an upstream `error` / `response.failed` SSE event into a CodexApiError
+ * with an HTTP-equivalent status. Used by the non-streaming collectors so the
+ * proxy's catch path can run the same recovery logic (strip + retry) it would
+ * have used for an HTTP-layer 4xx, instead of falling through as 502.
+ */
+export function codexApiErrorFromEvent(
+  err: { code: string; message: string },
+): CodexApiError {
+  const status = statusForCode(err.code);
+  const body = JSON.stringify({
+    error: { type: err.code, code: err.code, message: err.message },
+  });
+  return new CodexApiError(status, body);
+}
+
+function statusForCode(code: string): number {
+  const lower = code.toLowerCase();
+  if (lower.includes("invalid_request") || lower.includes("not_found")) return 400;
+  if (lower.includes("rate_limit") || lower.includes("usage_limit")) return 429;
+  if (lower.includes("unauthorized") || lower.includes("invalid_api_key")) return 401;
+  if (lower.includes("forbidden") || lower.includes("banned")) return 403;
+  if (lower.includes("payment") || lower.includes("quota")) return 402;
+  return 502;
+}

--- a/src/translation/codex-to-anthropic.ts
+++ b/src/translation/codex-to-anthropic.ts
@@ -18,6 +18,7 @@ import type {
   AnthropicUsage,
 } from "../types/anthropic.js";
 import { iterateCodexEvents, EmptyResponseError, type UsageInfo } from "./codex-event-extractor.js";
+import { codexApiErrorFromEvent } from "./codex-api-error-from-event.js";
 
 interface CacheUsageHint {
   reusedInputTokensUpperBound?: number;
@@ -330,7 +331,7 @@ export async function collectCodexToAnthropicResponse(
   for await (const evt of iterateCodexEvents(codexApi, rawResponse)) {
     if (evt.responseId) responseId = evt.responseId;
     if (evt.error) {
-      throw new Error(`Codex API error: ${evt.error.code}: ${evt.error.message}`);
+      throw codexApiErrorFromEvent(evt.error);
     }
     if (evt.textDelta) fullText += evt.textDelta;
     if (evt.reasoningDelta) fullReasoning += evt.reasoningDelta;

--- a/src/translation/codex-to-anthropic.ts
+++ b/src/translation/codex-to-anthropic.ts
@@ -142,20 +142,7 @@ export async function* streamCodexToAnthropic(
 
     // Handle upstream error events
     if (evt.error) {
-      yield* closeThinkingIfOpen();
-      yield* ensureTextBlock();
-      yield formatSSE("content_block_delta", {
-        type: "content_block_delta",
-        index: contentIndex,
-        delta: { type: "text_delta", text: `[Error] ${evt.error.code}: ${evt.error.message}` },
-      });
-      yield* closeBlock("text");
-      yield formatSSE("error", {
-        type: "error",
-        error: { type: "api_error", message: `${evt.error.code}: ${evt.error.message}` },
-      });
-      yield formatSSE("message_stop", { type: "message_stop" });
-      return;
+      throw codexApiErrorFromEvent(evt.error);
     }
 
     // Handle reasoning delta → thinking block (only if client wants thinking)

--- a/src/translation/codex-to-gemini.ts
+++ b/src/translation/codex-to-gemini.ts
@@ -42,21 +42,7 @@ export async function* streamCodexToGemini(
 
     // Handle upstream error events
     if (evt.error) {
-      const errorChunk: GeminiGenerateContentResponse = {
-        candidates: [
-          {
-            content: {
-              parts: [{ text: `[Error] ${evt.error.code}: ${evt.error.message}` }],
-              role: "model",
-            },
-            finishReason: "OTHER",
-            index: 0,
-          },
-        ],
-        modelVersion: model,
-      };
-      yield `data: ${JSON.stringify(errorChunk)}\n\n`;
-      return;
+      throw codexApiErrorFromEvent(evt.error);
     }
 
     // Function call done → emit as a candidate with functionCall part

--- a/src/translation/codex-to-gemini.ts
+++ b/src/translation/codex-to-gemini.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types/gemini.js";
 import { iterateCodexEvents, EmptyResponseError, type UsageInfo } from "./codex-event-extractor.js";
 import { reconvertTupleValues } from "./tuple-schema.js";
+import { codexApiErrorFromEvent } from "./codex-api-error-from-event.js";
 
 /**
  * Stream Codex Responses API events as Gemini SSE.
@@ -208,7 +209,7 @@ export async function collectCodexToGeminiResponse(
   for await (const evt of iterateCodexEvents(codexApi, rawResponse)) {
     if (evt.responseId) responseId = evt.responseId;
     if (evt.error) {
-      throw new Error(`Codex API error: ${evt.error.code}: ${evt.error.message}`);
+      throw codexApiErrorFromEvent(evt.error);
     }
     if (evt.textDelta) fullText += evt.textDelta;
     if (evt.usage) {

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -73,34 +73,7 @@ export async function* streamCodexToOpenAI(
 
     // Handle upstream error events
     if (evt.error) {
-      yield formatSSE({
-        id: chunkId,
-        object: "chat.completion.chunk",
-        created,
-        model,
-        choices: [
-          {
-            index: 0,
-            delta: { content: `[Error] ${evt.error.code}: ${evt.error.message}` },
-            finish_reason: null,
-          },
-        ],
-      });
-      yield formatSSE({
-        id: chunkId,
-        object: "chat.completion.chunk",
-        created,
-        model,
-        choices: [
-          {
-            index: 0,
-            delta: {},
-            finish_reason: "stop",
-          },
-        ],
-      });
-      yield "data: [DONE]\n\n";
-      return;
+      throw codexApiErrorFromEvent(evt.error);
     }
 
     // Handle function call events

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -20,6 +20,7 @@ import type {
 } from "../types/openai.js";
 import { iterateCodexEvents, EmptyResponseError, type UsageInfo } from "./codex-event-extractor.js";
 import { reconvertTupleValues } from "./tuple-schema.js";
+import { codexApiErrorFromEvent } from "./codex-api-error-from-event.js";
 
 /** Format an SSE chunk for streaming output */
 function formatSSE(chunk: ChatCompletionChunk): string {
@@ -347,7 +348,7 @@ export async function collectCodexResponse(
   for await (const evt of iterateCodexEvents(codexApi, rawResponse)) {
     if (evt.responseId) responseId = evt.responseId;
     if (evt.error) {
-      throw new Error(`Codex API error: ${evt.error.code}: ${evt.error.message}`);
+      throw codexApiErrorFromEvent(evt.error);
     }
     if (evt.textDelta) fullText += evt.textDelta;
     if (evt.reasoningDelta) fullReasoning += evt.reasoningDelta;

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -453,6 +453,45 @@ describe("proxy-handler integration", () => {
     });
   });
 
+  it("attributes collect CodexApiError after EmptyResponseError retry to the new account", async () => {
+    let acquireCount = 0;
+    const accountPool = createMockAccountPool({
+      acquire: vi.fn(() => {
+        acquireCount++;
+        if (acquireCount === 1) return { entryId: "e1", token: "tok1", accountId: "acc1" };
+        return { entryId: "e2", token: "tok2", accountId: "acc2" };
+      }),
+    });
+
+    let collectCallCount = 0;
+    const fmt = createMockFormatAdapter({
+      collectTranslator: vi.fn(async () => {
+        collectCallCount++;
+        if (collectCallCount === 1) {
+          throw new EmptyResponseError(
+            "resp_empty",
+            { input_tokens: 1, output_tokens: 0 },
+          );
+        }
+        throw new CodexApiError(422, JSON.stringify({
+          error: { type: "invalid_request_error", message: "bad retry collect" },
+        }));
+      }),
+    });
+
+    const { app } = buildTestApp({ accountPool, fmt });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(422);
+
+    expect(accountPool.recordEmptyResponse).toHaveBeenCalledWith("e1");
+    expect(accountPool.release).toHaveBeenCalledWith("e1", {
+      input_tokens: 1,
+      output_tokens: 0,
+    });
+    expect(accountPool.release).toHaveBeenCalledWith("e2", undefined);
+  });
+
   // 9. Empty response retries exhausted → 502
   it("returns 502 when all empty response retries are exhausted", async () => {
     const emptyUsage = { input_tokens: 0, output_tokens: 0 };

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -720,6 +720,45 @@ describe("proxy-handler integration", () => {
     expect(createCount).toBe(2);
   });
 
+  // 17c. unanswered function_call: upstream "No tool output found for function
+  // call call_X" means a stored function_call from the previous response was
+  // not answered. Recovery: strip previous_response_id, retry once on the same
+  // account (full input replay covers the missing context).
+  it("recovers from unanswered function_call by stripping ID and retrying", async () => {
+    const unansweredBody = JSON.stringify({
+      error: {
+        type: "invalid_request_error",
+        message: "No tool output found for function call call_8vO7oqvintBWH5bAoAz3vPh5.",
+      },
+    });
+
+    let createCount = 0;
+    const seenPrevIds: Array<string | undefined> = [];
+    const req: ProxyRequest = {
+      ...createDefaultRequest(),
+      codexRequest: {
+        ...createDefaultRequest().codexRequest,
+        previous_response_id: "resp_unanswered_chain",
+      },
+    };
+    mockCreateResponse = () => {
+      seenPrevIds.push(req.codexRequest.previous_response_id);
+      createCount++;
+      if (createCount === 1) return Promise.reject(new CodexApiError(400, unansweredBody));
+      return Promise.resolve(new Response("data: {}\n\n"));
+    };
+
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const { app } = buildTestApp({ accountPool, fmt, req });
+    const res = await app.request("/test", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    expect(createCount).toBe(2);
+    expect(seenPrevIds[0]).toBe("resp_unanswered_chain");
+    expect(seenPrevIds[1]).toBeUndefined();
+  });
+
   // 18. 403 ban with mixed pool states → descriptive error
   it("returns descriptive error when banned and remaining accounts disabled/expired", async () => {
     mockCreateResponse = () =>

--- a/tests/real/tools.test.ts
+++ b/tests/real/tools.test.ts
@@ -85,7 +85,10 @@ describe("real: tool use via /v1/chat/completions", () => {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({
-        model: "codex",
+        // /v1/chat/completions strictly gates on isRecognizedModelName
+        // (chat.ts:113); the historical "codex" alias was removed on
+        // 2026-04-23, so use the catalog default explicitly here.
+        model: "gpt-5.4",
         messages: [{ role: "user", content: TOOL_PROMPT }],
         tools: [WEATHER_TOOL_OPENAI],
         tool_choice: "auto",
@@ -129,7 +132,7 @@ describe("real: tool use via /v1/chat/completions", () => {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({
-        model: "codex",
+        model: "gpt-5.4",
         messages: [{ role: "user", content: TOOL_PROMPT }],
         tools: [WEATHER_TOOL_OPENAI],
         tool_choice: "auto",

--- a/tests/real/unanswered-tool-call.test.ts
+++ b/tests/real/unanswered-tool-call.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import {
-  PROXY_URL, TIMEOUT,
+  PROXY_URL,
   checkProxy, skip, anthropicHeaders,
 } from "./_helpers.js";
 
@@ -166,17 +166,16 @@ describe("real: partial tool_result triggers proxy recovery path", () => {
       },
     ]);
 
-    // Either:
-    //  - 200 (proxy recovered via reverse-check + full replay if upstream tolerates
-    //    a single missing pair on resubmit), or
-    //  - 4xx with a structured error body (proxy surfaced upstream's complaint
-    //    cleanly). Either is acceptable; what's NOT acceptable is a 5xx, hang,
-    //    or stream crash — and the proxy log must contain the diagnostic warn.
-    expect([200, 400, 422]).toContain(turn2.status);
-    if (turn2.status !== 200) {
-      const errBody = turn2.body as { error?: { message?: string } };
-      const msg = errBody.error?.message ?? "";
-      expect(msg.length).toBeGreaterThan(0);
-    }
+    // Layer 1 reverse-check disables implicit resume → full replay still has
+    // the orphan function_call → upstream rejects with 400 "No tool output
+    // found...". Layer 2 strip+retry can't fabricate the missing tool_result,
+    // so the final outcome is a structured 4xx surfaced to the client (NOT a
+    // 502 fallback or a stream crash). 5xx indicates the proxy lost the real
+    // upstream status somewhere in the SSE/collect path.
+    expect(turn2.status).toBeGreaterThanOrEqual(400);
+    expect(turn2.status).toBeLessThan(500);
+    const errBody = turn2.body as { error?: { message?: string } };
+    const msg = errBody.error?.message ?? "";
+    expect(msg.toLowerCase()).toContain("no tool output found for function call");
   }, TOOL_TIMEOUT * 4);
 });

--- a/tests/real/unanswered-tool-call.test.ts
+++ b/tests/real/unanswered-tool-call.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Real upstream test — validates the fix for "No tool output found for
+ * function call call_X" upstream error path.
+ *
+ * Two flows:
+ *  1. Happy path (regression guard): multi-tool parallel call_use →
+ *     complete tool_results follow-up should succeed.
+ *  2. Recovery path: when client's continuation skips one of the previous
+ *     turn's function_calls, the proxy's reverse-check (`unanswered_tool_calls`)
+ *     should disable implicit resume + replay full history; if upstream still
+ *     rejects (true client mismatch), Layer 2 catch must surface a graceful
+ *     error rather than spamming logs.
+ *
+ * Run with: npm run test:real -- unanswered-tool-call
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  PROXY_URL, TIMEOUT,
+  checkProxy, skip, anthropicHeaders,
+} from "./_helpers.js";
+
+beforeAll(async () => {
+  await checkProxy();
+});
+
+const TOOL_TIMEOUT = 60_000;
+
+const TOOLS = [
+  {
+    name: "get_weather",
+    description: "Get the current weather for a location",
+    input_schema: {
+      type: "object",
+      properties: { location: { type: "string", description: "City name" } },
+      required: ["location"],
+    },
+  },
+  {
+    name: "get_time",
+    description: "Get the current time in a location",
+    input_schema: {
+      type: "object",
+      properties: { location: { type: "string", description: "City name" } },
+      required: ["location"],
+    },
+  },
+];
+
+const PARALLEL_PROMPT =
+  "I need to know both the weather AND the current time in Tokyo. Call BOTH get_weather and get_time IN PARALLEL in a single response.";
+
+interface AnthropicContentBlock {
+  type: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  text?: string;
+}
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+}
+
+interface AnthropicResponse {
+  content: AnthropicContentBlock[];
+  stop_reason?: string;
+}
+
+async function sendMessages(
+  messages: AnthropicMessage[],
+): Promise<{ status: number; body: AnthropicResponse | { type: string; error: { message: string } } }> {
+  const res = await fetch(`${PROXY_URL}/v1/messages`, {
+    method: "POST",
+    headers: anthropicHeaders(),
+    body: JSON.stringify({
+      model: "codex",
+      max_tokens: 1024,
+      messages,
+      tools: TOOLS,
+      stream: false,
+    }),
+    signal: AbortSignal.timeout(TOOL_TIMEOUT),
+  });
+  const body = await res.json();
+  return { status: res.status, body: body as AnthropicResponse };
+}
+
+describe("real: parallel tool_use + complete follow-up (regression guard)", () => {
+  it("3 iterations: full parallel tool flow round-trips cleanly", async () => {
+    if (skip()) return;
+
+    for (let iteration = 1; iteration <= 3; iteration++) {
+      // Turn 1: model emits parallel tool_use blocks.
+      const turn1 = await sendMessages([
+        { role: "user", content: PARALLEL_PROMPT },
+      ]);
+      expect(turn1.status, `turn1 iteration ${iteration}`).toBe(200);
+      const r1 = turn1.body as AnthropicResponse;
+
+      const toolUses = r1.content.filter((b) => b.type === "tool_use");
+      // Some turns the model may serialize calls instead of paralleling them.
+      // Skip iterations that didn't actually parallel — they don't exercise
+      // the multi-call code path. Re-roll up to a few times.
+      if (toolUses.length < 2) {
+        iteration--;
+        continue;
+      }
+
+      // Turn 2: complete tool_results for ALL tool_uses (the well-formed case).
+      const turn2 = await sendMessages([
+        { role: "user", content: PARALLEL_PROMPT },
+        { role: "assistant", content: r1.content },
+        {
+          role: "user",
+          content: toolUses.map((tu) => ({
+            type: "tool_result",
+            tool_use_id: tu.id!,
+            content: tu.name === "get_weather" ? "Sunny, 22°C" : "14:30 JST",
+          })) as AnthropicContentBlock[],
+        },
+      ]);
+      expect(turn2.status, `turn2 iteration ${iteration}`).toBe(200);
+      const r2 = turn2.body as AnthropicResponse;
+      // Should now produce text output
+      expect(r2.content.some((b) => b.type === "text")).toBe(true);
+    }
+  }, TOOL_TIMEOUT * 6);
+});
+
+describe("real: partial tool_result triggers proxy recovery path", () => {
+  it("missing one tool_result returns a structured error, not a stream crash", async () => {
+    if (skip()) return;
+
+    // Turn 1: get parallel tool_use IDs.
+    let toolUses: AnthropicContentBlock[] = [];
+    let turn1Content: AnthropicContentBlock[] = [];
+    for (let attempt = 0; attempt < 3 && toolUses.length < 2; attempt++) {
+      const turn1 = await sendMessages([
+        { role: "user", content: PARALLEL_PROMPT },
+      ]);
+      if (turn1.status !== 200) continue;
+      const r1 = turn1.body as AnthropicResponse;
+      toolUses = r1.content.filter((b) => b.type === "tool_use");
+      turn1Content = r1.content;
+    }
+    if (toolUses.length < 2) {
+      console.warn("[real] could not get parallel tool_use, skipping");
+      return;
+    }
+
+    // Turn 2: deliberately answer ONLY the first tool_use, omit the second.
+    const turn2 = await sendMessages([
+      { role: "user", content: PARALLEL_PROMPT },
+      { role: "assistant", content: turn1Content },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUses[0].id!,
+            content: "Sunny, 22°C",
+          },
+        ] as AnthropicContentBlock[],
+      },
+    ]);
+
+    // Either:
+    //  - 200 (proxy recovered via reverse-check + full replay if upstream tolerates
+    //    a single missing pair on resubmit), or
+    //  - 4xx with a structured error body (proxy surfaced upstream's complaint
+    //    cleanly). Either is acceptable; what's NOT acceptable is a 5xx, hang,
+    //    or stream crash — and the proxy log must contain the diagnostic warn.
+    expect([200, 400, 422]).toContain(turn2.status);
+    if (turn2.status !== 200) {
+      const errBody = turn2.body as { error?: { message?: string } };
+      const msg = errBody.error?.message ?? "";
+      expect(msg.length).toBeGreaterThan(0);
+    }
+  }, TOOL_TIMEOUT * 4);
+});

--- a/tests/unit/proxy/error-classification.test.ts
+++ b/tests/unit/proxy/error-classification.test.ts
@@ -6,6 +6,7 @@ import {
   isQuotaExhaustedError,
   isTokenInvalidError,
   isModelNotSupportedError,
+  isUnansweredFunctionCallError,
 } from "@src/proxy/error-classification.js";
 
 describe("extractRetryAfterSec", () => {
@@ -127,5 +128,34 @@ describe("isModelNotSupportedError", () => {
   it("returns false when message lacks 'model'", () => {
     const err = new CodexApiError(400, '{"detail": "Feature not supported"}');
     expect(isModelNotSupportedError(err)).toBe(false);
+  });
+});
+
+describe("isUnansweredFunctionCallError", () => {
+  it("detects 'No tool output found for function call'", () => {
+    const body = JSON.stringify({
+      error: {
+        message: "No tool output found for function call call_8vO7oqvintBWH5bAoAz3vPh5.",
+        type: "invalid_request_error",
+      },
+    });
+    expect(isUnansweredFunctionCallError(new CodexApiError(400, body))).toBe(true);
+  });
+
+  it("returns false for unrelated 400", () => {
+    const body = JSON.stringify({ error: { message: "Something else broke" } });
+    expect(isUnansweredFunctionCallError(new CodexApiError(400, body))).toBe(false);
+  });
+
+  it("returns false for non-400", () => {
+    const body = JSON.stringify({
+      error: { message: "No tool output found for function call call_x." },
+    });
+    expect(isUnansweredFunctionCallError(new CodexApiError(429, body))).toBe(false);
+  });
+
+  it("returns false for non-CodexApiError", () => {
+    expect(isUnansweredFunctionCallError(new Error("No tool output found"))).toBe(false);
+    expect(isUnansweredFunctionCallError(null)).toBe(false);
   });
 });

--- a/tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts
+++ b/tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts
@@ -42,7 +42,7 @@ describe("shouldActivateImplicitResume", () => {
     })).toBe(false);
   });
 
-  it("tool_result 里的 call_id 属于上一轮 response 时允许隐式续链", () => {
+  it("tool_result 与上一轮 function_call 完全配对时允许隐式续链", () => {
     expect(shouldActivateImplicitResume({
       implicitPrevRespId: "resp_prev",
       continuationInputStart: 2,
@@ -51,8 +51,8 @@ describe("shouldActivateImplicitResume", () => {
       acquiredEntryId: "entry_1",
       currentInstructions: "system-a",
       storedInstructions: "system-a",
-      requiredFunctionCallOutputIds: ["call_ok"],
-      storedFunctionCallIds: ["call_ok", "call_other"],
+      requiredFunctionCallOutputIds: ["call_a", "call_b"],
+      storedFunctionCallIds: ["call_a", "call_b"],
     })).toBe(true);
   });
 
@@ -67,6 +67,20 @@ describe("shouldActivateImplicitResume", () => {
       storedInstructions: "system-a",
       requiredFunctionCallOutputIds: ["call_missing"],
       storedFunctionCallIds: ["call_ok"],
+    })).toBe(false);
+  });
+
+  it("上一轮 function_call 未被全部回复时禁止隐式续链（防 No tool output 上游错误）", () => {
+    expect(shouldActivateImplicitResume({
+      implicitPrevRespId: "resp_prev",
+      continuationInputStart: 2,
+      inputLength: 3,
+      preferredEntryId: "entry_1",
+      acquiredEntryId: "entry_1",
+      currentInstructions: "system-a",
+      storedInstructions: "system-a",
+      requiredFunctionCallOutputIds: ["call_a"],
+      storedFunctionCallIds: ["call_a", "call_b_unanswered"],
     })).toBe(false);
   });
 

--- a/tests/unit/translation/codex-to-anthropic.test.ts
+++ b/tests/unit/translation/codex-to-anthropic.test.ts
@@ -110,6 +110,11 @@ describe("streamCodexToAnthropic", () => {
     const msgDelta = events.find((e) => e.event === "message_delta");
     expect((msgDelta?.data.delta as Record<string, unknown>)?.stop_reason).toBe("end_turn");
   });
+
+  it("throws CodexApiError on upstream error events", async () => {
+    await expect(collectStreamOutput(errorStream()))
+      .rejects.toMatchObject({ status: 429 });
+  });
 });
 
 describe("collectCodexToAnthropicResponse", () => {

--- a/tests/unit/translation/codex-to-gemini.test.ts
+++ b/tests/unit/translation/codex-to-gemini.test.ts
@@ -71,12 +71,9 @@ describe("streamCodexToGemini", () => {
     expect(parsed.candidates[0].content.parts[0].functionCall.name).toBe("get_weather");
   });
 
-  it("handles error events", async () => {
-    const chunks = await collectStreamOutput(errorStream());
-    const dataChunks = chunks.filter((c) => c.startsWith("data: "));
-    expect(dataChunks.length).toBeGreaterThan(0);
-    const parsed = JSON.parse(dataChunks[0].slice(6));
-    expect(parsed.candidates[0].finishReason).toBe("OTHER");
+  it("throws CodexApiError on upstream error events", async () => {
+    await expect(collectStreamOutput(errorStream()))
+      .rejects.toMatchObject({ status: 429 });
   });
 
   it("injects error text for empty response", async () => {
@@ -145,12 +142,9 @@ describe("streamCodexToGemini — additional details", () => {
     expect(lastData.usageMetadata?.cachedContentTokenCount).toBe(30);
   });
 
-  it("emits correct finishReason OTHER with error text for error events", async () => {
-    const chunks = await collectStreamOutput(errorStream());
-    const dataChunks = chunks.filter((c) => c.startsWith("data: "));
-    const parsed = JSON.parse(dataChunks[0].slice(6));
-    expect(parsed.candidates[0].finishReason).toBe("OTHER");
-    expect(parsed.candidates[0].content.parts[0].text).toContain("[Error]");
+  it("throws CodexApiError with status for error events", async () => {
+    await expect(collectStreamOutput(errorStream()))
+      .rejects.toMatchObject({ status: 429 });
   });
 });
 

--- a/tests/unit/translation/codex-to-openai.test.ts
+++ b/tests/unit/translation/codex-to-openai.test.ts
@@ -83,10 +83,9 @@ describe("streamCodexToOpenAI", () => {
     expect(reasoningChunks.length).toBeGreaterThan(0);
   });
 
-  it("handles error events", async () => {
-    const chunks = await collectStreamOutput(errorStream());
-    const errorChunks = chunks.filter((c) => c.includes("[Error]"));
-    expect(errorChunks.length).toBeGreaterThan(0);
+  it("throws CodexApiError on upstream error events", async () => {
+    await expect(collectStreamOutput(errorStream()))
+      .rejects.toMatchObject({ status: 429 });
   });
 
   it("injects error text for empty response", async () => {


### PR DESCRIPTION
## Summary

`evaluateImplicitResume` 此前只做 forward 校验（新输入里每个 `function_call_output.call_id` 必须命中上一轮 stored function_call），漏了反向方向。当上一轮模型并发吐 N 个 tool_use 而客户端只回 N-1 个 tool_result 时，proxy 仍然带 `previous_response_id` 走 resume，上游用存的 context 触发 `invalid_request_error: No tool output found for function call call_X`。这条 400 在流式 catch 里只写一条 SSE error 事件、零日志，在非流式 collectErr 里又因为 translator 抛的是 plain `Error`、status 信息丢失，最终一律降级成 502。Claude Code 用户因此持续看到 4xx 报错而 proxy 日志里查不到任何 call_id 现场。

## Changes

- `src/routes/shared/proxy-handler.ts` — `evaluateImplicitResume` 增加反向检查（`reason: "unanswered_tool_calls"`），并在请求路径上 warn 出缺失的 call_id；catch 块新增 `isUnansweredFunctionCallError` 分支，复用 `prevRespNotFoundRetried` 单次保护，strip `previous_response_id` + 完整重放
- `src/proxy/error-classification.ts` — 新增 `isUnansweredFunctionCallError`（仅匹配 400 + "no tool output found for function call"）
- `src/translation/codex-{anthropic,openai,gemini}.ts` + 新文件 `codex-api-error-from-event.ts` — 上游 SSE error 事件改抛 `CodexApiError(status, body)`，按 error code 映射 400/401/402/403/429（默认 502）
- `src/routes/shared/proxy-handler.ts` (handleNonStreaming) — collectErr 加 `instanceof CodexApiError` 分支，透传上游真实 status 而不是走正则降 502
- `src/routes/shared/response-processor.ts` — 流式 catch 新增 `console.warn`，把 status / msg / body 写进 `dev-YYYY-MM-DD.log`
- `tests/real/tools.test.ts` — `/v1/chat/completions` 两个 case 把 `model:"codex"` 改成 `gpt-5.4`（codex alias 在 2026-04-23 已被 `config/models.yaml` 注释里说明的那次提交移除，chat.ts 路径严格走 `isRecognizedModelName` 会 404）

## Test Plan

- [x] `npx vitest run tests/unit tests/integration` — 1562/1562
- [x] `npm run test:real -- unanswered-tool-call` ×3 连跑全绿（每次 2/2，含 3 轮并行 tool_use 回归保护 + 缺 tool_result 走 4xx 透传分支）
- [x] `npm run test:real -- tools` — 8/8（修完后 `/v1/chat/completions` 两个 case 不再 404）
- [x] `npx tsc --noEmit`
- [x] 真实日志确认看到 `resume=off:unanswered_tool_calls` + `upstream 400 during collect: ... call_X` 双重证据

## Notes

reverse check 只是 best-effort 防御——客户端真的少送一个 tool_result 时 proxy 没法替它补，最终还是会拿到上游 400，但现在客户端拿到的是带原文 message 的 400 而不是 502，proxy 日志里也有完整 call_id 现场可追。