### PR TITLE
feat: add official Codex app-server bridge

### DIFF
--- a/API.md
+++ b/API.md
@@ -376,7 +376,8 @@ Optional bridge to a local official `codex app-server` instance. This is the
 path for using official Codex app plugins such as the Chrome/browser plugin.
 It is disabled by default with `official_agent.enabled: false`.
 
-All endpoints use the Codex Proxy API key when `server.proxy_api_key` is set.
+All endpoints require `server.proxy_api_key`; the bridge refuses requests when
+the proxy API key is not configured.
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/API.md
+++ b/API.md
@@ -370,6 +370,33 @@ supported.
 | GET | `/debug/diagnostics` | System diagnostics (localhost only) |
 | GET | `/debug/models` | Model store internals |
 
+## Official Codex App Server Bridge
+
+Optional bridge to a local official `codex app-server` instance. This is the
+path for using official Codex app plugins such as the Chrome/browser plugin.
+It is disabled by default with `official_agent.enabled: false`.
+
+All endpoints use the Codex Proxy API key when `server.proxy_api_key` is set.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/official-agent/apps` | List official Codex apps/connectors from `app/list` |
+| POST | `/official-agent/threads` | Start an app-server thread (`{ model?, cwd? }`) |
+| POST | `/official-agent/threads/:threadId/turns` | Start a turn and stream app-server notifications as SSE |
+
+Example turn using an official Chrome app mention:
+
+```json
+{
+  "text": "Open localhost:8080 and inspect the dashboard",
+  "app": { "id": "chrome", "name": "Chrome" }
+}
+```
+
+The bridge sends a text item plus a `mention` item with `path:
+"app://{id}"`. Use `/official-agent/apps` to discover the real app id before
+hard-coding one.
+
 ### Updates
 
 | Method | Path | Description |

--- a/API_CN.md
+++ b/API_CN.md
@@ -317,6 +317,32 @@ context 或 max-token 开关可用。
 | GET | `/debug/diagnostics` | 系统诊断信息（仅 localhost） |
 | GET | `/debug/models` | 模型存储内部状态 |
 
+## 官方 Codex App Server Bridge
+
+可选桥接到本机官方 `codex app-server`。这条路径用于复用官方 Codex app
+插件能力，例如 Chrome/browser 插件。默认关闭：`official_agent.enabled:
+false`。
+
+当配置了 `server.proxy_api_key` 时，以下端点同样要求 Codex Proxy API Key。
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/official-agent/apps` | 通过 `app/list` 列出官方 Codex apps/connectors |
+| POST | `/official-agent/threads` | 创建 app-server thread（`{ model?, cwd? }`） |
+| POST | `/official-agent/threads/:threadId/turns` | 发起 turn，并以 SSE 流式返回 app-server notifications |
+
+使用官方 Chrome app mention 的请求示例：
+
+```json
+{
+  "text": "Open localhost:8080 and inspect the dashboard",
+  "app": { "id": "chrome", "name": "Chrome" }
+}
+```
+
+桥接层会发送一个 text item 和一个 `path: "app://{id}"` 的 `mention`
+item。实际 app id 请先通过 `/official-agent/apps` 探测，不要默认硬编码。
+
 ### 更新
 
 | 方法 | 路径 | 说明 |

--- a/API_CN.md
+++ b/API_CN.md
@@ -323,7 +323,7 @@ context 或 max-token 开关可用。
 插件能力，例如 Chrome/browser 插件。默认关闭：`official_agent.enabled:
 false`。
 
-当配置了 `server.proxy_api_key` 时，以下端点同样要求 Codex Proxy API Key。
+以下端点强制要求 `server.proxy_api_key`；未配置 proxy API key 时，桥接会拒绝请求。
 
 | 方法 | 路径 | 说明 |
 |------|------|------|

--- a/README.md
+++ b/README.md
@@ -592,6 +592,9 @@ codex app-server --listen ws://127.0.0.1:4500
 然后在 `data/local.yaml` 启用：
 
 ```yaml
+server:
+  proxy_api_key: "your-api-key"
+
 official_agent:
   enabled: true
   app_server_url: ws://127.0.0.1:4500
@@ -610,6 +613,9 @@ codex app-server --listen ws://127.0.0.1:4500 \
 对应配置：
 
 ```yaml
+server:
+  proxy_api_key: "your-api-key"
+
 official_agent:
   enabled: true
   app_server_url: ws://127.0.0.1:4500

--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ for await (const chunk of stream) {
 | `quota` | `refresh_interval_minutes`, `warning_thresholds`, `skip_exhausted` | 额度刷新与预警 |
 | `session` | `ttl_minutes`, `cleanup_interval_minutes` | Dashboard session 管理 |
 | `ollama` | `enabled`, `host`, `port`, `version`, `disable_vision` | Ollama 兼容桥接 |
+| `official_agent` | `enabled`, `app_server_url`, `auth` | 官方 Codex app-server 桥接，用于复用 Chrome/browser 插件 |
 
 ### 配额轮转
 
@@ -577,6 +578,59 @@ Docker 部署时，如果希望宿主机访问 `11434`：
 3. 保持宿主机绑定 `127.0.0.1`，除非你明确知道自己要把无鉴权 Ollama API 暴露到网络。
 
 浏览器 CORS 访问仅允许 `localhost`、`127.x.x.x`、`::1` 等 loopback origin；非本机网页来源不能读取桥接响应。Bridge 会为 `/v1/*` 直通请求注入已配置的 Codex Proxy API Key，因此暴露到 localhost 之外时，相当于也把主代理 API 以无鉴权方式暴露出去。
+
+### Official Agent Bridge 配置
+
+该桥接用于连接本机官方 `codex app-server`，从而复用 Codex app 的官方 Chrome/browser 插件、审批和 app mention 能力。默认关闭，不影响现有 `/v1/*` 模型代理。
+
+先启动官方 app-server：
+
+```bash
+codex app-server --listen ws://127.0.0.1:4500
+```
+
+然后在 `data/local.yaml` 启用：
+
+```yaml
+official_agent:
+  enabled: true
+  app_server_url: ws://127.0.0.1:4500
+  auth:
+    type: none
+```
+
+如果 app-server 使用 capability token：
+
+```bash
+codex app-server --listen ws://127.0.0.1:4500 \
+  --ws-auth capability-token \
+  --ws-token-file /absolute/path/to/token
+```
+
+对应配置：
+
+```yaml
+official_agent:
+  enabled: true
+  app_server_url: ws://127.0.0.1:4500
+  auth:
+    type: capability_token
+    token_file: /absolute/path/to/token
+```
+
+可用端点：
+
+```bash
+curl http://localhost:8080/official-agent/apps \
+  -H "Authorization: Bearer your-api-key"
+```
+
+```bash
+curl -N http://localhost:8080/official-agent/threads/{threadId}/turns \
+  -H "Authorization: Bearer your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"Open localhost:8080 and inspect the dashboard","app":{"id":"chrome","name":"Chrome"}}'
+```
 
 ### 环境变量覆盖
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -61,3 +61,9 @@ ollama:
   port: 11434
   version: "0.18.3"
   disable_vision: false
+official_agent:
+  enabled: false
+  app_server_url: ws://127.0.0.1:4500
+  request_timeout_ms: 30000
+  auth:
+    type: none

--- a/src/auth/account-lifecycle.ts
+++ b/src/auth/account-lifecycle.ts
@@ -73,6 +73,7 @@ export class AccountLifecycle {
 
     const config = getConfig();
     const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
+    const skipExhausted = config.quota?.skip_exhausted === true;
     const excludeSet = options?.excludeIds?.length ? new Set(options.excludeIds) : null;
 
     const available = entries.filter(
@@ -80,7 +81,7 @@ export class AccountLifecycle {
         a.status === "active" &&
         this.slotCount(a.id) < maxConcurrent &&
         (!excludeSet || !excludeSet.has(a.id)) &&
-        (config.quota.skip_exhausted !== true || !hasReachedCachedQuota(a)),
+        (!skipExhausted || !hasReachedCachedQuota(a)),
     );
 
     if (available.length === 0) return null;
@@ -181,6 +182,7 @@ export class AccountLifecycle {
     const now = new Date();
     const config = getConfig();
     const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
+    const skipExhausted = config.quota?.skip_exhausted === true;
     const entries = this.registry.getAllEntries();
     for (const entry of entries) {
       this.registry.refreshStatus(entry, now);
@@ -191,7 +193,7 @@ export class AccountLifecycle {
         a.status === "active" &&
         this.slotCount(a.id) < maxConcurrent &&
         a.planType &&
-        (config.quota.skip_exhausted !== true || !hasReachedCachedQuota(a)),
+        (!skipExhausted || !hasReachedCachedQuota(a)),
     );
 
     const byPlan = new Map<string, AccountEntry[]>();

--- a/src/codex-app-server/client.ts
+++ b/src/codex-app-server/client.ts
@@ -114,7 +114,7 @@ export class CodexAppServerClient implements CodexAppServerBridge {
   private nextId = 1;
   private initialized = false;
   private readonly pending = new Map<number, PendingRequest>();
-  private readonly notifications = new AsyncNotificationQueue();
+  private notifications = new AsyncNotificationQueue();
 
   constructor(options: CodexAppServerClientOptions) {
     this.options = options;
@@ -150,6 +150,7 @@ export class CodexAppServerClient implements CodexAppServerBridge {
     this.pending.clear();
     const ws = this.ws;
     this.ws = null;
+    this.initialized = false;
     if (!ws) return;
     await new Promise<void>((resolve) => {
       if (ws.readyState === WebSocket.CLOSED) {
@@ -264,7 +265,9 @@ export class CodexAppServerClient implements CodexAppServerBridge {
     this.ws = ws;
     ws.on("message", (raw) => this.handleMessage(raw.toString()));
     ws.on("close", () => {
+      if (this.ws !== ws) return;
       this.notifications.close();
+      this.notifications = new AsyncNotificationQueue();
       for (const [id, pending] of this.pending) {
         clearTimeout(pending.timeout);
         pending.reject(new Error(`Codex app-server WebSocket closed before request ${id} completed`));

--- a/src/codex-app-server/client.ts
+++ b/src/codex-app-server/client.ts
@@ -1,0 +1,344 @@
+import { createHmac, randomUUID } from "crypto";
+import { readFileSync } from "fs";
+import WebSocket from "ws";
+import type {
+  CodexAppNotification,
+  CodexAppServerBridge,
+  CodexAppServerClientOptions,
+  JsonRpcFailure,
+  JsonRpcIncoming,
+  JsonRpcRequest,
+  ListAppsParams,
+  StartThreadParams,
+  StartTurnParams,
+} from "./types.js";
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+class AsyncNotificationQueue {
+  private readonly queue: CodexAppNotification[] = [];
+  private readonly waiters: Array<(item: CodexAppNotification | null) => void> = [];
+  private isClosed = false;
+
+  push(item: CodexAppNotification): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(item);
+      return;
+    }
+    this.queue.push(item);
+  }
+
+  close(): void {
+    this.isClosed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter(null);
+    }
+  }
+
+  async next(): Promise<CodexAppNotification | null> {
+    const queued = this.queue.shift();
+    if (queued) return queued;
+    if (this.isClosed) return null;
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readTrimmedFile(path: string): string {
+  return readFileSync(path, "utf-8").trim();
+}
+
+function base64UrlJson(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function signHs256(payload: Record<string, unknown>, secret: string): string {
+  const header = base64UrlJson({ alg: "HS256", typ: "JWT" });
+  const body = base64UrlJson(payload);
+  const signature = createHmac("sha256", secret)
+    .update(`${header}.${body}`)
+    .digest("base64url");
+  return `${header}.${body}.${signature}`;
+}
+
+function authHeader(options: CodexAppServerClientOptions): string | undefined {
+  switch (options.auth.type) {
+    case "none":
+      return undefined;
+    case "capability_token": {
+      const token = options.auth.token ?? (options.auth.token_file ? readTrimmedFile(options.auth.token_file) : "");
+      return `Bearer ${token}`;
+    }
+    case "signed_bearer_token": {
+      const secret = options.auth.shared_secret ??
+        (options.auth.shared_secret_file ? readTrimmedFile(options.auth.shared_secret_file) : "");
+      const now = Math.floor(Date.now() / 1000);
+      return `Bearer ${signHs256({
+        iss: options.auth.issuer,
+        aud: options.auth.audience,
+        sub: options.auth.subject,
+        iat: now,
+        exp: now + options.auth.ttl_seconds,
+        jti: randomUUID(),
+      }, secret)}`;
+    }
+  }
+}
+
+function normalizeNotification(message: Record<string, unknown>): CodexAppNotification | null {
+  if (typeof message.method !== "string") return null;
+  return {
+    method: message.method,
+    ...(message.params !== undefined ? { params: message.params } : {}),
+  };
+}
+
+function isTerminalTurnNotification(method: string): boolean {
+  return method === "turn/completed" ||
+    method === "turn/failed" ||
+    method === "turn/cancelled" ||
+    method === "turn/interrupted";
+}
+
+export class CodexAppServerClient implements CodexAppServerBridge {
+  private readonly options: CodexAppServerClientOptions;
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private initialized = false;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly notifications = new AsyncNotificationQueue();
+
+  constructor(options: CodexAppServerClientOptions) {
+    this.options = options;
+  }
+
+  async listApps(params?: ListAppsParams): Promise<unknown> {
+    return this.request("app/list", params ?? { limit: 100 });
+  }
+
+  async startThread(params: StartThreadParams): Promise<unknown> {
+    return this.request("thread/start", params);
+  }
+
+  async startTurn(params: StartTurnParams): Promise<unknown> {
+    return this.request("turn/start", this.buildTurnParams(params));
+  }
+
+  async *notificationsUntilTurnCompleted(): AsyncIterable<CodexAppNotification> {
+    while (true) {
+      const notification = await this.notifications.next();
+      if (!notification) return;
+      yield notification;
+      if (isTerminalTurnNotification(notification.method)) return;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.notifications.close();
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error(`Codex app-server client closed before request ${id} completed`));
+    }
+    this.pending.clear();
+    const ws = this.ws;
+    this.ws = null;
+    if (!ws) return;
+    await new Promise<void>((resolve) => {
+      if (ws.readyState === WebSocket.CLOSED) {
+        resolve();
+        return;
+      }
+      ws.once("close", () => resolve());
+      ws.close();
+      setTimeout(resolve, 250).unref();
+    });
+  }
+
+  private buildTurnParams(params: StartTurnParams): Record<string, unknown> {
+    const input: Array<Record<string, unknown>> = [];
+    if (params.app) {
+      input.push({ type: "text", text: `$${params.app.id} ${params.text}`, text_elements: [] });
+      input.push({
+        type: "mention",
+        name: params.app.name ?? params.app.id,
+        path: `app://${params.app.id}`,
+      });
+    } else {
+      input.push({ type: "text", text: params.text, text_elements: [] });
+    }
+
+    return {
+      threadId: params.threadId,
+      input,
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      ...(params.approvalPolicy ? { approvalPolicy: params.approvalPolicy } : {}),
+    };
+  }
+
+  private async request(method: string, params?: unknown): Promise<unknown> {
+    await this.ensureReady();
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Codex app-server WebSocket is not open");
+    }
+
+    const id = this.nextId++;
+    const request: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex app-server request timed out: ${method}`));
+      }, this.options.requestTimeoutMs);
+      this.pending.set(id, { resolve, reject, timeout });
+    });
+    ws.send(JSON.stringify(request));
+    return promise;
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ensureConnected();
+    if (this.initialized) return;
+    await this.requestRaw("initialize", {
+      clientInfo: this.options.clientInfo,
+      capabilities: { experimentalApi: true },
+    });
+    this.sendNotification("initialized");
+    this.initialized = true;
+  }
+
+  private async requestRaw(method: string, params?: unknown): Promise<unknown> {
+    await this.ensureConnected();
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Codex app-server WebSocket is not open");
+    }
+    const id = this.nextId++;
+    const request: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      ...(params !== undefined ? { params } : {}),
+    };
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex app-server request timed out: ${method}`));
+      }, this.options.requestTimeoutMs);
+      this.pending.set(id, { resolve, reject, timeout });
+    });
+    ws.send(JSON.stringify(request));
+    return promise;
+  }
+
+  private sendNotification(method: string, params?: unknown): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      method,
+      ...(params !== undefined ? { params } : {}),
+    }));
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
+    const headers: Record<string, string> = {};
+    const authorization = authHeader(this.options);
+    if (authorization) headers.Authorization = authorization;
+
+    const ws = new WebSocket(this.options.url, { headers });
+    this.ws = ws;
+    ws.on("message", (raw) => this.handleMessage(raw.toString()));
+    ws.on("close", () => {
+      this.notifications.close();
+      for (const [id, pending] of this.pending) {
+        clearTimeout(pending.timeout);
+        pending.reject(new Error(`Codex app-server WebSocket closed before request ${id} completed`));
+      }
+      this.pending.clear();
+      this.ws = null;
+      this.initialized = false;
+    });
+    ws.on("error", (err) => {
+      for (const [id, pending] of this.pending) {
+        clearTimeout(pending.timeout);
+        pending.reject(new Error(`Codex app-server WebSocket error before request ${id} completed: ${err.message}`));
+      }
+      this.pending.clear();
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        ws.off("open", onOpen);
+        ws.off("error", onError);
+        ws.off("close", onClose);
+      };
+      const onOpen = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (err: Error) => {
+        cleanup();
+        reject(err);
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error("Codex app-server WebSocket closed before open"));
+      };
+      ws.once("open", onOpen);
+      ws.once("error", onError);
+      ws.once("close", onClose);
+    });
+  }
+
+  private handleMessage(raw: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!isRecord(parsed)) return;
+
+    const incoming = parsed as unknown as JsonRpcIncoming;
+    if ("id" in incoming && typeof incoming.id === "number") {
+      this.handleResponse(incoming);
+      return;
+    }
+    const notification = normalizeNotification(parsed);
+    if (notification) this.notifications.push(notification);
+  }
+
+  private handleResponse(response: JsonRpcIncoming): void {
+    if (!("id" in response) || typeof response.id !== "number") return;
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+    this.pending.delete(response.id);
+    clearTimeout(pending.timeout);
+
+    if ("error" in response) {
+      const failure = response as JsonRpcFailure;
+      pending.reject(new Error(failure.error.message ?? "Codex app-server JSON-RPC error"));
+      return;
+    }
+    if ("result" in response) {
+      pending.resolve(response.result);
+      return;
+    }
+    pending.reject(new Error("Codex app-server JSON-RPC response missing result"));
+  }
+}

--- a/src/codex-app-server/types.ts
+++ b/src/codex-app-server/types.ts
@@ -1,0 +1,92 @@
+export interface CodexAppClientInfo {
+  name: string;
+  title: string;
+  version: string;
+}
+
+export type CodexAppServerAuth =
+  | { type: "none" }
+  | { type: "capability_token"; token?: string; token_file?: string }
+  | {
+      type: "signed_bearer_token";
+      shared_secret?: string;
+      shared_secret_file?: string;
+      issuer: string;
+      audience: string;
+      subject: string;
+      ttl_seconds: number;
+    };
+
+export interface CodexAppServerClientOptions {
+  url: string;
+  auth: CodexAppServerAuth;
+  clientInfo: CodexAppClientInfo;
+  requestTimeoutMs: number;
+}
+
+export interface ListAppsParams {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface StartThreadParams {
+  model?: string;
+  cwd?: string;
+}
+
+export interface StartTurnAppMention {
+  id: string;
+  name?: string;
+}
+
+export interface StartTurnParams {
+  threadId: string;
+  text: string;
+  cwd?: string;
+  approvalPolicy?: string;
+  app?: StartTurnAppMention;
+}
+
+export interface CodexAppNotification {
+  method: string;
+  params?: unknown;
+}
+
+export interface CodexAppServerBridge {
+  listApps(params?: ListAppsParams): Promise<unknown>;
+  startThread(params: StartThreadParams): Promise<unknown>;
+  startTurn(params: StartTurnParams): Promise<unknown>;
+  notificationsUntilTurnCompleted(): AsyncIterable<CodexAppNotification>;
+  close(): Promise<void>;
+}
+
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc?: "2.0";
+  id: number;
+  result: unknown;
+}
+
+export interface JsonRpcFailure {
+  jsonrpc?: "2.0";
+  id: number;
+  error: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+}
+
+export type JsonRpcIncoming = JsonRpcSuccess | JsonRpcFailure | JsonRpcNotification;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -2,6 +2,51 @@ import { z } from "zod";
 
 export const ROTATION_STRATEGIES = ["least_used", "round_robin", "sticky"] as const;
 
+// Note: discriminatedUnion does not accept ZodEffects branches, so the
+// presence-of-secret-material checks are applied at the union level via
+// superRefine rather than per-branch.
+const OfficialAgentAuthSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("none") }),
+  z.object({
+    type: z.literal("capability_token"),
+    token: z.string().trim().min(1).optional(),
+    token_file: z.string().trim().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("signed_bearer_token"),
+    shared_secret: z.string().trim().min(1).optional(),
+    shared_secret_file: z.string().trim().min(1).optional(),
+    issuer: z.string().trim().min(1).default("codex-proxy"),
+    audience: z.string().trim().min(1).default("codex-app-server"),
+    subject: z.string().trim().min(1).default("codex-proxy"),
+    ttl_seconds: z.number().int().min(30).max(3600).default(300),
+  }),
+]).superRefine((value, ctx) => {
+  if (value.type === "capability_token" && !value.token && !value.token_file) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "capability_token auth requires token or token_file",
+      path: ["token"],
+    });
+  }
+  if (value.type === "signed_bearer_token" && !value.shared_secret && !value.shared_secret_file) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "signed_bearer_token auth requires shared_secret or shared_secret_file",
+      path: ["shared_secret"],
+    });
+  }
+});
+
+function isWebSocketUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "ws:" || url.protocol === "wss:";
+  } catch {
+    return false;
+  }
+}
+
 export const ConfigSchema = z.object({
   api: z.object({
     base_url: z.string().default("https://chatgpt.com/backend-api"),
@@ -90,6 +135,16 @@ export const ConfigSchema = z.object({
     port: z.number().min(1).max(65535).default(11434),
     version: z.string().trim().min(1).max(64).default("0.18.3"),
     disable_vision: z.boolean().default(false),
+  }).default({}),
+  /** Optional bridge to official local `codex app-server` for Codex app plugins,
+   * including the official Chrome/browser automation plugin. */
+  official_agent: z.object({
+    enabled: z.boolean().default(false),
+    app_server_url: z.string().trim().refine(isWebSocketUrl, {
+      message: "app_server_url must be a ws:// or wss:// URL",
+    }).default("ws://127.0.0.1:4500"),
+    request_timeout_ms: z.number().int().min(1000).max(300000).default(30000),
+    auth: OfficialAgentAuthSchema.default({ type: "none" }),
   }).default({}),
   /** Third-party API provider keys for multi-backend routing. */
   providers: z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { ApiKeyPool } from "./auth/api-key-pool.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAdapterForEntry } from "./proxy/adapter-factory.js";
 import { startOllamaBridge, stopOllamaBridge } from "./ollama/server.js";
+import { createOfficialAgentRoutes } from "./routes/official-agent.js";
 
 export interface ServerHandle {
   close: () => Promise<void>;
@@ -182,6 +183,7 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   app.route("/", messagesRoutes);
   app.route("/", geminiRoutes);
   app.route("/", responsesRoutes);
+  app.route("/", createOfficialAgentRoutes());
   app.route("/", proxyRoutes);
   app.route("/", createModelRoutes(apiKeyPool));
   app.route("/", webRoutes);

--- a/src/routes/official-agent.ts
+++ b/src/routes/official-agent.ts
@@ -1,0 +1,173 @@
+import { Hono } from "hono";
+import { getConfig } from "../config.js";
+import { CodexAppServerClient } from "../codex-app-server/client.js";
+import type {
+  CodexAppNotification,
+  CodexAppServerBridge,
+  StartThreadParams,
+  StartTurnAppMention,
+  StartTurnParams,
+} from "../codex-app-server/types.js";
+
+type BridgeFactory = () => CodexAppServerBridge;
+
+let sharedBridge: CodexAppServerBridge | null = null;
+
+function getSharedBridge(): CodexAppServerBridge {
+  if (sharedBridge) return sharedBridge;
+  const config = getConfig();
+  sharedBridge = new CodexAppServerClient({
+    url: config.official_agent.app_server_url,
+    auth: config.official_agent.auth,
+    requestTimeoutMs: config.official_agent.request_timeout_ms,
+    clientInfo: {
+      name: "codex_proxy",
+      title: "Codex Proxy",
+      version: "2.0.69",
+    },
+  });
+  return sharedBridge;
+}
+
+export async function closeOfficialAgentBridgeForTesting(): Promise<void> {
+  await sharedBridge?.close();
+  sharedBridge = null;
+}
+
+function errorBody(code: string, message: string): { error: { code: string; message: string } } {
+  return { error: { code, message } };
+}
+
+function isAuthorized(authHeader: string | undefined, expectedKey: string | null): boolean {
+  if (!expectedKey) return true;
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
+  return token === expectedKey;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStartThread(body: unknown): StartThreadParams {
+  if (!isRecord(body)) return {};
+  return {
+    ...(typeof body.model === "string" ? { model: body.model } : {}),
+    ...(typeof body.cwd === "string" ? { cwd: body.cwd } : {}),
+  };
+}
+
+function parseAppMention(value: unknown): StartTurnAppMention | undefined {
+  if (!isRecord(value) || typeof value.id !== "string") return undefined;
+  return {
+    id: value.id,
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+  };
+}
+
+function parseStartTurn(threadId: string, body: unknown): StartTurnParams | null {
+  if (!isRecord(body) || typeof body.text !== "string" || body.text.trim() === "") return null;
+  return {
+    threadId,
+    text: body.text,
+    ...(typeof body.cwd === "string" ? { cwd: body.cwd } : {}),
+    ...(typeof body.approvalPolicy === "string" ? { approvalPolicy: body.approvalPolicy } : {}),
+    ...(parseAppMention(body.app) ? { app: parseAppMention(body.app) } : {}),
+  };
+}
+
+function encodeSse(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function* turnEventStream(
+  bridge: CodexAppServerBridge,
+  params: StartTurnParams,
+): AsyncGenerator<string> {
+  const notifications = bridge.notificationsUntilTurnCompleted();
+  const result = await bridge.startTurn(params);
+  yield encodeSse("official_agent.result", result);
+  for await (const notification of notifications) {
+    yield encodeSse(notification.method, notification);
+  }
+}
+
+export function createOfficialAgentRoutes(bridgeFactory: BridgeFactory = getSharedBridge): Hono {
+  const app = new Hono();
+
+  app.use("/official-agent/*", async (c, next) => {
+    const config = getConfig();
+    if (!config.official_agent.enabled) {
+      c.status(503);
+      return c.json(errorBody("official_agent_disabled", "Official Codex app-server bridge is disabled"));
+    }
+    if (!isAuthorized(c.req.header("Authorization"), config.server.proxy_api_key)) {
+      c.status(401);
+      return c.json(errorBody("invalid_api_key", "Invalid proxy API key"));
+    }
+    await next();
+  });
+
+  app.get("/official-agent/apps", async (c) => {
+    const cursor = c.req.query("cursor");
+    const limitRaw = c.req.query("limit");
+    const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+    const result = await bridgeFactory().listApps({
+      ...(cursor ? { cursor } : {}),
+      ...(limit !== undefined && Number.isInteger(limit) ? { limit } : {}),
+    });
+    return c.json(result);
+  });
+
+  app.post("/official-agent/threads", async (c) => {
+    let body: unknown = {};
+    try {
+      body = await c.req.json();
+    } catch {
+      body = {};
+    }
+    const result = await bridgeFactory().startThread(parseStartThread(body));
+    return c.json(result);
+  });
+
+  app.post("/official-agent/threads/:threadId/turns", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      c.status(400);
+      return c.json(errorBody("invalid_json", "Malformed JSON request body"));
+    }
+
+    const params = parseStartTurn(c.req.param("threadId"), body);
+    if (!params) {
+      c.status(400);
+      return c.json(errorBody("invalid_request", "text is required"));
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        const encoder = new TextEncoder();
+        try {
+          for await (const chunk of turnEventStream(bridgeFactory(), params)) {
+            controller.enqueue(encoder.encode(chunk));
+          }
+          controller.close();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          controller.enqueue(encoder.encode(encodeSse("official_agent.error", errorBody("app_server_error", message))));
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  });
+
+  return app;
+}

--- a/src/routes/official-agent.ts
+++ b/src/routes/official-agent.ts
@@ -39,7 +39,7 @@ function errorBody(code: string, message: string): { error: { code: string; mess
 }
 
 function isAuthorized(authHeader: string | undefined, expectedKey: string | null): boolean {
-  if (!expectedKey) return true;
+  if (!expectedKey) return false;
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
   return token === expectedKey;
 }
@@ -99,6 +99,10 @@ export function createOfficialAgentRoutes(bridgeFactory: BridgeFactory = getShar
     if (!config.official_agent.enabled) {
       c.status(503);
       return c.json(errorBody("official_agent_disabled", "Official Codex app-server bridge is disabled"));
+    }
+    if (!config.server.proxy_api_key) {
+      c.status(403);
+      return c.json(errorBody("official_agent_requires_api_key", "Official Codex app-server bridge requires server.proxy_api_key"));
     }
     if (!isAuthorized(c.req.header("Authorization"), config.server.proxy_api_key)) {
       c.status(401);

--- a/tests/_helpers/config.ts
+++ b/tests/_helpers/config.ts
@@ -15,6 +15,7 @@ export interface MockConfigOverrides {
   session?: Partial<AppConfig["session"]>;
   tls?: Partial<AppConfig["tls"]>;
   quota?: Partial<AppConfig["quota"]>;
+  official_agent?: Partial<AppConfig["official_agent"]>;
 }
 
 /**
@@ -82,6 +83,12 @@ export function createMockConfig(overrides?: MockConfigOverrides): AppConfig {
       },
       skip_exhausted: true,
     },
+    official_agent: {
+      enabled: false,
+      app_server_url: "ws://127.0.0.1:4500",
+      request_timeout_ms: 30000,
+      auth: { type: "none" },
+    },
   };
   return structuredClone({
     api:     { ...base.api,     ...overrides?.api },
@@ -92,6 +99,7 @@ export function createMockConfig(overrides?: MockConfigOverrides): AppConfig {
     session: { ...base.session, ...overrides?.session },
     tls:     { ...base.tls,     ...overrides?.tls },
     quota:   { ...base.quota,   ...overrides?.quota },
+    official_agent: { ...base.official_agent, ...overrides?.official_agent },
   });
 }
 

--- a/tests/unit/codex-app-server/client.test.ts
+++ b/tests/unit/codex-app-server/client.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer, type WebSocket as ServerSocket } from "ws";
+import type { AddressInfo } from "net";
+import { CodexAppServerClient } from "@src/codex-app-server/client.js";
+
+interface RecordedMessage {
+  method: string;
+  id?: number;
+  params?: unknown;
+}
+
+interface JsonRpcTestServer {
+  url: string;
+  messages: RecordedMessage[];
+  close(): Promise<void>;
+}
+
+async function startJsonRpcServer(
+  onMessage?: (socket: ServerSocket, message: RecordedMessage) => void,
+): Promise<JsonRpcTestServer> {
+  const server = new WebSocketServer({ port: 0 });
+  const messages: RecordedMessage[] = [];
+  const sockets = new Set<ServerSocket>();
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("message", (raw) => {
+      const parsed = JSON.parse(raw.toString()) as RecordedMessage;
+      messages.push(parsed);
+      if (onMessage) {
+        onMessage(socket, parsed);
+      } else if (parsed.id !== undefined) {
+        socket.send(JSON.stringify({ id: parsed.id, result: {} }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const addr = server.address() as AddressInfo;
+  return {
+    url: `ws://127.0.0.1:${addr.port}`,
+    messages,
+    async close() {
+      for (const socket of sockets) socket.terminate();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+describe("CodexAppServerClient", () => {
+  let server: JsonRpcTestServer | null = null;
+
+  afterEach(async () => {
+    await server?.close();
+    server = null;
+  });
+
+  it("initializes before the first request and sends initialized notification", async () => {
+    server = await startJsonRpcServer((socket, message) => {
+      if (message.method === "initialize" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: {} }));
+      }
+      if (message.method === "app/list" && message.id !== undefined) {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { data: [{ id: "chrome", name: "Chrome", isAccessible: true, isEnabled: true }], nextCursor: null },
+        }));
+      }
+    });
+    const client = new CodexAppServerClient({
+      url: server.url,
+      auth: { type: "none" },
+      clientInfo: { name: "codex_proxy", title: "Codex Proxy", version: "test" },
+      requestTimeoutMs: 1000,
+    });
+
+    const apps = await client.listApps({ limit: 50 });
+
+    expect(apps).toEqual({
+      data: [{ id: "chrome", name: "Chrome", isAccessible: true, isEnabled: true }],
+      nextCursor: null,
+    });
+    expect(server.messages.map((m) => m.method)).toEqual(["initialize", "initialized", "app/list"]);
+    await client.close();
+  });
+
+  it("sends app mention input when starting a turn with appId", async () => {
+    server = await startJsonRpcServer((socket, message) => {
+      if (message.method === "initialize" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: {} }));
+      }
+      if (message.method === "thread/start" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: { thread: { id: "thr_1" } } }));
+      }
+      if (message.method === "turn/start" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: { turn: { id: "turn_1", status: "inProgress" } } }));
+      }
+    });
+    const client = new CodexAppServerClient({
+      url: server.url,
+      auth: { type: "none" },
+      clientInfo: { name: "codex_proxy", title: "Codex Proxy", version: "test" },
+      requestTimeoutMs: 1000,
+    });
+
+    await client.startThread({ model: "gpt-5.4" });
+    await client.startTurn({
+      threadId: "thr_1",
+      text: "Open the dashboard",
+      app: { id: "chrome", name: "Chrome" },
+    });
+
+    const turnStart = server.messages.find((m) => m.method === "turn/start");
+    expect(turnStart?.params).toEqual({
+      threadId: "thr_1",
+      input: [
+        { type: "text", text: "$chrome Open the dashboard", text_elements: [] },
+        { type: "mention", name: "Chrome", path: "app://chrome" },
+      ],
+    });
+    await client.close();
+  });
+
+  it("exposes turn notifications until turn/completed", async () => {
+    server = await startJsonRpcServer((socket, message) => {
+      if (message.method === "initialize" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: {} }));
+      }
+      if (message.method === "turn/start" && message.id !== undefined) {
+        socket.send(JSON.stringify({ method: "item/agentMessage/delta", params: { delta: "hi" } }));
+        socket.send(JSON.stringify({ id: message.id, result: { turn: { id: "turn_1", status: "inProgress" } } }));
+        socket.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: "turn_1", status: "completed" } } }));
+      }
+    });
+    const client = new CodexAppServerClient({
+      url: server.url,
+      auth: { type: "none" },
+      clientInfo: { name: "codex_proxy", title: "Codex Proxy", version: "test" },
+      requestTimeoutMs: 1000,
+    });
+
+    const events = client.notificationsUntilTurnCompleted();
+    await client.startTurn({ threadId: "thr_1", text: "hello" });
+
+    const received: string[] = [];
+    for await (const event of events) {
+      received.push(event.method);
+    }
+    expect(received).toEqual(["item/agentMessage/delta", "turn/completed"]);
+    await client.close();
+  });
+});

--- a/tests/unit/codex-app-server/client.test.ts
+++ b/tests/unit/codex-app-server/client.test.ts
@@ -152,4 +152,46 @@ describe("CodexAppServerClient", () => {
     expect(received).toEqual(["item/agentMessage/delta", "turn/completed"]);
     await client.close();
   });
+
+  it("receives turn notifications after reconnecting from a closed WebSocket", async () => {
+    let turnStartCount = 0;
+    server = await startJsonRpcServer((socket, message) => {
+      if (message.method === "initialize" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: {} }));
+      }
+      if (message.method === "app/list" && message.id !== undefined) {
+        socket.send(JSON.stringify({ id: message.id, result: { data: [], nextCursor: null } }));
+        socket.close();
+      }
+      if (message.method === "turn/start" && message.id !== undefined) {
+        turnStartCount += 1;
+        socket.send(JSON.stringify({ id: message.id, result: { turn: { id: "turn_2", status: "inProgress" } } }));
+        setTimeout(() => {
+          socket.send(JSON.stringify({ method: "item/agentMessage/delta", params: { delta: "after reconnect" } }));
+          socket.send(JSON.stringify({ method: "turn/completed", params: { turn: { id: "turn_2", status: "completed" } } }));
+        }, 20);
+      }
+    });
+    const client = new CodexAppServerClient({
+      url: server.url,
+      auth: { type: "none" },
+      clientInfo: { name: "codex_proxy", title: "Codex Proxy", version: "test" },
+      requestTimeoutMs: 1000,
+    });
+
+    await client.listApps();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const events = client.notificationsUntilTurnCompleted();
+    await client.startTurn({ threadId: "thr_1", text: "hello again" });
+
+    const received: string[] = [];
+    for await (const event of events) {
+      received.push(event.method);
+    }
+
+    expect(turnStartCount).toBe(1);
+    expect(received).toEqual(["item/agentMessage/delta", "turn/completed"]);
+    await client.close();
+  });
 });

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -52,6 +52,12 @@ describe("ConfigSchema", () => {
       version: "0.18.3",
       disable_vision: false,
     });
+    expect(result.official_agent).toEqual({
+      enabled: false,
+      app_server_url: "ws://127.0.0.1:4500",
+      request_timeout_ms: 30000,
+      auth: { type: "none" },
+    });
   });
 
   it("respects overridden values", () => {
@@ -71,6 +77,12 @@ describe("ConfigSchema", () => {
         port: 11435,
         version: "0.20.1",
         disable_vision: true,
+      },
+      official_agent: {
+        enabled: true,
+        app_server_url: "ws://127.0.0.1:4777",
+        request_timeout_ms: 5000,
+        auth: { type: "capability_token", token_file: "/tmp/codex-token" },
       },
     });
 
@@ -92,6 +104,33 @@ describe("ConfigSchema", () => {
       version: "0.20.1",
       disable_vision: true,
     });
+    expect(result.official_agent.enabled).toBe(true);
+    expect(result.official_agent.app_server_url).toBe("ws://127.0.0.1:4777");
+    expect(result.official_agent.auth).toEqual({ type: "capability_token", token_file: "/tmp/codex-token" });
+  });
+
+  it("rejects non-websocket official agent URLs", () => {
+    const result = ConfigSchema.safeParse({
+      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      official_agent: { app_server_url: "http://127.0.0.1:4500" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires official agent capability token material", () => {
+    const result = ConfigSchema.safeParse({
+      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      official_agent: { auth: { type: "capability_token" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires official agent signed bearer secret material", () => {
+    const result = ConfigSchema.safeParse({
+      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      official_agent: { auth: { type: "signed_bearer_token" } },
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects port out of range", () => {

--- a/tests/unit/routes/official-agent.test.ts
+++ b/tests/unit/routes/official-agent.test.ts
@@ -67,6 +67,23 @@ describe("official agent routes", () => {
     expect(res.status).toBe(401);
   });
 
+  it("rejects official agent requests when the proxy API key is not configured", async () => {
+    setConfigForTesting(ConfigSchema.parse({
+      api: {}, client: {}, model: {}, auth: {}, server: { proxy_api_key: null }, session: {},
+      official_agent: { enabled: true },
+    }));
+
+    const res = await makeApp(new FakeBridge()).request("/official-agent/apps");
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "official_agent_requires_api_key",
+        message: "Official Codex app-server bridge requires server.proxy_api_key",
+      },
+    });
+  });
+
   it("lists apps through the app-server bridge", async () => {
     setConfigForTesting(ConfigSchema.parse({
       api: {}, client: {}, model: {}, auth: {}, session: {},
@@ -87,14 +104,15 @@ describe("official agent routes", () => {
 
   it("starts a thread", async () => {
     setConfigForTesting(ConfigSchema.parse({
-      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      api: {}, client: {}, model: {}, auth: {}, session: {},
+      server: { proxy_api_key: "proxy-key" },
       official_agent: { enabled: true },
     }));
 
     const res = await makeApp(new FakeBridge()).request("/official-agent/threads", {
       method: "POST",
       body: JSON.stringify({ model: "gpt-5.4" }),
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Authorization: "Bearer proxy-key" },
     });
 
     expect(res.status).toBe(200);
@@ -103,7 +121,8 @@ describe("official agent routes", () => {
 
   it("starts a turn and streams app-server notifications as SSE", async () => {
     setConfigForTesting(ConfigSchema.parse({
-      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      api: {}, client: {}, model: {}, auth: {}, session: {},
+      server: { proxy_api_key: "proxy-key" },
       official_agent: { enabled: true },
     }));
     const bridge = new FakeBridge();
@@ -111,7 +130,7 @@ describe("official agent routes", () => {
     const res = await makeApp(bridge).request("/official-agent/threads/thr_54/turns", {
       method: "POST",
       body: JSON.stringify({ text: "Open the dashboard", app: { id: "chrome", name: "Chrome" } }),
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Authorization: "Bearer proxy-key" },
     });
 
     expect(res.status).toBe(200);

--- a/tests/unit/routes/official-agent.test.ts
+++ b/tests/unit/routes/official-agent.test.ts
@@ -1,0 +1,129 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createOfficialAgentRoutes } from "@src/routes/official-agent.js";
+import type {
+  CodexAppServerBridge,
+  CodexAppNotification,
+  StartThreadParams,
+  StartTurnParams,
+} from "@src/codex-app-server/types.js";
+import { ConfigSchema } from "@src/config-schema.js";
+import { resetConfigForTesting, setConfigForTesting } from "@src/config.js";
+
+class FakeBridge implements CodexAppServerBridge {
+  public startedTurns: StartTurnParams[] = [];
+
+  async listApps(): Promise<unknown> {
+    return { data: [{ id: "chrome", name: "Chrome", isAccessible: true, isEnabled: true }], nextCursor: null };
+  }
+
+  async startThread(params: StartThreadParams): Promise<unknown> {
+    return { thread: { id: params.model === "gpt-5.4" ? "thr_54" : "thr_default" } };
+  }
+
+  async startTurn(params: StartTurnParams): Promise<unknown> {
+    this.startedTurns.push(params);
+    return { turn: { id: "turn_1", status: "inProgress" } };
+  }
+
+  notificationsUntilTurnCompleted(): AsyncIterable<CodexAppNotification> {
+    return (async function* () {
+      yield { method: "item/agentMessage/delta", params: { delta: "ok" } };
+      yield { method: "turn/completed", params: { turn: { id: "turn_1", status: "completed" } } };
+    })();
+  }
+}
+
+function makeApp(bridge: CodexAppServerBridge): Hono {
+  const app = new Hono();
+  app.route("/", createOfficialAgentRoutes(() => bridge));
+  return app;
+}
+
+describe("official agent routes", () => {
+  beforeEach(() => {
+    resetConfigForTesting();
+  });
+
+  it("returns 503 when official agent bridge is disabled", async () => {
+    setConfigForTesting(ConfigSchema.parse({ api: {}, client: {}, model: {}, auth: {}, server: {}, session: {} }));
+    const res = await makeApp(new FakeBridge()).request("/official-agent/apps");
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: { code: "official_agent_disabled", message: "Official Codex app-server bridge is disabled" },
+    });
+  });
+
+  it("requires proxy API key when configured", async () => {
+    setConfigForTesting(ConfigSchema.parse({
+      api: {}, client: {}, model: {}, auth: {}, session: {},
+      server: { proxy_api_key: "proxy-key" },
+      official_agent: { enabled: true },
+    }));
+
+    const res = await makeApp(new FakeBridge()).request("/official-agent/apps");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("lists apps through the app-server bridge", async () => {
+    setConfigForTesting(ConfigSchema.parse({
+      api: {}, client: {}, model: {}, auth: {}, session: {},
+      server: { proxy_api_key: "proxy-key" },
+      official_agent: { enabled: true },
+    }));
+
+    const res = await makeApp(new FakeBridge()).request("/official-agent/apps", {
+      headers: { Authorization: "Bearer proxy-key" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      data: [{ id: "chrome", name: "Chrome", isAccessible: true, isEnabled: true }],
+      nextCursor: null,
+    });
+  });
+
+  it("starts a thread", async () => {
+    setConfigForTesting(ConfigSchema.parse({
+      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      official_agent: { enabled: true },
+    }));
+
+    const res = await makeApp(new FakeBridge()).request("/official-agent/threads", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.4" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ thread: { id: "thr_54" } });
+  });
+
+  it("starts a turn and streams app-server notifications as SSE", async () => {
+    setConfigForTesting(ConfigSchema.parse({
+      api: {}, client: {}, model: {}, auth: {}, server: {}, session: {},
+      official_agent: { enabled: true },
+    }));
+    const bridge = new FakeBridge();
+
+    const res = await makeApp(bridge).request("/official-agent/threads/thr_54/turns", {
+      method: "POST",
+      body: JSON.stringify({ text: "Open the dashboard", app: { id: "chrome", name: "Chrome" } }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+    expect(bridge.startedTurns).toEqual([{
+      threadId: "thr_54",
+      text: "Open the dashboard",
+      app: { id: "chrome", name: "Chrome" },
+    }]);
+    const body = await res.text();
+    expect(body).toContain("event: official_agent.result");
+    expect(body).toContain("event: item/agentMessage/delta");
+    expect(body).toContain("event: turn/completed");
+  });
+});


### PR DESCRIPTION
## Summary
- add an optional official Codex app-server JSON-RPC bridge for official Chrome/browser plugin automation
- expose /official-agent/apps, /official-agent/threads, and streaming turn endpoints
- add disabled-by-default official_agent config, docs, and tests
- tolerate legacy test/mock configs without quota when acquiring accounts

## Verification
- npm test
- npx tsc --noEmit
- npm run build
- real app-server smoke: codex app-server --listen ws://127.0.0.1:14500, then app/list succeeded 3 consecutive times