### PR TITLE
chore: sync master back into dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.70",
+  "version": "2.0.71",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "type": "module",
   "workspaces": [

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-proxy/electron",
-  "version": "2.0.70",
+  "version": "2.0.71",
   "description": "Codex Proxy desktop app (Electron shell)",
   "private": true,
   "main": "dist-electron/main.cjs",


### PR DESCRIPTION
Bring `cc89dca chore: bump version to 2.0.71` from master into dev so today's promote-dev-to-master can fast-forward.

Mirrors PR #465 — same recurring chore that follows every stable bump.