### PR TITLE
Fix proxy handling for API-key upstream fetches

### DIFF
--- a/src/proxy/fetch-dispatcher.ts
+++ b/src/proxy/fetch-dispatcher.ts
@@ -1,0 +1,26 @@
+import { ProxyAgent, type Dispatcher } from "undici";
+import { getConfig } from "../config.js";
+
+let cachedProxyUrl: string | null = null;
+let cachedDispatcher: Dispatcher | undefined;
+
+export function getFetchDispatcher(): Dispatcher | undefined {
+  let proxyUrl: string | null = null;
+  try {
+    proxyUrl = getConfig().tls.proxy_url;
+  } catch {
+    proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy ?? null;
+  }
+
+  if (!proxyUrl) return undefined;
+  if (proxyUrl === cachedProxyUrl && cachedDispatcher) return cachedDispatcher;
+
+  cachedProxyUrl = proxyUrl;
+  cachedDispatcher = new ProxyAgent(proxyUrl);
+  return cachedDispatcher;
+}
+
+export function withFetchDispatcher(init: RequestInit): RequestInit & { dispatcher?: Dispatcher } {
+  const dispatcher = getFetchDispatcher();
+  return dispatcher ? { ...init, dispatcher } : init;
+}

--- a/src/proxy/gemini-upstream.ts
+++ b/src/proxy/gemini-upstream.ts
@@ -18,6 +18,7 @@ import type { CodexResponsesRequest, CodexSSEEvent } from "./codex-types.js";
 import { CodexApiError } from "./codex-types.js";
 import { parseSSEStream } from "./codex-sse.js";
 import { translateCodexToGeminiRequest } from "../translation/codex-request-to-gemini.js";
+import { withFetchDispatcher } from "./fetch-dispatcher.js";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -46,7 +47,7 @@ export class GeminiUpstream implements UpstreamAdapter {
     // Always use streaming endpoint; non-streaming requests also use it for simplicity
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(modelId)}:streamGenerateContent?alt=sse&key=${encodeURIComponent(this.apiKey)}`;
 
-    const response = await fetch(url, {
+    const response = await fetch(url, withFetchDispatcher({
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -54,7 +55,7 @@ export class GeminiUpstream implements UpstreamAdapter {
       },
       body: JSON.stringify(body),
       signal,
-    });
+    }));
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);

--- a/src/proxy/openai-upstream.ts
+++ b/src/proxy/openai-upstream.ts
@@ -13,6 +13,7 @@ import type { CodexResponsesRequest, CodexSSEEvent } from "./codex-types.js";
 import { CodexApiError } from "./codex-types.js";
 import { parseSSEStream } from "./codex-sse.js";
 import { translateCodexToOpenAIRequest } from "../translation/codex-request-to-openai.js";
+import { withFetchDispatcher } from "./fetch-dispatcher.js";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -41,7 +42,7 @@ export class OpenAIUpstream implements UpstreamAdapter {
     const modelId = extractModelId(req.model);
     const body = translateCodexToOpenAIRequest(req, modelId, req.stream);
 
-    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+    const response = await fetch(`${this.baseUrl}/chat/completions`, withFetchDispatcher({
       method: "POST",
       headers: {
         "Authorization": `Bearer ${this.apiKey}`,
@@ -50,7 +51,7 @@ export class OpenAIUpstream implements UpstreamAdapter {
       },
       body: JSON.stringify(body),
       signal,
-    });
+    }));
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);

--- a/tests/unit/proxy/fetch-dispatcher.test.ts
+++ b/tests/unit/proxy/fetch-dispatcher.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockGetConfig = vi.fn();
+const mockProxyAgent = vi.fn((url: string) => ({ proxyUrl: url }));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: () => mockGetConfig(),
+}));
+
+vi.mock("undici", () => ({
+  ProxyAgent: mockProxyAgent,
+}));
+
+describe("fetch dispatcher", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+  });
+
+  it("does not add a dispatcher when no proxy is configured", async () => {
+    mockGetConfig.mockReturnValue({ tls: { proxy_url: null } });
+    const { withFetchDispatcher } = await import("@src/proxy/fetch-dispatcher.js");
+
+    const init = { method: "POST" };
+
+    expect(withFetchDispatcher(init)).toBe(init);
+    expect(mockProxyAgent).not.toHaveBeenCalled();
+  });
+
+  it("adds a ProxyAgent dispatcher from tls.proxy_url", async () => {
+    mockGetConfig.mockReturnValue({ tls: { proxy_url: "http://127.0.0.1:7890" } });
+    const { withFetchDispatcher } = await import("@src/proxy/fetch-dispatcher.js");
+
+    const init = { method: "POST" };
+    const result = withFetchDispatcher(init);
+
+    expect(result).not.toBe(init);
+    expect(result.dispatcher).toEqual({ proxyUrl: "http://127.0.0.1:7890" });
+    expect(mockProxyAgent).toHaveBeenCalledWith("http://127.0.0.1:7890");
+  });
+
+  it("falls back to HTTPS_PROXY before config is loaded", async () => {
+    mockGetConfig.mockImplementation(() => {
+      throw new Error("Config not loaded");
+    });
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7891";
+    const { withFetchDispatcher } = await import("@src/proxy/fetch-dispatcher.js");
+
+    const result = withFetchDispatcher({ method: "POST" });
+
+    expect(result.dispatcher).toEqual({ proxyUrl: "http://127.0.0.1:7891" });
+    expect(mockProxyAgent).toHaveBeenCalledWith("http://127.0.0.1:7891");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared undici fetch dispatcher helper that uses configured `tls.proxy_url` or `HTTPS_PROXY`/`https_proxy`
- Apply the dispatcher to OpenAI-compatible/custom and Gemini API-key upstream fetch calls
- Add unit coverage for dispatcher behavior and env fallback before config load

## Test plan
- [x] npm test -- tests/unit/proxy/fetch-dispatcher.test.ts
- [x] npm run build