### PR TITLE
fix: prefer Claude Code session for prompt cache key

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -52,7 +52,7 @@ export interface ProxyRequest {
   isNewConversation?: boolean;
   /** True iff the request declared `tools: [{type: "image_generation"}]`.
    *  Used to attribute success/failure to the image_generation request counters
-   *  even when the upstream call fails before any SSE arrives. */
+   *  even when the upstream call fails before the first SSE event arrives. */
   expectsImageGen?: boolean;
 }
 
@@ -100,6 +100,42 @@ const MAX_EMPTY_RETRIES = 2;
 
 function normalizeInstructions(instructions: string | null | undefined): string {
   return instructions ?? "";
+}
+
+function nonEmptyString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export interface PromptCacheIdentity {
+  promptCacheKey: string;
+  conversationId: string;
+  explicitPromptCacheKey: string | null;
+  clientConversationId: string | null;
+  derivedConversationId: string | null;
+}
+
+export function resolvePromptCacheIdentity(
+  codexRequest: CodexResponsesRequest,
+  clientConversationId?: string,
+  generateFallbackId: () => string = () => crypto.randomUUID(),
+): PromptCacheIdentity {
+  const explicitPromptCacheKey = nonEmptyString(codexRequest.prompt_cache_key);
+  const normalizedClientConversationId = nonEmptyString(clientConversationId);
+  const derivedConversationId = deriveStableConversationKey(codexRequest);
+  const promptCacheKey =
+    explicitPromptCacheKey ??
+    normalizedClientConversationId ??
+    derivedConversationId ??
+    generateFallbackId();
+
+  return {
+    promptCacheKey,
+    conversationId: promptCacheKey,
+    explicitPromptCacheKey,
+    clientConversationId: normalizedClientConversationId,
+    derivedConversationId,
+  };
 }
 
 /** Strip CodexApiError's "Codex API error (NNN): " prefix so log warns that
@@ -274,12 +310,13 @@ export async function handleProxyRequest(
   const originalUseWebSocket = req.codexRequest.useWebSocket;
   const currentInstructions = req.codexRequest.instructions;
   const explicitPrevRespId = req.codexRequest.previous_response_id;
-  const derivedConversationId = deriveStableConversationKey(req.codexRequest);
-  const promptCacheKey = derivedConversationId ?? req.clientConversationId ?? crypto.randomUUID();
+  const promptCacheIdentity = resolvePromptCacheIdentity(req.codexRequest, req.clientConversationId);
+  const promptCacheKey = promptCacheIdentity.promptCacheKey;
   const continuationInputStart = explicitPrevRespId ? 0 : getContinuationInputStartIndex(req.codexRequest.input);
   const explicitConversationId = explicitPrevRespId ? affinityMap.lookupConversationId(explicitPrevRespId) : null;
-  // effectiveConversationId: client explicit ID > content hash derived ID > promptCacheKey
-  const effectiveConversationId = req.clientConversationId || derivedConversationId || promptCacheKey;
+  // effectiveConversationId follows the same identity used by prompt_cache_key:
+  // explicit key > client session > content hash > random fallback.
+  const effectiveConversationId = promptCacheIdentity.conversationId;
   const chainConversationId = explicitConversationId ?? effectiveConversationId;
   const implicitPrevRespId =
     !explicitPrevRespId &&
@@ -306,9 +343,8 @@ export async function handleProxyRequest(
         ? affinityMap.lookup(implicitPrevRespId)
         : null;
 
-  // Conversation ID: inherit from previous response chain, or derive from
-  // content hash (enables cache hits across turns even without previous_response_id),
-  // or fall back to a random UUID.
+  // Conversation ID: honor explicit prompt_cache_key first, otherwise prefer
+  // client session IDs (Claude Code), then content hash, then random fallback.
   req.codexRequest.prompt_cache_key = promptCacheKey;
 
   // Turn state: sticky routing token from upstream, echoed back on subsequent requests

--- a/tests/e2e/messages.test.ts
+++ b/tests/e2e/messages.test.ts
@@ -14,6 +14,7 @@ import {
   setTransportPost,
   resetTransportState,
   getMockTransport,
+  getLastTransportBody,
   makeTransportResponse,
   makeErrorTransportResponse,
 } from "@helpers/e2e-setup.js";
@@ -160,6 +161,28 @@ describe("E2E: POST /v1/messages", () => {
     const usage = body.usage as Record<string, unknown>;
     expect(typeof usage.input_tokens).toBe("number");
     expect(typeof usage.output_tokens).toBe("number");
+  });
+
+  it("uses Claude Code session id as prompt_cache_key", async () => {
+    const res = await ctx.app.request("/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-claude-code-session-id": "claude-code-session-123",
+      },
+      body: JSON.stringify(defaultBody({
+        messages: [{ role: "user", content: "Start a project task" }],
+      })),
+    });
+    expect(res.status).toBe(200);
+
+    const transportBody = getLastTransportBody();
+    if (!transportBody) {
+      throw new Error("Expected upstream transport body to be captured");
+    }
+
+    const upstreamRequest = JSON.parse(transportBody) as { prompt_cache_key?: unknown };
+    expect(upstreamRequest.prompt_cache_key).toBe("claude-code-session-123");
   });
 
   // ── Anthropic error format ─────────────────────────────────────

--- a/tests/unit/routes/implicit-resume-from-derived-key.test.ts
+++ b/tests/unit/routes/implicit-resume-from-derived-key.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
+import type { CodexResponsesRequest } from "@src/proxy/codex-api.js";
+
+const mockState = vi.hoisted(() => ({
+  responseIdCount: 0,
+}));
 
 // ── Mocks ───────────────────────────────────────────────
 const mockConfig = {
@@ -74,15 +79,15 @@ vi.mock("@src/utils/retry.js", () => ({
 }));
 
 // Capture upstream requests
-let capturedCodexRequest: any = null;
+let capturedCodexRequest: CodexResponsesRequest | null = null;
 
 vi.mock("@src/proxy/codex-api.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@src/proxy/codex-api.js")>();
   return {
     ...actual,
     CodexApi: vi.fn().mockImplementation(() => ({
-      createResponse: vi.fn(async (req: any) => {
-        capturedCodexRequest = JSON.parse(JSON.stringify(req));
+      createResponse: vi.fn(async (req: CodexResponsesRequest) => {
+        capturedCodexRequest = structuredClone(req);
         return {
           status: 200,
           headers: new Headers({ "x-codex-turn-state": "turn-123" }),
@@ -92,14 +97,11 @@ vi.mock("@src/proxy/codex-api.js", async (importOriginal) => {
   };
 });
 
-// Use global to pass state into hoisted mocks safely
-globalThis.__mockResponseIdCount = 0;
-
 vi.mock("@src/translation/codex-to-openai.js", () => ({
   streamCodexToOpenAI: vi.fn(),
   collectCodexResponse: vi.fn(async (_api, _resp, _model, _wantReasoning, _tuple, usageHint, onMetadata) => {
-    (globalThis as any).__mockResponseIdCount++;
-    const id = `resp-${(globalThis as any).__mockResponseIdCount}`;
+    mockState.responseIdCount++;
+    const id = `resp-${mockState.responseIdCount}`;
     return {
       response: { id, choices: [{ message: { role: "assistant", content: "ok" } }] },
       usage: { input_tokens: 10, output_tokens: 5 },
@@ -111,8 +113,8 @@ vi.mock("@src/translation/codex-to-openai.js", () => ({
 vi.mock("@src/translation/codex-to-gemini.js", () => ({
   streamCodexToGemini: vi.fn(),
   collectCodexToGeminiResponse: vi.fn(async (_api, _resp, _model, _tuple) => {
-    (globalThis as any).__mockResponseIdCount++;
-    const id = `resp-${(globalThis as any).__mockResponseIdCount}`;
+    mockState.responseIdCount++;
+    const id = `resp-${mockState.responseIdCount}`;
     return {
       response: { candidates: [{ content: { parts: [{ text: "ok" }] } }] },
       usage: { input_tokens: 10, output_tokens: 5 },
@@ -132,6 +134,13 @@ import { getSessionAffinityMap } from "@src/auth/session-affinity.js";
 
 // ── Tests ───────────────────────────────────────────────────────────
 
+function getCapturedCodexRequest(): CodexResponsesRequest {
+  if (!capturedCodexRequest) {
+    throw new Error("Expected Codex request to be captured");
+  }
+  return capturedCodexRequest;
+}
+
 describe("Implicit Resume from Derived Key", () => {
   let pool: AccountPool;
   let chatApp: Hono;
@@ -140,7 +149,7 @@ describe("Implicit Resume from Derived Key", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedCodexRequest = null;
-    (globalThis as any).__mockResponseIdCount = 0;
+    mockState.responseIdCount = 0;
     delete process.env.CODEX_JWT_TOKEN; // Prevent AccountPool from loading multiple accounts
     pool = new AccountPool();
     pool.addAccount("test-token-1");
@@ -165,9 +174,9 @@ describe("Implicit Resume from Derived Key", () => {
       }),
     });
     
-    expect(capturedCodexRequest).toBeDefined();
-    expect(capturedCodexRequest.previous_response_id).toBeUndefined(); // First turn, no implicit resume
-    const derivedKeyT1 = capturedCodexRequest.prompt_cache_key;
+    let captured = getCapturedCodexRequest();
+    expect(captured.previous_response_id).toBeUndefined(); // First turn, no implicit resume
+    const derivedKeyT1 = captured.prompt_cache_key;
     expect(derivedKeyT1).toBeDefined();
     
     // Turn 2
@@ -188,8 +197,9 @@ describe("Implicit Resume from Derived Key", () => {
     });
     
     // T2 should have triggered implicit resume
-    expect(capturedCodexRequest.previous_response_id).toBe("resp-1");
-    expect(capturedCodexRequest.input).toEqual([{ role: "user", content: "Hello again" }]);
+    captured = getCapturedCodexRequest();
+    expect(captured.previous_response_id).toBe("resp-1");
+    expect(captured.input).toEqual([{ role: "user", content: "Hello again" }]);
   });
 
   it("Test 1 & 2b: Chat endpoint uses client session via 'user' field if provided", async () => {
@@ -204,7 +214,7 @@ describe("Implicit Resume from Derived Key", () => {
       }),
     });
     expect(req1.status).toBe(200);
-    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
+    expect(getCapturedCodexRequest().prompt_cache_key).toBe(explicitUserId);
     
     // The chainConversationId used for affinity should be the client ID
     const affinityMap = getSessionAffinityMap();
@@ -223,7 +233,7 @@ describe("Implicit Resume from Derived Key", () => {
       }),
     });
     expect(req1.status).toBe(200);
-    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
+    expect(getCapturedCodexRequest().prompt_cache_key).toBe("gemini-test-session-id");
 
     const affinityMap = getSessionAffinityMap();
     expect(affinityMap.lookupConversationId("resp-1")).toBe("gemini-test-session-id");
@@ -241,7 +251,8 @@ describe("Implicit Resume from Derived Key", () => {
     expect(req1.status).toBe(200);
 
     // Derived key will be null for empty request, so promptCacheKey will be UUID
-    expect(capturedCodexRequest.prompt_cache_key).toBeDefined();
-    expect(capturedCodexRequest.prompt_cache_key.length).toBeGreaterThan(16); // UUID
+    const promptCacheKey = getCapturedCodexRequest().prompt_cache_key;
+    expect(promptCacheKey).toBeDefined();
+    expect(promptCacheKey?.length).toBeGreaterThan(16); // UUID
   });
 });

--- a/tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts
+++ b/tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts
@@ -1,9 +1,70 @@
 import { describe, it, expect } from "vitest";
 import { PreviousResponseWebSocketError } from "@src/proxy/codex-api.js";
+import type { CodexResponsesRequest } from "@src/proxy/codex-api.js";
 import {
+  resolvePromptCacheIdentity,
   shouldActivateImplicitResume,
   shouldReplayFullInputAfterImplicitResumeError,
 } from "@src/routes/shared/proxy-handler.js";
+
+function makeCodexRequest(overrides: Partial<CodexResponsesRequest> = {}): CodexResponsesRequest {
+  return {
+    model: "gpt-5.4",
+    input: [{ role: "user", content: "first message" }],
+    stream: true,
+    store: false,
+    instructions: "system prompt",
+    ...overrides,
+  };
+}
+
+describe("resolvePromptCacheIdentity", () => {
+  it("显式 prompt_cache_key 优先于 Claude Code session 和内容 hash", () => {
+    const result = resolvePromptCacheIdentity(
+      makeCodexRequest({ prompt_cache_key: " explicit-thread " }),
+      "claude-session",
+      () => "fallback-thread",
+    );
+
+    expect(result.promptCacheKey).toBe("explicit-thread");
+    expect(result.conversationId).toBe("explicit-thread");
+  });
+
+  it("Claude Code session id 优先于内容 hash，避免同 session 被首条消息拆成多个 key", () => {
+    const firstTurn = makeCodexRequest({
+      input: [{ role: "user", content: "first task" }],
+    });
+    const laterTurnWithDifferentAnchor = makeCodexRequest({
+      input: [
+        { role: "user", content: "different internal task" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "continue" },
+      ],
+      tools: [{ type: "function", name: "read_file" }],
+    });
+
+    expect(resolvePromptCacheIdentity(firstTurn, "claude-session").promptCacheKey).toBe("claude-session");
+    expect(resolvePromptCacheIdentity(laterTurnWithDifferentAnchor, "claude-session").promptCacheKey).toBe("claude-session");
+  });
+
+  it("没有显式 key 或 session id 时回退到稳定内容 hash", () => {
+    const result = resolvePromptCacheIdentity(makeCodexRequest(), undefined, () => "fallback-thread");
+
+    expect(result.promptCacheKey).not.toBe("fallback-thread");
+    expect(result.promptCacheKey).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("空字符串 key/session 被忽略，避免退化成共享空会话", () => {
+    const result = resolvePromptCacheIdentity(
+      makeCodexRequest({ prompt_cache_key: " " }),
+      "",
+      () => "fallback-thread",
+    );
+
+    expect(result.promptCacheKey).not.toBe("");
+    expect(result.promptCacheKey).not.toBe("fallback-thread");
+  });
+});
 
 describe("shouldActivateImplicitResume", () => {
   it("同账号且 system 未变化时允许隐式续链", () => {


### PR DESCRIPTION
## Summary
- Prefer explicit prompt_cache_key, then Claude Code/client session id, then content hash for prompt cache identity
- Keep prompt_cache_key and implicit resume conversation identity aligned
- Add regression coverage for Claude Code session id propagation through /v1/messages

## Verification
- npm test -- tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts tests/unit/routes/responses-optional-instructions.test.ts tests/e2e/messages.test.ts
- npx tsc --noEmit
- real /v1/messages smoke: 3 consecutive upstream calls succeeded, cache_read_input_tokens rose to 7296 on turns 2 and 3

Note: web typecheck on this dev baseline currently fails in unrelated web/shared files (use-accounts/App/SettingsTab/AccountList).