### PR TITLE
fix: restore fast model suffix service tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- 恢复模型名 `-fast` 后缀的上游出口语义：`gpt-5.4-high-fast` / `codex-fast` 仍先解析为标准模型名 + `service_tier=fast`，最终发往 Codex backend 时再映射成官方接受的 `service_tier="priority"`（HTTP SSE 与 WebSocket 路径一致）；补回单测和 `/v1/responses` E2E，防止 PR #453 的 review quota plumbing 再次把 `service_tier` 丢掉
 - Dashboard 更新状态兼容旧响应：`/admin/update-status` 尚未返回 `settings` 字段时，前端默认按 `show_update_dialog=false` 处理，避免读取 `settings.show_update_dialog` 抛错导致页面白屏
 - Official Codex app-server bridge 审计加固：首批并发请求现在复用同一个 WebSocket 连接与 `initialize` 流程，避免 CONNECTING 阶段重复建连/覆盖 `this.ws`；并发 turn SSE 改为串行执行，避免共享 notification queue 把 A/B 两个 turn 的 delta/completed 交叉发错；`/official-agent/*` 改用独立 `official_agent.api_key`，不再复用通用 `server.proxy_api_key`，并限制 `approvalPolicy` 只能是 `untrusted` / `on-request` / `on-failure` / `never`
 - 隐式续链反向校验缺失导致客户端持续看到上游 `invalid_request_error: No tool output found for function call call_X`：`evaluateImplicitResume` 此前只做 forward 检查（新输入里的 `function_call_output.call_id` 必须命中上一轮 stored function_call），漏了反向（上一轮 stored function_call 必须在新输入里有 output）。当上一轮模型并发吐 N 个 tool_use、客户端只回 N-1 个 tool_result 时，proxy 仍然 resume + `previous_response_id` 发出去，上游存的 context 里那个未回复的 function_call 触发 400。新增反向检查 → 走完整重放（`reason: "unanswered_tool_calls"`），同时 `error-classification.ts` 加 `isUnansweredFunctionCallError`，proxy-handler catch 块兜底：strip `previous_response_id` + 完整历史重放 + 同账号重试一次（与 `previous_response_not_found` 同款），避免 ws/sse 路径上的 400 静默吞掉变成 502

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -33,6 +33,11 @@ const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER = "x-responsesapi-include-tim
 const X_CODEX_PARENT_THREAD_ID_HEADER = "x-codex-parent-thread-id";
 const X_CODEX_WINDOW_ID_HEADER = "x-codex-window-id";
 
+function normalizeServiceTierForUpstream(serviceTier: string | null | undefined): string | undefined {
+  if (!serviceTier) return undefined;
+  return serviceTier === "fast" ? "priority" : serviceTier;
+}
+
 // Re-export types from codex-types.ts for backward compatibility
 export type {
   CodexResponsesRequest,
@@ -327,7 +332,8 @@ export class CodexApi {
     wsRequest.tool_choice = request.tool_choice ?? "auto";
     wsRequest.parallel_tool_calls = request.parallel_tool_calls ?? true;
     if (request.text) wsRequest.text = request.text;
-    // service_tier is stripped — Codex backend rejects it ("Unsupported service_tier")
+    const serviceTier = normalizeServiceTierForUpstream(request.service_tier);
+    if (serviceTier) wsRequest.service_tier = serviceTier;
     if (request.prompt_cache_key) wsRequest.prompt_cache_key = request.prompt_cache_key;
     if (request.include?.length) wsRequest.include = request.include;
     wsRequest.client_metadata = this.buildCodexClientMetadata(request, installationId, identity.windowId);
@@ -376,11 +382,13 @@ export class CodexApi {
       includeTimingMetrics: _timing,
       codexWindowId: _window,
       parentThreadId: _parent,
-      service_tier: _st,
+      service_tier,
       ...bodyFields
     } = request;
+    const upstreamServiceTier = normalizeServiceTierForUpstream(service_tier);
     const bodyWithMetadata = {
       ...bodyFields,
+      ...(upstreamServiceTier ? { service_tier: upstreamServiceTier } : {}),
       client_metadata: this.buildCodexClientMetadata(request, installationId, identity.windowId),
     };
     const body = JSON.stringify(bodyWithMetadata);

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -113,6 +113,7 @@ export interface WsCreateRequest {
       strict?: boolean;
     };
   };
+  service_tier?: string;
   prompt_cache_key?: string;
   client_metadata?: Record<string, string>;
   include?: string[];

--- a/tests/e2e/responses.test.ts
+++ b/tests/e2e/responses.test.ts
@@ -211,6 +211,8 @@ describe("E2E: POST /v1/responses", () => {
     expect(sentBody.model).toBe("gpt-5.4");
     // Reasoning effort should be set from suffix
     expect(sentBody.reasoning?.effort).toBe("high");
+    // Fast suffix should survive the final Codex API serialization as upstream's priority tier.
+    expect(sentBody.service_tier).toBe("priority");
   });
 
   it("unauthenticated: returns 401 with invalid_api_key", async () => {

--- a/tests/unit/proxy/codex-api-headers.test.ts
+++ b/tests/unit/proxy/codex-api-headers.test.ts
@@ -117,14 +117,21 @@ describe("codex-api headers", () => {
       expect(transport.lastHeaders!["x-codex-turn-state"]).toBeUndefined();
     });
 
-    it("excludes turnState and service_tier from JSON body", async () => {
+    it("excludes turnState from JSON body and maps fast service_tier to priority", async () => {
       const api = await createApi();
       await api.createResponse(
         makeRequest({ turnState: "abc", service_tier: "fast" }),
       );
       const body = JSON.parse(transport.lastBody!) as Record<string, unknown>;
       expect(body.turnState).toBeUndefined();
-      expect(body.service_tier).toBeUndefined();
+      expect(body.service_tier).toBe("priority");
+    });
+
+    it("preserves non-fast service_tier in JSON body", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest({ service_tier: "flex" }));
+      const body = JSON.parse(transport.lastBody!) as Record<string, unknown>;
+      expect(body.service_tier).toBe("flex");
     });
 
     it("sends x-codex-installation-id header and inside body.client_metadata", async () => {
@@ -258,6 +265,27 @@ describe("codex-api headers", () => {
         "x-openai-subagent": "review",
         "x-codex-installation-id": "11111111-2222-3333-4444-555555555555",
       });
+    });
+
+    it("maps fast service_tier to priority on WebSocket requests", async () => {
+      mockCreateWebSocketResponse.mockResolvedValue(
+        new Response("data: {}\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      );
+
+      const api = await createApi();
+      await api.createResponse(
+        makeRequest({
+          useWebSocket: true,
+          service_tier: "fast",
+        }),
+      );
+
+      const wsRequest = mockCreateWebSocketResponse.mock.calls[0][2] as {
+        service_tier?: string;
+      };
+      expect(wsRequest.service_tier).toBe("priority");
     });
 
     it("uses prompt_cache_key as WebSocket conversation identity", async () => {


### PR DESCRIPTION
## Summary
- restore final Codex API serialization for model `-fast` suffixes by mapping `service_tier: fast` to upstream `priority`
- apply the mapping consistently to HTTP SSE and WebSocket requests
- add regression coverage for HTTP, WebSocket, and `/v1/responses` suffix flow

## Tests
- `npm test -- tests/e2e/responses.test.ts tests/unit/proxy/codex-api-headers.test.ts tests/unit/models/model-store.test.ts tests/unit/translation/openai-to-codex.test.ts`
- `npx tsc --noEmit`
- Real upstream E2E via `/v1/responses` on PR branch:
  - `gpt-5.5-fast`: 3/3 HTTP 200 with `response.completed`
  - `gpt-5.5-xhigh-fast`: 3/3 HTTP 200 with `response.completed`

## Notes
- Verified proxy logs showed `gpt-5.5-xhigh-fast` parsed to `reasoning=[effort=xhigh summary=auto]`.
- The fast suffix path completed through the restored service tier serialization (`fast` -> `priority`).