### PR TITLE
refactor: extract proxy fallback retry planning

### DIFF
--- a/src/routes/shared/proxy-fallback-retry-plan.ts
+++ b/src/routes/shared/proxy-fallback-retry-plan.ts
@@ -1,0 +1,42 @@
+import type { ErrorAction } from "./proxy-error-handler.js";
+import {
+  buildAccountExhaustionDetail,
+  type AccountPoolSummary,
+} from "./proxy-error-response.js";
+
+export type ProxyFallbackAvailability =
+  | { available: true }
+  | { available: false; summary: AccountPoolSummary };
+
+type RetryDecision = Extract<ErrorAction, { action: "retry" }>;
+
+export type ProxyFallbackRetryPlan =
+  | { action: "acquire" }
+  | {
+      action: "respond";
+      status: number;
+      message: string;
+      useFormat429?: true;
+    };
+
+export interface BuildProxyFallbackRetryPlanOptions {
+  decision: RetryDecision;
+  availability: ProxyFallbackAvailability;
+}
+
+export function buildProxyFallbackRetryPlan(
+  options: BuildProxyFallbackRetryPlanOptions,
+): ProxyFallbackRetryPlan {
+  const { decision, availability } = options;
+
+  if (availability.available) {
+    return { action: "acquire" };
+  }
+
+  return {
+    action: "respond",
+    status: decision.status,
+    message: buildAccountExhaustionDetail(availability.summary, decision.message),
+    ...(decision.useFormat429 ? { useFormat429: true } : {}),
+  };
+}

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -6,6 +6,7 @@
  *   - account-acquisition.ts  — acquire / release with idempotent guard
  *   - proxy-egress-log.ts     — upstream request audit log entries
  *   - proxy-error-handler.ts  — CodexApiError classification + pool state mutations
+ *   - proxy-fallback-retry-plan.ts — account fallback retry response planning
  *   - proxy-debug-dump.ts     — opt-in request payload diagnostics
  *   - proxy-request-diagnostics.ts — request summary / large payload logs
  *   - proxy-stagger.ts        — request interval staggering
@@ -32,10 +33,10 @@ import { getSessionAffinityMap } from "../../auth/session-affinity.js";
 import { randomUUID } from "crypto";
 import { computeVariantHash } from "./variant-hash.js";
 import {
-  buildAccountExhaustionDetail,
   respondWithNoAccount,
   respondWithProxyError,
 } from "./proxy-error-response.js";
+import { buildProxyFallbackRetryPlan } from "./proxy-fallback-retry-plan.js";
 import { recordProxyEgressLog } from "./proxy-egress-log.js";
 import { applyParsedRateLimits, applyRateLimitHeaders, type ApplyParsedRateLimitsOptions } from "./proxy-rate-limit.js";
 import { buildRequestDiagnostics } from "./proxy-request-diagnostics.js";
@@ -361,19 +362,21 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         modelRetried = true;
       }
 
-      // Early exit: skip acquire overhead when no active accounts remain.
-      // Lock already cleared by handleCodexApiError (markRateLimited/markStatus
-      // → clearLock), so no releaseAccount call needed — matches existing !retry path.
-      if (!accountPool.hasAvailableAccounts(triedEntryIds)) {
-        const summary = accountPool.getPoolSummary();
-        const detail = buildAccountExhaustionDetail(summary, decision.message);
+      const fallbackAvailability = accountPool.hasAvailableAccounts(triedEntryIds)
+        ? { available: true } as const
+        : { available: false, summary: accountPool.getPoolSummary() } as const;
+      const fallbackPlan = buildProxyFallbackRetryPlan({
+        decision,
+        availability: fallbackAvailability,
+      });
+      if (fallbackPlan.action === "respond") {
         return respondWithProxyError({
           c,
           req,
           fmt,
-          status: decision.status,
-          message: detail,
-          useFormat429: decision.useFormat429,
+          status: fallbackPlan.status,
+          message: fallbackPlan.message,
+          ...(fallbackPlan.useFormat429 ? { useFormat429: true } : {}),
         });
       }
 

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -811,6 +811,7 @@ describe("proxy-handler integration", () => {
     const message = fmt.format429.mock.calls[0][0] as string;
     expect(message).toContain("All accounts exhausted");
     expect(message).toContain("2 rate-limited");
+    expect(accountPool.acquire).toHaveBeenCalledTimes(1);
   });
 
   // 17. previous_response_not_found: should strip previous_response_id and retry

--- a/tests/unit/routes/shared/proxy-error-response-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-error-response-boundary.test.ts
@@ -73,7 +73,7 @@ describe("proxy error response module boundary", () => {
 
     expect(importsNamedBinding(proxyHandler, "proxy-error-response.js", "respondWithNoAccount", PROXY_HANDLER_MODULE)).toBe(true);
     expect(importsNamedBinding(proxyHandler, "proxy-error-response.js", "respondWithProxyError", PROXY_HANDLER_MODULE)).toBe(true);
-    expect(importsNamedBinding(proxyHandler, "proxy-error-response.js", "buildAccountExhaustionDetail", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-error-response.js", "buildAccountExhaustionDetail", PROXY_HANDLER_MODULE)).toBe(false);
     expect(importedModuleSpecifiers(proxyHandler, PROXY_HANDLER_MODULE)).not.toEqual(expect.arrayContaining([
       "hono/utils/http-status",
       "./stream-error-response.js",

--- a/tests/unit/routes/shared/proxy-fallback-retry-plan-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-fallback-retry-plan-boundary.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as fallbackRetryPlan from "@src/routes/shared/proxy-fallback-retry-plan.js";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const FALLBACK_RETRY_PLAN_MODULE = "src/routes/shared/proxy-fallback-retry-plan.ts";
+const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
+
+function source(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function parseSource(path: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleSpecifierText(node: ts.ImportDeclaration): string | null {
+  const moduleSpecifier = node.moduleSpecifier;
+  return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null;
+}
+
+function importsNamedBinding(content: string, moduleSuffix: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const specifier = moduleSpecifierText(statement);
+    if (!specifier?.endsWith(moduleSuffix)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importedModuleSpecifiers(content: string, path = "inline.ts"): string[] {
+  const file = parseSource(path, content);
+  return file.statements
+    .filter(ts.isImportDeclaration)
+    .map(moduleSpecifierText)
+    .filter((specifier): specifier is string => Boolean(specifier));
+}
+
+function importsNamedBindingFromAnyModule(content: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("proxy fallback retry plan module boundary", () => {
+  it("exports the fallback retry planning helper from its own module", () => {
+    expect(fallbackRetryPlan.buildProxyFallbackRetryPlan).toBeTypeOf("function");
+  });
+
+  it("keeps account exhaustion response planning out of the proxy orchestrator", () => {
+    const proxyHandler = source(PROXY_HANDLER_MODULE);
+
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-fallback-retry-plan.js",
+      "buildProxyFallbackRetryPlan",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(importsNamedBindingFromAnyModule(
+      proxyHandler,
+      "buildAccountExhaustionDetail",
+      PROXY_HANDLER_MODULE,
+    )).toBe(false);
+  });
+
+  it("keeps account switching side effects out of the fallback retry planner", () => {
+    const fallbackRetryPlan = source(FALLBACK_RETRY_PLAN_MODULE);
+
+    expect(importedModuleSpecifiers(fallbackRetryPlan, FALLBACK_RETRY_PLAN_MODULE)).not.toEqual(expect.arrayContaining([
+      "./account-acquisition.js",
+      "./proxy-handler-utils.js",
+      "./proxy-stagger.js",
+      "./proxy-handler.js",
+      "hono",
+    ]));
+  });
+});

--- a/tests/unit/routes/shared/proxy-fallback-retry-plan.test.ts
+++ b/tests/unit/routes/shared/proxy-fallback-retry-plan.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProxyFallbackRetryPlan,
+  type ProxyFallbackAvailability,
+} from "@src/routes/shared/proxy-fallback-retry-plan.js";
+import type { ErrorAction } from "@src/routes/shared/proxy-error-handler.js";
+
+type RetryDecision = Extract<ErrorAction, { action: "retry" }>;
+
+const baseRetryDecision = {
+  action: "retry",
+  status: 429,
+  message: "Rate limited",
+  useFormat429: true,
+} satisfies RetryDecision;
+
+const exhaustedAvailability = {
+  available: false,
+  summary: {
+    total: 2,
+    active: 0,
+    expired: 0,
+    quota_exhausted: 0,
+    rate_limited: 2,
+    refreshing: 0,
+    disabled: 0,
+    banned: 0,
+  },
+} satisfies ProxyFallbackAvailability;
+
+describe("buildProxyFallbackRetryPlan", () => {
+  it("continues to fallback account acquisition when an untried account is available", () => {
+    const plan = buildProxyFallbackRetryPlan({
+      decision: baseRetryDecision,
+      availability: { available: true },
+    });
+
+    expect(plan).toEqual({ action: "acquire" });
+  });
+
+  it("returns a formatted exhaustion response plan when no retry account remains", () => {
+    const plan = buildProxyFallbackRetryPlan({
+      decision: baseRetryDecision,
+      availability: exhaustedAvailability,
+    });
+
+    expect(plan).toEqual({
+      action: "respond",
+      status: 429,
+      message: "All accounts exhausted (2 rate-limited). Rate limited",
+      useFormat429: true,
+    });
+  });
+
+  it("does not add format429 when the retry decision does not request it", () => {
+    const plan = buildProxyFallbackRetryPlan({
+      decision: {
+        action: "retry",
+        status: 401,
+        message: "Unauthorized",
+      },
+      availability: exhaustedAvailability,
+    });
+
+    expect(plan).toEqual({
+      action: "respond",
+      status: 401,
+      message: "All accounts exhausted (2 rate-limited). Unauthorized",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract proxy fallback retry response planning into a pure helper
- keep account acquisition, release, API rebuild, and staggering in the proxy orchestrator
- add unit/boundary coverage plus an integration assertion that exhausted fallback does not acquire again

## Verification
- npx vitest run tests/unit/routes/shared/proxy-fallback-retry-plan.test.ts tests/unit/routes/shared/proxy-fallback-retry-plan-boundary.test.ts tests/unit/routes/shared/proxy-error-response-boundary.test.ts tests/integration/proxy-handler.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- npm test
- git diff --check
- no-any scan on changed TS files