### PR TITLE
fix(release/smoke): tolerate single-arch electron-builder output dir

### DIFF
--- a/.github/scripts/electron-smoke.sh
+++ b/.github/scripts/electron-smoke.sh
@@ -57,12 +57,27 @@ case "$RUNNER_OS" in
     ;;
   macOS)
     ARCH="${MAC_ARCH:-arm64}"
-    APP="$(ls -d "$RELEASE_DIR"/mac-${ARCH}/*.app 2>/dev/null | head -1 || true)"
-    if [ -z "$APP" ] && [ "$ARCH" = "arm64" ]; then
-      # electron-builder uses bare 'mac/' for arm64 when only arm64 is built
-      APP="$(ls -d "$RELEASE_DIR"/mac/*.app 2>/dev/null | head -1 || true)"
+    # electron-builder's output directory depends on whether one or
+    # multiple archs were built in the same invocation. Single-arch
+    # builds (the build-mac-x64 job invokes `--mac --x64` alone) land
+    # in `release/mac/`; multi-arch matrix builds produce
+    # `release/mac-arm64/` and `release/mac-x64/`. Search both shapes
+    # before giving up.
+    CANDIDATES=(
+      "$RELEASE_DIR/mac-${ARCH}"
+      "$RELEASE_DIR/mac"
+    )
+    APP=""
+    for dir in "${CANDIDATES[@]}"; do
+      APP="$(ls -d "$dir"/*.app 2>/dev/null | head -1 || true)"
+      [ -n "$APP" ] && break
+    done
+    if [ -z "$APP" ]; then
+      echo "::warning::Looked for .app in: ${CANDIDATES[*]}"
+      echo "::warning::Contents of $RELEASE_DIR:"
+      ls -la "$RELEASE_DIR" 2>&1 || true
+      die "macOS .app ($ARCH) not found under $RELEASE_DIR"
     fi
-    [ -n "$APP" ] || die "macOS .app ($ARCH) not found under $RELEASE_DIR"
     APP_NAME="$(basename "$APP" .app)"
     BINARY="$APP/Contents/MacOS/$APP_NAME"
     [ -x "$BINARY" ] || die "Mac binary not executable: $BINARY"


### PR DESCRIPTION
Refs #479. Follow-up to round 2 dry run.

Round 2 (post #486): linux ✅, win ✅, mac arm64 ✅ (race fix worked), **mac x64 ❌ "macOS .app (x64) not found"**.

## Root cause

electron-builder uses different output directory shapes depending on whether one or multiple arches are built per invocation:

| Build invocation | Output dir |
|---|---|
| Multi-arch matrix (`--mac --arm64` alongside x64) | `release/mac-arm64/*.app`, `release/mac-x64/*.app` |
| Single arch only (build-mac-x64 job: `--mac --x64`) | `release/mac/*.app` |

Smoke script was looking for `mac-x64/`; build-mac-x64 ships to `mac/`. Linux smoke and main `build` job (which uses `--mac --arm64` in a separate matrix entry that effectively does single-arch arm64) happened to land in dirs the script knew about (or had explicit fallback for arm64 → `mac/`).

## Fix

Search both candidate dirs (`mac-{ARCH}` and `mac/`) before giving up. Logs the searched paths + dir contents on failure so future packaging changes are easy to debug.

## Test plan

- [x] `bash -n` syntax check
- [x] `npx vitest run tests/unit/ci/` — 6 fail-loud tests still pass
- After merge: round 3 throwaway tag dry run to confirm all 4 platforms green

Refs #479.