### PR TITLE
refactor: extract implicit resume request state

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -7,6 +7,7 @@
  *   - proxy-egress-log.ts     — upstream request audit log entries
  *   - proxy-error-handler.ts  — CodexApiError classification + pool state mutations
  *   - proxy-fallback-retry-plan.ts — account fallback retry response planning
+ *   - proxy-implicit-resume-request.ts — implicit-resume request apply/restore state
  *   - proxy-debug-dump.ts     — opt-in request payload diagnostics
  *   - proxy-request-diagnostics.ts — request summary / large payload logs
  *   - proxy-stagger.ts        — request interval staggering
@@ -37,6 +38,11 @@ import {
   respondWithProxyError,
 } from "./proxy-error-response.js";
 import { buildProxyFallbackRetryPlan } from "./proxy-fallback-retry-plan.js";
+import {
+  applyImplicitResumeRequest,
+  captureImplicitResumeRequestState,
+  restoreImplicitResumeRequestState,
+} from "./proxy-implicit-resume-request.js";
 import { recordProxyEgressLog } from "./proxy-egress-log.js";
 import { applyParsedRateLimits, applyRateLimitHeaders, type ApplyParsedRateLimitsOptions } from "./proxy-rate-limit.js";
 import { buildRequestDiagnostics } from "./proxy-request-diagnostics.js";
@@ -63,10 +69,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   if (!Array.isArray(req.codexRequest.input)) {
     req.codexRequest.input = [];
   }
-  const originalInput = req.codexRequest.input;
-  const originalPreviousResponseId = req.codexRequest.previous_response_id;
-  const originalTurnState = req.codexRequest.turnState;
-  const originalUseWebSocket = req.codexRequest.useWebSocket;
+  const originalRequestState = captureImplicitResumeRequestState(req);
   const currentInstructions = req.codexRequest.instructions;
   const explicitPrevRespId = req.codexRequest.previous_response_id;
   const promptCacheIdentity = resolvePromptCacheIdentity(req.codexRequest, req.clientConversationId);
@@ -169,24 +172,18 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
     );
   }
   if (resumeEval.active) {
-    req.codexRequest.previous_response_id = implicitPrevRespId!;
-    req.codexRequest.useWebSocket = true;
-    req.codexRequest.input = req.codexRequest.input.slice(continuationInputStart);
-    const implicitTurnState = affinityMap.lookupTurnState(implicitPrevRespId!);
-    if (implicitTurnState) req.codexRequest.turnState = implicitTurnState;
-    activeUsageHint = {
-      reusedInputTokensUpperBound: affinityMap.lookupInputTokens(implicitPrevRespId!) ?? undefined,
-    };
+    activeUsageHint = applyImplicitResumeRequest({
+      request: req,
+      implicitPrevRespId: implicitPrevRespId!,
+      continuationInputStart,
+      affinityMap,
+    });
     implicitResumeActive = true;
   }
 
   const restoreImplicitResumeRequest = (): void => {
     if (!implicitResumeActive) return;
-    req.codexRequest.previous_response_id = originalPreviousResponseId;
-    req.codexRequest.turnState = originalTurnState;
-    req.codexRequest.useWebSocket = originalUseWebSocket;
-    req.codexRequest.input = originalInput;
-    req.codexRequest.instructions = currentInstructions;
+    restoreImplicitResumeRequestState({ request: req, snapshot: originalRequestState });
     activeUsageHint = undefined;
     implicitResumeActive = false;
   };

--- a/src/routes/shared/proxy-implicit-resume-request.ts
+++ b/src/routes/shared/proxy-implicit-resume-request.ts
@@ -1,0 +1,66 @@
+import type { ProxyRequest, UsageHint } from "./proxy-handler-types.js";
+
+export interface ImplicitResumeAffinityLookup {
+  lookupTurnState(responseId: string): string | null;
+  lookupInputTokens(responseId: string): number | null;
+}
+
+export interface ImplicitResumeRequestSnapshot {
+  input: ProxyRequest["codexRequest"]["input"];
+  previousResponseId: ProxyRequest["codexRequest"]["previous_response_id"];
+  turnState: ProxyRequest["codexRequest"]["turnState"];
+  useWebSocket: ProxyRequest["codexRequest"]["useWebSocket"];
+  instructions: ProxyRequest["codexRequest"]["instructions"];
+}
+
+export interface ApplyImplicitResumeRequestOptions {
+  request: ProxyRequest;
+  implicitPrevRespId: string;
+  continuationInputStart: number;
+  affinityMap: ImplicitResumeAffinityLookup;
+}
+
+export interface RestoreImplicitResumeRequestStateOptions {
+  request: ProxyRequest;
+  snapshot: ImplicitResumeRequestSnapshot;
+}
+
+export function captureImplicitResumeRequestState(
+  request: ProxyRequest,
+): ImplicitResumeRequestSnapshot {
+  return {
+    input: request.codexRequest.input,
+    previousResponseId: request.codexRequest.previous_response_id,
+    turnState: request.codexRequest.turnState,
+    useWebSocket: request.codexRequest.useWebSocket,
+    instructions: request.codexRequest.instructions,
+  };
+}
+
+export function applyImplicitResumeRequest(
+  options: ApplyImplicitResumeRequestOptions,
+): UsageHint {
+  const { request, implicitPrevRespId, continuationInputStart, affinityMap } = options;
+
+  request.codexRequest.previous_response_id = implicitPrevRespId;
+  request.codexRequest.useWebSocket = true;
+  request.codexRequest.input = request.codexRequest.input.slice(continuationInputStart);
+  const implicitTurnState = affinityMap.lookupTurnState(implicitPrevRespId);
+  if (implicitTurnState) request.codexRequest.turnState = implicitTurnState;
+
+  return {
+    reusedInputTokensUpperBound: affinityMap.lookupInputTokens(implicitPrevRespId) ?? undefined,
+  };
+}
+
+export function restoreImplicitResumeRequestState(
+  options: RestoreImplicitResumeRequestStateOptions,
+): void {
+  const { request, snapshot } = options;
+
+  request.codexRequest.previous_response_id = snapshot.previousResponseId;
+  request.codexRequest.turnState = snapshot.turnState;
+  request.codexRequest.useWebSocket = snapshot.useWebSocket;
+  request.codexRequest.input = snapshot.input;
+  request.codexRequest.instructions = snapshot.instructions;
+}

--- a/tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as implicitResumeRequest from "@src/routes/shared/proxy-implicit-resume-request.js";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
+const IMPLICIT_RESUME_REQUEST_MODULE = "src/routes/shared/proxy-implicit-resume-request.ts";
+
+function source(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function parseSource(path: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleSpecifierText(node: ts.ImportDeclaration): string | null {
+  const moduleSpecifier = node.moduleSpecifier;
+  return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null;
+}
+
+function importsNamedBinding(content: string, moduleSuffix: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const specifier = moduleSpecifierText(statement);
+    if (!specifier?.endsWith(moduleSuffix)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importedModuleSpecifiers(content: string, path = "inline.ts"): string[] {
+  const file = parseSource(path, content);
+  return file.statements
+    .filter(ts.isImportDeclaration)
+    .map(moduleSpecifierText)
+    .filter((specifier): specifier is string => Boolean(specifier));
+}
+
+describe("proxy implicit resume request helper boundary", () => {
+  it("exports request state helpers from their own module", () => {
+    expect(implicitResumeRequest.captureImplicitResumeRequestState).toBeTypeOf("function");
+    expect(implicitResumeRequest.applyImplicitResumeRequest).toBeTypeOf("function");
+    expect(implicitResumeRequest.restoreImplicitResumeRequestState).toBeTypeOf("function");
+  });
+
+  it("keeps implicit-resume request mutation details out of the proxy orchestrator", () => {
+    const proxyHandler = source(PROXY_HANDLER_MODULE);
+
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-implicit-resume-request.js",
+      "captureImplicitResumeRequestState",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-implicit-resume-request.js",
+      "applyImplicitResumeRequest",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-implicit-resume-request.js",
+      "restoreImplicitResumeRequestState",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(proxyHandler).not.toContain("req.codexRequest.previous_response_id = implicitPrevRespId!");
+    expect(proxyHandler).not.toContain("req.codexRequest.input = req.codexRequest.input.slice(continuationInputStart)");
+  });
+
+  it("keeps account lifecycle side effects out of the implicit-resume request helper", () => {
+    const helper = source(IMPLICIT_RESUME_REQUEST_MODULE);
+
+    expect(importedModuleSpecifiers(helper, IMPLICIT_RESUME_REQUEST_MODULE)).not.toEqual(expect.arrayContaining([
+      "./account-acquisition.js",
+      "./proxy-handler-utils.js",
+      "./proxy-stagger.js",
+      "./proxy-handler.js",
+      "hono",
+    ]));
+  });
+});

--- a/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
+++ b/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyImplicitResumeRequest,
+  captureImplicitResumeRequestState,
+  restoreImplicitResumeRequestState,
+  type ImplicitResumeAffinityLookup,
+} from "@src/routes/shared/proxy-implicit-resume-request.js";
+import type { ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
+
+function makeProxyRequest(): ProxyRequest {
+  return {
+    model: "gpt-5.4",
+    isStreaming: true,
+    codexRequest: {
+      model: "gpt-5.4",
+      input: [
+        { role: "user", content: "first" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "continue" },
+      ],
+      instructions: "system-a",
+      previous_response_id: "explicit-prev",
+      turnState: "turn-original",
+      useWebSocket: false,
+      stream: true,
+      store: false,
+    },
+  };
+}
+
+function makeAffinityLookup(options: {
+  turnState?: string | null;
+  inputTokens?: number | null;
+} = {}): ImplicitResumeAffinityLookup {
+  return {
+    lookupTurnState: vi.fn(() => options.turnState ?? null),
+    lookupInputTokens: vi.fn(() => options.inputTokens ?? null),
+  };
+}
+
+describe("implicit resume request state helpers", () => {
+  it("captures the request fields that implicit resume mutates", () => {
+    const request = makeProxyRequest();
+    const snapshot = captureImplicitResumeRequestState(request);
+
+    expect(snapshot).toEqual({
+      input: request.codexRequest.input,
+      previousResponseId: "explicit-prev",
+      turnState: "turn-original",
+      useWebSocket: false,
+      instructions: "system-a",
+    });
+  });
+
+  it("applies implicit resume by using the previous response id, WebSocket, sliced input, and usage hint", () => {
+    const request = makeProxyRequest();
+    const affinityMap = makeAffinityLookup({
+      turnState: "turn-implicit",
+      inputTokens: 123,
+    });
+
+    const usageHint = applyImplicitResumeRequest({
+      request,
+      implicitPrevRespId: "resp_implicit",
+      continuationInputStart: 2,
+      affinityMap,
+    });
+
+    expect(request.codexRequest.previous_response_id).toBe("resp_implicit");
+    expect(request.codexRequest.useWebSocket).toBe(true);
+    expect(request.codexRequest.turnState).toBe("turn-implicit");
+    expect(request.codexRequest.input).toEqual([
+      { role: "user", content: "continue" },
+    ]);
+    expect(usageHint).toEqual({ reusedInputTokensUpperBound: 123 });
+    expect(affinityMap.lookupTurnState).toHaveBeenCalledWith("resp_implicit");
+    expect(affinityMap.lookupInputTokens).toHaveBeenCalledWith("resp_implicit");
+  });
+
+  it("does not overwrite an existing turn state when the affinity map has none", () => {
+    const request = makeProxyRequest();
+
+    applyImplicitResumeRequest({
+      request,
+      implicitPrevRespId: "resp_no_turn",
+      continuationInputStart: 1,
+      affinityMap: makeAffinityLookup(),
+    });
+
+    expect(request.codexRequest.turnState).toBe("turn-original");
+  });
+
+  it("restores the original request fields after an implicit resume retry fallback", () => {
+    const request = makeProxyRequest();
+    const snapshot = captureImplicitResumeRequestState(request);
+
+    applyImplicitResumeRequest({
+      request,
+      implicitPrevRespId: "resp_implicit",
+      continuationInputStart: 2,
+      affinityMap: makeAffinityLookup({ turnState: "turn-implicit", inputTokens: 123 }),
+    });
+    request.codexRequest.instructions = "mutated-system";
+
+    restoreImplicitResumeRequestState({ request, snapshot });
+
+    expect(request.codexRequest.previous_response_id).toBe("explicit-prev");
+    expect(request.codexRequest.turnState).toBe("turn-original");
+    expect(request.codexRequest.useWebSocket).toBe(false);
+    expect(request.codexRequest.input).toBe(snapshot.input);
+    expect(request.codexRequest.instructions).toBe("system-a");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract implicit-resume request capture/apply/restore mutation into a focused helper.
- Keep account acquisition, retry control flow, and upstream side effects in the proxy orchestrator.
- Add unit and boundary tests for the helper and orchestrator dependency boundary.

## Verification
- npx vitest run tests/unit/routes/shared/proxy-implicit-resume-request.test.ts tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/integration/proxy-handler.test.ts tests/unit/routes/shared/proxy-retry-recovery.test.ts tests/unit/routes/shared/proxy-fallback-retry-plan.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- npm test
- git diff --cached --check
- rg -n "any|as any|: any|<any>" src/routes/shared/proxy-handler.ts src/routes/shared/proxy-implicit-resume-request.ts tests/unit/routes/shared/proxy-implicit-resume-request.test.ts tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts (no matches)