### PR TITLE
fix(proxy): fall back to HTTPS_PROXY env when WS proxyUrl is undefined

### DIFF
--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -140,12 +140,18 @@ async function buildWsConstructorOpts(
   proxyUrl: string | null | undefined,
 ): Promise<ConstructorParameters<typeof WS>[2]> {
   const wsOpts: ConstructorParameters<typeof WS>[2] = { headers };
-  if (proxyUrl) {
-    let agent = _agentCache.get(proxyUrl);
+  // Fall back to HTTPS_PROXY env when caller passes undefined ("global" pool
+  // assignment). The native (rustls) transport already does this for HTTPS
+  // POST; without the same fallback here, WS connects go direct and TLS to
+  // chatgpt.com fails from within a container with only proxied egress.
+  const effectiveProxyUrl =
+    proxyUrl || process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (effectiveProxyUrl) {
+    let agent = _agentCache.get(effectiveProxyUrl);
     if (!agent) {
       const { HttpsProxyAgent } = await import("https-proxy-agent");
-      agent = new HttpsProxyAgent(proxyUrl);
-      _agentCache.set(proxyUrl, agent);
+      agent = new HttpsProxyAgent(effectiveProxyUrl);
+      _agentCache.set(effectiveProxyUrl, agent);
     }
     wsOpts.agent = agent;
   }

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -18,6 +18,7 @@ import type { CodexInputItem } from "./codex-api.js";
 import type { ParsedRateLimit } from "./rate-limit-headers.js";
 import { parseRateLimitsEvent } from "./rate-limit-headers.js";
 import { CodexApiError } from "./codex-types.js";
+import { getProxyUrl } from "../tls/proxy.js";
 import {
   PersistentWs,
   WsReusedConnectionError,
@@ -140,12 +141,10 @@ async function buildWsConstructorOpts(
   proxyUrl: string | null | undefined,
 ): Promise<ConstructorParameters<typeof WS>[2]> {
   const wsOpts: ConstructorParameters<typeof WS>[2] = { headers };
-  // Fall back to HTTPS_PROXY env when caller passes undefined ("global" pool
-  // assignment). The native (rustls) transport already does this for HTTPS
-  // POST; without the same fallback here, WS connects go direct and TLS to
-  // chatgpt.com fails from within a container with only proxied egress.
+  // Mirror native transport proxy semantics:
+  // undefined = global default, null = explicit direct, string = specific proxy.
   const effectiveProxyUrl =
-    proxyUrl || process.env.HTTPS_PROXY || process.env.https_proxy;
+    proxyUrl === undefined ? getProxyUrl() : proxyUrl;
   if (effectiveProxyUrl) {
     let agent = _agentCache.get(effectiveProxyUrl);
     if (!agent) {

--- a/tests/unit/proxy/ws-transport.test.ts
+++ b/tests/unit/proxy/ws-transport.test.ts
@@ -5,6 +5,7 @@
 import { EventEmitter } from "node:events";
 
 const wsInstances = vi.hoisted(() => [] as EventEmitter[]);
+const globalProxyUrl = vi.hoisted(() => ({ value: null as string | null }));
 
 vi.mock("ws", () => {
   const { EventEmitter: EE } = require("node:events") as typeof import("node:events");
@@ -37,6 +38,22 @@ vi.mock("ws", () => {
   }
   return { default: MockWebSocket };
 });
+
+vi.mock("https-proxy-agent", () => {
+  class HttpsProxyAgent {
+    proxyUrl: string;
+
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+    }
+  }
+
+  return { HttpsProxyAgent };
+});
+
+vi.mock("@src/tls/proxy.js", () => ({
+  getProxyUrl: () => globalProxyUrl.value,
+}));
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -88,8 +105,9 @@ async function waitForOpen(): Promise<void> {
 async function startConnect(
   req: WsCreateRequest = BASE_REQUEST,
   headers: Record<string, string> = {},
+  proxyUrl?: string | null,
 ): Promise<{ promise: Promise<Response>; ws: MockWs }> {
-  const promise = createWebSocketResponse("wss://test/ws", headers, req);
+  const promise = createWebSocketResponse("wss://test/ws", headers, req, undefined, proxyUrl);
   // Swallow the rejection if the test never awaits `promise` (e.g. it
   // expects the promise to reject). We re-throw on any awaiter via the
   // returned reference, so this only suppresses unhandled-rejection noise.
@@ -125,6 +143,7 @@ async function readStream(response: Response): Promise<string> {
 describe("createWebSocketResponse", () => {
   beforeEach(() => {
     wsInstances.length = 0;
+    globalProxyUrl.value = null;
   });
 
   it("connects and sends the request message", async () => {
@@ -139,6 +158,38 @@ describe("createWebSocketResponse", () => {
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
     const response = await promise;
     expect(response.status).toBe(200);
+
+    ws.close();
+  });
+
+  it("uses the global proxy only when proxyUrl is undefined", async () => {
+    globalProxyUrl.value = "http://global-proxy.local:8080";
+
+    const { ws } = await startConnect(BASE_REQUEST, {}, undefined);
+
+    expect((ws.opts?.agent as { proxyUrl?: string } | undefined)?.proxyUrl)
+      .toBe("http://global-proxy.local:8080");
+
+    ws.close();
+  });
+
+  it("does not use the global proxy when proxyUrl is explicit direct", async () => {
+    globalProxyUrl.value = "http://global-proxy.local:8080";
+
+    const { ws } = await startConnect(BASE_REQUEST, {}, null);
+
+    expect(ws.opts?.agent).toBeUndefined();
+
+    ws.close();
+  });
+
+  it("uses an explicit proxy URL instead of the global proxy", async () => {
+    globalProxyUrl.value = "http://global-proxy.local:8080";
+
+    const { ws } = await startConnect(BASE_REQUEST, {}, "http://account-proxy.local:8080");
+
+    expect((ws.opts?.agent as { proxyUrl?: string } | undefined)?.proxyUrl)
+      .toBe("http://account-proxy.local:8080");
 
     ws.close();
   });


### PR DESCRIPTION
`buildWsConstructorOpts` only attached the `https-proxy-agent` when its `proxyUrl` argument was truthy. For accounts using the default "global" proxy assignment, `ProxyPool.resolveProxyUrl` returns `undefined`, so the WS path skipped the agent entirely and `new WebSocket(...)` connected direct to `chatgpt.com:443`. From inside a container whose only egress is through `HTTPS_PROXY`, that direct TLS hello gets dropped, surfacing as `Client network socket disconnected before secure TLS connection was established`. The pool then logs `[ws-pool] acquire failed` / `ws=bypass(factory_error)` and falls back to full-history HTTPS replay, adding ~80–165 s per turn whenever `previous_response_id` continuation should have hit.

The HTTPS POST path is unaffected because the native (rustls) transport reads `HTTPS_PROXY` itself. Mirror the same env fallback here so the WS path uses the proxy whenever no per-account override is set.

Verified end-to-end with a 3-turn smoke test through Clash on `http://172.17.0.1:7890`:

  Before: turn 2 = 165 s, `ws=bypass(factory_error)`, full replay.
  After:  turn 2 = 5.5 s, `ws=new:…` then `ws=reuse:…` on turn 3.