### PR TITLE
refactor: extract proxy request preparation

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -8,6 +8,7 @@
  *   - proxy-error-handler.ts  — CodexApiError classification + pool state mutations
  *   - proxy-fallback-retry-plan.ts — account fallback retry response planning
  *   - proxy-implicit-resume-request.ts — implicit-resume request apply/restore state
+ *   - proxy-request-preparation.ts — request input/default forwarding fields
  *   - proxy-debug-dump.ts     — opt-in request payload diagnostics
  *   - proxy-request-diagnostics.ts — request summary / large payload logs
  *   - proxy-stagger.ts        — request interval staggering
@@ -43,6 +44,10 @@ import {
   captureImplicitResumeRequestState,
   restoreImplicitResumeRequestState,
 } from "./proxy-implicit-resume-request.js";
+import {
+  applyProxyRequestForwardingDefaults,
+  ensureProxyRequestInputArray,
+} from "./proxy-request-preparation.js";
 import { recordProxyEgressLog } from "./proxy-egress-log.js";
 import { applyParsedRateLimits, applyRateLimitHeaders, type ApplyParsedRateLimitsOptions } from "./proxy-rate-limit.js";
 import { buildRequestDiagnostics } from "./proxy-request-diagnostics.js";
@@ -66,9 +71,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
 
   const affinityMap = getSessionAffinityMap();
   const requestId = c.get("requestId") ?? randomUUID().slice(0, 8);
-  if (!Array.isArray(req.codexRequest.input)) {
-    req.codexRequest.input = [];
-  }
+  ensureProxyRequestInputArray(req);
   const originalRequestState = captureImplicitResumeRequestState(req);
   const currentInstructions = req.codexRequest.instructions;
   const explicitPrevRespId = req.codexRequest.previous_response_id;
@@ -119,18 +122,13 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         ? affinityMap.lookup(implicitPrevRespId)
         : null;
 
-  // Conversation ID: honor explicit prompt_cache_key first, otherwise prefer
-  // client session IDs (Claude Code), then content hash, then random fallback.
-  req.codexRequest.prompt_cache_key = promptCacheKey;
-
   // Turn state: sticky routing token from upstream, echoed back on subsequent requests
   const explicitTurnState = explicitPrevRespId ? affinityMap.lookupTurnState(explicitPrevRespId) : null;
-  if (explicitTurnState) req.codexRequest.turnState = explicitTurnState;
-
-  // Set include for reasoning-enabled requests (matches Codex CLI behavior)
-  if (req.codexRequest.reasoning && !req.codexRequest.include?.length) {
-    req.codexRequest.include = ["reasoning.encrypted_content"];
-  }
+  applyProxyRequestForwardingDefaults({
+    request: req,
+    promptCacheKey,
+    explicitTurnState,
+  });
 
   // Single acquire call — preferredEntryId is a hint, not a hard requirement
   const acquired = acquireAccount(accountPool, req.codexRequest.model, undefined, fmt.tag, preferredEntryId ?? undefined);

--- a/src/routes/shared/proxy-request-preparation.ts
+++ b/src/routes/shared/proxy-request-preparation.ts
@@ -1,0 +1,29 @@
+import type { ProxyRequest } from "./proxy-handler-types.js";
+
+export interface ApplyProxyRequestForwardingDefaultsOptions {
+  request: ProxyRequest;
+  promptCacheKey: string;
+  explicitTurnState: string | null;
+}
+
+export function ensureProxyRequestInputArray(request: ProxyRequest): void {
+  if (!Array.isArray(request.codexRequest.input)) {
+    request.codexRequest.input = [];
+  }
+}
+
+export function applyProxyRequestForwardingDefaults(
+  options: ApplyProxyRequestForwardingDefaultsOptions,
+): void {
+  const { request, promptCacheKey, explicitTurnState } = options;
+
+  request.codexRequest.prompt_cache_key = promptCacheKey;
+
+  if (explicitTurnState) {
+    request.codexRequest.turnState = explicitTurnState;
+  }
+
+  if (request.codexRequest.reasoning && !request.codexRequest.include?.length) {
+    request.codexRequest.include = ["reasoning.encrypted_content"];
+  }
+}

--- a/tests/unit/routes/shared/proxy-request-preparation-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-request-preparation-boundary.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as proxyRequestPreparation from "@src/routes/shared/proxy-request-preparation.js";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const PREPARATION_MODULE = "src/routes/shared/proxy-request-preparation.ts";
+const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
+
+function source(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function parseSource(path: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleSpecifierText(node: ts.ImportDeclaration): string | null {
+  const moduleSpecifier = node.moduleSpecifier;
+  return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null;
+}
+
+function importsNamedBinding(content: string, moduleSuffix: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const specifier = moduleSpecifierText(statement);
+    if (!specifier?.endsWith(moduleSuffix)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importedModuleSpecifiers(content: string, path = "inline.ts"): string[] {
+  const file = parseSource(path, content);
+  return file.statements
+    .filter(ts.isImportDeclaration)
+    .map(moduleSpecifierText)
+    .filter((specifier): specifier is string => Boolean(specifier));
+}
+
+describe("proxy request preparation boundary", () => {
+  it("exports request preparation helpers from their own module", () => {
+    expect(proxyRequestPreparation.ensureProxyRequestInputArray).toBeTypeOf("function");
+    expect(proxyRequestPreparation.applyProxyRequestForwardingDefaults).toBeTypeOf("function");
+  });
+
+  it("keeps request preparation field mutation out of the proxy orchestrator", () => {
+    const proxyHandler = source(PROXY_HANDLER_MODULE);
+
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-request-preparation.js",
+      "ensureProxyRequestInputArray",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-request-preparation.js",
+      "applyProxyRequestForwardingDefaults",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(proxyHandler).not.toContain("!Array.isArray(req.codexRequest.input)");
+    expect(proxyHandler).not.toContain("req.codexRequest.prompt_cache_key = promptCacheKey");
+    expect(proxyHandler).not.toContain("req.codexRequest.include = [\"reasoning.encrypted_content\"]");
+  });
+
+  it("keeps account lifecycle and upstream side effects out of request preparation", () => {
+    const helper = source(PREPARATION_MODULE);
+
+    expect(importedModuleSpecifiers(helper, PREPARATION_MODULE)).not.toEqual(expect.arrayContaining([
+      "./account-acquisition.js",
+      "./proxy-stagger.js",
+      "./proxy-handler.js",
+      "./proxy-handler-utils.js",
+      "../../proxy/codex-api.js",
+      "hono",
+    ]));
+  });
+});

--- a/tests/unit/routes/shared/proxy-request-preparation.test.ts
+++ b/tests/unit/routes/shared/proxy-request-preparation.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyProxyRequestForwardingDefaults,
+  ensureProxyRequestInputArray,
+} from "@src/routes/shared/proxy-request-preparation.js";
+import type { ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
+
+function makeProxyRequest(): ProxyRequest {
+  return {
+    model: "gpt-5.4",
+    isStreaming: true,
+    codexRequest: {
+      model: "gpt-5.4",
+      input: [{ role: "user", content: "hello" }],
+      instructions: "system",
+      stream: true,
+      store: false,
+    },
+  };
+}
+
+describe("proxy request preparation", () => {
+  it("preserves a valid input array reference", () => {
+    const request = makeProxyRequest();
+    const originalInput = request.codexRequest.input;
+
+    ensureProxyRequestInputArray(request);
+
+    expect(request.codexRequest.input).toBe(originalInput);
+  });
+
+  it("normalizes invalid input to an empty array before later request snapshots", () => {
+    const request = makeProxyRequest();
+    request.codexRequest.input = "not-array" as unknown as ProxyRequest["codexRequest"]["input"];
+
+    ensureProxyRequestInputArray(request);
+
+    expect(request.codexRequest.input).toEqual([]);
+  });
+
+  it("applies prompt cache key and explicit turn state for upstream forwarding", () => {
+    const request = makeProxyRequest();
+
+    applyProxyRequestForwardingDefaults({
+      request,
+      promptCacheKey: "cache-key-1",
+      explicitTurnState: "turn-explicit",
+    });
+
+    expect(request.codexRequest.prompt_cache_key).toBe("cache-key-1");
+    expect(request.codexRequest.turnState).toBe("turn-explicit");
+  });
+
+  it("does not clear an existing turn state when no explicit turn state is available", () => {
+    const request = makeProxyRequest();
+    request.codexRequest.turnState = "turn-existing";
+
+    applyProxyRequestForwardingDefaults({
+      request,
+      promptCacheKey: "cache-key-1",
+      explicitTurnState: null,
+    });
+
+    expect(request.codexRequest.turnState).toBe("turn-existing");
+  });
+
+  it("adds reasoning encrypted content include only when reasoning has no include list", () => {
+    const request = makeProxyRequest();
+    request.codexRequest.reasoning = { effort: "high" };
+
+    applyProxyRequestForwardingDefaults({
+      request,
+      promptCacheKey: "cache-key-1",
+      explicitTurnState: null,
+    });
+
+    expect(request.codexRequest.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
+  it("preserves an existing include list for reasoning requests", () => {
+    const request = makeProxyRequest();
+    request.codexRequest.reasoning = { effort: "high" };
+    request.codexRequest.include = ["custom.include"];
+
+    applyProxyRequestForwardingDefaults({
+      request,
+      promptCacheKey: "cache-key-1",
+      explicitTurnState: null,
+    });
+
+    expect(request.codexRequest.include).toEqual(["custom.include"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract proxy request input normalization and forwarding-default mutations into a focused helper.
- Keep session identity calculation, implicit resume decisions, account lifecycle, retry control flow, and upstream side effects in the proxy orchestrator.
- Add unit and boundary tests for the helper and orchestrator dependency boundary.

## Verification
- npx vitest run tests/unit/routes/shared/proxy-request-preparation.test.ts tests/unit/routes/shared/proxy-request-preparation-boundary.test.ts tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/integration/proxy-handler.test.ts tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
- npx tsc --noEmit --pretty false
- npm run build
- npm test
- git diff --check
- rg -n "any|as any|: any|<any>" src/routes/shared/proxy-handler.ts src/routes/shared/proxy-request-preparation.ts tests/unit/routes/shared/proxy-request-preparation.test.ts tests/unit/routes/shared/proxy-request-preparation-boundary.test.ts (no matches)