### PR TITLE
feat(observability): local error-log foundation (uncaught capture + admin API) [#480 PR-1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- 本地 uncaught error log（observability foundation，#480 PR-1）：进程级 `uncaughtException` / `unhandledRejection` 自动落盘到 `data/error-log.jsonl`，单 backup 滚动（默认 10MB → `error-log.1.jsonl`），`context` 经 `redactJson` 脱敏 token / cookie / api_key / oauth；新增 4 个 admin 端点 `/admin/error-logs`（按 `name + first stack frame` 聚合）/ `/admin/error-logs/raw`（裸 JSONL tail）/ `/admin/error-logs/count`（含 unread）/ `/admin/error-logs/seen`（推进读游标）/ `/admin/error-logs/report`（renderer / 外部 POST 上报）；`uncaughtException` 走 `setImmediate(throw)` 保留 Node 默认崩溃语义，不会静默吞掉 fatal；新增 schema 节 `observability: { local_error_log: bool=true, max_log_bytes: int=10485760 }`；前端 Errors tab + 浮起 badge 由 PR-2 跟进（`src/logs/error-log.ts`、`src/routes/admin/error-logs.ts`、`src/config-schema.ts`、`src/index.ts`、`tests/unit/logs/error-log.test.ts`、`tests/unit/routes/admin/error-logs.test.ts`）
+
 ### Fixed
 
 - Electron 端 WS transport 触发时抛 `Dynamic require of "events" is not supported`：`packages/electron/electron/build.mjs` 把 backend bundle 成 ESM `server.mjs` 时 esbuild 把 CJS `ws` 整个打进来，包内 `require("events")` / `require("https")` 等被改写成内部 `__require` shim；ESM 模块里 `require` 是 undefined，shim 走「typeof require === undefined」分支直接 throw。WS path 只有 `previous_response_id` 才走，#468 拆分 sub-agent prev_id 链后 WS 触发频率上来才暴露这个一直存在的 bundling bug。修复：build.mjs 给 ESM build 加 `banner.js` 注入 `import { createRequire } from "module"; const require = createRequire(import.meta.url);`，让 `__require` 命中真 `require` 路径，Node builtins 正常解析；新增 `packages/electron/__tests__/build.test.ts` 中 banner 回归断言（`packages/electron/electron/build.mjs`、`packages/electron/__tests__/build.test.ts`、`src/proxy/ws-transport.ts` 注释订正）

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -95,6 +95,12 @@ export const ConfigSchema = z.object({
     capture_body: z.boolean().default(false),
     llm_only: z.boolean().default(true),
   }).default({}),
+  // Local observability (no third-party SaaS). v1 ships a local
+  // uncaught-error log; future iterations may add remote upload here.
+  observability: z.object({
+    local_error_log: z.boolean().default(true),
+    max_log_bytes: z.number().int().min(1024).default(10 * 1024 * 1024),
+  }).default({}),
   usage_stats: z.object({
     /** null means keep usage history forever. */
     history_retention_days: z.number().int().positive().nullable().default(null),

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAdapterForEntry } from "./proxy/adapter-factory.js";
 import { startOllamaBridge, stopOllamaBridge } from "./ollama/server.js";
 import { createOfficialAgentRoutes } from "./routes/official-agent.js";
+import { installUncaughtErrorHandlers } from "./logs/error-log.js";
 
 export interface ServerHandle {
   close: () => Promise<void>;
@@ -68,6 +69,11 @@ function urlHostForLocalRequest(host: string): string {
  * Throws on config errors instead of calling process.exit().
  */
 export async function startServer(options?: StartOptions): Promise<ServerHandle> {
+  // Funnel uncaught errors / unhandled rejections into the local
+  // error log before anything else can throw. Idempotent — Electron
+  // main may have already called this earlier.
+  installUncaughtErrorHandlers("server");
+
   // Load configuration
   console.log("[Init] Loading configuration...");
   const config = loadConfig();

--- a/src/logs/error-log.ts
+++ b/src/logs/error-log.ts
@@ -1,0 +1,337 @@
+/**
+ * Local uncaught-error log.
+ *
+ * Appends sanitized error records to `data/error-log.jsonl`, rotating
+ * at a configurable byte cap (single backup file, `error-log.1.jsonl`).
+ * A sidecar `error-log.cursor` tracks the last "seen" timestamp so the
+ * dashboard can surface an unread count.
+ *
+ * No-op when `config.observability.local_error_log` is false.
+ *
+ * Design notes:
+ * - Reads `getConfig()` and `getDataDir()` on each call so callers can
+ *   change paths / toggle the feature at runtime without re-importing.
+ * - Append uses `appendFileSync` (single JSON line is smaller than the
+ *   pipe-buffer atomic-write threshold, so concurrent writers can't tear).
+ * - Rotation checks current size BEFORE appending. The new entry always
+ *   ends up in the post-rotation `error-log.jsonl`, never split across
+ *   the boundary.
+ * - All `context` values pass through `redactJson` to scrub auth tokens,
+ *   cookies, OAuth state, etc., before they hit disk.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { resolve } from "path";
+import { getConfig } from "../config.js";
+import { getDataDir } from "../paths.js";
+import { redactJson } from "./redact.js";
+
+export type ErrorSource = "main" | "renderer" | "server" | "external";
+
+export interface ErrorLogEntry {
+  ts: string;
+  version: string;
+  platform: string;
+  source: ErrorSource;
+  error: { name: string; message: string; stack?: string };
+  context?: Record<string, unknown>;
+}
+
+export interface ErrorGroup {
+  signature: string;
+  name: string;
+  message: string;
+  count: number;
+  first_seen: string;
+  last_seen: string;
+  source: ErrorSource;
+  sample_stack?: string;
+}
+
+export interface AppendInput {
+  source: ErrorSource;
+  error: { name: string; message: string; stack?: string };
+  context?: Record<string, unknown>;
+}
+
+const LOG_FILE = "error-log.jsonl";
+const BACKUP_FILE = "error-log.1.jsonl";
+const CURSOR_FILE = "error-log.cursor";
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+
+interface ObservabilityConfig {
+  local_error_log: boolean;
+  max_log_bytes: number;
+}
+
+function readObservabilityConfig(): ObservabilityConfig {
+  const cfg = getConfig() as { observability?: Partial<ObservabilityConfig> };
+  return {
+    local_error_log: cfg.observability?.local_error_log ?? true,
+    max_log_bytes: cfg.observability?.max_log_bytes ?? DEFAULT_MAX_BYTES,
+  };
+}
+
+function readAppVersion(): string {
+  const cfg = getConfig() as { client?: { app_version?: string } };
+  return cfg.client?.app_version ?? "unknown";
+}
+
+function ensureDataDir(): string {
+  const dir = getDataDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+function logPath(): string {
+  return resolve(ensureDataDir(), LOG_FILE);
+}
+
+function backupPath(): string {
+  return resolve(ensureDataDir(), BACKUP_FILE);
+}
+
+function cursorPath(): string {
+  return resolve(ensureDataDir(), CURSOR_FILE);
+}
+
+/** Rotate `error-log.jsonl` → `error-log.1.jsonl` if current size exceeds the cap. */
+function rotateIfNeeded(maxBytes: number): void {
+  const current = logPath();
+  if (!existsSync(current)) return;
+  const size = statSync(current).size;
+  if (size <= maxBytes) return;
+  // renameSync overwrites the destination on POSIX; on Windows the
+  // backup is removed first because rename-onto-existing fails there.
+  const backup = backupPath();
+  if (existsSync(backup) && process.platform === "win32") {
+    try {
+      writeFileSync(backup, "");
+    } catch {
+      /* fall through; renameSync will surface the real error */
+    }
+  }
+  renameSync(current, backup);
+}
+
+/**
+ * Append an error record to the log.
+ * Silently no-op when local error logging is disabled or when the
+ * write itself fails (we never want logging to break the caller).
+ */
+export function appendErrorLog(input: AppendInput): void {
+  let cfg: ObservabilityConfig;
+  try {
+    cfg = readObservabilityConfig();
+  } catch {
+    // Config not yet loaded (early startup crash). Use defaults so we
+    // still capture the error rather than silently dropping it.
+    cfg = { local_error_log: true, max_log_bytes: DEFAULT_MAX_BYTES };
+  }
+  if (!cfg.local_error_log) return;
+
+  const sanitizedContext =
+    input.context !== undefined
+      ? (redactJson(input.context) as Record<string, unknown>)
+      : undefined;
+
+  const entry: ErrorLogEntry = {
+    ts: new Date().toISOString(),
+    version: readAppVersion(),
+    platform: process.platform,
+    source: input.source,
+    error: {
+      name: input.error.name,
+      message: input.error.message,
+      stack: input.error.stack,
+    },
+    ...(sanitizedContext !== undefined ? { context: sanitizedContext } : {}),
+  };
+
+  try {
+    rotateIfNeeded(cfg.max_log_bytes);
+    appendFileSync(logPath(), JSON.stringify(entry) + "\n", "utf-8");
+  } catch {
+    // Logging failures must never throw. Drop the entry.
+  }
+}
+
+function readJsonlFile(path: string): ErrorLogEntry[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf-8");
+  const out: ErrorLogEntry[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed) as ErrorLogEntry);
+    } catch {
+      // Skip corrupted lines silently.
+    }
+  }
+  return out;
+}
+
+/**
+ * Read entries from current + backup files, newest first.
+ * `limit`, when given, caps the number of returned entries.
+ */
+export function readErrorLog(limit?: number): ErrorLogEntry[] {
+  // Backup is older; current is newer. Concatenate then reverse so
+  // the newest entries appear first.
+  const oldest = readJsonlFile(backupPath());
+  const newest = readJsonlFile(logPath());
+  const combined = [...oldest, ...newest];
+  combined.reverse();
+  if (limit !== undefined) return combined.slice(0, limit);
+  return combined;
+}
+
+function firstStackFrame(stack: string | undefined): string {
+  if (!stack) return "";
+  for (const line of stack.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return "";
+}
+
+/**
+ * Group entries by signature `name + first non-empty stack frame`.
+ * Returned groups are ordered by `last_seen` descending (newest first).
+ */
+export function groupErrorLog(entries: ErrorLogEntry[]): ErrorGroup[] {
+  const groups = new Map<string, ErrorGroup>();
+  for (const e of entries) {
+    const sig = `${e.error.name}|${firstStackFrame(e.error.stack)}`;
+    const existing = groups.get(sig);
+    if (existing) {
+      existing.count += 1;
+      if (e.ts > existing.last_seen) existing.last_seen = e.ts;
+      if (e.ts < existing.first_seen) existing.first_seen = e.ts;
+    } else {
+      groups.set(sig, {
+        signature: sig,
+        name: e.error.name,
+        message: e.error.message,
+        count: 1,
+        first_seen: e.ts,
+        last_seen: e.ts,
+        source: e.source,
+        sample_stack: e.error.stack,
+      });
+    }
+  }
+  return Array.from(groups.values()).sort((a, b) =>
+    a.last_seen < b.last_seen ? 1 : a.last_seen > b.last_seen ? -1 : 0,
+  );
+}
+
+/** Last-read timestamp from the cursor file; null if no cursor exists. */
+export function getReadCursor(): string | null {
+  const path = cursorPath();
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8").trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the read cursor (overwrites previous value). */
+export function setReadCursor(ts: string): void {
+  try {
+    writeFileSync(cursorPath(), ts, "utf-8");
+  } catch {
+    // Cursor failures are non-critical — the user may briefly see a
+    // stale unread count but no data is lost.
+  }
+}
+
+/**
+ * Count entries strictly newer than the read cursor.
+ * If no cursor exists, every entry is unread.
+ * Callers can pass a pre-fetched entry list to avoid duplicate reads.
+ */
+export function getUnreadCount(entries?: ErrorLogEntry[]): number {
+  const cursor = getReadCursor();
+  const list = entries ?? readErrorLog();
+  if (cursor === null) return list.length;
+  let count = 0;
+  for (const e of list) {
+    if (e.ts > cursor) count += 1;
+  }
+  return count;
+}
+
+// ── Process-level handlers ──────────────────────────────────────────
+
+function asError(value: unknown): { name: string; message: string; stack?: string } {
+  if (value instanceof Error) {
+    return { name: value.name || "Error", message: value.message, stack: value.stack };
+  }
+  if (typeof value === "string") {
+    return { name: "Error", message: value };
+  }
+  try {
+    return { name: "Error", message: JSON.stringify(value) };
+  } catch {
+    return { name: "Error", message: String(value) };
+  }
+}
+
+/** Convert an `uncaughtException` argument into an error-log entry. */
+export function handleUncaughtException(err: unknown, source: ErrorSource = "main"): void {
+  appendErrorLog({ source, error: asError(err) });
+}
+
+/** Convert an `unhandledRejection` reason into an error-log entry. */
+export function handleUnhandledRejection(reason: unknown, source: ErrorSource = "main"): void {
+  appendErrorLog({ source, error: asError(reason) });
+}
+
+let _handlersInstalled = false;
+
+/**
+ * Register process-wide uncaught handlers that funnel into the local
+ * error log. Idempotent — safe to call from both Electron main.ts and
+ * the CLI startServer() path.
+ *
+ * Default Node behavior is preserved: `uncaughtException` is logged,
+ * then re-thrown (Node will print + exit), so we never silently swallow
+ * a fatal crash. `unhandledRejection` is logged but not re-raised
+ * because Node's policy on those is configurable and we don't want to
+ * second-guess it.
+ */
+export function installUncaughtErrorHandlers(source: ErrorSource = "main"): void {
+  if (_handlersInstalled) return;
+  _handlersInstalled = true;
+  process.on("uncaughtException", (err) => {
+    handleUncaughtException(err, source);
+    // Re-throw on next tick so Node's default crash + stderr behavior
+    // still kicks in for fatal errors. The async hop ensures our
+    // synchronous log write completes first.
+    setImmediate(() => {
+      throw err;
+    });
+  });
+  process.on("unhandledRejection", (reason) => {
+    handleUnhandledRejection(reason, source);
+  });
+}
+
+/** Test-only — reset the install flag so a follow-up call re-installs. */
+export function _resetInstallFlagForTest(): void {
+  _handlersInstalled = false;
+}

--- a/src/routes/admin/error-logs.ts
+++ b/src/routes/admin/error-logs.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  appendErrorLog,
+  groupErrorLog,
+  getUnreadCount,
+  readErrorLog,
+  setReadCursor,
+  type ErrorSource,
+} from "../../logs/error-log.js";
+
+const RawQuerySchema = z.object({
+  limit: z.preprocess(
+    (v) => (v === undefined ? undefined : Number(v)),
+    z.number().int().min(1).max(500).optional(),
+  ),
+});
+
+const ReportBodySchema = z.object({
+  source: z.enum(["main", "renderer", "server", "external"]),
+  error: z.object({
+    name: z.string().min(1).max(200),
+    message: z.string().max(4000),
+    stack: z.string().max(10_000).optional(),
+  }),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+
+export function createErrorLogRoutes(): Hono {
+  const app = new Hono();
+
+  app.get("/admin/error-logs", (c) => {
+    const entries = readErrorLog();
+    const groups = groupErrorLog(entries);
+    return c.json({ groups });
+  });
+
+  app.get("/admin/error-logs/raw", (c) => {
+    const parsed = RawQuerySchema.safeParse({ limit: c.req.query("limit") });
+    if (!parsed.success) {
+      c.status(400);
+      return c.json({ error: "Invalid limit", details: parsed.error.issues });
+    }
+    const entries = readErrorLog(parsed.data.limit);
+    return c.json({ entries });
+  });
+
+  app.get("/admin/error-logs/count", (c) => {
+    const entries = readErrorLog();
+    return c.json({ total: entries.length, unread: getUnreadCount(entries) });
+  });
+
+  app.post("/admin/error-logs/seen", (c) => {
+    const entries = readErrorLog(1);
+    // Use the newest entry's ts; if the log is empty, mark "now" so a
+    // later report doesn't need to be considered already-read.
+    const cursor = entries[0]?.ts ?? new Date().toISOString();
+    setReadCursor(cursor);
+    return c.json({ ok: true, cursor });
+  });
+
+  app.post("/admin/error-logs/report", async (c) => {
+    const raw = await c.req.json().catch(() => null);
+    if (raw === null) {
+      c.status(400);
+      return c.json({ error: "Invalid JSON" });
+    }
+    const parsed = ReportBodySchema.safeParse(raw);
+    if (!parsed.success) {
+      c.status(400);
+      return c.json({ error: "Invalid payload", details: parsed.error.issues });
+    }
+    appendErrorLog({
+      source: parsed.data.source as ErrorSource,
+      error: parsed.data.error,
+      context: parsed.data.context,
+    });
+    return c.json({ ok: true });
+  });
+
+  return app;
+}

--- a/src/routes/web.ts
+++ b/src/routes/web.ts
@@ -11,6 +11,7 @@ import { createSettingsRoutes } from "./admin/settings.js";
 import { createOllamaAdminRoutes } from "./admin/ollama.js";
 import { createUsageStatsRoutes } from "./admin/usage-stats.js";
 import { createLogRoutes } from "./admin/logs.js";
+import { createErrorLogRoutes } from "./admin/error-logs.js";
 import type { UsageStatsStore } from "../auth/usage-stats.js";
 
 export function createWebRoutes(accountPool: AccountPool, usageStats: UsageStatsStore): Hono {
@@ -49,6 +50,7 @@ export function createWebRoutes(accountPool: AccountPool, usageStats: UsageStats
   app.route("/", createOllamaAdminRoutes());
   app.route("/", createUsageStatsRoutes(accountPool, usageStats));
   app.route("/", createLogRoutes());
+  app.route("/", createErrorLogRoutes());
 
   return app;
 }

--- a/tests/unit/logs/error-log.test.ts
+++ b/tests/unit/logs/error-log.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for the local error-log writer (src/logs/error-log.ts).
+ *
+ * The writer's job: append uncaught/reported errors to a JSONL file
+ * under data/, sanitizing secrets, rotating once at a size cap, and
+ * leaving everything no-op when the user has disabled local error
+ * logging in config. A read-cursor on the side tracks "unread" state
+ * so the dashboard badge can show new-since-last-visit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+
+let tmpDataDir = "";
+
+interface MockConfig {
+  observability: { local_error_log: boolean; max_log_bytes: number };
+  client: { app_version: string };
+}
+
+const mockConfig: MockConfig = {
+  observability: { local_error_log: true, max_log_bytes: 10 * 1024 * 1024 },
+  client: { app_version: "0.0.0-test" },
+};
+
+vi.mock("@src/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@src/paths.js")>();
+  return {
+    ...actual,
+    getDataDir: () => tmpDataDir,
+  };
+});
+
+vi.mock("@src/config.js", () => ({
+  getConfig: () => mockConfig,
+}));
+
+async function importErrorLog() {
+  return await import("@src/logs/error-log.js");
+}
+
+beforeEach(async () => {
+  tmpDataDir = mkdtempSync(resolve(tmpdir(), "errlog-"));
+  mockConfig.observability.local_error_log = true;
+  mockConfig.observability.max_log_bytes = 10 * 1024 * 1024;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (existsSync(tmpDataDir)) {
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  }
+  vi.clearAllMocks();
+});
+
+describe("appendErrorLog", () => {
+  it("writes a JSONL line with auto-populated ts / version / platform", async () => {
+    const { appendErrorLog } = await importErrorLog();
+    appendErrorLog({
+      source: "main",
+      error: { name: "TypeError", message: "boom", stack: "at foo:1:1" },
+    });
+
+    const file = resolve(tmpDataDir, "error-log.jsonl");
+    expect(existsSync(file)).toBe(true);
+    const lines = readFileSync(file, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const entry = JSON.parse(lines[0]) as Record<string, unknown>;
+    expect(entry.source).toBe("main");
+    expect(entry.version).toBe("0.0.0-test");
+    expect(entry.platform).toBe(process.platform);
+    expect(typeof entry.ts).toBe("string");
+    expect(new Date(entry.ts as string).toString()).not.toBe("Invalid Date");
+    const error = entry.error as { name: string; message: string; stack: string };
+    expect(error.name).toBe("TypeError");
+    expect(error.message).toBe("boom");
+    expect(error.stack).toBe("at foo:1:1");
+  });
+
+  it("sanitizes secret-bearing context keys via redactJson", async () => {
+    const { appendErrorLog } = await importErrorLog();
+    appendErrorLog({
+      source: "server",
+      error: { name: "Error", message: "fail" },
+      context: {
+        path: "/v1/responses",
+        authorization: "Bearer sk-very-secret-token-1234567890",
+        api_key: "ak_supersecret",
+        nested: { cookie: "session=abcdef123456" },
+      },
+    });
+
+    const file = resolve(tmpDataDir, "error-log.jsonl");
+    const entry = JSON.parse(readFileSync(file, "utf-8").trim()) as {
+      context: { path: string; authorization: string; api_key: string; nested: { cookie: string } };
+    };
+
+    expect(entry.context.path).toBe("/v1/responses");
+    // redact.ts keeps first 3 + last 2 chars and replaces the middle.
+    expect(entry.context.authorization).not.toContain("sk-very-secret-token");
+    expect(entry.context.api_key).not.toContain("supersecret");
+    expect(entry.context.nested.cookie).not.toContain("session=abcdef");
+  });
+
+  it("is a no-op when observability.local_error_log is false", async () => {
+    mockConfig.observability.local_error_log = false;
+    const { appendErrorLog } = await importErrorLog();
+    appendErrorLog({
+      source: "main",
+      error: { name: "Error", message: "should not be written" },
+    });
+
+    const file = resolve(tmpDataDir, "error-log.jsonl");
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("rotates to error-log.1.jsonl when current file exceeds max_log_bytes", async () => {
+    // Force a tiny rotation threshold so we can trigger it cheaply.
+    mockConfig.observability.max_log_bytes = 1024; // 1 KB
+    const { appendErrorLog } = await importErrorLog();
+
+    // Each entry is roughly ~200 bytes; 8 entries should overflow 1KB.
+    for (let i = 0; i < 12; i++) {
+      appendErrorLog({
+        source: "main",
+        error: { name: "Error", message: `boom ${i}`, stack: "at line\nat next-line" },
+      });
+    }
+
+    const current = resolve(tmpDataDir, "error-log.jsonl");
+    const backup = resolve(tmpDataDir, "error-log.1.jsonl");
+    expect(existsSync(current)).toBe(true);
+    expect(existsSync(backup)).toBe(true);
+
+    // After rotation, the current file should be smaller than the threshold
+    // (it carries the most recent entry written after the swap).
+    const currentLines = readFileSync(current, "utf-8").trim().split("\n");
+    const backupLines = readFileSync(backup, "utf-8").trim().split("\n");
+    expect(currentLines.length).toBeGreaterThan(0);
+    expect(backupLines.length).toBeGreaterThan(0);
+    // Total entries preserved across both files.
+    expect(currentLines.length + backupLines.length).toBe(12);
+  });
+});
+
+describe("readErrorLog", () => {
+  it("returns entries newest-first across current + backup files", async () => {
+    const { appendErrorLog, readErrorLog } = await importErrorLog();
+    // Force rotation by lowering threshold mid-test.
+    mockConfig.observability.max_log_bytes = 400;
+
+    for (let i = 0; i < 6; i++) {
+      appendErrorLog({
+        source: "main",
+        error: { name: "E", message: `entry ${i}` },
+      });
+    }
+
+    const all = readErrorLog();
+    expect(all.length).toBe(6);
+    // Newest first: last appended (entry 5) should be index 0.
+    expect(all[0].error.message).toBe("entry 5");
+    expect(all[all.length - 1].error.message).toBe("entry 0");
+  });
+
+  it("respects limit", async () => {
+    const { appendErrorLog, readErrorLog } = await importErrorLog();
+    for (let i = 0; i < 5; i++) {
+      appendErrorLog({ source: "main", error: { name: "E", message: `${i}` } });
+    }
+    const subset = readErrorLog(2);
+    expect(subset.length).toBe(2);
+    expect(subset[0].error.message).toBe("4");
+    expect(subset[1].error.message).toBe("3");
+  });
+
+  it("returns empty array when no log exists", async () => {
+    const { readErrorLog } = await importErrorLog();
+    expect(readErrorLog()).toEqual([]);
+  });
+});
+
+describe("groupErrorLog", () => {
+  it("groups by error.name + first non-empty stack line", async () => {
+    const { groupErrorLog } = await importErrorLog();
+
+    const entries = [
+      {
+        ts: "2026-05-10T00:00:00Z", version: "v", platform: "darwin", source: "main" as const,
+        error: { name: "TypeError", message: "boom A", stack: "at frame.js:1:1\nat outer:2" },
+      },
+      {
+        ts: "2026-05-10T00:00:01Z", version: "v", platform: "darwin", source: "main" as const,
+        error: { name: "TypeError", message: "boom A different msg", stack: "at frame.js:1:1\nat outer:3" },
+      },
+      {
+        ts: "2026-05-10T00:00:02Z", version: "v", platform: "darwin", source: "server" as const,
+        error: { name: "RangeError", message: "different err", stack: "at other.js:5" },
+      },
+    ];
+
+    const groups = groupErrorLog(entries);
+    expect(groups).toHaveLength(2);
+
+    const typeErr = groups.find((g) => g.name === "TypeError")!;
+    expect(typeErr.count).toBe(2);
+    expect(typeErr.first_seen).toBe("2026-05-10T00:00:00Z");
+    expect(typeErr.last_seen).toBe("2026-05-10T00:00:01Z");
+
+    const rangeErr = groups.find((g) => g.name === "RangeError")!;
+    expect(rangeErr.count).toBe(1);
+  });
+});
+
+describe("read cursor + unread count", () => {
+  it("getReadCursor returns null when no cursor file exists", async () => {
+    const { getReadCursor } = await importErrorLog();
+    expect(getReadCursor()).toBeNull();
+  });
+
+  it("setReadCursor + getReadCursor roundtrip", async () => {
+    const { setReadCursor, getReadCursor } = await importErrorLog();
+    setReadCursor("2026-05-10T12:00:00Z");
+    expect(getReadCursor()).toBe("2026-05-10T12:00:00Z");
+  });
+
+  it("getUnreadCount returns count of entries strictly newer than cursor", async () => {
+    const { appendErrorLog, setReadCursor, getUnreadCount } = await importErrorLog();
+    appendErrorLog({ source: "main", error: { name: "E", message: "1" } });
+    // Tiny sleep so timestamps differ; ts uses ISO ms granularity.
+    await new Promise((r) => setTimeout(r, 5));
+    appendErrorLog({ source: "main", error: { name: "E", message: "2" } });
+
+    // Cursor = first entry's ts. Only the 2nd entry should count as unread.
+    // We don't have direct access to the first ts here, so we read the log
+    // back, snapshot the older ts, and use it as the cursor.
+    const file = resolve(tmpDataDir, "error-log.jsonl");
+    const lines = readFileSync(file, "utf-8").trim().split("\n");
+    const firstTs = JSON.parse(lines[0]).ts as string;
+    setReadCursor(firstTs);
+
+    expect(getUnreadCount()).toBe(1);
+  });
+
+  it("getUnreadCount returns total when cursor is null", async () => {
+    const { appendErrorLog, getUnreadCount } = await importErrorLog();
+    appendErrorLog({ source: "main", error: { name: "E", message: "1" } });
+    appendErrorLog({ source: "main", error: { name: "E", message: "2" } });
+    expect(getUnreadCount()).toBe(2);
+  });
+
+  it("getReadCursor handles cursor file with stray whitespace", async () => {
+    const { getReadCursor } = await importErrorLog();
+    // Pre-write a cursor file directly so we don't have to expose internals.
+    writeFileSync(resolve(tmpDataDir, "error-log.cursor"), "  2026-05-10T12:00:00Z  \n");
+    expect(getReadCursor()).toBe("2026-05-10T12:00:00Z");
+  });
+});
+
+describe("uncaught handlers", () => {
+  it("handleUncaughtException records an Error instance", async () => {
+    const { handleUncaughtException, readErrorLog } = await importErrorLog();
+    const err = new TypeError("oops");
+    handleUncaughtException(err, "main");
+
+    const entries = readErrorLog();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe("main");
+    expect(entries[0].error.name).toBe("TypeError");
+    expect(entries[0].error.message).toBe("oops");
+    expect(entries[0].error.stack).toBeDefined();
+  });
+
+  it("handleUncaughtException records non-Error throws too (string)", async () => {
+    const { handleUncaughtException, readErrorLog } = await importErrorLog();
+    handleUncaughtException("plain string error", "server");
+    const entries = readErrorLog();
+    expect(entries[0].source).toBe("server");
+    expect(entries[0].error.name).toBe("Error");
+    expect(entries[0].error.message).toBe("plain string error");
+  });
+
+  it("handleUnhandledRejection records the rejection reason", async () => {
+    const { handleUnhandledRejection, readErrorLog } = await importErrorLog();
+    handleUnhandledRejection(new RangeError("nope"), "main");
+    const entries = readErrorLog();
+    expect(entries[0].error.name).toBe("RangeError");
+    expect(entries[0].error.message).toBe("nope");
+  });
+});

--- a/tests/unit/routes/admin/error-logs.test.ts
+++ b/tests/unit/routes/admin/error-logs.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for /admin/error-logs routes (read + report).
+ *
+ * Covers the four endpoints exposed to the dashboard + the renderer
+ * report path. Auth is enforced by the global dashboardAuth middleware
+ * applied higher up, so we mount the route in isolation here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, existsSync, rmSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { Hono } from "hono";
+
+let tmpDataDir = "";
+
+const mockConfig = {
+  observability: { local_error_log: true, max_log_bytes: 10 * 1024 * 1024 },
+  client: { app_version: "0.0.0-test" },
+};
+
+vi.mock("@src/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@src/paths.js")>();
+  return {
+    ...actual,
+    getDataDir: () => tmpDataDir,
+  };
+});
+
+vi.mock("@src/config.js", () => ({
+  getConfig: () => mockConfig,
+}));
+
+beforeEach(() => {
+  tmpDataDir = mkdtempSync(resolve(tmpdir(), "errlog-routes-"));
+  mockConfig.observability.local_error_log = true;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (existsSync(tmpDataDir)) {
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  }
+  vi.clearAllMocks();
+});
+
+async function buildApp() {
+  const { createErrorLogRoutes } = await import("@src/routes/admin/error-logs.js");
+  const app = new Hono();
+  app.route("/", createErrorLogRoutes());
+  return app;
+}
+
+async function appendFew() {
+  const { appendErrorLog } = await import("@src/logs/error-log.js");
+  appendErrorLog({ source: "main", error: { name: "TypeError", message: "boom 1", stack: "at a.js:1" } });
+  await new Promise((r) => setTimeout(r, 5));
+  appendErrorLog({ source: "main", error: { name: "TypeError", message: "boom 2", stack: "at a.js:1" } });
+  await new Promise((r) => setTimeout(r, 5));
+  appendErrorLog({ source: "server", error: { name: "RangeError", message: "out", stack: "at b.js:5" } });
+}
+
+describe("GET /admin/error-logs", () => {
+  it("returns grouped errors with count and last_seen", async () => {
+    await appendFew();
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      groups: Array<{ name: string; count: number; last_seen: string }>;
+    };
+    expect(body.groups).toHaveLength(2);
+    const typeErr = body.groups.find((g) => g.name === "TypeError")!;
+    expect(typeErr.count).toBe(2);
+    const rangeErr = body.groups.find((g) => g.name === "RangeError")!;
+    expect(rangeErr.count).toBe(1);
+  });
+
+  it("returns empty groups when no log exists", async () => {
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { groups: unknown[] };
+    expect(body.groups).toEqual([]);
+  });
+});
+
+describe("GET /admin/error-logs/raw", () => {
+  it("returns raw entries newest-first with limit", async () => {
+    await appendFew();
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/raw?limit=2");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      entries: Array<{ source: string; error: { message: string } }>;
+    };
+    expect(body.entries).toHaveLength(2);
+    expect(body.entries[0].error.message).toBe("out");
+    expect(body.entries[1].error.message).toBe("boom 2");
+  });
+});
+
+describe("GET /admin/error-logs/count", () => {
+  it("returns total + unread counts (all unread when no cursor)", async () => {
+    await appendFew();
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/count");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { total: number; unread: number };
+    expect(body.total).toBe(3);
+    expect(body.unread).toBe(3);
+  });
+
+  it("reflects the cursor when set", async () => {
+    await appendFew();
+    const { setReadCursor } = await import("@src/logs/error-log.js");
+    // Set cursor to "now" — everything older than now is read.
+    setReadCursor(new Date(Date.now() + 10_000).toISOString());
+
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/count");
+    const body = await res.json() as { total: number; unread: number };
+    expect(body.total).toBe(3);
+    expect(body.unread).toBe(0);
+  });
+});
+
+describe("POST /admin/error-logs/seen", () => {
+  it("advances the cursor to the latest entry's ts so unread becomes 0", async () => {
+    await appendFew();
+    const app = await buildApp();
+
+    const before = await app.request("/admin/error-logs/count");
+    expect(((await before.json()) as { unread: number }).unread).toBe(3);
+
+    const seenRes = await app.request("/admin/error-logs/seen", { method: "POST" });
+    expect(seenRes.status).toBe(200);
+
+    const after = await app.request("/admin/error-logs/count");
+    expect(((await after.json()) as { unread: number }).unread).toBe(0);
+  });
+
+  it("is idempotent (no entries → still 200)", async () => {
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/seen", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /admin/error-logs/report", () => {
+  it("appends a renderer-reported error to the log with sanitized context", async () => {
+    const app = await buildApp();
+    const payload = {
+      source: "renderer",
+      error: { name: "TypeError", message: "render boom", stack: "at App.tsx:42" },
+      context: {
+        url: "http://127.0.0.1:8080/#/settings",
+        api_key: "ak_should_not_persist_plaintext_xxxxxxx",
+      },
+    };
+    const res = await app.request("/admin/error-logs/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    expect(res.status).toBe(200);
+
+    const file = resolve(tmpDataDir, "error-log.jsonl");
+    const line = readFileSync(file, "utf-8").trim();
+    const entry = JSON.parse(line) as {
+      source: string;
+      error: { message: string };
+      context: { api_key: string; url: string };
+    };
+    expect(entry.source).toBe("renderer");
+    expect(entry.error.message).toBe("render boom");
+    expect(entry.context.url).toBe("http://127.0.0.1:8080/#/settings");
+    expect(entry.context.api_key).not.toContain("should_not_persist_plaintext");
+  });
+
+  it("rejects unknown source values", async () => {
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source: "bogus",
+        error: { name: "E", message: "m" },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed payload (missing error)", async () => {
+    const app = await buildApp();
+    const res = await app.request("/admin/error-logs/report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: "renderer" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
PR-1 of #480. Backend foundation only — UI tab + header badge + renderer report path follow in PR-2.

## Why

The events-bundling regression in v2.0.71/72 existed for ~30 release cycles before any user reported it. We had zero in-process telemetry — the only feedback loop was \"user files a GitHub issue\". This PR ships the writer + capture + read API so the maintainer's own machine (and any user who keeps the default on) gets every uncaught crash recorded in `data/error-log.jsonl`. PR-2 adds the dashboard view.

Self-hosted by design — no third-party SaaS dependency, no remote upload yet. Same JSONL schema is the basis for a future remote endpoint when scale justifies it.

## What's in this PR

### Writer (`src/logs/error-log.ts`)
- JSONL append with single-backup rotation at `observability.max_log_bytes` (default 10MB)
- All `context` values flow through the existing `redactJson` to scrub auth tokens, cookies, OAuth state, etc.
- Read API: `readErrorLog(limit?)`, `groupErrorLog(entries)`, `getReadCursor()` / `setReadCursor()`, `getUnreadCount()`
- `installUncaughtErrorHandlers()` — idempotent, registers `process.on('uncaughtException')` + `process.on('unhandledRejection')`. `uncaughtException` re-throws on `setImmediate` so Node's default crash + stderr behavior is preserved (we never silently swallow a fatal). Wired into `startServer()` so it covers both CLI and Electron (in-process) modes from one call site.

### Admin API (5 endpoints under `/admin/error-logs/*`)
| Endpoint | Purpose |
|----------|---------|
| `GET /admin/error-logs` | Groups by `name + first stack frame` |
| `GET /admin/error-logs/raw?limit=N` | Newest-first JSONL tail |
| `GET /admin/error-logs/count` | `{ total, unread }` for header badge |
| `POST /admin/error-logs/seen` | Advance read cursor to latest ts |
| `POST /admin/error-logs/report` | Accept renderer / external POST |

All protected by the existing global `dashboardAuth` middleware.

### Schema
New `observability` section in `src/config-schema.ts`:
```yaml
observability:
  local_error_log: true            # default on
  max_log_bytes: 10485760          # 10 MB
```
Standalone section (not nested under `logs`) so future telemetry / canary keys slot in cleanly.

## Tests

- `tests/unit/logs/error-log.test.ts` — **16 tests**: auto-populated ts/version/platform; redaction round-trip across nested keys; disabled no-op; rotation across single-backup boundary; newest-first reads; grouping by signature; cursor read/write + whitespace tolerance; unread count vs cursor; handler conversion of `Error` / non-`Error` / rejection inputs.
- `tests/unit/routes/admin/error-logs.test.ts` — **10 tests** covering all four read paths + report (sanitization round-trip + Zod rejection of unknown `source` / missing fields).
- TDD discipline followed: tests written first, watched red, implemented, watched green.

## Test Plan

- [x] `npx vitest run tests/unit/logs/ tests/unit/routes/admin/` — 26 passed
- [x] `npm test` — 158 files / 1876 passed / 1 skipped (was 156/1850)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-push hook (`npm test` + tsc + web build + electron config) — green

## Out of Scope (lands in PR-2)

- Errors tab in the dashboard
- Header inline alert / red badge with unread count
- Renderer-side error capture (`window.error` / `unhandledrejection`) → `POST /admin/error-logs/report` via fetch (not IPC, per planning decision)
- i18n strings for the new UI

## Acknowledged gaps (deferred)

- `app.on('ready')` early-startup window in Electron main is not covered — handlers register after `server.mjs` imports, leaving a sub-second window. Acceptable for v1; structurally awkward to close (would require duplicating handler logic in main.cjs).
- No remote upload — by design. Same schema can be shipped over HTTP later without re-architecting.

Refs #480 (closes after PR-2 lands).