### PR TITLE
fix(release): scope PREV_TAG search to same channel (stable vs beta)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,7 +356,24 @@ jobs:
       - name: Generate release notes and publish
         run: |
           TAG="${{ steps.tag.outputs.name }}"
-          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | grep -v "^${TAG}$" | head -1)
+          # PREV_TAG must stay within the same channel (stable vs beta) or
+          # release notes get cross-channel bleed. Old logic took the
+          # numerically-highest other v-tag, which would pick a v2.1.0-beta.X
+          # left over from a test branch as "previous" when shipping v2.0.73,
+          # producing a 30-commit changelog spanning unrelated history.
+          if [[ "$TAG" == *-* ]]; then
+            # Current is a beta (has -suffix). Prefer another beta; fall
+            # back to the latest stable so the very first beta in a series
+            # still gets a sensible diff base.
+            PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-' | grep -v "^${TAG}$" | head -1 || true)
+            if [ -z "$PREV_TAG" ]; then
+              PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+            fi
+          else
+            # Current is stable. Compare only to other stables — never let
+            # a beta tag (which lives on its own ref) sneak in as PREV_TAG.
+            PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1 || true)
+          fi
           if [ -z "$PREV_TAG" ]; then
             BODY="Initial release"
           else


### PR DESCRIPTION
v2.0.73 stable release notes ended up listing ~30 commits spanning unrelated test-branch history. Root cause: `PREV_TAG` algorithm took the numerically-highest other v-tag without channel awareness, so a stale `v2.1.0-beta.a17a699` (left over from a beta-bump test on a side branch) was picked as the diff base. The notes then became `git log v2.1.0-beta.a17a699..v2.0.73` — basically every commit on dev not present in that dead-end beta branch.

## Fix

Channel-aware lookup:

- **Current is stable** (`v2.0.73`, no `-suffix`): only consider other stable tags as PREV_TAG. Cross-channel comparisons banned.
- **Current is beta** (`v2.0.74-beta.X`): prefer another beta in the same series; fall back to the latest stable so the very first beta in a new series still gets a sensible diff base.

Both branches use `|| true` so a missing PREV_TAG falls through to the existing `Initial release` / `Bug fixes and improvements` defaults.

## Effect

For v2.0.74 (next stable): PREV_TAG = `v2.0.73`, notes contain only commits between v2.0.73 and v2.0.74 — i.e. just what changed.

## Test plan

- [x] `node -e "yaml.load(...)"` on release.yml — parses
- After merge: next bump-electron run will exercise the new logic. Verify v2.0.74 release notes are scoped to v2.0.73→v2.0.74 only.

## Note

Identified during a release post-mortem; the fix was independently authored in a local stash by the maintainer. This PR cherry-picks just the PREV_TAG section.