### PR TITLE
fix(release/smoke): retry health probe to absorb serve() bind race

### DIFF
--- a/.github/scripts/electron-smoke.sh
+++ b/.github/scripts/electron-smoke.sh
@@ -138,9 +138,24 @@ done
 
 echo "App reports server on port $PORT"
 
-# Health probe — short timeout so a hung response shows up as failure.
-if ! curl -fsS --max-time 10 "http://127.0.0.1:$PORT/health" >/dev/null; then
-  die "Health probe failed: GET http://127.0.0.1:$PORT/health"
+# Health probe — retry briefly because Electron logs "Server started"
+# the moment startServer() returns, but `serve()` from
+# @hono/node-server doesn't await the underlying socket bind. On fast
+# hosts (observed on macOS arm64 GHA runner) the smoke script can
+# race the bind and hit "connection refused" if it tries only once.
+# 30 attempts × 1s = ~30s of patience; that's still well below the
+# 90s outer timeout and just absorbs millisecond-scale jitter.
+HEALTH_OK=false
+for i in $(seq 1 30); do
+  if curl -fsS --max-time 5 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    HEALTH_OK=true
+    [ "$i" -gt 1 ] && echo "Health probe succeeded after $i attempt(s)"
+    break
+  fi
+  sleep 1
+done
+if [ "$HEALTH_OK" != "true" ]; then
+  die "Health probe failed: GET http://127.0.0.1:$PORT/health (gave up after 30s)"
 fi
 
 echo "✓ Smoke OK on $RUNNER_OS"


### PR DESCRIPTION
Refs #479. Follow-up to #484/#485 dry run.

## What the dry run found

Pushed throwaway tag `v0.0.1-smoketest` to verify #484's smoke step on all 4 platforms. Results:

- ✅ Linux: smoke passed
- ✅ Windows: smoke passed
- ❌ Mac arm64: smoke failed (`curl: (7) Failed to connect to 127.0.0.1 port 8080 after 2 ms: Couldn't connect to server`)
- ⏭️ Mac x64 / release: skipped (correctly — smoke gates upload)

## Root cause

`@hono/node-server`'s `serve()` returns the `Server` instance synchronously without awaiting the underlying socket bind. Sequence:

1. `src/index.ts:247` calls `serve(...)` → returns immediately, `server.address()` already has the port
2. `src/index.ts:280` returns `{ close, port: actualPort }` — `startServer()` resolves
3. `packages/electron/electron/main.ts:147` logs `[Electron] Server started on port N`
4. The smoke script greps the log line, then immediately curls `/health` (single shot)
5. **Socket hasn't actually finished binding** → `connect: refused`

Linux/Windows runners happen to give the bind enough wallclock to complete before the curl arrives. Mac arm64 GHA runners are fast enough to lose this race.

## Fix

Single-shot curl → 30 attempts × 1s retry loop in the smoke script. Still well below the 90s outer timeout; just absorbs millisecond-scale jitter without changing semantics for genuine failures.

Source-side fix (have `startServer()` actually await `listening`) would be cleaner but touches production code and risks behavior change in a different blast radius. Smoke retry is contained.

## Test plan

- [x] `bash -n .github/scripts/electron-smoke.sh` — syntax OK
- [x] `npx vitest run tests/unit/ci/` — 6 passed (existing fail-loud assertions still hold)
- After merge: re-tag a throwaway `v0.0.1-smoketest-2` and re-dispatch release.yml to confirm Mac arm64 + x64 now pass

Refs #479.