### PR TITLE
fix(release): create draft release before manual upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,13 @@ jobs:
         shell: bash
         run: |
           TAG="${{ inputs.tag || github.ref_name }}"
+          # Ensure the GitHub Release exists. With --publish never above,
+          # electron-builder no longer creates it, so the first uploader
+          # to arrive needs to. `|| true` swallows the 422 that the
+          # concurrent matrix jobs hit when a peer wins the race.
+          IS_PRERELEASE=""
+          if [[ "$TAG" == *-* ]]; then IS_PRERELEASE="--prerelease"; fi
+          gh release create "$TAG" --title "$TAG" --notes "" --draft=false $IS_PRERELEASE 2>/dev/null || true
           cd packages/electron/release
           case "${{ matrix.platform }}" in
             mac)
@@ -289,6 +296,12 @@ jobs:
       - name: Upload x64 artifacts to release
         run: |
           TAG="${{ inputs.tag || github.ref_name }}"
+          # Same release-create safety net as the main build job —
+          # this job runs after `build` but if all 3 main matrix
+          # platforms failed smoke, the release wouldn't exist yet.
+          IS_PRERELEASE=""
+          if [[ "$TAG" == *-* ]]; then IS_PRERELEASE="--prerelease"; fi
+          gh release create "$TAG" --title "$TAG" --notes "" --draft=false $IS_PRERELEASE 2>/dev/null || true
           cd packages/electron/release
           for f in *; do
             [ -f "$f" ] || continue


### PR DESCRIPTION
Refs #479. Follow-up to #484.

PR #484 changed Pack from `--publish always` to `--publish never` so the smoke step can gate uploads. Side effect: electron-builder no longer auto-creates the GitHub Release page, so the first `gh release upload` would 404 with "release not found".

Add an idempotent `gh release create --draft=false ... 2>/dev/null || true` before each upload step. Concurrent matrix jobs all attempt this simultaneously; the 422 "already exists" response is swallowed via `|| true`. Auto-detects prerelease from tag (`v1.2.3-beta.X` → `--prerelease`).

Same patch applied to both the main `build` job's Upload step and the `build-mac-x64` Upload step (the latter as a defensive net in case all 3 main matrix platforms fail smoke).

Caught before any tag dispatch, so no live release was broken.

Test plan:
- [x] `node yaml.load` on release.yml — parses
- [x] `npx vitest run tests/unit/ci/` — 6 passed (smoke script tests still green)