### PR TITLE
fix: keep usage history snapshots enabled

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -35,6 +35,8 @@ logs:
   capture_body: false
   llm_only: true
 usage_stats:
+  # 0 = disable local usage history snapshots
+  snapshot_interval_minutes: 5
   # null = keep usage history forever
   history_retention_days: null
 session:

--- a/src/auth/usage-refresher.ts
+++ b/src/auth/usage-refresher.ts
@@ -1,10 +1,8 @@
 /**
  * SnapshotTimer — periodically records usage stats snapshots for the dashboard.
  *
- * Previously this module also polled GET /codex/usage for each account.
- * That active polling was removed because quota data is now collected passively
- * from response headers on every proxied request (see proxy-handler.ts +
- * rate-limit-headers.ts).  Only the local snapshot recording remains.
+ * Quota refresh can be disabled independently; usage history still needs
+ * local snapshots so the dashboard can show historical windows.
  */
 
 import { getConfig } from "../config.js";
@@ -28,10 +26,10 @@ export class SnapshotTimer {
   start(): void {
     this.stopped = false;
     const config = getConfig();
-    const intervalMin = config.quota.refresh_interval_minutes;
+    const intervalMin = config.usage_stats.snapshot_interval_minutes;
 
     if (intervalMin === 0) {
-      console.log("[SnapshotTimer] Disabled (refresh_interval_minutes = 0)");
+      console.log("[SnapshotTimer] Disabled (usage_stats.snapshot_interval_minutes = 0)");
       return;
     }
 
@@ -62,7 +60,12 @@ export class SnapshotTimer {
   private scheduleNext(): void {
     if (this.stopped) return;
     const config = getConfig();
-    const intervalMs = jitter(config.quota.refresh_interval_minutes * 60 * 1000, 0.15);
+    const intervalMin = config.usage_stats.snapshot_interval_minutes;
+    if (intervalMin === 0) {
+      this.timer = null;
+      return;
+    }
+    const intervalMs = jitter(intervalMin * 60 * 1000, 0.15);
     this.timer = setTimeout(() => this.tick(), intervalMs);
   }
 }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -102,6 +102,8 @@ export const ConfigSchema = z.object({
     max_log_bytes: z.number().int().min(1024).default(10 * 1024 * 1024),
   }).default({}),
   usage_stats: z.object({
+    /** How often to record local usage history snapshots. 0 disables history recording. */
+    snapshot_interval_minutes: z.number().int().min(0).default(5),
     /** null means keep usage history forever. */
     history_retention_days: z.number().int().positive().nullable().default(null),
   }).default({}),

--- a/tests/unit/auth/usage-refresher.test.ts
+++ b/tests/unit/auth/usage-refresher.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConfig = vi.hoisted(() => ({
+  usage_stats: {
+    snapshot_interval_minutes: 5,
+  },
+  quota: {
+    refresh_interval_minutes: 0,
+  },
+}));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/utils/jitter.js", () => ({
+  jitter: vi.fn((ms: number) => ms),
+}));
+
+import { SnapshotTimer } from "@src/auth/usage-refresher.js";
+import type { AccountPool } from "@src/auth/account-pool.js";
+import type { UsageStatsStore } from "@src/auth/usage-stats.js";
+
+function createSnapshotTimer(): {
+  timer: SnapshotTimer;
+  recordSnapshot: ReturnType<typeof vi.fn>;
+} {
+  const pool = {} as AccountPool;
+  const recordSnapshot = vi.fn();
+  const usageStats = { recordSnapshot } as unknown as UsageStatsStore;
+  return {
+    timer: new SnapshotTimer(pool, usageStats),
+    recordSnapshot,
+  };
+}
+
+describe("SnapshotTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockConfig.usage_stats.snapshot_interval_minutes = 5;
+    mockConfig.quota.refresh_interval_minutes = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("records usage history snapshots even when quota refresh is disabled", () => {
+    const { timer, recordSnapshot } = createSnapshotTimer();
+
+    timer.start();
+
+    vi.advanceTimersByTime(2_999);
+    expect(recordSnapshot).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(recordSnapshot).toHaveBeenCalledTimes(1);
+
+    timer.stop();
+  });
+});

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -39,6 +39,8 @@ describe("ConfigSchema", () => {
     expect(result.model.default).toBe("gpt-5.4");
     expect(result.model.default_reasoning_effort).toBeNull();
     expect(result.tls.force_http11).toBe(false);
+    expect(result.usage_stats.snapshot_interval_minutes).toBe(5);
+    expect(result.usage_stats.history_retention_days).toBeNull();
     expect(result.quota.refresh_interval_minutes).toBe(5);
     expect(result.quota.warning_thresholds.primary).toEqual([80, 90]);
     expect(result.quota.skip_exhausted).toBe(true);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -93,6 +93,7 @@ describe("config", () => {
     expect(config.api.base_url).toBe("https://chatgpt.com/backend-api");
     expect(config.server.port).toBe(8080);
     expect(config.model.default).toBe("gpt-5.4");
+    expect(config.usage_stats.snapshot_interval_minutes).toBe(5);
     expect(config.usage_stats.history_retention_days).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- keep the usage stats UI on selected history-window totals
- add an independent usage_stats.snapshot_interval_minutes setting, defaulting to 5 minutes
- stop tying local usage history snapshots to quota.refresh_interval_minutes, so quota refresh can be disabled without making history stay at zero

## Tests
- npx vitest run tests/unit/auth/usage-refresher.test.ts tests/unit/config-schema.test.ts tests/unit/config.test.ts
- cd web && npx vitest run src/pages/__tests__/usage-stats.test.tsx
- npm run build
- git diff --check