### PR TITLE
fix: handle Codex token metadata and quota skip

### DIFF
--- a/API.md
+++ b/API.md
@@ -25,6 +25,7 @@ OpenAI-compatible chat completion.
 - Streaming: SSE with `choice.delta` events
 - Non-streaming: `{ id, choices, usage }`
 - Errors: `{ error: { message, type, code } }`
+- `max_tokens`, `max_completion_tokens`, and `max_output_tokens` are accepted for client compatibility but are not forwarded to Codex.
 
 ### POST /v1/messages
 Anthropic Messages API compatible.
@@ -77,6 +78,7 @@ Native Codex Responses API passthrough (WebSocket transport).
 
 - Streaming: SSE with `response.created`, `response.output_text.delta`, `response.completed`
 - Non-streaming: `{ response, usage, responseId }`
+- Do not send `max_output_tokens` to native Codex. The proxy accepts it only for compatibility and strips it, because the real Codex backend rejects it with `400 Unsupported parameter: max_output_tokens`.
 
 #### image_generation tool
 
@@ -150,6 +152,11 @@ Legal content-part types (from upstream enum validation): `input_text`,
 `input_image`, `output_text`, `refusal`, `input_file`, `computer_screenshot`,
 `summary_text`.
 
+OpenAI Chat compatibility accepts `tools: [{"type":"image_generation"}]`, but
+the stable image payload is exposed by `/v1/responses` as
+`image_generation_call.result`. Use `/v1/responses` for clients that need the
+base64 image bytes.
+
 ### Ollama-Compatible Bridge
 
 The optional bridge runs on a separate listener, defaulting to `http://127.0.0.1:11434`.
@@ -205,6 +212,24 @@ Supported request mappings:
 | GET | `/v1/models/:id/info` | Extended model info |
 | GET | `/v1beta/models` | List models (Gemini format) |
 | POST | `/admin/refresh-models` | Force refresh from upstream |
+
+Model catalog entries can include token metadata:
+
+| Field | Meaning |
+|-------|---------|
+| `contextWindow` | Static or backend-provided context window for display and client hints |
+| `maxContextWindow` | Backend-provided maximum expandable context window, when reported |
+| `maxOutputTokens` | Static or backend-provided maximum output tokens for display and client hints |
+| `truncationPolicyLimit` | Backend-provided truncation policy limit, when reported |
+
+Static catalog values are defined in `config/models.yaml`; dynamic entries from
+`/backend-api/codex/models` win when the same model ID is returned by upstream.
+On 2026-05-08, real Codex backend metadata returned `context_window=272000`,
+`max_context_window=272000`, `truncation_policy.limit=10000` for `gpt-5.5`, and
+`context_window=272000`, `max_context_window=1000000`,
+`truncation_policy.limit=10000` for `gpt-5.4`. Treat these as runtime Codex
+limits, not as proof that request-level context or max-token switches are
+supported.
 
 ---
 
@@ -365,6 +390,16 @@ Supported request mappings:
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/auth/quota/warnings` | Active quota warnings |
+
+When `quota.skip_exhausted` is enabled, account acquisition filters out active
+accounts whose cached quota has `rate_limit.limit_reached === true`,
+`secondary_rate_limit.limit_reached === true`, or
+`code_review_rate_limit.limit_reached === true`. This happens before session
+affinity, so `preferredEntryId` cannot keep a request on an exhausted account.
+Near-full quota such as `used_percent=99` is not skipped until upstream marks
+`limit_reached` or the account receives a 429 and enters `rate_limited` backoff.
+Secondary and code-review cache windows are cleared after their own `reset_at`
+passes.
 
 ---
 

--- a/API_CN.md
+++ b/API_CN.md
@@ -25,6 +25,7 @@ OpenAI 兼容的聊天补全接口。
 - 流式：SSE，事件包含 `choice.delta`
 - 非流式：`{ id, choices, usage }`
 - 错误格式：`{ error: { message, type, code } }`
+- `max_tokens`、`max_completion_tokens`、`max_output_tokens` 仅做客户端兼容解析，不会转发给 Codex。
 
 ### POST /v1/messages
 Anthropic Messages API 兼容接口。
@@ -77,6 +78,7 @@ Google Gemini 兼容接口。
 
 - 流式：SSE 事件 `response.created`、`response.output_text.delta`、`response.completed`
 - 非流式：`{ response, usage, responseId }`
+- 不要向原生 Codex 发送 `max_output_tokens`。代理只兼容解析并剥离该字段，因为真实 Codex 后端会返回 `400 Unsupported parameter: max_output_tokens`。
 
 #### image_generation 工具
 
@@ -145,6 +147,10 @@ token 混到一起。
 合法 content-part 类型（由上游枚举校验回显）：`input_text`、`input_image`、
 `output_text`、`refusal`、`input_file`、`computer_screenshot`、`summary_text`。
 
+OpenAI Chat 兼容路径会接受 `tools: [{"type":"image_generation"}]`，但稳定的
+图像 payload 只会通过 `/v1/responses` 的 `image_generation_call.result` 暴露。
+需要拿到 base64 图片字节时，请使用 `/v1/responses`。
+
 ---
 
 ## 模型
@@ -157,6 +163,23 @@ token 混到一起。
 | GET | `/v1/models/:id/info` | 扩展模型信息 |
 | GET | `/v1beta/models` | 列出模型（Gemini 格式） |
 | POST | `/admin/refresh-models` | 强制从上游刷新模型列表 |
+
+模型目录条目可以包含 token 元数据：
+
+| 字段 | 含义 |
+|------|------|
+| `contextWindow` | 静态或上游提供的上下文窗口，用于展示和客户端参考 |
+| `maxContextWindow` | 上游提供的最大可扩展上下文窗口（如果返回） |
+| `maxOutputTokens` | 静态或上游提供的最大输出 token，用于展示和客户端参考 |
+| `truncationPolicyLimit` | 上游提供的截断策略限制（如果返回） |
+
+静态值定义在 `config/models.yaml`；同一模型 ID 如果从
+`/backend-api/codex/models` 拉到动态条目，则以上游动态值为准。实测
+2026-05-08 的 Codex 后端对 `gpt-5.5` 回传 `context_window=272000`、
+`max_context_window=272000`、`truncation_policy.limit=10000`，对 `gpt-5.4`
+回传 `context_window=272000`、`max_context_window=1000000`、
+`truncation_policy.limit=10000`。这些是 Codex 运行时限制，不代表请求级
+context 或 max-token 开关可用。
 
 ---
 
@@ -314,6 +337,16 @@ token 混到一起。
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | GET | `/auth/quota/warnings` | 当前活跃的配额告警 |
+
+启用 `quota.skip_exhausted` 后，账号池会在获取账号时过滤缓存额度中
+`rate_limit.limit_reached === true` 或
+`secondary_rate_limit.limit_reached === true` 或
+`code_review_rate_limit.limit_reached === true` 的 active 账号。过滤发生在
+session affinity 之前，所以 `preferredEntryId` 不能把请求继续粘到已耗尽账号。
+如果只是 `used_percent=99` 这类临近满额，但上游还没标记 `limit_reached`，代理
+不会主动跳过；等上游返回 429 后，该账号会进入 `rate_limited` 退避并切换账号。
+secondary / code review 窗口自己的 `reset_at` 过期后会从缓存中清除，避免账号被
+永久跳过。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,24 +213,26 @@ curl http://localhost:8080/v1/chat/completions \
 
 ## 📦 可用模型
 
-| 模型 ID | 推理等级 | 输出 | 说明 |
-|---------|---------|------|------|
-| `gpt-5.5` | low / medium / high / xhigh | 文本 | 通用旗舰（Plus+） |
-| `gpt-5.4` | low / medium / high / xhigh | 文本 | 最新旗舰模型（默认） |
-| `gpt-5.4-mini` | low / medium / high / xhigh | 文本 | 5.4 轻量版 |
-| `gpt-5.3-codex` | low / medium / high / xhigh | 文本 | 5.3 编程优化模型 |
-| `gpt-5.2` | low / medium / high / xhigh | 文本 | 专业工作 + 长时间代理 |
-| `gpt-5-codex` | low / medium / high | 文本 | GPT-5 编程模型 |
-| `gpt-5-codex-mini` | medium / high | 文本 | 轻量编程模型 |
-| `gpt-oss-120b` | low / medium / high | 文本 | 开源 120B 模型 |
-| `gpt-oss-20b` | low / medium / high | 文本 | 开源 20B 模型 |
-| `gpt-image-2` | — | 图像 | 图像生成后端（Plus+，通过 `image_generation` 工具调用） |
+| 模型 ID | 推理等级 | 当前上下文 | 最大上下文 | 最大输出 | 输出 | 说明 |
+|---------|---------|------------|------------|----------|------|------|
+| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | 文本 | 通用旗舰（Plus+） |
+| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | 文本 | 最新旗舰模型（默认） |
+| `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | 未公开 | 128,000 | 文本 | 5.4 轻量版 |
+| `gpt-5.3-codex` | low / medium / high / xhigh | 400,000 | 未公开 | 128,000 | 文本 | 5.3 编程优化模型 |
+| `gpt-5.2` | low / medium / high / xhigh | 400,000 | 未公开 | 128,000 | 文本 | 专业工作 + 长时间代理 |
+| `gpt-5-codex` | low / medium / high | 400,000 | 未公开 | 128,000 | 文本 | GPT-5 编程模型 |
+| `gpt-5-codex-mini` | medium / high | 未公开 | 未公开 | 未公开 | 文本 | 轻量编程模型 |
+| `gpt-oss-120b` | low / medium / high | 131,072 | 未公开 | 未公开 | 文本 | 开源 120B 模型 |
+| `gpt-oss-20b` | low / medium / high | 131,072 | 未公开 | 未公开 | 文本 | 开源 20B 模型 |
+| `gpt-image-2` | — | — | — | — | 图像 | 图像生成后端（Plus+，通过 `image_generation` 工具调用） |
 
 > **后缀**：任意 chat 模型名后追加 `-fast` 启用 Fast 模式，`-high`/`-low` 切换推理等级。例如：`gpt-5.4-fast`、`gpt-5.4-high-fast`。图像模型（`gpt-image-2`）不支持后缀。
 >
 > **Plan Routing**：不同 plan（free/plus/team/business）的账号自动路由到各自支持的模型。模型列表由后端动态获取，自动同步。
 >
 > **前端模型选择 ≠ 配置文件**：Dashboard 中切换模型只影响前端展示和 API 示例中的模型名，**不会修改** `config/default.yaml` 或 `data/local.yaml` 中的 `model.default`。实际使用哪个模型取决于客户端请求中的 `model` 字段（如 Cursor、Claude Code 等自行指定），配置文件中的 `model.default` 仅在客户端未指定模型时作为兜底。
+>
+> **Max token 说明**：上表是 Codex 运行时模型目录元数据，用于展示和客户端参考；运行时从 Codex 后端拉到的模型信息会覆盖静态值，并保留 `contextWindow`、`maxContextWindow`、`maxOutputTokens`、`truncationPolicyLimit`。实测 2026-05-08 的 Codex 后端对 `gpt-5.5` 回传 `context_window=272000`、`max_context_window=272000`、`truncation_policy.limit=10000`，对 `gpt-5.4` 回传 `context_window=272000`、`max_context_window=1000000`、`truncation_policy.limit=10000`，可能和公开模型页不同。请求体里的 `context_window` / `max_context_window` / `truncation_policy` / `max_output_tokens` 都不是可用开关；直接转发给 Codex 原生接口会返回 `400 Unsupported parameter`。
 
 ### 🖼️ 图像生成
 
@@ -255,6 +257,8 @@ curl -N http://localhost:8080/v1/responses \
 事件流里 `image_generation_call` item 的 `result` 字段即 base64 编码的图像；`revised_prompt` 是上游改写后的最终提示词。
 
 **编辑模式**（带参考图）：在 user message 的 `content` 里追加 `{"type":"input_image","image_url":"data:image/png;base64,..."}` 即可。
+
+> `/v1/chat/completions` 兼容路径会接受 `image_generation` 工具，避免 OpenAI 客户端因 schema 失败；但图像 payload 只有 `/v1/responses` 会稳定透出 `image_generation_call.result`。需要拿到图片字节时请使用 `/v1/responses`。
 
 ## 🔗 客户端接入
 
@@ -499,6 +503,12 @@ for await (const chunk of stream) {
 | `quota` | `refresh_interval_minutes`, `warning_thresholds`, `skip_exhausted` | 额度刷新与预警 |
 | `session` | `ttl_minutes`, `cleanup_interval_minutes` | Dashboard session 管理 |
 | `ollama` | `enabled`, `host`, `port`, `version`, `disable_vision` | Ollama 兼容桥接 |
+
+### 配额轮转
+
+`quota.skip_exhausted: true` 时，账号池会在选择账号前跳过缓存额度已经耗尽的账号；这个过滤发生在 session affinity / `preferredEntryId` 之前，所以长对话也不会强行粘到已耗尽账号上。
+
+当前跳过条件是缓存额度里的 `rate_limit.limit_reached === true`、`secondary_rate_limit.limit_reached === true` 或 `code_review_rate_limit.limit_reached === true`。如果只是 `used_percent` 接近 100（例如 99%）但上游还没标记 `limit_reached`，代理仍会继续使用该账号；真正打到上游 429 后，账号会进入 `rate_limited` 退避并切换到其他可用账号。secondary / code review 窗口自己的 `reset_at` 过期后会从缓存中清除，避免账号被永久跳过。
 
 ### 局域网访问
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -184,24 +184,26 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 
 ## 📦 Available Models
 
-| Model ID | Reasoning | Output | Description |
-|----------|-----------|--------|-------------|
-| `gpt-5.5` | low / medium / high / xhigh | text | General-purpose flagship (Plus+) |
-| `gpt-5.4` | low / medium / high / xhigh | text | Latest flagship (default) |
-| `gpt-5.4-mini` | low / medium / high / xhigh | text | 5.4 lightweight version |
-| `gpt-5.3-codex` | low / medium / high / xhigh | text | 5.3 coding-optimized model |
-| `gpt-5.2` | low / medium / high / xhigh | text | Professional work & long-running agents |
-| `gpt-5-codex` | low / medium / high | text | GPT-5 coding model |
-| `gpt-5-codex-mini` | medium / high | text | Lightweight coding model |
-| `gpt-oss-120b` | low / medium / high | text | Open-source 120B model |
-| `gpt-oss-20b` | low / medium / high | text | Open-source 20B model |
-| `gpt-image-2` | — | image | Image-generation backend (Plus+, invoked via the `image_generation` tool) |
+| Model ID | Reasoning | Current context | Max context | Max output | Output | Description |
+|----------|-----------|-----------------|-------------|------------|--------|-------------|
+| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | text | General-purpose flagship (Plus+) |
+| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | text | Latest flagship (default) |
+| `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | not published | 128,000 | text | 5.4 lightweight version |
+| `gpt-5.3-codex` | low / medium / high / xhigh | 400,000 | not published | 128,000 | text | 5.3 coding-optimized model |
+| `gpt-5.2` | low / medium / high / xhigh | 400,000 | not published | 128,000 | text | Professional work & long-running agents |
+| `gpt-5-codex` | low / medium / high | 400,000 | not published | 128,000 | text | GPT-5 coding model |
+| `gpt-5-codex-mini` | medium / high | not published | not published | not published | text | Lightweight coding model |
+| `gpt-oss-120b` | low / medium / high | 131,072 | not published | not published | text | Open-source 120B model |
+| `gpt-oss-20b` | low / medium / high | 131,072 | not published | not published | text | Open-source 20B model |
+| `gpt-image-2` | — | — | — | — | image | Image-generation backend (Plus+, invoked via the `image_generation` tool) |
 
 > **Suffixes**: Append `-fast` to any chat model for Fast mode, `-high`/`-low` for reasoning effort. E.g. `gpt-5.4-fast`, `gpt-5.4-high-fast`. The image model (`gpt-image-2`) does not take suffixes.
 >
 > **Plan Routing**: Accounts on different plans auto-route to their supported models. Models are dynamically fetched and auto-synced.
 >
 > **Dashboard model picker ≠ config file**: Changing the model in the Dashboard only affects the UI display and API examples — it does **not** modify `model.default` in `config/default.yaml` or `data/local.yaml`. The actual model used is determined by the `model` field in each client request (Cursor, Claude Code, etc.). The `model.default` config is only a fallback when the client omits the model field.
+>
+> **Max token note**: the table is Codex runtime model catalog metadata for display and client hints; runtime model data fetched from the Codex backend overrides static values and preserves `contextWindow`, `maxContextWindow`, `maxOutputTokens`, and `truncationPolicyLimit`. On 2026-05-08, real Codex backend metadata returned `context_window=272000`, `max_context_window=272000`, `truncation_policy.limit=10000` for `gpt-5.5`, and `context_window=272000`, `max_context_window=1000000`, `truncation_policy.limit=10000` for `gpt-5.4`, which can differ from public model pages. Request fields such as `context_window`, `max_context_window`, `truncation_policy`, and `max_output_tokens` are not usable switches; forwarding them to the native Codex API returns `400 Unsupported parameter`.
 
 ### 🖼️ Image Generation
 
@@ -226,6 +228,8 @@ Tunable fields: `size` (1024×1024 / 1024×1536 / 1536×1024 / 2048×2048 / 2048
 In the stream, the `image_generation_call` item's `result` field is a base64-encoded image; `revised_prompt` contains the final prompt used by the model.
 
 **Edit mode** (with a reference image): include `{"type":"input_image","image_url":"data:image/png;base64,..."}` in the user message `content` array.
+
+> The `/v1/chat/completions` compatibility path accepts the `image_generation` tool so OpenAI clients do not fail schema validation, but image payloads are only exposed reliably through `/v1/responses` as `image_generation_call.result`. Use `/v1/responses` when you need the image bytes.
 
 ## 🔗 Client Setup
 
@@ -445,6 +449,12 @@ All configuration in `config/default.yaml`:
 | `quota` | `refresh_interval_minutes`, `warning_thresholds`, `skip_exhausted` | Quota refresh and warnings |
 | `session` | `ttl_minutes`, `cleanup_interval_minutes` | Dashboard session management |
 | `ollama` | `enabled`, `host`, `port`, `version`, `disable_vision` | Ollama-compatible bridge |
+
+### Quota Rotation
+
+When `quota.skip_exhausted: true`, the account pool skips accounts whose cached quota is already exhausted before session affinity / `preferredEntryId` is applied. A long conversation therefore cannot force routing back to a cached-exhausted account.
+
+The skip condition is currently `rate_limit.limit_reached === true`, `secondary_rate_limit.limit_reached === true`, or `code_review_rate_limit.limit_reached === true` in cached quota. If `used_percent` is merely near 100, for example 99%, but upstream has not set `limit_reached`, the proxy may still use that account. Once upstream returns 429, the account is marked `rate_limited`, enters backoff, and the request is retried with another available account. Secondary and code-review windows are removed from cache after their own `reset_at` passes, so an account is not skipped forever on stale quota data.
 
 ### Ollama Bridge Configuration
 

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -7,7 +7,7 @@
 # Dynamic fetch merges with static; backend entries win for shared IDs.
 # Models endpoint now requires ?client_version= query parameter.
 #
-# Last updated: 2026-04-23 (added gpt-5.5, gpt-image-2; default → gpt-5.4; removed codex alias)
+# Last updated: 2026-05-08 (Codex runtime context metadata)
 
 models:
   # ── GPT-5.5 (newest general-purpose, Plus-only) ─────────────────────
@@ -23,6 +23,10 @@ models:
     defaultReasoningEffort: medium
     inputModalities: [text, image]
     outputModalities: [text]
+    contextWindow: 272000
+    maxContextWindow: 272000
+    maxOutputTokens: 128000
+    truncationPolicyLimit: 10000
     supportsPersonality: false
     upgrade: null
 
@@ -39,6 +43,10 @@ models:
     defaultReasoningEffort: medium
     inputModalities: [text, image]
     outputModalities: [text]
+    contextWindow: 272000
+    maxContextWindow: 1000000
+    maxOutputTokens: 128000
+    truncationPolicyLimit: 10000
     supportsPersonality: false
     upgrade: null
 
@@ -54,6 +62,8 @@ models:
     defaultReasoningEffort: medium
     inputModalities: [text, image]
     outputModalities: [text]
+    contextWindow: 400000
+    maxOutputTokens: 128000
     supportsPersonality: false
     upgrade: null
 
@@ -69,6 +79,8 @@ models:
       - { reasoningEffort: xhigh,  description: "Extra high reasoning depth" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
+    contextWindow: 400000
+    maxOutputTokens: 128000
     supportsPersonality: false
     upgrade: null
 
@@ -84,6 +96,8 @@ models:
       - { reasoningEffort: xhigh,  description: "Extra high reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
+    contextWindow: 400000
+    maxOutputTokens: 128000
     supportsPersonality: true
     upgrade: null
 
@@ -98,9 +112,12 @@ models:
       - { reasoningEffort: high,   description: "Deepest reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
+    contextWindow: 400000
+    maxOutputTokens: 128000
     supportsPersonality: false
     upgrade: null
 
+  # No exact official token-limit page found for id gpt-5-codex-mini on 2026-05-08.
   - id: gpt-5-codex-mini
     displayName: GPT-5 Codex Mini
     description: GPT-5 Codex Mini — lightweight
@@ -136,6 +153,7 @@ models:
       - { reasoningEffort: high,   description: "Deepest reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text]
+    contextWindow: 131072
     supportsPersonality: false
     upgrade: null
 
@@ -149,5 +167,6 @@ models:
       - { reasoningEffort: high,   description: "Deepest reasoning" }
     defaultReasoningEffort: medium
     inputModalities: [text]
+    contextWindow: 131072
     supportsPersonality: false
     upgrade: null

--- a/src/auth/account-lifecycle.ts
+++ b/src/auth/account-lifecycle.ts
@@ -7,6 +7,7 @@
 
 import { getConfig } from "../config.js";
 import { getModelPlanTypes, isPlanFetched } from "../models/model-store.js";
+import { hasReachedCachedQuota } from "./quota-skip.js";
 import { getRotationStrategy } from "./rotation-strategy.js";
 import type { RotationStrategy, RotationState, RotationStrategyName } from "./rotation-strategy.js";
 import type { AccountRegistry } from "./account-registry.js";
@@ -70,14 +71,16 @@ export class AccountLifecycle {
       }
     }
 
-    const maxConcurrent = getConfig().auth.max_concurrent_per_account ?? 3;
+    const config = getConfig();
+    const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
     const excludeSet = options?.excludeIds?.length ? new Set(options.excludeIds) : null;
 
     const available = entries.filter(
       (a) =>
         a.status === "active" &&
         this.slotCount(a.id) < maxConcurrent &&
-        (!excludeSet || !excludeSet.has(a.id)),
+        (!excludeSet || !excludeSet.has(a.id)) &&
+        (config.quota.skip_exhausted !== true || !hasReachedCachedQuota(a)),
     );
 
     if (available.length === 0) return null;
@@ -101,7 +104,7 @@ export class AccountLifecycle {
     }
 
     // Tier-based filtering: when configured, restrict to the highest available tier
-    const tierPriority = getConfig().auth.tier_priority;
+    const tierPriority = config.auth.tier_priority;
     if (tierPriority && tierPriority.length > 0) {
       const tierOrder = new Map(tierPriority.map((t, i) => [t, i]));
       let bestIdx = Infinity;
@@ -176,14 +179,19 @@ export class AccountLifecycle {
     accountId: string | null;
   }> {
     const now = new Date();
-    const maxConcurrent = getConfig().auth.max_concurrent_per_account ?? 3;
+    const config = getConfig();
+    const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
     const entries = this.registry.getAllEntries();
     for (const entry of entries) {
       this.registry.refreshStatus(entry, now);
     }
 
     const available = entries.filter(
-      (a: AccountEntry) => a.status === "active" && this.slotCount(a.id) < maxConcurrent && a.planType,
+      (a: AccountEntry) =>
+        a.status === "active" &&
+        this.slotCount(a.id) < maxConcurrent &&
+        a.planType &&
+        (config.quota.skip_exhausted !== true || !hasReachedCachedQuota(a)),
     );
 
     const byPlan = new Map<string, AccountEntry[]>();

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -23,6 +23,7 @@ import type {
   AccountInfo,
   CodexQuota,
 } from "./types.js";
+import { hasReachedCachedQuota } from "./quota-skip.js";
 
 export class AccountRegistry {
   private accounts: Map<string, AccountEntry> = new Map();
@@ -250,10 +251,15 @@ export class AccountRegistry {
   /** Fast check: is there at least one active account not in the exclude list? */
   hasAvailableAccounts(excludeIds?: string[]): boolean {
     const now = new Date();
+    const skipExhausted = getConfig().quota.skip_exhausted === true;
     const excludeSet = excludeIds?.length ? new Set(excludeIds) : null;
     for (const entry of this.accounts.values()) {
       this.refreshStatus(entry, now);
-      if (entry.status === "active" && (!excludeSet || !excludeSet.has(entry.id))) {
+      if (
+        entry.status === "active" &&
+        (!excludeSet || !excludeSet.has(entry.id)) &&
+        (!skipExhausted || !hasReachedCachedQuota(entry))
+      ) {
         return true;
       }
     }
@@ -474,12 +480,38 @@ export class AccountRegistry {
       this.schedulePersist();
     }
 
-    // Clear stale cached quota when its own reset time has passed
-    const quotaReset = entry.cachedQuota?.rate_limit?.reset_at;
+    // Clear stale cached quota windows when their own reset time has passed.
+    const quota = entry.cachedQuota;
+    const quotaReset = quota?.rate_limit?.reset_at;
     if (quotaReset != null && nowSec >= quotaReset) {
       entry.cachedQuota = null;
       entry.quotaFetchedAt = null;
       this.schedulePersist();
+    } else if (quota) {
+      let changed = false;
+      const secondaryReset = quota.secondary_rate_limit?.reset_at;
+      if (
+        quota.secondary_rate_limit?.limit_reached === true &&
+        secondaryReset != null &&
+        nowSec >= secondaryReset
+      ) {
+        quota.secondary_rate_limit = null;
+        changed = true;
+      }
+
+      const reviewReset = quota.code_review_rate_limit?.reset_at;
+      if (
+        quota.code_review_rate_limit?.limit_reached === true &&
+        reviewReset != null &&
+        nowSec >= reviewReset
+      ) {
+        quota.code_review_rate_limit = null;
+        changed = true;
+      }
+
+      if (changed) {
+        this.schedulePersist();
+      }
     }
   }
 

--- a/src/auth/quota-skip.ts
+++ b/src/auth/quota-skip.ts
@@ -1,0 +1,7 @@
+import type { AccountEntry } from "./types.js";
+
+export function hasReachedCachedQuota(entry: AccountEntry): boolean {
+  return entry.cachedQuota?.rate_limit.limit_reached === true ||
+    entry.cachedQuota?.secondary_rate_limit?.limit_reached === true ||
+    entry.cachedQuota?.code_review_rate_limit?.limit_reached === true;
+}

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -32,6 +32,14 @@ export interface CodexModelInfo {
   outputModalities?: string[];
   supportsPersonality: boolean;
   upgrade: string | null;
+  /** Maximum total context window in tokens, when known. */
+  contextWindow?: number;
+  /** Maximum expandable context window reported by the Codex backend, when known. */
+  maxContextWindow?: number;
+  /** Maximum configurable output token budget, when known. */
+  maxOutputTokens?: number;
+  /** Backend truncation policy limit, when reported. */
+  truncationPolicyLimit?: number;
   /** Where this model entry came from */
   source?: "static" | "backend";
 }
@@ -69,6 +77,17 @@ export interface BackendModelEntry {
   upgrade?: string | null;
   prefer_websockets?: boolean;
   context_window?: number;
+  contextWindow?: number;
+  max_context_window?: number;
+  maxContextWindow?: number;
+  max_output_tokens?: number;
+  maxOutputTokens?: number;
+  truncation_policy?: {
+    limit?: number;
+  };
+  truncationPolicy?: {
+    limit?: number;
+  };
   available_in_plans?: string[];
   priority?: number;
   visibility?: string;
@@ -414,6 +433,26 @@ function normalizeBackendModel(raw: BackendModelEntry): NormalizedModelWithMeta 
   // Only set outputModalities when backend provided it — otherwise the spread
   // in applyBackendModels would clobber the static catalog value with undefined.
   if (raw.output_modalities) out.outputModalities = raw.output_modalities;
+  if (typeof raw.context_window === "number") {
+    out.contextWindow = raw.context_window;
+  } else if (typeof raw.contextWindow === "number") {
+    out.contextWindow = raw.contextWindow;
+  }
+  if (typeof raw.max_context_window === "number") {
+    out.maxContextWindow = raw.max_context_window;
+  } else if (typeof raw.maxContextWindow === "number") {
+    out.maxContextWindow = raw.maxContextWindow;
+  }
+  if (typeof raw.max_output_tokens === "number") {
+    out.maxOutputTokens = raw.max_output_tokens;
+  } else if (typeof raw.maxOutputTokens === "number") {
+    out.maxOutputTokens = raw.maxOutputTokens;
+  }
+  if (typeof raw.truncation_policy?.limit === "number") {
+    out.truncationPolicyLimit = raw.truncation_policy.limit;
+  } else if (typeof raw.truncationPolicy?.limit === "number") {
+    out.truncationPolicyLimit = raw.truncationPolicy.limit;
+  }
   return out;
 }
 

--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -37,7 +37,12 @@ export interface CodexHostedWebSearchTool {
   user_location?: Record<string, unknown>;
 }
 
-export type CodexTool = CodexToolDefinition | CodexHostedWebSearchTool;
+export interface CodexImageGenerationTool {
+  type: "image_generation";
+  [key: string]: unknown;
+}
+
+export type CodexTool = CodexToolDefinition | CodexHostedWebSearchTool | CodexImageGenerationTool;
 
 export interface AnthropicToolConversionOptions {
   mapClaudeCodeWebSearch?: boolean;
@@ -124,6 +129,11 @@ export function openAIToolsToCodex(
     const hosted = normalizeHostedWebSearchTool(t);
     if (hosted) {
       defs.push(hosted);
+      continue;
+    }
+
+    if (t.type === "image_generation") {
+      defs.push(t);
       continue;
     }
 

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -39,6 +39,8 @@ export const ChatCompletionRequestSchema = z.object({
   temperature: z.number().optional(),
   top_p: z.number().optional(),
   max_tokens: z.number().optional(),
+  max_completion_tokens: z.number().optional(),
+  max_output_tokens: z.number().optional(),
   presence_penalty: z.number().optional(),
   frequency_penalty: z.number().optional(),
   stop: z.union([z.string(), z.array(z.string())]).optional(),
@@ -62,6 +64,9 @@ export const ChatCompletionRequestSchema = z.object({
       type: z.enum(["web_search", "web_search_preview"]),
       search_context_size: z.enum(["low", "medium", "high"]).optional(),
       user_location: z.record(z.unknown()).optional(),
+    }).passthrough(),
+    z.object({
+      type: z.literal("image_generation"),
     }).passthrough(),
   ])).optional(),
   tool_choice: z.union([

--- a/tests/unit/auth/account-pool-has-available.test.ts
+++ b/tests/unit/auth/account-pool-has-available.test.ts
@@ -26,6 +26,9 @@ vi.mock("@src/config.js", () => ({
       rate_limit_backoff_seconds: 60,
       max_concurrent_per_account: 3,
     },
+    quota: {
+      skip_exhausted: true,
+    },
   })),
 }));
 
@@ -50,6 +53,23 @@ vi.mock("@src/models/model-store.js", () => ({
 
 import { AccountPool } from "@src/auth/account-pool.js";
 import { isTokenExpired } from "@src/auth/jwt-utils.js";
+import type { CodexQuota } from "@src/auth/types.js";
+
+function makeQuota(overrides?: Partial<CodexQuota>): CodexQuota {
+  return {
+    plan_type: "plus",
+    rate_limit: {
+      allowed: true,
+      limit_reached: false,
+      used_percent: 25,
+      reset_at: Math.floor(Date.now() / 1000) + 3600,
+      limit_window_seconds: 3600,
+    },
+    secondary_rate_limit: null,
+    code_review_rate_limit: null,
+    ...overrides,
+  };
+}
 
 describe("AccountPool.hasAvailableAccounts", () => {
   let pool: AccountPool;
@@ -108,6 +128,46 @@ describe("AccountPool.hasAvailableAccounts", () => {
     const id1 = pool.addAccount("token-a");
     const id2 = pool.addAccount("token-b");
     expect(pool.hasAvailableAccounts([id1, id2])).toBe(false);
+  });
+
+  it("returns false when active accounts only have cached primary quota exhaustion", () => {
+    const id = pool.addAccount("token-a");
+    pool.updateCachedQuota(id, makeQuota({
+      rate_limit: {
+        allowed: false,
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: Math.floor(Date.now() / 1000) + 3600,
+        limit_window_seconds: 3600,
+      },
+    }));
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns false when active accounts only have cached secondary quota exhaustion", () => {
+    const id = pool.addAccount("token-a");
+    pool.updateCachedQuota(id, makeQuota({
+      secondary_rate_limit: {
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: Math.floor(Date.now() / 1000) + 3600,
+        limit_window_seconds: 3600,
+      },
+    }));
+    expect(pool.hasAvailableAccounts()).toBe(false);
+  });
+
+  it("returns false when active accounts only have cached code review quota exhaustion", () => {
+    const id = pool.addAccount("token-a");
+    pool.updateCachedQuota(id, makeQuota({
+      code_review_rate_limit: {
+        allowed: false,
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    }));
+    expect(pool.hasAvailableAccounts()).toBe(false);
   });
 
   it("refreshes rate_limit_until and counts expired accounts correctly", () => {

--- a/tests/unit/auth/account-pool-quota.test.ts
+++ b/tests/unit/auth/account-pool-quota.test.ts
@@ -179,5 +179,121 @@ describe("AccountPool quota methods", () => {
       const acquired = pool.acquire();
       expect(acquired).toBeNull();
     });
+
+    it("skips active accounts with cached primary quota limit_reached", () => {
+      const id1 = pool.addAccount(createValidJwt({ accountId: "d1" }));
+      const id2 = pool.addAccount(createValidJwt({ accountId: "d2" }));
+      pool.updateCachedQuota(id1, makeQuota({
+        rate_limit: {
+          allowed: false,
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) + 7200,
+          limit_window_seconds: 7200,
+        },
+      }));
+
+      const acquired = pool.acquire({ preferredEntryId: id1 });
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id2);
+      pool.release(acquired!.entryId);
+    });
+
+    it("skips active accounts with cached secondary quota limit_reached", () => {
+      const id1 = pool.addAccount(createValidJwt({ accountId: "e1" }));
+      const id2 = pool.addAccount(createValidJwt({ accountId: "e2" }));
+      pool.updateCachedQuota(id1, makeQuota({
+        secondary_rate_limit: {
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) + 3600,
+          limit_window_seconds: 3600,
+        },
+      }));
+
+      const acquired = pool.acquire();
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id2);
+      pool.release(acquired!.entryId);
+    });
+
+    it("skips active accounts with cached code review quota limit_reached", () => {
+      const id1 = pool.addAccount(createValidJwt({ accountId: "r1" }));
+      const id2 = pool.addAccount(createValidJwt({ accountId: "r2" }));
+      pool.updateCachedQuota(id1, makeQuota({
+        code_review_rate_limit: {
+          allowed: false,
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) + 3600,
+        },
+      }));
+
+      const acquired = pool.acquire({ preferredEntryId: id1 });
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id2);
+      pool.release(acquired!.entryId);
+    });
+
+    it("allows account after cached secondary quota reset time has passed", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "s1" }));
+      pool.updateCachedQuota(id, makeQuota({
+        secondary_rate_limit: {
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) - 10,
+          limit_window_seconds: 3600,
+        },
+      }));
+
+      const acquired = pool.acquire({ preferredEntryId: id });
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id);
+      pool.release(acquired!.entryId);
+
+      const entry = pool.getEntry(id);
+      expect(entry?.cachedQuota?.secondary_rate_limit).toBeNull();
+    });
+
+    it("allows account after cached code review quota reset time has passed", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "r3" }));
+      pool.updateCachedQuota(id, makeQuota({
+        code_review_rate_limit: {
+          allowed: false,
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) - 10,
+        },
+      }));
+
+      const acquired = pool.acquire({ preferredEntryId: id });
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id);
+      pool.release(acquired!.entryId);
+
+      const entry = pool.getEntry(id);
+      expect(entry?.cachedQuota?.code_review_rate_limit).toBeNull();
+    });
+
+    it("allows cached exhausted accounts when skip_exhausted is false", () => {
+      resetConfigForTesting();
+      setConfigForTesting(createMockConfig({ quota: { skip_exhausted: false } }));
+      pool = new AccountPool({ persistence: createMemoryPersistence() });
+      const id = pool.addAccount(createValidJwt({ accountId: "f1" }));
+      pool.updateCachedQuota(id, makeQuota({
+        rate_limit: {
+          allowed: false,
+          limit_reached: true,
+          used_percent: 100,
+          reset_at: Math.floor(Date.now() / 1000) + 7200,
+          limit_window_seconds: 7200,
+        },
+      }));
+
+      const acquired = pool.acquire();
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(id);
+      pool.release(acquired!.entryId);
+    });
   });
 });

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -62,6 +62,10 @@ models:
       - { reasoningEffort: high, description: "High" }
     defaultReasoningEffort: medium
     inputModalities: [text, image]
+    contextWindow: 272000
+    maxContextWindow: 1000000
+    maxOutputTokens: 128000
+    truncationPolicyLimit: 10000
     supportsPersonality: true
     upgrade: null
   - id: gpt-5.3-codex
@@ -74,6 +78,8 @@ models:
       - { reasoningEffort: high, description: "High" }
     defaultReasoningEffort: medium
     inputModalities: [text]
+    contextWindow: 400000
+    maxOutputTokens: 128000
     supportsPersonality: false
     upgrade: null
   - id: gpt-5.3-codex-high
@@ -253,6 +259,15 @@ describe("ModelStore", () => {
       expect(info!.isDefault).toBe(true);
     });
 
+    it("returns static token limits by ID", () => {
+      const info = getModelInfo("gpt-5.4");
+      expect(info).toBeDefined();
+      expect(info!.contextWindow).toBe(272_000);
+      expect(info!.maxContextWindow).toBe(1_000_000);
+      expect(info!.maxOutputTokens).toBe(128_000);
+      expect(info!.truncationPolicyLimit).toBe(10_000);
+    });
+
     it("returns undefined for unknown ID", () => {
       expect(getModelInfo("nonexistent")).toBeUndefined();
     });
@@ -375,6 +390,36 @@ describe("ModelStore", () => {
         output_modalities: ["text", "audio"],
       }]);
       expect(getModelInfo("gpt-5.3-codex-spark")!.outputModalities).toEqual(["text", "audio"]);
+    });
+
+    it("lets backend override token limit metadata when present", () => {
+      loadStaticModels("/tmp/test-config");
+      applyBackendModels([{
+        slug: "gpt-5.4",
+        display_name: "Backend 5.4",
+        context_window: 2_000_000,
+        max_context_window: 2_500_000,
+        max_output_tokens: 256_000,
+        truncation_policy: { limit: 10_000 },
+      }]);
+      const info = getModelInfo("gpt-5.4");
+      expect(info!.contextWindow).toBe(2_000_000);
+      expect(info!.maxContextWindow).toBe(2_500_000);
+      expect(info!.maxOutputTokens).toBe(256_000);
+      expect(info!.truncationPolicyLimit).toBe(10_000);
+    });
+
+    it("preserves static token limit metadata when backend omits it", () => {
+      loadStaticModels("/tmp/test-config");
+      applyBackendModels([{
+        slug: "gpt-5.4",
+        display_name: "Backend 5.4",
+      }]);
+      const info = getModelInfo("gpt-5.4");
+      expect(info!.contextWindow).toBe(272_000);
+      expect(info!.maxContextWindow).toBe(1_000_000);
+      expect(info!.maxOutputTokens).toBe(128_000);
+      expect(info!.truncationPolicyLimit).toBe(10_000);
     });
   });
 

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -62,6 +62,13 @@ function makeRequest(overrides: Partial<AnthropicMessagesRequest> = {}): Anthrop
 }
 
 describe("translateAnthropicToCodexRequest", () => {
+  it("does not forward max_tokens to Codex", () => {
+    const result = translateAnthropicToCodexRequest(
+      makeRequest({ max_tokens: 8192 }),
+    );
+    expect(result).not.toHaveProperty("max_output_tokens");
+  });
+
   // ── System instructions ──────────────────────────────────────────────
 
   describe("system instructions", () => {

--- a/tests/unit/translation/gemini-to-codex.test.ts
+++ b/tests/unit/translation/gemini-to-codex.test.ts
@@ -242,6 +242,18 @@ describe("translateGeminiToCodexRequest", () => {
     expect(result.reasoning?.effort).toBe("medium");
   });
 
+  it("does not forward maxOutputTokens to Codex", () => {
+    const result = translateGeminiToCodexRequest(
+      makeRequest({
+        generationConfig: {
+          maxOutputTokens: 8192,
+        },
+      }),
+      "gpt-5.4",
+    );
+    expect(result).not.toHaveProperty("max_output_tokens");
+  });
+
   it("maps model suffix -fast to service_tier", () => {
     const result = translateGeminiToCodexRequest(makeRequest(), "gpt-5.4-fast");
     expect(result.service_tier).toBe("fast");

--- a/tests/unit/translation/openai-to-codex.test.ts
+++ b/tests/unit/translation/openai-to-codex.test.ts
@@ -74,6 +74,15 @@ describe("translateToCodexRequest", () => {
     expect(result.store).toBe(false);
   });
 
+  it("does not forward max token compatibility fields to Codex", () => {
+    const result = translateToCodexRequest(makeRequest({
+      max_tokens: 4096,
+      max_completion_tokens: 8192,
+      max_output_tokens: 16384,
+    }));
+    expect(result).not.toHaveProperty("max_output_tokens");
+  });
+
   it("extracts system messages as instructions", () => {
     const result = translateToCodexRequest(makeRequest({
       messages: [

--- a/tests/unit/translation/tool-format.test.ts
+++ b/tests/unit/translation/tool-format.test.ts
@@ -108,6 +108,15 @@ describe("openAIToolsToCodex", () => {
     expect(result[1].name).toBe("b");
     expect(result[1].description).toBe("B tool");
   });
+
+  it("preserves image_generation tools for native Codex image generation", () => {
+    const result = openAIToolsToCodex([
+      { type: "image_generation", size: "1024x1024", quality: "high" },
+    ]);
+    expect(result).toEqual([
+      { type: "image_generation", size: "1024x1024", quality: "high" },
+    ]);
+  });
 });
 
 // ── openAIToolChoiceToCodex ─────────────────────────────────────

--- a/tests/unit/types/openai-schemas.test.ts
+++ b/tests/unit/types/openai-schemas.test.ts
@@ -57,6 +57,26 @@ describe("ChatCompletionRequestSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("parses native image_generation tools", () => {
+    const result = ChatCompletionRequestSchema.safeParse({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "Draw a red circle." }],
+      tools: [{ type: "image_generation", size: "1024x1024" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses max token compatibility fields", () => {
+    const result = ChatCompletionRequestSchema.safeParse({
+      model: "gpt-5.4",
+      messages: [{ role: "user", content: "Write a long answer." }],
+      max_tokens: 4096,
+      max_completion_tokens: 8192,
+      max_output_tokens: 16384,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("parses request with legacy functions", () => {
     const result = ChatCompletionRequestSchema.safeParse({
       model: "gpt-5.4",


### PR DESCRIPTION
Summary: Adds model token metadata, strips unsupported max token fields before native Codex forwarding, preserves image_generation tools, and skips cached quota-exhausted accounts before affinity. Updates README/API docs with max token, image_generation, and quota rotation behavior. Tests: npm test -- tests/unit/auth/account-pool-quota.test.ts tests/unit/translation/openai-to-codex.test.ts tests/unit/translation/anthropic-to-codex.test.ts tests/unit/translation/gemini-to-codex.test.ts tests/unit/translation/tool-format.test.ts tests/unit/types/openai-schemas.test.ts tests/unit/models/model-store.test.ts; npm run build. Note: ignored local docs/ files were updated locally but not included because docs/ is gitignored and project rules forbid git add -f.