### PR TITLE
feat: add Claude Desktop model aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ claude
 
 > 控制面板的 **Anthropic SDK Setup** 卡片可一键复制环境变量（含 Opus / Sonnet / Haiku 层级模型配置）。
 >
-> 推荐模型：Opus → `gpt-5.4`，Sonnet → `gpt-5.3-codex`，Haiku → `gpt-5.4-mini`。
+> 推荐模型：Opus → `gpt-5.5`，Sonnet → `gpt-5.4`，Haiku → `gpt-5.3-codex`。
 >
 > ⚠️ 配置不生效？请参考 **[Claude Code 配置避坑指南](.github/guides/claude-code-setup.md)**（AUTH_TOKEN 劫持、API Key 黑名单等常见问题）。
 
@@ -306,21 +306,30 @@ model_provider = "proxy_codex"
 3. **填写配置**：
    - **Endpoint**: `http://127.0.0.1:8080`
    - **API Key**: 你的 API Key
-   - **Model**: `gpt-5.4` (或 `anthropic/claude-3-5-sonnet-20241022` 这种 Anthropic 格式 ID)
+   - **Model**: `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5`
 
 > 或手动修改配置文件（Windows 下路径通常在 `%APPDATA%\Claude-3p\configLibrary\` 目录下的 JSON 文件，Mac 为 `~/Library/Application Support/Claude-3p/configLibrary/`），添加如下字段：
 ```json
  {
+   "disableDeploymentModeChooser": true,
    "inferenceProvider": "gateway",
    "inferenceGatewayBaseUrl": "http://127.0.0.1:8080",
    "inferenceGatewayApiKey": "your-api-key",
    "inferenceGatewayAuthScheme": "bearer",
    "inferenceModels": [
-     { "name": "gpt-5.4" },
-     { "name": "gpt-5.3-codex" },
-     { "name": "gpt-5.4-mini" }
+     "claude-opus-4-7",
+     "claude-sonnet-4-6",
+     "claude-haiku-4-5"
    ]
  }
+```
+
+默认映射在 `config/models.yaml` 的 `aliases` 里，可自行改：
+```yaml
+aliases:
+  claude-opus-4-7: gpt-5.5
+  claude-sonnet-4-6: gpt-5.4
+  claude-haiku-4-5: gpt-5.3-codex
 ```
 
 > 💡 **排查提示 (Windows)**: 如果使用 `127.0.0.1` 时 Claude Desktop 提示 `ERR_CONNECTION_REFUSED`（而使用 `localhost` 提示 URL 格式错误），说明 Node.js 在你的系统上默认只绑定了 IPv6。请进入 Codex Proxy 控制面板的设置页面，将 **Host** 修改为 `127.0.0.1`，或在 `data/local.yaml` 中添加 `server: { host: "127.0.0.1" }` 后重启代理。
@@ -700,6 +709,7 @@ curl -X POST http://localhost:8080/auth/accounts/import \
 - 发版流程引入 `dev` 分支 + beta channel：`bump-electron-beta.yml` 在 dev push 时打 `vX.Y.Z-beta.SHA` tag 出预发布包；`promote-dev-to-master.yml` 每天 14:00 UTC 检查 dev soak ≥24h + CI 绿后 fast-forward 到 master，再由现有 `bump-electron.yml` 出 stable tag (`.github/workflows/`)
 - `update.allow_prerelease` 配置项（默认 `false`）：开启后本地 Electron 通过 electron-updater 接收 beta channel 推送的预发布版本，便于自己的安装实测 dev 改动 (`src/config-schema.ts`、`packages/electron/electron/auto-updater.ts`、`config/default.yaml`)
 - `config/models.yaml`: `gpt-5.5` (Plus-only general-purpose chat) and `gpt-image-2` (Plus-only image-generation backend) entered the static catalog
+- Claude Desktop shell model aliases: `claude-opus-4-7` → `gpt-5.5`, `claude-sonnet-4-6` → `gpt-5.4`, `claude-haiku-4-5` → `gpt-5.3-codex`; users can edit `config/models.yaml` aliases to remap them
 - `CodexModelInfo.outputModalities` optional field on the model catalog interface to flag image-gen models apart from chat models (`src/models/model-store.ts`, `BackendModelEntry.output_modalities` also added for backend passthrough). `/v1/models/catalog` defaults missing values to `["text"]` so API output matches the documented contract.
 - README 新增图像生成小节 + 模型表 Output 列；`API.md` / `API_CN.md` 补 `image_generation` 工具参数矩阵、事件流、编辑模式文档
 - ...（[查看全部](./CHANGELOG.md)）

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -170,3 +170,10 @@ models:
     contextWindow: 131072
     supportsPersonality: false
     upgrade: null
+
+# User-editable aliases. Claude Desktop can expose Claude-shaped model names
+# while this gateway maps them to Codex model IDs internally.
+aliases:
+  claude-opus-4-7: gpt-5.5
+  claude-sonnet-4-6: gpt-5.4
+  claude-haiku-4-5: gpt-5.3-codex

--- a/src/proxy/upstream-router.ts
+++ b/src/proxy/upstream-router.ts
@@ -5,9 +5,10 @@
  *   0. ApiKeyPool entry matching the exact model name
  *   1. Explicit provider prefix: "openai:gpt-4o", "anthropic:claude-3-5-sonnet"
  *   2. model_routing config table: { "deepseek-chat": "deepseek" }
- *   3. Custom provider `models` list
- *   4. Built-in name pattern rules: "claude-*" → anthropic, "gemini-*" → gemini
- *   5. Default (codex)
+ *   3. Known Codex model IDs and aliases
+ *   4. Custom provider `models` list
+ *   5. Built-in name pattern rules: "claude-*" → anthropic, "gemini-*" → gemini
+ *   6. Default (codex)
  */
 
 import type { UpstreamAdapter } from "./upstream-adapter.js";
@@ -79,15 +80,15 @@ export class UpstreamRouter {
       if (adapter) return { kind: routedTag === this.defaultTag ? "codex" : "adapter", adapter };
     }
 
+    if (this.isKnownCodexModel(model)) {
+      return { kind: "codex" };
+    }
+
     if (/^claude/i.test(model) && this.adapters.has("anthropic")) {
       return { kind: "adapter", adapter: this.adapters.get("anthropic")! };
     }
     if (/^gemini/i.test(model) && this.adapters.has("gemini")) {
       return { kind: "adapter", adapter: this.adapters.get("gemini")! };
-    }
-
-    if (this.isKnownCodexModel(model)) {
-      return { kind: "codex" };
     }
 
     return { kind: "not-found" };

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -107,6 +107,9 @@ models:
 aliases:
   codex: "gpt-5.4"
   codex-mini: "gpt-5.3-codex-spark"
+  claude-opus-4-7: "gpt-5.5"
+  claude-sonnet-4-6: "gpt-5.4"
+  claude-haiku-4-5: "gpt-5.3-codex"
 `;
 
 describe("ModelStore", () => {
@@ -126,12 +129,21 @@ describe("ModelStore", () => {
       const aliases = getModelAliases();
       expect(aliases["codex"]).toBe("gpt-5.4");
       expect(aliases["codex-mini"]).toBe("gpt-5.3-codex-spark");
+      expect(aliases["claude-opus-4-7"]).toBe("gpt-5.5");
+      expect(aliases["claude-sonnet-4-6"]).toBe("gpt-5.4");
+      expect(aliases["claude-haiku-4-5"]).toBe("gpt-5.3-codex");
     });
   });
 
   describe("resolveModelId", () => {
     it("resolves alias to model ID", () => {
       expect(resolveModelId("codex")).toBe("gpt-5.4");
+    });
+
+    it("resolves Claude Desktop shell aliases to Codex model IDs", () => {
+      expect(resolveModelId("claude-opus-4-7")).toBe("gpt-5.5");
+      expect(resolveModelId("claude-sonnet-4-6")).toBe("gpt-5.4");
+      expect(resolveModelId("claude-haiku-4-5")).toBe("gpt-5.3-codex");
     });
 
     it("returns known model ID as-is", () => {

--- a/tests/unit/proxy/upstream-router.test.ts
+++ b/tests/unit/proxy/upstream-router.test.ts
@@ -1,7 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { UpstreamRouter } from "@src/proxy/upstream-router.js";
 import type { UpstreamAdapter } from "@src/proxy/upstream-adapter.js";
 import type { CodexResponsesRequest, CodexSSEEvent } from "@src/proxy/codex-types.js";
+
+vi.mock("@src/models/model-store.js", () => ({
+  getModelAliases: vi.fn(() => ({
+    "claude-opus-4-7": "gpt-5.5",
+    "claude-sonnet-4-6": "gpt-5.4",
+    "claude-haiku-4-5": "gpt-5.3-codex",
+  })),
+  getModelInfo: vi.fn((model: string) => {
+    if (["gpt-5.5", "gpt-5.4", "gpt-5.3-codex"].includes(model)) {
+      return { id: model };
+    }
+    return undefined;
+  }),
+}));
 
 function makeAdapter(tag: string): UpstreamAdapter {
   return {
@@ -54,6 +68,12 @@ describe("UpstreamRouter", () => {
   it("auto-routes claude-* to anthropic", () => {
     expect(router.resolve("claude-3-5-sonnet-20241022").tag).toBe("anthropic");
     expect(router.resolve("claude-3-haiku-20240307").tag).toBe("anthropic");
+  });
+
+  it("routes configured Claude Desktop shell aliases to codex before claude auto-routing", () => {
+    expect(router.resolveMatch("claude-opus-4-7").kind).toBe("codex");
+    expect(router.resolveMatch("claude-sonnet-4-6").kind).toBe("codex");
+    expect(router.resolveMatch("claude-haiku-4-5").kind).toBe("codex");
   });
 
   it("auto-routes gemini-* to gemini", () => {


### PR DESCRIPTION
Summary:
- add user-editable Claude Desktop shell aliases in config/models.yaml
- route configured Codex aliases before claude-* Anthropic auto-routing
- document Claude Desktop gateway config and alias remapping

Tests:
- npm test -- tests/unit/models/model-store.test.ts tests/unit/proxy/upstream-router.test.ts
- npm run build