### PR TITLE
test(responses): align e2e 429 assertion with streaming error contract

### DIFF
--- a/tests/e2e/responses.test.ts
+++ b/tests/e2e/responses.test.ts
@@ -269,12 +269,41 @@ describe("E2E: POST /v1/responses", () => {
     expect(sent.instructions).toBe("");
   });
 
-  it("upstream 429: returns 429 with rate_limit_error", async () => {
+  // Streaming path: once the SSE response has been opened, upstream
+  // failures (incl. 429) cannot change the HTTP status. The proxy emits
+  // a `response.failed` SSE event with the structured error instead.
+  // See PR #466 (858fb7c).
+  it("upstream 429 in streaming mode: emits response.failed SSE event with rate_limit_error", async () => {
     setTransportPost(async () =>
       makeErrorTransportResponse(429, JSON.stringify({ detail: "Rate limited" })),
     );
 
     const res = await responsesRequest(defaultBody());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const events = parseNamedSSE(await res.text());
+    const failed = events.find((e) => e.event === "response.failed");
+    expect(failed).toBeDefined();
+
+    const data = failed!.data as {
+      response: { status: string; error: { type: string; code: string; message: string } };
+      error: { type: string; code: string; message: string };
+    };
+    expect(data.response.status).toBe("failed");
+    expect(data.response.error.type).toBe("rate_limit_error");
+    expect(data.response.error.code).toBe("rate_limit_exceeded");
+    expect(data.error.type).toBe("rate_limit_error");
+  });
+
+  // Non-streaming path: upstream 429 still surfaces as HTTP 429 + JSON
+  // error body — no SSE involved, so the status code is preserved.
+  it("upstream 429 in non-streaming mode: returns HTTP 429 with rate_limit_error JSON", async () => {
+    setTransportPost(async () =>
+      makeErrorTransportResponse(429, JSON.stringify({ detail: "Rate limited" })),
+    );
+
+    const res = await responsesRequest(defaultBody({ stream: false }));
     expect(res.status).toBe(429);
 
     type ErrorResponse = {


### PR DESCRIPTION
## Summary

PR #466 (858fb7c) changed `/v1/responses` streaming-mode upstream errors from
`HTTP 429 + JSON` to `HTTP 200 + SSE response.failed event` — once the SSE
response is open, the HTTP status code can no longer change. A unit test was
added in the same PR (`tests/unit/routes/responses-stream-error-format.test.ts`),
but the corresponding assertion in `tests/e2e/responses.test.ts` was missed.
That left `npm test` red on dev tip and the pre-push hook blocks every
subsequent PR.

## Changes

- `tests/e2e/responses.test.ts`:
  - Update streaming `upstream 429` test: assert HTTP 200 + `text/event-stream`,
    parse the SSE `response.failed` event, verify `error.type === "rate_limit_error"`
    / `code === "rate_limit_exceeded"`.
  - Add a sibling test for the non-stream path: `stream: false` → HTTP 429 +
    JSON `rate_limit_error` body. Preserves coverage of the original branch.

## Test Plan

- [x] `npx vitest run tests/e2e/responses.test.ts -t "rate_limit"` — 2 passed
- [x] `npm test` — 157 files, 1856 passed, 1 skipped
- [x] pre-push hook (npm test + tsc + web build + electron config) — green

## Notes

Test-only change, no production code touched. Once this lands on dev, the
locally-parked `fix/electron-bundle-require-banner` branch (Electron ESM
`Dynamic require of "events"` fix) can rebase and push without the hook
tripping on this pre-existing failure.