### PR TITLE
test(electron): cover bundled ws runtime regression with subprocess smoke

### DIFF
--- a/packages/electron/__tests__/build.test.ts
+++ b/packages/electron/__tests__/build.test.ts
@@ -82,4 +82,66 @@ describe("electron build (esbuild)", () => {
     expect(head).toContain('from "module"');
     expect(head).toContain("createRequire");
   });
+
+  // Runtime regression: the banner-string assertion above is necessary
+  // but not sufficient. esbuild could change `__require`'s shim shape,
+  // or `ws` could be replaced by another lazy-CJS dependency, and the
+  // banner check would still pass while the bundle explodes at runtime.
+  //
+  // The only way to be sure is to actually instantiate the bundled
+  // ws module so that ws/lib/websocket.js's `__require("events")` /
+  // `__require("https")` chain executes. If the banner is missing or
+  // broken, those throw `Dynamic require of "X" is not supported`.
+  //
+  // CRITICAL: this MUST run in a fresh Node subprocess, not in-process
+  // via vitest's `await import(...)`. vite-node injects a `require`
+  // into the ESM module scope, which masks the bug — the bundle that
+  // would crash inside Electron's real Node loader passes silently
+  // here. A `node --input-type=module` subprocess matches Electron's
+  // runtime semantics: globally-undefined `require`, `__require` shim
+  // is forced through its throwing branch unless the banner has
+  // already synthesized a real `require` via `module.createRequire`.
+  it("server.mjs loadWebSocketModule actually instantiates bundled ws under native Node", () => {
+    buildOnce();
+    const serverMjs = resolve(DIST, "server.mjs");
+
+    // The script imports the bundle and forces ws's lazy CJS factory
+    // to run. Stdout marker proves end-to-end success; any throw from
+    // the bundle surfaces as a non-zero exit + stderr.
+    const script = `
+      const mod = await import(${JSON.stringify(serverMjs)});
+      if (typeof mod.loadWebSocketModule !== "function") {
+        console.error("loadWebSocketModule export missing");
+        process.exit(2);
+      }
+      const WS = await mod.loadWebSocketModule();
+      if (typeof WS !== "function" || !/WebSocket$/.test(WS.name)) {
+        console.error("loadWebSocketModule did not return a WebSocket constructor (got: " + typeof WS + " " + (WS && WS.name) + ")");
+        process.exit(3);
+      }
+      console.log("OK:" + WS.name);
+    `;
+
+    let stdout = "";
+    let stderr = "";
+    let exitCode = 0;
+    try {
+      stdout = execFileSync(
+        "node",
+        ["--input-type=module", "-e", script],
+        { cwd: PKG_DIR, timeout: 30_000, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; status?: number; message?: string };
+      stdout = e.stdout ?? "";
+      stderr = e.stderr ?? e.message ?? "";
+      exitCode = e.status ?? -1;
+    }
+
+    expect(stderr, `subprocess stderr:\n${stderr}\nstdout:\n${stdout}`).not.toMatch(
+      /Dynamic require of/,
+    );
+    expect(exitCode, `subprocess exited ${exitCode}\nstderr:\n${stderr}`).toBe(0);
+    expect(stdout.trim()).toMatch(/^OK:.*WebSocket$/);
+  });
 });

--- a/packages/electron/src/electron-entry.ts
+++ b/packages/electron/src/electron-entry.ts
@@ -7,3 +7,6 @@ export { setPaths } from "../../../src/paths.js";
 export { startServer } from "../../../src/index.js";
 export type { ServerHandle, StartOptions } from "../../../src/index.js";
 export { getConfig } from "../../../src/config.js";
+// Exposed so the bundle smoke test can trigger ws's CJS factory and
+// catch broken esbuild banners that would explode at runtime.
+export { loadWebSocketModule } from "../../../src/proxy/ws-transport.js";

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -99,6 +99,14 @@ async function getWS(): Promise<typeof import("ws").default> {
   return _WS;
 }
 
+/**
+ * Public alias of `getWS` — exposes the lazy ws loader so the Electron
+ * bundle smoke test can force ws's CJS factory to run without spinning
+ * up the full server. Re-exported via packages/electron/src/electron-entry.ts;
+ * consumed by packages/electron/__tests__/build.test.ts.
+ */
+export const loadWebSocketModule = getWS;
+
 /** Flat WebSocket message format expected by the Codex backend. */
 export interface WsCreateRequest {
   type: "response.create";


### PR DESCRIPTION
Closes #478.

## Summary

The banner-string assertion shipped in PR #477 (v2.0.73) is necessary but **not sufficient** for catching the events-bundling class of regression. esbuild could change `__require`'s shim shape, or `ws` could be replaced by another lazy-CJS dep, and the static check would pass while the bundle explodes the moment anything touches the WS path at runtime.

This PR adds a real runtime smoke that proves the bundle actually works.

## Approach

Two pieces:

### 1. Public `loadWebSocketModule` export

`src/proxy/ws-transport.ts` already had an internal `getWS()` lazy-loader. Aliased it as a public export `loadWebSocketModule` and re-exported through `packages/electron/src/electron-entry.ts`. The bundle now exposes this, and the smoke test can force ws's CJS factory to execute without spinning up the full server.

Zero behavior change to production code paths — purely additive surface.

### 2. Subprocess-based runtime test

New `it()` block in `packages/electron/__tests__/build.test.ts`:

- Spawns a Node subprocess via `node --input-type=module -e "..."`
- Subprocess imports the freshly-built `dist-electron/server.mjs`
- Calls `await loadWebSocketModule()` — this triggers ws's `__commonJS` factory which calls `__require("events")`, `__require("https")`, `__require("crypto")`, etc.
- Test asserts subprocess exits 0 with no `Dynamic require of` in stderr, and returned value is a `*WebSocket` constructor

### Why subprocess (load-bearing)

vite-node injects a `require` into ESM module scope. So an in-process `await import(serverMjs)` inside vitest **silently passes even when the banner is missing** — masking the very bug the test exists to catch. Native Node matches Electron's real runtime semantics: `require` is globally undefined in ESM, and the bundled `__require` shim is forced through its throwing branch unless the banner has already synthesized a real `require` via `module.createRequire`.

I verified this empirically: the in-process version of the test passed even with the banner removed, while the subprocess version fails with exactly `Dynamic require of \"events\" is not supported` — the symptom v2.0.71/72 users reported.

## TDD evidence

- ✅ Wrote test first → red (export missing)
- ✅ Added export → green
- ✅ Temporarily removed banner from `build.mjs` → red with exactly the production bug message in subprocess stderr
- ✅ Restored banner → green

## Test Plan

- [x] `npx vitest run packages/electron/__tests__/build.test.ts` — 6 passed (5 existing + new runtime smoke)
- [x] `npm test` — 156 files / 1850 passed / 1 skipped
- [x] `npx tsc --noEmit` — clean
- [x] Manual regression validation: removed banner → test failed with the production bug message

## Cost

- Test runtime: +~700ms (one subprocess spawn + bundle import + ws factory init)
- API surface: +1 public export (`loadWebSocketModule`), no behavior change

## Notes

- This stacks on top of the v2.0.73 banner-string assertion — both kept (cheap belt-and-suspenders, catches different failure modes)
- Future #479 (artifact smoke in release.yml) covers a complementary class — packaging-level issues that even a correct bundle could expose. Both layers are valuable.