### PR TITLE
Fix quota cache visibility after reset

### DIFF
--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -24,6 +24,31 @@ import type {
   CodexQuota,
 } from "./types.js";
 
+type ResettableQuotaWindow = {
+  used_percent: number | null;
+  reset_at: number | null;
+  limit_window_seconds?: number | null;
+  limit_reached: boolean;
+};
+
+function nextResetAt(resetAt: number, windowSec: number | null | undefined, nowSec: number): number | null {
+  if (windowSec == null || windowSec <= 0) return null;
+  const elapsedWindows = Math.floor((nowSec - resetAt) / windowSec) + 1;
+  return resetAt + elapsedWindows * windowSec;
+}
+
+function resetExpiredQuotaWindow(
+  quotaWindow: ResettableQuotaWindow | null | undefined,
+  nowSec: number,
+): boolean {
+  const resetAt = quotaWindow?.reset_at;
+  if (quotaWindow == null || resetAt == null || nowSec < resetAt) return false;
+  quotaWindow.used_percent = 0;
+  quotaWindow.limit_reached = false;
+  quotaWindow.reset_at = nextResetAt(resetAt, quotaWindow.limit_window_seconds, nowSec);
+  return true;
+}
+
 export class AccountRegistry {
   private accounts: Map<string, AccountEntry> = new Map();
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -474,12 +499,18 @@ export class AccountRegistry {
       this.schedulePersist();
     }
 
-    // Clear stale cached quota when its own reset time has passed
-    const quotaReset = entry.cachedQuota?.rate_limit?.reset_at;
-    if (quotaReset != null && nowSec >= quotaReset) {
-      entry.cachedQuota = null;
-      entry.quotaFetchedAt = null;
-      this.schedulePersist();
+    // Keep quota cards visible across reset boundaries. Passive quota collection
+    // will overwrite these inferred values on the next successful upstream turn.
+    const quota = entry.cachedQuota;
+    if (quota) {
+      let changed = false;
+      changed = resetExpiredQuotaWindow(quota.rate_limit, nowSec) || changed;
+      changed = resetExpiredQuotaWindow(quota.secondary_rate_limit, nowSec) || changed;
+      changed = resetExpiredQuotaWindow(quota.code_review_rate_limit, nowSec) || changed;
+
+      if (changed) {
+        this.schedulePersist();
+      }
     }
   }
 

--- a/tests/unit/auth/account-pool-quota.test.ts
+++ b/tests/unit/auth/account-pool-quota.test.ts
@@ -156,6 +156,37 @@ describe("AccountPool quota methods", () => {
       const acct = accounts.find((a) => a.id === id);
       expect(acct?.quota).toBeUndefined();
     });
+
+    it("keeps cached quota visible after the primary reset time passes", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "a10", planType: "plus" }));
+      const nowSec = Math.floor(Date.now() / 1000);
+
+      pool.updateCachedQuota(id, makeQuota({
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          used_percent: 87,
+          reset_at: nowSec - 10,
+          limit_window_seconds: 3600,
+        },
+        secondary_rate_limit: {
+          limit_reached: false,
+          used_percent: 33,
+          reset_at: nowSec + 7200,
+          limit_window_seconds: 604800,
+        },
+      }));
+
+      const accounts = pool.getAccounts();
+      const acct = accounts.find((a) => a.id === id);
+
+      expect(acct?.quota).toBeDefined();
+      expect(acct?.quota?.rate_limit.used_percent).toBe(0);
+      expect(acct?.quota?.rate_limit.limit_reached).toBe(false);
+      expect(acct?.quota?.rate_limit.reset_at).toBeGreaterThan(nowSec);
+      expect(acct?.quota?.secondary_rate_limit?.used_percent).toBe(33);
+      expect(acct?.quotaFetchedAt).toBeTruthy();
+    });
   });
 
   describe("acquire skips exhausted accounts", () => {


### PR DESCRIPTION
## Summary
- keep cached quota visible when a rate-limit reset time passes instead of clearing the entire quota object
- roll expired quota windows back to 0% and advance reset_at when window duration is known
- add a regression test for account quota visibility after primary reset

Fixes #461

## Tests
- npm test -- tests/unit/auth/account-pool-quota.test.ts tests/e2e/quota-refresh.test.ts
- ./node_modules/.bin/tsc --noEmit

Note: npm run test:unit currently fails because the existing script uses Vitest's unsupported --include option.