### PR TITLE
fix: handle premature response stream closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- `/v1/responses` streaming 提前断流时不再让客户端只看到裸 EOF：HTTP/WS passthrough 现在追踪 `response.completed` / `response.failed` / `error` 终止事件；上游在终止事件前结束或 WebSocket 首帧后中断时，会合成 `response.failed`（`code=stream_disconnected`）或让上层转换为该失败事件，避免 Codex CLI 报 `stream disconnected before completion: stream closed before response.completed` 且没有结构化错误
 - 恢复模型名 `-fast` 后缀的上游出口语义：`gpt-5.4-high-fast` / `codex-fast` 仍先解析为标准模型名 + `service_tier=fast`，最终发往 Codex backend 时再映射成官方接受的 `service_tier="priority"`（HTTP SSE 与 WebSocket 路径一致）；补回单测和 `/v1/responses` E2E，防止 PR #453 的 review quota plumbing 再次把 `service_tier` 丢掉
 - Dashboard 更新状态兼容旧响应：`/admin/update-status` 尚未返回 `settings` 字段时，前端默认按 `show_update_dialog=false` 处理，避免读取 `settings.show_update_dialog` 抛错导致页面白屏
 - Official Codex app-server bridge 审计加固：首批并发请求现在复用同一个 WebSocket 连接与 `initialize` 流程，避免 CONNECTING 阶段重复建连/覆盖 `this.ws`；并发 turn SSE 改为串行执行，避免共享 notification queue 把 A/B 两个 turn 的 delta/completed 交叉发错；`/official-agent/*` 改用独立 `official_agent.api_key`，不再复用通用 `server.proxy_api_key`，并限制 `approvalPolicy` 只能是 `untrusted` / `on-request` / `on-failure` / `never`

--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -72,6 +72,7 @@ interface InFlightSession {
   controller: ReadableStreamDefaultController<Uint8Array>;
   onRateLimits: ((rl: ParsedRateLimit) => void) | undefined;
   earlyDecisionMade: boolean;
+  sawTerminalEvent: boolean;
   /** Resolves the outer send() Promise with the SSE Response.
    *  Closes over the freshly-built ReadableStream so callers don't need to
    *  pass it back in. */
@@ -137,6 +138,10 @@ function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number; c
   const lower = codeRaw.toLowerCase();
   const status = ROTATABLE_ERROR_CODES[lower];
   return status ? { status, code: lower } : null;
+}
+
+function isTerminalWsEvent(type: string): boolean {
+  return type === "response.completed" || type === "response.failed" || type === "error";
 }
 
 // ── PersistentWs ───────────────────────────────────────────────────
@@ -303,6 +308,7 @@ export class PersistentWs {
             controller,
             onRateLimits: opts.onRateLimits,
             earlyDecisionMade: false,
+            sawTerminalEvent: false,
             resolveResponse: () => resolve(this.buildResponse(stream)),
             reject: wrappedReject,
             abortListener: null,
@@ -425,7 +431,8 @@ export class PersistentWs {
       const sse = `event: ${type}\ndata: ${raw}\n\n`;
       sess.controller.enqueue(this.encoder.encode(sse));
 
-      if (type === "response.completed" || type === "response.failed" || type === "error") {
+      if (isTerminalWsEvent(type)) {
+        sess.sawTerminalEvent = true;
         queueMicrotask(() => this.releaseAfterTerminalFrame());
       }
     } else {
@@ -476,7 +483,16 @@ export class PersistentWs {
           (reasonStr ? ` reason=${reasonStr}` : ""),
       ));
     } else if (sess && !sess.streamClosed) {
-      try { sess.controller.close(); } catch { /* already closed */ }
+      if (sess.sawTerminalEvent) {
+        try { sess.controller.close(); } catch { /* already closed */ }
+      } else {
+        try {
+          sess.controller.error(new Error(
+            `WebSocket closed before terminal event: code=${code}` +
+              (reasonStr ? ` reason=${reasonStr}` : ""),
+          ));
+        } catch { /* already closed */ }
+      }
       sess.streamClosed = true;
     }
     this.markDead(`closed code=${code}${reasonStr ? ` reason=${reasonStr}` : ""}`);

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -77,6 +77,10 @@ function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } 
   return status ? { status } : null;
 }
 
+function isTerminalWsEvent(type: string): boolean {
+  return type === "response.completed" || type === "response.failed" || type === "error";
+}
+
 /** Cached ws module — loaded once on first use. */
 let _WS: typeof import("ws").default | undefined;
 
@@ -298,6 +302,7 @@ async function openOneShotWs(
     // for a real first frame so we can detect early upstream errors and
     // route them through the existing CodexApiError → rotation path.
     let earlyDecisionMade = false;
+    let sawTerminalEvent = false;
 
     function closeStream() {
       if (!streamClosed && controller) {
@@ -400,7 +405,8 @@ async function openOneShotWs(
         controller!.enqueue(encoder.encode(sse));
 
         // Close stream after response.completed, response.failed, or error
-        if (type === "response.completed" || type === "response.failed" || type === "error") {
+        if (isTerminalWsEvent(type)) {
+          sawTerminalEvent = true;
           queueMicrotask(() => {
             closeStream();
             ws.close(1000);
@@ -432,6 +438,15 @@ async function openOneShotWs(
           `WebSocket closed before any data: code=${code}` +
             (reasonStr ? ` reason=${reasonStr}` : ""),
         ));
+        return;
+      }
+      if (earlyDecisionMade && !sawTerminalEvent) {
+        const reasonStr = reason && reason.length ? reason.toString("utf-8") : "";
+        errorStream(new Error(
+          `WebSocket closed before terminal event: code=${code}` +
+            (reasonStr ? ` reason=${reasonStr}` : ""),
+        ));
+        return;
       }
       closeStream();
     });

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -12,7 +12,7 @@ import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { CodexApi, CodexApiError } from "../proxy/codex-api.js";
-import type { CodexResponsesRequest, CodexCompactRequest, CodexInputItem } from "../proxy/codex-api.js";
+import type { CodexResponsesRequest, CodexCompactRequest, CodexInputItem, CodexSSEEvent } from "../proxy/codex-api.js";
 import { enqueueLogEntry } from "../logs/entry.js";
 import { summarizeRequestForLog } from "../logs/request-summary.js";
 import { getRealClientIp } from "../utils/get-real-client-ip.js";
@@ -91,6 +91,37 @@ function syncOutputTextFromOutput(response: Record<string, unknown>): void {
 
 // ── Passthrough stream translator ──────────────────────────────────
 
+const STREAM_DISCONNECTED_CODE = "stream_disconnected";
+const STREAM_DISCONNECTED_MESSAGE = "Upstream stream closed before response.completed";
+
+function isTerminalResponsesEvent(event: string): boolean {
+  return event === "response.completed" || event === "response.failed" || event === "error";
+}
+
+function extractResponseIdFromEventData(data: unknown): string | null {
+  if (!isRecord(data) || !isRecord(data.response)) return null;
+  return typeof data.response.id === "string" ? data.response.id : null;
+}
+
+function buildPrematureCloseFailedEvent(responseId: string | null, detail?: string): string {
+  const id = responseId ?? `resp_proxy_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+  const message = detail ? `${STREAM_DISCONNECTED_MESSAGE}: ${detail}` : STREAM_DISCONNECTED_MESSAGE;
+  const error = {
+    type: "server_error",
+    code: STREAM_DISCONNECTED_CODE,
+    message,
+  };
+  return `event: response.failed\ndata: ${JSON.stringify({
+    type: "response.failed",
+    response: {
+      id,
+      status: "failed",
+      error,
+    },
+    error,
+  })}\n\n`;
+}
+
 /** Extract usage from a response.completed payload, including cached_tokens
  *  (nested in input_tokens_details per the OpenAI Responses API contract). */
 export function extractResponseUsage(usage: Record<string, unknown>): { input_tokens: number; output_tokens: number; cached_tokens?: number } {
@@ -117,7 +148,7 @@ export function extractImageGenUsage(response: Record<string, unknown>): { image
   return { image_input_tokens, image_output_tokens };
 }
 
-async function* streamPassthrough(
+export async function* streamPassthrough(
   api: UpstreamAdapter,
   response: Response,
   _model: string,
@@ -129,74 +160,113 @@ async function* streamPassthrough(
   // This means the client receives zero incremental text — all text arrives at once
   // after response.completed. This is a known tradeoff for tuple reconversion correctness.
   let tupleTextBuffer = tupleSchema ? "" : null;
+  let sawTerminal = false;
+  let responseId: string | null = null;
 
-  for await (const raw of api.parseStream(response)) {
-    // Buffer text deltas when tuple reconversion is active
-    if (tupleTextBuffer !== null && raw.event === "response.output_text.delta") {
-      const data = raw.data;
-      if (isRecord(data) && typeof data.delta === "string") {
-        tupleTextBuffer += data.delta;
-        continue; // suppress this event — will flush reconverted text on completion
+  const stream = api.parseStream(response);
+  let upstreamDone = false;
+  try {
+    while (true) {
+      let next: IteratorResult<CodexSSEEvent>;
+      try {
+        next = await stream.next();
+      } catch (err) {
+        if (sawTerminal) return;
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[Responses] premature stream close before terminal event responseId=${responseId ?? "unknown"}: ${detail}`,
+        );
+        yield buildPrematureCloseFailedEvent(responseId, detail);
+        return;
       }
-    }
 
-    // On completion, flush reconverted text before emitting the completed event
-    if (tupleTextBuffer !== null && tupleSchema && raw.event === "response.completed") {
-      if (tupleTextBuffer) {
-        let reconvertedText = tupleTextBuffer;
-        try {
-          const parsed = JSON.parse(tupleTextBuffer) as unknown;
-          reconvertedText = JSON.stringify(reconvertTupleValues(parsed, tupleSchema));
-        } catch (e) {
-          console.warn("[tuple-reconvert] streaming JSON parse failed, emitting raw text:", e);
+      if (next.done) {
+        upstreamDone = true;
+        break;
+      }
+
+      const raw = next.value;
+      responseId = extractResponseIdFromEventData(raw.data) ?? responseId;
+      if (isTerminalResponsesEvent(raw.event)) sawTerminal = true;
+
+      // Buffer text deltas when tuple reconversion is active
+      if (tupleTextBuffer !== null && raw.event === "response.output_text.delta") {
+        const data = raw.data;
+        if (isRecord(data) && typeof data.delta === "string") {
+          tupleTextBuffer += data.delta;
+          continue; // suppress this event — will flush reconverted text on completion
         }
-        // Emit a single text delta with reconverted content
-        yield `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: reconvertedText })}\n\n`;
       }
-      // Patch the completed event's output text if present
-      const data = raw.data;
-      if (isRecord(data) && isRecord(data.response) && tupleTextBuffer) {
-        const resp = data.response;
-        if (Array.isArray(resp.output)) {
-          for (const item of resp.output as unknown[]) {
-            if (isRecord(item) && Array.isArray(item.content)) {
-              for (const part of item.content as unknown[]) {
-                if (
-                  isRecord(part) &&
-                  (part.type === "output_text" || part.type === "text") &&
-                  typeof part.text === "string"
-                ) {
-                  try {
-                    const parsed = JSON.parse(part.text) as unknown;
-                    part.text = JSON.stringify(reconvertTupleValues(parsed, tupleSchema));
-                  } catch { /* leave as-is */ }
+
+      // On completion, flush reconverted text before emitting the completed event
+      if (tupleTextBuffer !== null && tupleSchema && raw.event === "response.completed") {
+        if (tupleTextBuffer) {
+          let reconvertedText = tupleTextBuffer;
+          try {
+            const parsed = JSON.parse(tupleTextBuffer) as unknown;
+            reconvertedText = JSON.stringify(reconvertTupleValues(parsed, tupleSchema));
+          } catch (e) {
+            console.warn("[tuple-reconvert] streaming JSON parse failed, emitting raw text:", e);
+          }
+          // Emit a single text delta with reconverted content
+          yield `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: reconvertedText })}\n\n`;
+        }
+        // Patch the completed event's output text if present
+        const data = raw.data;
+        if (isRecord(data) && isRecord(data.response) && tupleTextBuffer) {
+          const resp = data.response;
+          if (Array.isArray(resp.output)) {
+            for (const item of resp.output as unknown[]) {
+              if (isRecord(item) && Array.isArray(item.content)) {
+                for (const part of item.content as unknown[]) {
+                  if (
+                    isRecord(part) &&
+                    (part.type === "output_text" || part.type === "text") &&
+                    typeof part.text === "string"
+                  ) {
+                    try {
+                      const parsed = JSON.parse(part.text) as unknown;
+                      part.text = JSON.stringify(reconvertTupleValues(parsed, tupleSchema));
+                    } catch { /* leave as-is */ }
+                  }
                 }
               }
             }
           }
         }
       }
-    }
 
-    // Re-emit raw SSE event
-    yield `event: ${raw.event}\ndata: ${JSON.stringify(raw.data)}\n\n`;
+      // Re-emit raw SSE event
+      yield `event: ${raw.event}\ndata: ${JSON.stringify(raw.data)}\n\n`;
 
-    // Extract usage and responseId for account pool bookkeeping
-    if (
-      raw.event === "response.created" ||
-      raw.event === "response.in_progress" ||
-      raw.event === "response.completed"
-    ) {
-      const data = raw.data;
-      if (isRecord(data) && isRecord(data.response)) {
-        const resp = data.response;
-        if (typeof resp.id === "string") onResponseId(resp.id);
-        if (raw.event === "response.completed" && isRecord(resp.usage)) {
-          const imgUsage = extractImageGenUsage(resp);
-          onUsage({ ...extractResponseUsage(resp.usage), ...(imgUsage ?? {}) });
+      // Extract usage and responseId for account pool bookkeeping
+      if (
+        raw.event === "response.created" ||
+        raw.event === "response.in_progress" ||
+        raw.event === "response.completed"
+      ) {
+        const data = raw.data;
+        if (isRecord(data) && isRecord(data.response)) {
+          const resp = data.response;
+          if (typeof resp.id === "string") onResponseId(resp.id);
+          if (raw.event === "response.completed" && isRecord(resp.usage)) {
+            const imgUsage = extractImageGenUsage(resp);
+            onUsage({ ...extractResponseUsage(resp.usage), ...(imgUsage ?? {}) });
+          }
         }
       }
     }
+  } finally {
+    if (!upstreamDone) {
+      try { await stream.return(undefined); } catch { /* cleanup best effort */ }
+    }
+  }
+
+  if (!sawTerminal) {
+    console.warn(
+      `[Responses] premature stream close before terminal event responseId=${responseId ?? "unknown"}`,
+    );
+    yield buildPrematureCloseFailedEvent(responseId);
   }
 }
 

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -94,6 +94,12 @@ function syncOutputTextFromOutput(response: Record<string, unknown>): void {
 const STREAM_DISCONNECTED_CODE = "stream_disconnected";
 const STREAM_DISCONNECTED_MESSAGE = "Upstream stream closed before response.completed";
 
+interface ResponsesStreamError {
+  type: string;
+  code: string;
+  message: string;
+}
+
 function isTerminalResponsesEvent(event: string): boolean {
   return event === "response.completed" || event === "response.failed" || event === "error";
 }
@@ -104,13 +110,16 @@ function extractResponseIdFromEventData(data: unknown): string | null {
 }
 
 function buildPrematureCloseFailedEvent(responseId: string | null, detail?: string): string {
-  const id = responseId ?? `resp_proxy_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
   const message = detail ? `${STREAM_DISCONNECTED_MESSAGE}: ${detail}` : STREAM_DISCONNECTED_MESSAGE;
-  const error = {
+  return buildResponseFailedEvent(responseId, {
     type: "server_error",
     code: STREAM_DISCONNECTED_CODE,
     message,
-  };
+  });
+}
+
+function buildResponseFailedEvent(responseId: string | null, error: ResponsesStreamError): string {
+  const id = responseId ?? `resp_proxy_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
   return `event: response.failed\ndata: ${JSON.stringify({
     type: "response.failed",
     response: {
@@ -120,6 +129,44 @@ function buildPrematureCloseFailedEvent(responseId: string | null, detail?: stri
     },
     error,
   })}\n\n`;
+}
+
+function stripCodexErrorPrefix(message: string): string {
+  return message.replace(/^Codex API error \(\d+\):\s*/, "");
+}
+
+function classifyResponsesStreamError(status: number, message: string): ResponsesStreamError {
+  const cleanMessage = stripCodexErrorPrefix(message);
+  if (status === 429) {
+    return {
+      type: "rate_limit_error",
+      code: "rate_limit_exceeded",
+      message: cleanMessage,
+    };
+  }
+  if (status === 401 || status === 403) {
+    return {
+      type: "invalid_request_error",
+      code: "authentication_error",
+      message: cleanMessage,
+    };
+  }
+  if (cleanMessage.toLowerCase().includes("error sending request")) {
+    return {
+      type: "server_error",
+      code: "upstream_transport_error",
+      message: cleanMessage,
+    };
+  }
+  return {
+    type: status >= 400 && status < 500 ? "invalid_request_error" : "server_error",
+    code: "codex_api_error",
+    message: cleanMessage,
+  };
+}
+
+function buildResponsesStreamError(status: number, message: string): string {
+  return buildResponseFailedEvent(null, classifyResponsesStreamError(status, message));
 }
 
 /** Extract usage from a response.completed payload, including cached_tokens
@@ -408,6 +455,7 @@ const PASSTHROUGH_FORMAT: FormatAdapter = {
       message: msg,
     },
   }),
+  formatStreamError: (status, msg) => buildResponsesStreamError(status, msg),
   streamTranslator: (api, response, model, onUsage, onResponseId, tupleSchema) =>
     streamPassthrough(api, response, model, onUsage, onResponseId, tupleSchema),
   collectTranslator: (api, response, model, tupleSchema) =>

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -496,7 +496,10 @@ export async function handleProxyRequest(
         const capturedApi = codexApi;
 
         return stream(c, async (s) => {
-          s.onAbort(() => abortController.abort());
+          s.onAbort(() => {
+            console.warn(`[stream-client-abort] rid=${requestId.slice(0, 8)} tag=${fmt.tag} model=${req.model}`);
+            abortController.abort();
+          });
           const recordStreamAffinity = (): void => {
             if (!capturedResponseId) return;
             affinityMap.record(
@@ -528,6 +531,7 @@ export async function handleProxyRequest(
                 }
                 recordStreamAffinity();
               },
+              { requestId: requestId.slice(0, 8), tag: fmt.tag },
             );
           } finally {
             abortController.abort();
@@ -949,8 +953,23 @@ export async function handleDirectRequest(
     c.header("Connection", "keep-alive");
 
     return stream(c, async (s) => {
-      s.onAbort(() => abortController.abort());
-      await streamResponse(s, upstream, rawResponse, req.model, fmt, () => {}, req.tupleSchema, () => {});
+      s.onAbort(() => {
+        console.warn(`[stream-client-abort] rid=${requestId.slice(0, 8)} tag=${fmt.tag} model=${req.model}`);
+        abortController.abort();
+      });
+      await streamResponse(
+        s,
+        upstream,
+        rawResponse,
+        req.model,
+        fmt,
+        () => {},
+        req.tupleSchema,
+        () => {},
+        undefined,
+        undefined,
+        { requestId: requestId.slice(0, 8), tag: fmt.tag },
+      );
     });
   }
 

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -71,6 +71,7 @@ export interface FormatAdapter {
   formatNoAccount: () => unknown;
   format429: (message: string) => unknown;
   formatError: (status: number, message: string) => unknown;
+  formatStreamError?: (status: number, message: string) => string;
   streamTranslator: (
     api: UpstreamAdapter,
     response: Response,
@@ -230,6 +231,28 @@ function buildCodexApi(
   return new CodexApi(token, accountId, cookieJar, entryId, proxyUrl);
 }
 
+function canReturnStreamError(req: ProxyRequest, fmt: FormatAdapter): boolean {
+  return req.isStreaming && typeof fmt.formatStreamError === "function";
+}
+
+function streamErrorResponse(
+  c: Context,
+  fmt: FormatAdapter,
+  status: number,
+  message: string,
+): Response {
+  c.header("Content-Type", "text/event-stream");
+  c.header("Cache-Control", "no-cache");
+  c.header("Connection", "keep-alive");
+
+  return stream(c, async (s) => {
+    await s.write(
+      fmt.formatStreamError?.(status, message) ??
+        `data: ${JSON.stringify({ error: { message, type: "stream_error" } })}\n\n`,
+    );
+  });
+}
+
 export async function handleProxyRequest(
   c: Context,
   accountPool: AccountPool,
@@ -300,6 +323,14 @@ export async function handleProxyRequest(
   // Single acquire call — preferredEntryId is a hint, not a hard requirement
   const acquired = acquireAccount(accountPool, req.codexRequest.model, undefined, fmt.tag, preferredEntryId ?? undefined);
   if (!acquired) {
+    if (canReturnStreamError(req, fmt)) {
+      return streamErrorResponse(
+        c,
+        fmt,
+        fmt.noAccountStatus,
+        "No available accounts. All accounts are expired or rate-limited.",
+      );
+    }
     c.status(fmt.noAccountStatus);
     return c.json(fmt.formatNoAccount());
   }
@@ -646,6 +677,9 @@ export async function handleProxyRequest(
 
       if (decision.action === "respond") {
         releaseAccount(accountPool, entryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
+        if (canReturnStreamError(req, fmt)) {
+          return streamErrorResponse(c, fmt, decision.status, decision.message);
+        }
         c.status(decision.status as StatusCode);
         return c.json(fmt.formatError(decision.status, decision.message));
       }
@@ -674,6 +708,9 @@ export async function handleProxyRequest(
           ? `All accounts exhausted (${parts.join(", ")}). ${decision.message}`
           : `No accounts available. ${decision.message}`;
         const status = decision.status as StatusCode;
+        if (canReturnStreamError(req, fmt)) {
+          return streamErrorResponse(c, fmt, status, detail);
+        }
         c.status(status);
         if (decision.useFormat429) {
           return c.json(fmt.format429(detail));
@@ -684,6 +721,9 @@ export async function handleProxyRequest(
       const retry = acquireAccount(accountPool, req.codexRequest.model, triedEntryIds, fmt.tag);
       if (!retry) {
         const status = decision.status as StatusCode;
+        if (canReturnStreamError(req, fmt)) {
+          return streamErrorResponse(c, fmt, status, decision.message);
+        }
         c.status(status);
         if (decision.useFormat429) {
           return c.json(fmt.format429(decision.message));
@@ -930,6 +970,9 @@ export async function handleDirectRequest(
     });
     if (err instanceof CodexApiError) {
       const code = toErrorStatus(err.status) as StatusCode;
+      if (canReturnStreamError(req, fmt)) {
+        return streamErrorResponse(c, fmt, code, err.message);
+      }
       c.status(code);
       // For API-key upstreams, forward the raw upstream error body transparently
       try {
@@ -942,6 +985,9 @@ export async function handleDirectRequest(
         return c.json(fmt.format429(err.message));
       }
       return c.json(fmt.formatError(code, err.message));
+    }
+    if (canReturnStreamError(req, fmt)) {
+      return streamErrorResponse(c, fmt, 502, msg);
     }
     c.status(502);
     return c.json(fmt.formatError(502, msg));

--- a/src/routes/shared/response-processor.ts
+++ b/src/routes/shared/response-processor.ts
@@ -15,6 +15,71 @@ export interface StreamWriter {
   onAbort(cb: () => void): void;
 }
 
+export interface StreamDiagnostics {
+  requestId?: string;
+  tag?: string;
+}
+
+interface WrittenStreamTrace {
+  chunks: number;
+  bytes: number;
+  lastEvent: string | null;
+  sawTerminal: boolean;
+}
+
+interface ChunkTrace {
+  bytes: number;
+  lastEvent: string | null;
+  terminal: boolean;
+}
+
+function isTerminalStreamEvent(event: string): boolean {
+  return event === "response.completed" ||
+    event === "response.failed" ||
+    event === "error" ||
+    event === "message_stop" ||
+    event === "[DONE]";
+}
+
+function inspectStreamChunk(chunk: string): ChunkTrace {
+  const trace: ChunkTrace = {
+    bytes: Buffer.byteLength(chunk, "utf8"),
+    lastEvent: null,
+    terminal: false,
+  };
+
+  for (const line of chunk.split(/\r?\n/)) {
+    if (line.startsWith("event: ")) {
+      const event = line.slice("event: ".length).trim();
+      if (event) {
+        trace.lastEvent = event;
+        if (isTerminalStreamEvent(event)) trace.terminal = true;
+      }
+      continue;
+    }
+    if (line.startsWith("data: ")) {
+      const data = line.slice("data: ".length).trim();
+      if (data === "[DONE]") {
+        trace.lastEvent = "[DONE]";
+        trace.terminal = true;
+      }
+    }
+  }
+
+  return trace;
+}
+
+function applyWrittenChunkTrace(written: WrittenStreamTrace, chunk: ChunkTrace): void {
+  written.chunks += 1;
+  written.bytes += chunk.bytes;
+  if (chunk.lastEvent) written.lastEvent = chunk.lastEvent;
+  if (chunk.terminal) written.sawTerminal = true;
+}
+
+function formatDiagnosticValue(value: string | null | undefined): string {
+  return value && value.length > 0 ? value : "none";
+}
+
 /**
  * Stream SSE chunks from the Codex upstream to the client.
  *
@@ -32,7 +97,14 @@ export async function streamResponse(
   onResponseId?: (id: string) => void,
   usageHint?: UsageHint,
   onResponseMetadata?: (metadata: ResponseMetadata) => void,
+  diagnostics?: StreamDiagnostics,
 ): Promise<void> {
+  const written: WrittenStreamTrace = {
+    chunks: 0,
+    bytes: 0,
+    lastEvent: null,
+    sawTerminal: false,
+  };
   try {
     for await (const chunk of adapter.streamTranslator(
       api,
@@ -44,9 +116,22 @@ export async function streamResponse(
       usageHint,
       onResponseMetadata,
     )) {
+      const chunkTrace = inspectStreamChunk(chunk);
       try {
         await s.write(chunk);
-      } catch {
+        applyWrittenChunkTrace(written, chunkTrace);
+      } catch (writeErr) {
+        const errMsg = writeErr instanceof Error ? writeErr.message : String(writeErr);
+        console.warn(
+          `[stream-client-disconnect] rid=${formatDiagnosticValue(diagnostics?.requestId)}` +
+            ` tag=${formatDiagnosticValue(diagnostics?.tag ?? adapter.tag)} model=${model}` +
+            ` written_chunks=${written.chunks} written_bytes=${written.bytes}` +
+            ` last_sent_event=${formatDiagnosticValue(written.lastEvent)}` +
+            ` sent_terminal=${written.sawTerminal}` +
+            ` failed_chunk_event=${formatDiagnosticValue(chunkTrace.lastEvent)}` +
+            ` failed_chunk_terminal=${chunkTrace.terminal}` +
+            ` err=${errMsg}`,
+        );
         // Client disconnected mid-stream — stop reading upstream
         return;
       }
@@ -56,7 +141,13 @@ export async function streamResponse(
     const errStatus = err instanceof CodexApiError ? err.status : "?";
     const errBody = err instanceof CodexApiError ? err.body : undefined;
     console.warn(
-      `[stream-error] status=${errStatus} msg=${errMsg}` +
+      `[stream-error] rid=${formatDiagnosticValue(diagnostics?.requestId)}` +
+        ` tag=${formatDiagnosticValue(diagnostics?.tag ?? adapter.tag)} model=${model}` +
+        ` status=${errStatus}` +
+        ` written_chunks=${written.chunks} written_bytes=${written.bytes}` +
+        ` last_sent_event=${formatDiagnosticValue(written.lastEvent)}` +
+        ` sent_terminal=${written.sawTerminal}` +
+        ` msg=${errMsg}` +
         (errBody ? ` body=${errBody.slice(0, 1000)}` : ""),
     );
     // Send error SSE event to client before closing

--- a/src/routes/shared/response-processor.ts
+++ b/src/routes/shared/response-processor.ts
@@ -80,6 +80,13 @@ function formatDiagnosticValue(value: string | null | undefined): string {
   return value && value.length > 0 ? value : "none";
 }
 
+function streamErrorStatus(err: unknown): number {
+  if (err instanceof CodexApiError && err.status >= 400 && err.status < 600) {
+    return err.status;
+  }
+  return 502;
+}
+
 /**
  * Stream SSE chunks from the Codex upstream to the client.
  *
@@ -140,6 +147,7 @@ export async function streamResponse(
     const errMsg = err instanceof Error ? err.message : "Stream interrupted";
     const errStatus = err instanceof CodexApiError ? err.status : "?";
     const errBody = err instanceof CodexApiError ? err.body : undefined;
+    const responseStatus = streamErrorStatus(err);
     console.warn(
       `[stream-error] rid=${formatDiagnosticValue(diagnostics?.requestId)}` +
         ` tag=${formatDiagnosticValue(diagnostics?.tag ?? adapter.tag)} model=${model}` +
@@ -153,7 +161,8 @@ export async function streamResponse(
     // Send error SSE event to client before closing
     try {
       await s.write(
-        `data: ${JSON.stringify({ error: { message: errMsg, type: "stream_error" } })}\n\n`,
+        adapter.formatStreamError?.(responseStatus, errMsg) ??
+          `data: ${JSON.stringify({ error: { message: errMsg, type: "stream_error" } })}\n\n`,
       );
     } catch { /* client already gone */ }
   }

--- a/tests/_helpers/format-adapter.ts
+++ b/tests/_helpers/format-adapter.ts
@@ -8,6 +8,7 @@ export function createMockFormatAdapter(overrides?: Partial<FormatAdapter>): For
     formatNoAccount: vi.fn(() => ({ error: "no_account" })),
     format429: vi.fn((msg: string) => ({ error: "rate_limited", message: msg })),
     formatError: vi.fn((status: number, msg: string) => ({ error: "api_error", status, message: msg })),
+    formatStreamError: vi.fn((_status: number, msg: string) => `event: response.failed\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`),
     streamTranslator: vi.fn(async function* (
       _api: unknown,
       _resp: unknown,

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -201,6 +201,29 @@ describe("proxy-handler integration", () => {
     expect(fmt.streamTranslator).toHaveBeenCalled();
   });
 
+  it("returns a streaming error event when upstream request fails before SSE starts", async () => {
+    mockCreateResponse = () =>
+      Promise.reject(new CodexApiError(0, "error sending request for url"));
+
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const req = createStreamingRequest();
+    const { app } = buildTestApp({ accountPool, fmt, req });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const text = await res.text();
+    expect(text).toContain("event: response.failed");
+    expect(text).toContain("error sending request for url");
+    expect(fmt.formatStreamError).toHaveBeenCalledWith(
+      502,
+      "Codex API error (0): error sending request for url",
+    );
+    expect(accountPool.release).toHaveBeenCalledWith("e1", undefined);
+  });
+
   // 4. CodexApiError 429 → markRateLimited with parsed retryAfterSec + fallback to next account
   it("handles 429 by parsing resets_in_seconds and falling back to next account", async () => {
     const body429 = JSON.stringify({

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -139,6 +139,25 @@ describe("PersistentWs", () => {
     expect(text).toContain("event: response.completed");
   });
 
+  it("errors the response stream when the WS closes after first frame without terminal event", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created", response: { id: "resp_mid" } });
+    const resp = await promise;
+    ws.pushClose(1006, "tcp rst");
+
+    await expect(resp.text()).rejects.toThrow("WebSocket closed before terminal event");
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalled();
+  });
+
   it("after response.completed the WS becomes available for the next send", async () => {
     const { ws, persistent } = newPersistentWs();
     persistent.tryAcquire();

--- a/tests/unit/proxy/ws-transport-premature-close.test.ts
+++ b/tests/unit/proxy/ws-transport-premature-close.test.ts
@@ -87,7 +87,7 @@ describe("ws-transport close behavior", () => {
     expect(output).not.toContain("premature_close");
   });
 
-  it("closes stream when WS closes without terminal event", async () => {
+  it("errors stream when WS closes without terminal event", async () => {
     vi.doMock("ws", () => ({
       default: createMockWsClass([
         { type: "response.created", response: { id: "resp_1" } },
@@ -102,8 +102,8 @@ describe("ws-transport close behavior", () => {
       { type: "response.create", model: "test", instructions: "", input: [] },
     );
 
-    // Stream should still close (not hang) even without terminal event
-    const output = await collectSSE(response);
-    expect(output).toContain("event: response.created");
+    await expect(collectSSE(response)).rejects.toThrow(
+      "WebSocket closed before terminal event",
+    );
   });
 });

--- a/tests/unit/routes/responses-premature-close.test.ts
+++ b/tests/unit/routes/responses-premature-close.test.ts
@@ -29,7 +29,7 @@ vi.mock("@src/paths.js", () => ({
   STATE_DIR: "/tmp/codex-proxy-test",
 }));
 
-import { collectPassthrough } from "@src/routes/responses.js";
+import { collectPassthrough, streamPassthrough } from "@src/routes/responses.js";
 
 interface CodexSSEEvent {
   event: string;
@@ -46,6 +46,154 @@ function createMockApi(events: CodexSSEEvent[], throwAfter?: Error) {
     },
   };
 }
+
+function parseSSEEvents(text: string): Array<{ event: string; data: Record<string, unknown> }> {
+  return text
+    .trim()
+    .split("\n\n")
+    .filter(Boolean)
+    .map((block) => {
+      const lines = block.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLine = lines.find((line) => line.startsWith("data: "));
+      const data = dataLine ? JSON.parse(dataLine.slice("data: ".length)) as Record<string, unknown> : {};
+      return {
+        event: eventLine?.slice("event: ".length) ?? "",
+        data,
+      };
+    });
+}
+
+async function collectStreamEvents(events: CodexSSEEvent[], throwAfter?: Error) {
+  const api = createMockApi(events, throwAfter);
+  const chunks: string[] = [];
+  for await (const chunk of streamPassthrough(
+    api as never,
+    new Response("ok"),
+    "test-model",
+    () => {},
+    () => {},
+  )) {
+    chunks.push(chunk);
+  }
+  return parseSSEEvents(chunks.join(""));
+}
+
+describe("streamPassthrough premature close handling", () => {
+  it("emits response.failed when the stream ends before response.completed", async () => {
+    const events = await collectStreamEvents([
+      { event: "response.created", data: { response: { id: "resp_stream_1" } } },
+      { event: "response.output_text.delta", data: { delta: "partial text" } },
+    ]);
+
+    expect(events.map((event) => event.event)).toEqual([
+      "response.created",
+      "response.output_text.delta",
+      "response.failed",
+    ]);
+    const failed = events.at(-1);
+    expect(failed?.data).toMatchObject({
+      type: "response.failed",
+      response: {
+        id: "resp_stream_1",
+        status: "failed",
+        error: {
+          code: "stream_disconnected",
+          message: "Upstream stream closed before response.completed",
+        },
+      },
+      error: {
+        code: "stream_disconnected",
+        message: "Upstream stream closed before response.completed",
+      },
+    });
+  });
+
+  it("emits response.failed when parseStream throws before a terminal event", async () => {
+    const events = await collectStreamEvents(
+      [
+        { event: "response.created", data: { response: { id: "resp_stream_2" } } },
+      ],
+      new Error("WebSocket closed unexpectedly"),
+    );
+
+    const failed = events.at(-1);
+    expect(failed?.event).toBe("response.failed");
+    expect(failed?.data).toMatchObject({
+      response: {
+        id: "resp_stream_2",
+        status: "failed",
+      },
+      error: {
+        code: "stream_disconnected",
+        message: "Upstream stream closed before response.completed: WebSocket closed unexpectedly",
+      },
+    });
+  });
+
+  it("does not synthesize response.failed after response.completed", async () => {
+    const events = await collectStreamEvents([
+      { event: "response.created", data: { response: { id: "resp_stream_3" } } },
+      {
+        event: "response.completed",
+        data: {
+          response: {
+            id: "resp_stream_3",
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          },
+        },
+      },
+    ]);
+
+    expect(events.map((event) => event.event)).toEqual([
+      "response.created",
+      "response.completed",
+    ]);
+  });
+
+  it("does not synthesize response.failed after upstream response.failed", async () => {
+    const events = await collectStreamEvents([
+      { event: "response.created", data: { response: { id: "resp_stream_4" } } },
+      {
+        event: "response.failed",
+        data: {
+          type: "response.failed",
+          response: {
+            id: "resp_stream_4",
+            status: "failed",
+            error: { code: "upstream_error", message: "failed upstream" },
+          },
+        },
+      },
+    ]);
+
+    expect(events.map((event) => event.event)).toEqual([
+      "response.created",
+      "response.failed",
+    ]);
+  });
+
+  it("propagates local callback errors instead of synthesizing response.failed", async () => {
+    const api = createMockApi([
+      { event: "response.created", data: { response: { id: "resp_callback" } } },
+    ]);
+
+    await expect((async () => {
+      for await (const _chunk of streamPassthrough(
+        api as never,
+        new Response("ok"),
+        "test-model",
+        () => {},
+        () => {
+          throw new Error("callback broke");
+        },
+      )) {
+        // Drain the generator.
+      }
+    })()).rejects.toThrow("callback broke");
+  });
+});
 
 describe("collectPassthrough premature close handling", () => {
   it("throws EmptyResponseError when stream ends normally without response.completed", async () => {

--- a/tests/unit/routes/responses-stream-error-format.test.ts
+++ b/tests/unit/routes/responses-stream-error-format.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockConfig = {
+  server: {
+    proxy_api_key: null as string | null,
+    trust_proxy: false,
+  },
+  model: {
+    default: "gpt-5.3-codex",
+    default_reasoning_effort: null as string | null,
+    default_service_tier: null as string | null,
+    suppress_desktop_directives: false,
+  },
+  auth: {
+    jwt_token: undefined as string | undefined,
+    rotation_strategy: "least_used" as const,
+    rate_limit_backoff_seconds: 60,
+    request_interval_ms: 0,
+  },
+  logs: {
+    capture_body: false,
+  },
+};
+
+let mockCreateResponse: (() => Promise<Response>) | null = null;
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/logs/entry.js", () => ({
+  enqueueLogEntry: vi.fn(),
+}));
+
+vi.mock("@src/utils/retry.js", () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock("@src/proxy/codex-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@src/proxy/codex-api.js")>();
+  return {
+    ...actual,
+    CodexApi: vi.fn().mockImplementation(() => ({
+      tag: "codex",
+      createResponse: vi.fn((): Promise<Response> => {
+        if (mockCreateResponse) return mockCreateResponse();
+        return Promise.resolve(new Response("data: {}\n\n"));
+      }),
+      parseStream: vi.fn(async function* () {
+        yield { event: "response.completed", data: { response: { id: "resp_ok" } } };
+      }),
+    })),
+  };
+});
+
+import { CodexApiError } from "@src/proxy/codex-api.js";
+import { createResponsesRoutes } from "@src/routes/responses.js";
+
+function createMockAccountPool() {
+  return {
+    isAuthenticated: vi.fn(() => true),
+    validateProxyApiKey: vi.fn(() => true),
+    acquire: vi.fn(() => ({
+      entryId: "entry_1",
+      token: "token_1",
+      accountId: "acct_1",
+      prevSlotMs: null,
+    })),
+    release: vi.fn(),
+    getEntry: vi.fn(() => ({
+      email: "test@example.com",
+      planType: null,
+      cachedQuota: null,
+    })),
+    updateCachedQuota: vi.fn(),
+    syncRateLimitWindow: vi.fn(),
+    markRateLimited: vi.fn(),
+    markStatus: vi.fn(),
+    hasAvailableAccounts: vi.fn(() => false),
+    getPoolSummary: vi.fn(() => ({
+      total: 1,
+      active: 0,
+      expired: 0,
+      quota_exhausted: 0,
+      rate_limited: 0,
+      refreshing: 0,
+      disabled: 0,
+      banned: 0,
+    })),
+    recordEmptyResponse: vi.fn(),
+  };
+}
+
+function parseFirstSSEEvent(text: string): { event: string; data: unknown } {
+  const block = text.trim().split("\n\n").find(Boolean);
+  if (!block) throw new Error("No SSE event found");
+
+  const lines = block.split("\n");
+  const eventLine = lines.find((line) => line.startsWith("event: "));
+  const data = lines
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice("data: ".length))
+    .join("\n");
+
+  return {
+    event: eventLine?.slice("event: ".length) ?? "",
+    data: JSON.parse(data) as unknown,
+  };
+}
+
+describe("/v1/responses stream error formatting", () => {
+  beforeEach(() => {
+    mockCreateResponse = null;
+    vi.clearAllMocks();
+  });
+
+  it("emits upstream_transport_error when the upstream request fails before SSE starts", async () => {
+    mockCreateResponse = () =>
+      Promise.reject(new CodexApiError(0, "error sending request for url"));
+
+    const accountPool = createMockAccountPool();
+    const app = createResponsesRoutes(accountPool as never);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "codex",
+        input: [{ role: "user", content: "Hello" }],
+        stream: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const event = parseFirstSSEEvent(await res.text());
+    expect(event.event).toBe("response.failed");
+    expect(event.data).toMatchObject({
+      type: "response.failed",
+      response: {
+        status: "failed",
+        error: {
+          type: "server_error",
+          code: "upstream_transport_error",
+          message: "error sending request for url",
+        },
+      },
+      error: {
+        type: "server_error",
+        code: "upstream_transport_error",
+        message: "error sending request for url",
+      },
+    });
+    expect(accountPool.release).toHaveBeenCalledWith("entry_1", undefined);
+  });
+});

--- a/tests/unit/routes/shared/response-processor.test.ts
+++ b/tests/unit/routes/shared/response-processor.test.ts
@@ -35,6 +35,10 @@ function createMockCodexApi() {
 }
 
 describe("streamResponse", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("writes all chunks to the stream", async () => {
     const s = createMockStream();
     const adapter = createMockAdapter({ streamChunks: ["a", "b", "c"] });
@@ -97,5 +101,44 @@ describe("streamResponse", () => {
     // Only attempted first write which failed
     expect(s.write).toHaveBeenCalledTimes(1);
   });
-});
 
+  it("logs whether a client disconnect happened while writing the terminal event", async () => {
+    const s = createMockStream();
+    s.write
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("client gone"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = createMockAdapter({
+      streamChunks: [
+        "event: response.created\ndata: {}\n\n",
+        "event: response.completed\ndata: {}\n\n",
+      ],
+    });
+    const api = createMockCodexApi();
+    const rawResponse = new Response("ok");
+
+    await streamResponse(
+      s as never,
+      api,
+      rawResponse,
+      "gpt-5.4",
+      adapter as never,
+      vi.fn(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { requestId: "rid-terminal", tag: "Responses" },
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[stream-client-disconnect] rid=rid-terminal tag=Responses model=gpt-5.4"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("last_sent_event=response.created"),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed_chunk_event=response.completed failed_chunk_terminal=true"),
+    );
+  });
+});

--- a/tests/unit/routes/shared/response-processor.test.ts
+++ b/tests/unit/routes/shared/response-processor.test.ts
@@ -88,6 +88,26 @@ describe("streamResponse", () => {
     expect(errorChunk).toContain("upstream died");
   });
 
+  it("uses a protocol-specific stream error formatter when stream throws", async () => {
+    const s = createMockStream();
+    const adapter = {
+      ...createMockAdapter({ streamError: new Error("error sending request for url") }),
+      formatStreamError: vi.fn(
+        (status: number, message: string) =>
+          `event: response.failed\ndata: ${JSON.stringify({ status, message })}\n\n`,
+      ),
+    };
+    const api = createMockCodexApi();
+    const rawResponse = new Response("ok");
+
+    await streamResponse(s as never, api, rawResponse, "gpt-5.4", adapter as never, vi.fn());
+
+    expect(adapter.formatStreamError).toHaveBeenCalledWith(502, "error sending request for url");
+    expect(s.written.at(-1)).toBe(
+      `event: response.failed\ndata: ${JSON.stringify({ status: 502, message: "error sending request for url" })}\n\n`,
+    );
+  });
+
   it("handles client disconnect during write gracefully", async () => {
     const s = createMockStream();
     s.write.mockRejectedValueOnce(new Error("client gone"));


### PR DESCRIPTION
## Summary
- synthesize a structured Responses API failure when an upstream stream ends before a terminal event
- make one-shot and pooled WebSocket streams error on mid-stream closes before response.completed/response.failed/error
- emit protocol-specific SSE failure events when streaming requests fail before upstream SSE starts
- keep `/v1/responses` clients from seeing bare transport disconnects such as `error sending request`
- add regression coverage for premature EOF, parseStream errors, terminal pass-through, callback error propagation, and pre-SSE upstream failures

## Tests
- `npm test -- tests/unit/routes/shared/response-processor.test.ts tests/integration/proxy-handler.test.ts`
- `npm test -- tests/unit/routes/responses-premature-close.test.ts tests/unit/routes/shared/error-forwarding.test.ts`
- `npm run typecheck`
- Real upstream via local proxy: `PROXY_URL=http://127.0.0.1:18083 npm run test:real -- tests/real/streaming.test.ts -t "real: Codex streaming reliability|real: Anthropic streaming reliability"` (4 passed, 3 skipped)

## Notes
- Does not change model alias or `/v1/chat/completions` model routing behavior.
