### PR TITLE
Refactor proxy handlers to use options objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Changed
 
+- `handleProxyRequest` / `handleDirectRequest` 改为 named options object 调用契约，顺带把 private `handleNonStreaming` 的 20 个位置参数收敛成内部 options object，避免后续新增可选上下文时错位；所有 route 调用与直接 handler 测试同步迁移，并补 direct upstream route guard 锁住 adapter/raw model/format tag 传递（`src/routes/shared/proxy-handler.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/upstream-auth-bypass.test.ts`）
 - 更新提示默认不再弹窗：新增 `update.show_update_dialog`（默认 `false`），Dashboard 设置页可手动开启“显示更新弹窗”。Web 自更新弹窗与 Electron 自动更新的系统对话框都受该开关控制；更新检查和托盘/菜单入口仍保留，避免默认后台检查打断使用
 - `src/routes/api-keys.ts` 简化第三方 API key 绑定路由：合并 add/import 的重复 Zod schema，统一 JSON 解析与校验错误返回，复用按 `models` 展开写入的逻辑，并新增 `tests/unit/routes/api-keys.test.ts` 覆盖添加、导入、导出、custom provider 校验与批量删除，确保行为不变
 - README / README_EN 的 Codex CLI + Codex Desktop 两节示例从 `env_key = "PROXY_API_KEY"` 改成 `[model_providers.proxy_codex.http_headers]` 内嵌 `Authorization = "Bearer ..."`：原写法在 GUI 客户端启动时会因为 macOS / Windows GUI 进程不继承 shell rc 的环境变量而报 `Missing environment variable: PROXY_API_KEY`，普通用户得额外学 `launchctl setenv` 或 LaunchAgent 才能让 Codex Desktop 看到环境变量；http_headers 把 key 直接写在 config 文件里，重启 Codex 即用。`env_key` 写法作为「需要密钥从配置文件解耦」（多人共享 / 仓库提交）场景的备选保留在文档说明里

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -155,7 +155,7 @@ export function createChatRoutes(
         model: req.model,
         codexRequest: { ...codexRequest, model: req.model },
       };
-      return handleDirectRequest(c, routeMatch.adapter, directReq, fmt);
+      return handleDirectRequest({ c, upstream: routeMatch.adapter, req: directReq, fmt });
     }
 
     // Auth check for Codex route only
@@ -173,7 +173,7 @@ export function createChatRoutes(
 
     const summary = accountPool.getPoolSummary();
     if (summary.active === 0) {
-      return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);
+      return handleProxyRequest({ c, accountPool, cookieJar, req: proxyReq, fmt, proxyPool });
     }
 
     const config = getConfig();
@@ -193,7 +193,7 @@ export function createChatRoutes(
       }
     }
 
-    return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);
+    return handleProxyRequest({ c, accountPool, cookieJar, req: proxyReq, fmt, proxyPool });
   });
 
   return app;

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -174,10 +174,10 @@ export function createGeminiRoutes(
 
     if (routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter") {
       const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: geminiModel } };
-      return handleDirectRequest(c, routeMatch.adapter, directReq, GEMINI_FORMAT);
+      return handleDirectRequest({ c, upstream: routeMatch.adapter, req: directReq, fmt: GEMINI_FORMAT });
     }
 
-    return handleProxyRequest(c, accountPool, cookieJar, proxyReq, GEMINI_FORMAT, proxyPool);
+    return handleProxyRequest({ c, accountPool, cookieJar, req: proxyReq, fmt: GEMINI_FORMAT, proxyPool });
   });
 
   // List available models (Gemini format)

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -172,10 +172,10 @@ export function createMessagesRoutes(
         model: req.model,
         codexRequest: { ...codexRequest, model: req.model },
       };
-      return handleDirectRequest(c, routeMatch.adapter, directReq, fmt);
+      return handleDirectRequest({ c, upstream: routeMatch.adapter, req: directReq, fmt });
     }
 
-    return handleProxyRequest(c, accountPool, cookieJar, proxyReq, fmt, proxyPool);
+    return handleProxyRequest({ c, accountPool, cookieJar, req: proxyReq, fmt, proxyPool });
   });
 
   return app;

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -638,7 +638,7 @@ async function handleCompact(
       model: rawModel,
       isStreaming: false,
     };
-    return handleDirectRequest(c, compactRouteMatch.adapter, directReq, PASSTHROUGH_FORMAT);
+    return handleDirectRequest({ c, upstream: compactRouteMatch.adapter, req: directReq, fmt: PASSTHROUGH_FORMAT });
   }
 
   // Acquire account
@@ -906,11 +906,11 @@ export function createResponsesRoutes(
 
     if (routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter") {
       // Use raw model name so adapter's extractModelId can strip the provider prefix
-      const directReq = { ...proxyReq, codexRequest: { ...codexRequest, model: rawModel } };
-      return handleDirectRequest(c, routeMatch.adapter, directReq, PASSTHROUGH_FORMAT);
+      const directReq = { ...proxyReq, model: rawModel, codexRequest: { ...codexRequest, model: rawModel } };
+      return handleDirectRequest({ c, upstream: routeMatch.adapter, req: directReq, fmt: PASSTHROUGH_FORMAT });
     }
 
-    return handleProxyRequest(c, accountPool, cookieJar, proxyReq, PASSTHROUGH_FORMAT, proxyPool);
+    return handleProxyRequest({ c, accountPool, cookieJar, req: proxyReq, fmt: PASSTHROUGH_FORMAT, proxyPool });
   };
 
   // ── POST /v1/responses/compact — non-streaming JSON proxy ──

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -104,6 +104,22 @@ export interface FormatAdapter {
   }>;
 }
 
+export interface HandleProxyRequestOptions {
+  c: Context;
+  accountPool: AccountPool;
+  cookieJar?: CookieJar;
+  req: ProxyRequest;
+  fmt: FormatAdapter;
+  proxyPool?: ProxyPool;
+}
+
+export interface HandleDirectRequestOptions {
+  c: Context;
+  upstream: UpstreamAdapter;
+  req: ProxyRequest;
+  fmt: FormatAdapter;
+}
+
 const MAX_EMPTY_RETRIES = 2;
 
 /** Upper bound on how stale an implicit-resume `previous_response_id` may be.
@@ -320,14 +336,8 @@ function streamErrorResponse(
   });
 }
 
-export async function handleProxyRequest(
-  c: Context,
-  accountPool: AccountPool,
-  cookieJar: CookieJar | undefined,
-  req: ProxyRequest,
-  fmt: FormatAdapter,
-  proxyPool?: ProxyPool,
-): Promise<Response> {
+export async function handleProxyRequest(options: HandleProxyRequestOptions): Promise<Response> {
+  const { c, accountPool, cookieJar, req, fmt, proxyPool } = options;
   c.set("logForwarded", true);
 
   const affinityMap = getSessionAffinityMap();
@@ -709,32 +719,32 @@ export async function handleProxyRequest(
       }
 
       // ── Non-streaming path (with empty-response retry) ──
-      return await handleNonStreaming(
+      return await handleNonStreaming({
         c,
         accountPool,
         cookieJar,
         req,
         fmt,
         proxyPool,
-        codexApi,
-        rawResponse,
-        entryId,
+        initialApi: codexApi,
+        initialResponse: rawResponse,
+        initialEntryId: entryId,
         abortController,
         released,
         requestId,
         affinityMap,
-        chainConversationId,
-        upstreamTurnState,
-        () => activeUsageHint,
+        conversationId: chainConversationId,
+        turnState: upstreamTurnState,
+        getUsageHint: () => activeUsageHint,
         restoreImplicitResumeRequest,
         buildPoolCtx,
-        (nextEntryId, nextApi) => {
+        setActiveAccount: (nextEntryId, nextApi) => {
           entryId = nextEntryId;
           codexApi = nextApi;
           if (!triedEntryIds.includes(nextEntryId)) triedEntryIds.push(nextEntryId);
         },
         variantHash,
-      );
+      });
     } catch (err) {
       if (!(err instanceof CodexApiError)) {
         releaseAccount(accountPool, entryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
@@ -854,31 +864,52 @@ export async function handleProxyRequest(
   }
 }
 
-// TODO: this signature has grown to 14 positional params with 7 trailing
-// optionals. Future work: refactor to an options object so adding a new
-// optional doesn't risk callers slotting it into the wrong position.
-async function handleNonStreaming(
-  c: Context,
-  accountPool: AccountPool,
-  cookieJar: CookieJar | undefined,
-  req: ProxyRequest,
-  fmt: FormatAdapter,
-  proxyPool: ProxyPool | undefined,
-  initialApi: CodexApi,
-  initialResponse: Response,
-  initialEntryId: string,
-  abortController: AbortController,
-  released: Set<string>,
-  requestId: string,
-  affinityMap?: SessionAffinityMap,
-  conversationId?: string,
-  turnState?: string,
-  getUsageHint?: () => UsageHint | undefined,
-  restoreImplicitResumeRequest?: () => void,
-  buildPoolCtx?: (forEntryId: string) => WsPoolContext | undefined,
-  setActiveAccount?: (entryId: string, api: CodexApi) => void,
-  variantHash?: string,
-): Promise<Response> {
+interface HandleNonStreamingOptions {
+  c: Context;
+  accountPool: AccountPool;
+  cookieJar?: CookieJar;
+  req: ProxyRequest;
+  fmt: FormatAdapter;
+  proxyPool?: ProxyPool;
+  initialApi: CodexApi;
+  initialResponse: Response;
+  initialEntryId: string;
+  abortController: AbortController;
+  released: Set<string>;
+  requestId: string;
+  affinityMap?: SessionAffinityMap;
+  conversationId?: string | null;
+  turnState?: string;
+  getUsageHint?: () => UsageHint | undefined;
+  restoreImplicitResumeRequest?: () => void;
+  buildPoolCtx?: (forEntryId: string) => WsPoolContext | undefined;
+  setActiveAccount?: (entryId: string, api: CodexApi) => void;
+  variantHash?: string;
+}
+
+async function handleNonStreaming(options: HandleNonStreamingOptions): Promise<Response> {
+  const {
+    c,
+    accountPool,
+    cookieJar,
+    req,
+    fmt,
+    proxyPool,
+    initialApi,
+    initialResponse,
+    initialEntryId,
+    abortController,
+    released,
+    requestId,
+    affinityMap,
+    conversationId,
+    turnState,
+    getUsageHint,
+    restoreImplicitResumeRequest,
+    buildPoolCtx,
+    setActiveAccount,
+    variantHash,
+  } = options;
   let currentEntryId = initialEntryId;
   let currentApi = initialApi;
   let currentRawResponse = initialResponse;
@@ -1064,12 +1095,8 @@ async function handleNonStreaming(
  * Lightweight handler for API-key-based upstreams (OpenAI, Anthropic, Gemini, custom).
  * No account pool management, no session affinity, no retry logic — just proxy + translate.
  */
-export async function handleDirectRequest(
-  c: Context,
-  upstream: UpstreamAdapter,
-  req: ProxyRequest,
-  fmt: FormatAdapter,
-): Promise<Response> {
+export async function handleDirectRequest(options: HandleDirectRequestOptions): Promise<Response> {
+  const { c, upstream, req, fmt } = options;
   const abortController = new AbortController();
   c.req.raw.signal.addEventListener("abort", () => abortController.abort(), { once: true });
 

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -147,13 +147,13 @@ function buildTestApp(opts: {
 
   const app = new Hono();
   app.post("/test", (c) =>
-    handleProxyRequest(
+    handleProxyRequest({
       c,
-      accountPool as never,
+      accountPool: accountPool as never,
       cookieJar,
-      proxyReq,
+      req: proxyReq,
       fmt,
-    ),
+    }),
   );
 
   return { app, accountPool, fmt, proxyReq };

--- a/tests/unit/routes/implicit-resume-from-derived-key.test.ts
+++ b/tests/unit/routes/implicit-resume-from-derived-key.test.ts
@@ -173,17 +173,16 @@ function createDirectProxyRoutes(pool: AccountPool): Hono {
   const app = new Hono();
   app.post("/direct", async (c) => {
     const codexRequest = await c.req.json<CodexResponsesRequest>();
-    return handleProxyRequest(
+    return handleProxyRequest({
       c,
-      pool,
-      undefined,
-      {
+      accountPool: pool,
+      req: {
         codexRequest,
         model: codexRequest.model,
         isStreaming: false,
       },
-      directProxyFormat,
-    );
+      fmt: directProxyFormat,
+    });
   });
   return app;
 }

--- a/tests/unit/routes/plan-routing-integration.test.ts
+++ b/tests/unit/routes/plan-routing-integration.test.ts
@@ -200,13 +200,12 @@ describe("plan routing through proxy handler", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(
+      handleProxyRequest({
         c,
-        pool,
-        undefined,
-        makeProxyRequest("gpt-5.4"),
-        createTestFormat(),
-      ),
+        accountPool: pool,
+        req: makeProxyRequest("gpt-5.4"),
+        fmt: createTestFormat(),
+      }),
     );
 
     const res = await app.request("/test", { method: "POST" });
@@ -228,13 +227,12 @@ describe("plan routing through proxy handler", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(
+      handleProxyRequest({
         c,
-        pool,
-        undefined,
-        makeProxyRequest("gpt-5.4"),
-        createTestFormat(),
-      ),
+        accountPool: pool,
+        req: makeProxyRequest("gpt-5.4"),
+        fmt: createTestFormat(),
+      }),
     );
 
     const res = await app.request("/test", { method: "POST" });
@@ -248,13 +246,12 @@ describe("plan routing through proxy handler", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(
+      handleProxyRequest({
         c,
-        pool,
-        undefined,
-        makeProxyRequest("gpt-5.4"),
-        createTestFormat(),
-      ),
+        accountPool: pool,
+        req: makeProxyRequest("gpt-5.4"),
+        fmt: createTestFormat(),
+      }),
     );
 
     // Blocked — free can't use team-only model
@@ -282,13 +279,12 @@ describe("plan routing through proxy handler", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(
+      handleProxyRequest({
         c,
-        pool,
-        undefined,
-        makeProxyRequest("gpt-5.4"),
-        createTestFormat(),
-      ),
+        accountPool: pool,
+        req: makeProxyRequest("gpt-5.4"),
+        fmt: createTestFormat(),
+      }),
     );
 
     const res = await app.request("/test", { method: "POST" });
@@ -306,13 +302,12 @@ describe("plan routing through proxy handler", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(
+      handleProxyRequest({
         c,
-        pool,
-        undefined,
-        makeProxyRequest("gpt-5.4"),
-        createTestFormat(),
-      ),
+        accountPool: pool,
+        req: makeProxyRequest("gpt-5.4"),
+        fmt: createTestFormat(),
+      }),
     );
 
     const res = await app.request("/test", { method: "POST" });

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -7,7 +7,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
+import type { HandleDirectRequestOptions } from "@src/routes/shared/proxy-handler.js";
 
 // ── Mocks (before imports) ──────────────────────────────────────────
 
@@ -78,10 +79,10 @@ vi.mock("@src/utils/retry.js", () => ({
 }));
 
 // Mock shared proxy handler
-const mockHandleDirectRequest = vi.fn(async (c) => c.json({ ok: true }));
+const mockHandleDirectRequest = vi.fn(async (options: HandleDirectRequestOptions) => options.c.json({ ok: true }));
 vi.mock("@src/routes/shared/proxy-handler.js", () => ({
-  handleProxyRequest: vi.fn(async (c) => c.json({ ok: true })),
-  handleDirectRequest: (...args: unknown[]) => mockHandleDirectRequest(...args),
+  handleProxyRequest: vi.fn(async (options: { c: Context }) => options.c.json({ ok: true })),
+  handleDirectRequest: (options: HandleDirectRequestOptions) => mockHandleDirectRequest(options),
   staggerIfNeeded: vi.fn(async () => {}),
 }));
 
@@ -125,7 +126,7 @@ describe("POST /v1/responses/compact", () => {
     mockCompactResponse = { output: [{ role: "user", content: "compacted" }] };
     mockCompactThrow = null;
     mockConfig.server.proxy_api_key = null;
-    mockHandleDirectRequest.mockImplementation(async (c) => c.json({ ok: true }));
+    mockHandleDirectRequest.mockImplementation(async (options: HandleDirectRequestOptions) => options.c.json({ ok: true }));
     loadStaticModels();
     pool = new AccountPool();
     pool.addAccount("test-token-1");
@@ -171,7 +172,7 @@ describe("POST /v1/responses/compact", () => {
 
     expect(res.status).toBe(200);
     expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
-    const [, , directReq] = mockHandleDirectRequest.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    const directReq = mockHandleDirectRequest.mock.calls[0][0].req as Record<string, unknown>;
     expect(directReq.model).toBe("my-custom-model");
     expect(directReq.isStreaming).toBe(false);
     expect(directReq.codexRequest).toEqual({

--- a/tests/unit/routes/responses-optional-instructions.test.ts
+++ b/tests/unit/routes/responses-optional-instructions.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
+import type { HandleProxyRequestOptions } from "@src/routes/shared/proxy-handler.js";
 
 // ── Mocks (before imports) ──────────────────────────────────────────
 
@@ -78,9 +79,9 @@ vi.mock("@src/utils/retry.js", () => ({
 let capturedCodexRequest: unknown = null;
 
 vi.mock("@src/routes/shared/proxy-handler.js", () => ({
-  handleProxyRequest: vi.fn(async (c, _pool, _jar, proxyReq) => {
-    capturedCodexRequest = proxyReq.codexRequest;
-    return c.json({ ok: true });
+  handleProxyRequest: vi.fn(async (options: HandleProxyRequestOptions) => {
+    capturedCodexRequest = options.req.codexRequest;
+    return options.c.json({ ok: true });
   }),
 }));
 

--- a/tests/unit/routes/shared/error-forwarding.test.ts
+++ b/tests/unit/routes/shared/error-forwarding.test.ts
@@ -149,7 +149,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(404);
@@ -172,7 +172,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(502);
@@ -198,7 +198,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(429);
@@ -217,7 +217,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(429);
@@ -239,7 +239,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(400);
@@ -258,7 +258,7 @@ describe("handleDirectRequest error forwarding", () => {
     const req = createDefaultRequest();
     const fmt = createMockFormatAdapter();
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     expect(res.status).toBe(502);
@@ -278,7 +278,7 @@ describe("handleDirectRequest error forwarding", () => {
       }),
     });
 
-    app.post("/test", (c) => handleDirectRequest(c, upstream as never, req, fmt));
+    app.post("/test", (c) => handleDirectRequest({ c, upstream: upstream as never, req, fmt }));
 
     const res = await app.request("/test", { method: "POST" });
     await res.text();
@@ -313,7 +313,7 @@ describe("handleProxyRequest uses proxy error format (no passthrough)", () => {
 
     const app = new Hono();
     app.post("/test", (c) =>
-      handleProxyRequest(c, accountPool as never, undefined, req, fmt),
+      handleProxyRequest({ c, accountPool: accountPool as never, req, fmt }),
     );
 
     const res = await app.request("/test", { method: "POST" });

--- a/tests/unit/routes/upstream-auth-bypass.test.ts
+++ b/tests/unit/routes/upstream-auth-bypass.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
+import type { UpstreamAdapter } from "@src/proxy/upstream-adapter.js";
+import type { HandleDirectRequestOptions } from "@src/routes/shared/proxy-handler.js";
 
 const mockConfig = {
   server: { proxy_api_key: null as string | null },
@@ -66,10 +68,11 @@ vi.mock("@src/utils/retry.js", () => ({
   withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
-const mockHandleDirectRequest = vi.fn(async (c) => c.json({ ok: true }));
+const mockHandleDirectRequest = vi.fn(async (options: HandleDirectRequestOptions) => options.c.json({ ok: true }));
+const mockHandleProxyRequest = vi.fn(async (options: { c: Context }) => options.c.json({ proxied: true }));
 vi.mock("@src/routes/shared/proxy-handler.js", () => ({
-  handleProxyRequest: vi.fn(async (c) => c.json({ proxied: true })),
-  handleDirectRequest: (...args: unknown[]) => mockHandleDirectRequest(...args),
+  handleProxyRequest: (options: { c: Context }) => mockHandleProxyRequest(options),
+  handleDirectRequest: (options: HandleDirectRequestOptions) => mockHandleDirectRequest(options),
 }));
 
 import { AccountPool } from "@src/auth/account-pool.js";
@@ -79,19 +82,42 @@ import { createMessagesRoutes } from "@src/routes/messages.js";
 import { createGeminiRoutes } from "@src/routes/gemini.js";
 import { createResponsesRoutes } from "@src/routes/responses.js";
 
+function createSentinelAdapter(tag: string): UpstreamAdapter {
+  return {
+    tag,
+    createResponse: vi.fn(async () => new Response()),
+    parseStream: vi.fn(async function* () {}),
+  };
+}
+
+function expectDirectOptions(expected: {
+  adapter: UpstreamAdapter;
+  model: string;
+  formatTag: string;
+}): void {
+  expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
+  const [options] = mockHandleDirectRequest.mock.calls[0] as [HandleDirectRequestOptions];
+  expect(options.upstream).toBe(expected.adapter);
+  expect(options.req.model).toBe(expected.model);
+  expect(options.req.codexRequest.model).toBe(expected.model);
+  expect(options.fmt.tag).toBe(expected.formatTag);
+  expect(mockHandleProxyRequest).not.toHaveBeenCalled();
+}
+
 describe("upstream direct routing without Codex auth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfig.server.proxy_api_key = null;
-    mockHandleDirectRequest.mockImplementation(async (c) => c.json({ ok: true }));
+    mockHandleDirectRequest.mockImplementation(async (options: HandleDirectRequestOptions) => options.c.json({ ok: true }));
     loadStaticModels();
   });
 
   it("allows OpenAI chat direct upstream routing without local accounts", async () => {
     const pool = new AccountPool();
+    const adapter = createSentinelAdapter("custom-upstream");
     const app = createChatRoutes(pool, undefined, undefined, {
-      resolveMatch: vi.fn(() => ({ kind: "adapter" })),
-      resolve: vi.fn(() => ({ tag: "custom-upstream" })),
+      resolveMatch: vi.fn(() => ({ kind: "adapter", adapter })),
+      resolve: vi.fn(() => adapter),
     } as never);
 
     const res = await app.request("/v1/chat/completions", {
@@ -104,14 +130,90 @@ describe("upstream direct routing without Codex auth", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
-    const [, , directReq] = mockHandleDirectRequest.mock.calls[0] as [
-      unknown,
-      unknown,
-      { codexRequest: { tools?: unknown[] } },
-      unknown,
-    ];
-    expect(directReq.codexRequest.tools).toEqual([]);
+    expectDirectOptions({ adapter, model: "my-custom-model", formatTag: "Chat" });
+    expect(mockHandleDirectRequest.mock.calls[0][0].req.codexRequest.tools).toEqual([]);
+    pool.destroy();
+  });
+
+  it.each([
+    {
+      name: "chat",
+      formatTag: "Chat",
+      model: "my-custom-model",
+      makeApp: (pool: AccountPool, adapter: UpstreamAdapter) =>
+        createChatRoutes(pool, undefined, undefined, {
+          resolveMatch: vi.fn(() => ({ kind: "adapter", adapter })),
+          resolve: vi.fn(() => adapter),
+        } as never),
+      path: "/v1/chat/completions",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        model: "my-custom-model",
+        messages: [{ role: "user", content: "hello" }],
+      },
+    },
+    {
+      name: "messages",
+      formatTag: "Messages",
+      model: "claude-opus-4-6",
+      makeApp: (pool: AccountPool, adapter: UpstreamAdapter) =>
+        createMessagesRoutes(pool, undefined, undefined, {
+          resolveMatch: vi.fn(() => ({ kind: "adapter", adapter })),
+        } as never),
+      path: "/v1/messages",
+      headers: { "Content-Type": "application/json", "anthropic-version": "2023-06-01" },
+      body: {
+        model: "claude-opus-4-6",
+        max_tokens: 16,
+        messages: [{ role: "user", content: "hello" }],
+      },
+    },
+    {
+      name: "responses",
+      formatTag: "Responses",
+      model: "my-custom-model",
+      makeApp: (pool: AccountPool, adapter: UpstreamAdapter) =>
+        createResponsesRoutes(pool, undefined, undefined, {
+          resolveMatch: vi.fn(() => ({ kind: "adapter", adapter })),
+        } as never),
+      path: "/v1/responses",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        model: "my-custom-model",
+        input: [{ role: "user", content: "hello" }],
+      },
+    },
+    {
+      name: "gemini",
+      formatTag: "Gemini",
+      model: "gemini-2.5-pro",
+      makeApp: (pool: AccountPool, adapter: UpstreamAdapter) =>
+        createGeminiRoutes(pool, undefined, undefined, {
+          resolveMatch: vi.fn(() => ({ kind: "adapter", adapter })),
+        } as never),
+      path: "/v1beta/models/gemini-2.5-pro:generateContent",
+      headers: { "Content-Type": "application/json" },
+      body: {
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+      },
+    },
+  ])("passes $name direct routes to handleDirectRequest with named options", async (testCase) => {
+    const pool = new AccountPool();
+    const adapter = createSentinelAdapter(`sentinel-${testCase.name}`);
+    const app = testCase.makeApp(pool, adapter);
+
+    const res = await app.request(testCase.path, {
+      method: "POST",
+      headers: testCase.headers,
+      body: JSON.stringify(testCase.body),
+    });
+
+    expect(res.status).toBe(200);
+    expectDirectOptions({
+      adapter,
+      model: testCase.model,
+      formatTag: testCase.formatTag,
+    });
     pool.destroy();
   });
 
@@ -171,18 +273,13 @@ describe("upstream direct routing without Codex auth", () => {
 
     expect(res.status).toBe(200);
     expect(mockHandleDirectRequest).toHaveBeenCalledTimes(1);
-    const [, , directReq] = mockHandleDirectRequest.mock.calls[0] as [
-      unknown,
-      unknown,
-      {
-        codexRequest: {
-          useWebSocket?: boolean;
-          tools?: unknown[];
-          tool_choice?: unknown;
-        };
-      },
-      unknown,
-    ];
+    const directReq = mockHandleDirectRequest.mock.calls[0][0].req as {
+      codexRequest: {
+        useWebSocket?: boolean;
+        tools?: unknown[];
+        tool_choice?: unknown;
+      };
+    };
     expect(directReq.codexRequest.useWebSocket).toBeUndefined();
     expect(directReq.codexRequest.tools).toEqual([
       {


### PR DESCRIPTION
## Summary
- Convert handleProxyRequest and handleDirectRequest to named options objects and migrate route/test call sites.
- Convert the private handleNonStreaming helper from a long positional argument list to an internal options object.
- Add direct upstream route guard coverage for adapter identity, raw model propagation, format tag, and avoiding the Codex proxy path.

## Verification
- RED: npx vitest run tests/unit/routes/upstream-auth-bypass.test.ts failed before implementation because routes still called handleDirectRequest positionally.
- npx vitest run tests/unit/routes/upstream-auth-bypass.test.ts
- npx vitest run tests/unit/routes/upstream-auth-bypass.test.ts tests/unit/routes/shared/response-processor.test.ts tests/integration/proxy-handler.test.ts tests/unit/routes/shared/error-forwarding.test.ts tests/unit/routes/responses-compact.test.ts tests/unit/routes/responses-optional-instructions.test.ts tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/unit/routes/plan-routing-integration.test.ts
- npx vitest run tests/e2e/chat.test.ts tests/e2e/messages.test.ts tests/e2e/responses.test.ts tests/e2e/gemini.test.ts
- npm run build
- npx vitest run --exclude tests/unit/update-scripts-path.test.ts
- git diff --check

## Known base issue
- npm test currently fails on origin/dev in tests/unit/update-scripts-path.test.ts because that test expects scripts/build/check-update.ts and scripts/build/apply-update.ts, but origin/dev only tracks scripts/build/extract-fingerprint.ts. This branch intentionally does not stack on PR #509; PR #509 contains the missing package-boundary/update script files.