### PR TITLE
refactor: extract proxy upstream attempt

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -9,6 +9,7 @@
  *   - proxy-fallback-retry-plan.ts — account fallback retry response planning
  *   - proxy-implicit-resume-request.ts — implicit-resume request apply/restore state
  *   - proxy-request-preparation.ts — request input/default forwarding fields
+ *   - proxy-upstream-attempt.ts — one upstream request attempt + egress/rate-limit capture
  *   - proxy-debug-dump.ts     — opt-in request payload diagnostics
  *   - proxy-request-diagnostics.ts — request summary / large payload logs
  *   - proxy-stagger.ts        — request interval staggering
@@ -18,13 +19,11 @@
  */
 
 import { CodexApiError } from "../../proxy/codex-api.js";
-import { withRetry } from "../../utils/retry.js";
 import { acquireAccount, releaseAccount } from "./account-acquisition.js";
 import { handleCodexApiError } from "./proxy-error-handler.js";
 import { handleStreaming } from "./streaming-handler.js";
 import { handleNonStreaming } from "./non-streaming-handler.js";
 import { annotateImageGenOutcome, buildCodexApi } from "./proxy-handler-utils.js";
-import { dumpProxyRequest } from "./proxy-debug-dump.js";
 import type {
   FormatAdapter,
   HandleProxyRequestOptions,
@@ -48,11 +47,10 @@ import {
   applyProxyRequestForwardingDefaults,
   ensureProxyRequestInputArray,
 } from "./proxy-request-preparation.js";
-import { recordProxyEgressLog } from "./proxy-egress-log.js";
-import { applyParsedRateLimits, applyRateLimitHeaders, type ApplyParsedRateLimitsOptions } from "./proxy-rate-limit.js";
 import { buildRequestDiagnostics } from "./proxy-request-diagnostics.js";
 import { buildProxyRetryRecoveryDecision } from "./proxy-retry-recovery.js";
 import { staggerIfNeeded } from "./proxy-stagger.js";
+import { sendProxyUpstreamAttempt } from "./proxy-upstream-attempt.js";
 import { buildWsPoolContext } from "./proxy-ws-context.js";
 import {
   buildVariantIdentity,
@@ -223,37 +221,19 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
 
   for (;;) {
     try {
-      const applyRateLimits = (rateLimits: ApplyParsedRateLimitsOptions["rateLimits"]): void => {
-        applyParsedRateLimits({ accountPool, entryId, rateLimits });
-      };
-
-      const startMs = Date.now();
-      dumpProxyRequest({
+      const { rawResponse, upstreamTurnState } = await sendProxyUpstreamAttempt({
+        accountPool,
+        api: codexApi,
+        request: req,
+        entryId,
+        abortSignal: abortController.signal,
+        buildPoolCtx,
         requestId,
         tag: fmt.tag,
-        entryId,
         conversationId: chainConversationId,
         implicitResumeActive,
         resumeReason: resumeEval.active ? null : resumeEval.reason,
-        payload: req.codexRequest,
       });
-      const rawResponse = await withRetry(
-        () => codexApi.createResponse(req.codexRequest, abortController.signal, applyRateLimits, buildPoolCtx()),
-        { tag: fmt.tag },
-      );
-      const status: number | null = rawResponse.status;
-      recordProxyEgressLog({
-        requestId,
-        request: req,
-        status,
-        startMs,
-      });
-
-      // Capture upstream turn-state for sticky routing
-      const upstreamTurnState = rawResponse.headers.get("x-codex-turn-state") ?? undefined;
-
-      // Extract rate-limit quota from upstream response headers (passive collection — HTTP path)
-      applyRateLimitHeaders({ accountPool, entryId, headers: rawResponse.headers });
 
       // ── Streaming path ──
       if (req.isStreaming) {

--- a/src/routes/shared/proxy-upstream-attempt.ts
+++ b/src/routes/shared/proxy-upstream-attempt.ts
@@ -1,0 +1,96 @@
+import type { WsPoolContext } from "../../proxy/codex-api.js";
+import type { CodexResponsesRequest } from "../../proxy/codex-types.js";
+import type { ParsedRateLimit } from "../../proxy/rate-limit-headers.js";
+import { withRetry } from "../../utils/retry.js";
+import { dumpProxyRequest } from "./proxy-debug-dump.js";
+import { recordProxyEgressLog } from "./proxy-egress-log.js";
+import type { ProxyRequest } from "./proxy-handler-types.js";
+import {
+  applyParsedRateLimits,
+  applyRateLimitHeaders,
+  type RateLimitAccountPool,
+} from "./proxy-rate-limit.js";
+
+export interface ProxyUpstreamAttemptApi {
+  createResponse(
+    request: CodexResponsesRequest,
+    signal: AbortSignal,
+    onRateLimits?: (rateLimits: ParsedRateLimit) => void,
+    poolCtx?: WsPoolContext,
+  ): Promise<Response>;
+}
+
+export interface SendProxyUpstreamAttemptOptions {
+  accountPool: RateLimitAccountPool;
+  api: ProxyUpstreamAttemptApi;
+  request: ProxyRequest;
+  entryId: string;
+  abortSignal: AbortSignal;
+  buildPoolCtx: () => WsPoolContext | undefined;
+  requestId: string;
+  tag: string;
+  conversationId: string | null | undefined;
+  implicitResumeActive: boolean;
+  resumeReason: string | null | undefined;
+  nowMs?: () => number;
+  retryOptions?: {
+    maxRetries?: number;
+    baseDelayMs?: number;
+  };
+}
+
+export interface ProxyUpstreamAttemptResult {
+  rawResponse: Response;
+  upstreamTurnState: string | undefined;
+}
+
+export async function sendProxyUpstreamAttempt(
+  options: SendProxyUpstreamAttemptOptions,
+): Promise<ProxyUpstreamAttemptResult> {
+  const {
+    accountPool,
+    api,
+    request,
+    entryId,
+    abortSignal,
+    buildPoolCtx,
+    requestId,
+    tag,
+    conversationId,
+    implicitResumeActive,
+    resumeReason,
+    retryOptions,
+  } = options;
+  const nowMs = options.nowMs ?? Date.now;
+
+  const applyRateLimits = (rateLimits: ParsedRateLimit): void => {
+    applyParsedRateLimits({ accountPool, entryId, rateLimits });
+  };
+
+  const startMs = nowMs();
+  dumpProxyRequest({
+    requestId,
+    tag,
+    entryId,
+    conversationId,
+    implicitResumeActive,
+    resumeReason,
+    payload: request.codexRequest,
+  });
+  const rawResponse = await withRetry(
+    () => api.createResponse(request.codexRequest, abortSignal, applyRateLimits, buildPoolCtx()),
+    { tag, ...retryOptions },
+  );
+  recordProxyEgressLog({
+    requestId,
+    request,
+    status: rawResponse.status,
+    startMs,
+  });
+  applyRateLimitHeaders({ accountPool, entryId, headers: rawResponse.headers });
+
+  return {
+    rawResponse,
+    upstreamTurnState: rawResponse.headers.get("x-codex-turn-state") ?? undefined,
+  };
+}

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -8,12 +8,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import type { FormatCollectTranslatorOptions, ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
+import type { WsPoolContext } from "@src/proxy/codex-api.js";
+import type { CodexResponsesRequest } from "@src/proxy/codex-types.js";
+import type { ParsedRateLimit } from "@src/proxy/rate-limit-headers.js";
 import { createMockFormatAdapter } from "@helpers/format-adapter.js";
 import { getSessionAffinityMap } from "@src/auth/session-affinity.js";
 
 // ── Module-level control for CodexApi.createResponse ──────────────────
 
-let mockCreateResponse: (() => Promise<Response>) | null = null;
+type MockCreateResponse = (
+  request: CodexResponsesRequest,
+  signal?: AbortSignal,
+  onRateLimits?: (rateLimits: ParsedRateLimit) => void,
+  poolCtx?: WsPoolContext,
+) => Promise<Response>;
+
+let mockCreateResponse: MockCreateResponse | null = null;
 
 vi.mock("@src/proxy/codex-api.js", () => {
   class CodexApiError extends Error {
@@ -34,8 +44,13 @@ vi.mock("@src/proxy/codex-api.js", () => {
   }
 
   const CodexApi = vi.fn().mockImplementation(() => ({
-    createResponse: vi.fn((): Promise<Response> => {
-      if (mockCreateResponse) return mockCreateResponse();
+    createResponse: vi.fn((
+      request: CodexResponsesRequest,
+      signal?: AbortSignal,
+      onRateLimits?: (rateLimits: ParsedRateLimit) => void,
+      poolCtx?: WsPoolContext,
+    ): Promise<Response> => {
+      if (mockCreateResponse) return mockCreateResponse(request, signal, onRateLimits, poolCtx);
       return Promise.resolve(new Response("data: {}\n\n"));
     }),
   }));
@@ -101,6 +116,8 @@ function createMockAccountPool(overrides: Record<string, unknown> = {}) {
     release: vi.fn(),
     markRateLimited: vi.fn(),
     applyRateLimit429: vi.fn(),
+    updateCachedQuota: vi.fn(),
+    syncRateLimitWindow: vi.fn(),
     markStatus: vi.fn(),
     getEntry: vi.fn(() => ({ email: "test@test.com" })),
     recordEmptyResponse: vi.fn(),
@@ -342,6 +359,59 @@ describe("proxy-handler integration", () => {
       countRequest: true,
     });
     // Second account succeeds — release called with usage
+    expect(accountPool.release).toHaveBeenCalledWith("e2", {
+      input_tokens: 10,
+      output_tokens: 20,
+    });
+  });
+
+  it("attributes WebSocket rate-limit callback updates to the failed account before fallback", async () => {
+    const body429 = JSON.stringify({
+      error: { type: "usage_limit_reached", message: "Limit reached", resets_in_seconds: 123 },
+    });
+    const parsedRateLimit: ParsedRateLimit = {
+      primary: { used_percent: 100, window_minutes: 60, reset_at: 2_000_000_300 },
+      secondary: null,
+      code_review: null,
+    };
+    let createCount = 0;
+    mockCreateResponse = (_request, _signal, onRateLimits) => {
+      createCount++;
+      if (createCount === 1) {
+        onRateLimits?.(parsedRateLimit);
+        return Promise.reject(new CodexApiError(429, body429));
+      }
+      return Promise.resolve(new Response("data: {}\n\n"));
+    };
+
+    let acquireCount = 0;
+    const accountPool = createMockAccountPool({
+      acquire: vi.fn(() => {
+        acquireCount++;
+        if (acquireCount === 1) return { entryId: "e1", token: "tok1", accountId: "acc1" };
+        return { entryId: "e2", token: "tok2", accountId: "acc2" };
+      }),
+    });
+    const fmt = createMockFormatAdapter();
+    const { app } = buildTestApp({ accountPool, fmt });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(200);
+
+    expect(accountPool.updateCachedQuota).toHaveBeenCalledTimes(1);
+    expect(accountPool.updateCachedQuota).toHaveBeenCalledWith("e1", expect.objectContaining({
+      rate_limit: expect.objectContaining({
+        used_percent: 100,
+        limit_reached: true,
+      }),
+    }));
+    expect(accountPool.syncRateLimitWindow).toHaveBeenCalledWith("e1", 2_000_000_300, 3_600);
+    expect(accountPool.applyRateLimit429).toHaveBeenCalledWith("e1", { resetsAtSec: 2_000_000_300 });
+    expect(accountPool.applyRateLimit429).toHaveBeenCalledWith("e1", {
+      retryAfterSec: 123,
+      countRequest: true,
+    });
+    expect(accountPool.release).toHaveBeenCalledTimes(1);
     expect(accountPool.release).toHaveBeenCalledWith("e2", {
       input_tokens: 10,
       output_tokens: 20,

--- a/tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts
@@ -6,6 +6,7 @@ import { dumpProxyRequest } from "@src/routes/shared/proxy-debug-dump.js";
 
 const ROOT = process.cwd();
 const DEBUG_DUMP_MODULE = "src/routes/shared/proxy-debug-dump.ts";
+const UPSTREAM_ATTEMPT_MODULE = "src/routes/shared/proxy-upstream-attempt.ts";
 const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
 
 function source(path: string): string {
@@ -56,8 +57,11 @@ describe("proxy debug dump boundary", () => {
 
   it("keeps debug dump utility wiring out of the proxy orchestrator", () => {
     const proxyHandler = source(PROXY_HANDLER_MODULE);
+    const upstreamAttempt = source(UPSTREAM_ATTEMPT_MODULE);
 
-    expect(importsNamedBinding(proxyHandler, "proxy-debug-dump.js", "dumpProxyRequest", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-upstream-attempt.js", "sendProxyUpstreamAttempt", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-debug-dump.js", "dumpProxyRequest", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(upstreamAttempt, "proxy-debug-dump.js", "dumpProxyRequest", UPSTREAM_ATTEMPT_MODULE)).toBe(true);
     expect(importsNamedBinding(proxyHandler, "debug-dump.js", "debugDump", PROXY_HANDLER_MODULE)).toBe(false);
     expect(importsNamedBinding(proxyHandler, "debug-dump.js", "debugDumpEnabled", PROXY_HANDLER_MODULE)).toBe(false);
     expect(proxyHandler).not.toContain('debugDump("request"');

--- a/tests/unit/routes/shared/proxy-egress-log-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-egress-log-boundary.test.ts
@@ -6,6 +6,7 @@ import { recordProxyEgressLog } from "@src/routes/shared/proxy-egress-log.js";
 
 const ROOT = process.cwd();
 const EGRESS_LOG_MODULE = "src/routes/shared/proxy-egress-log.ts";
+const UPSTREAM_ATTEMPT_MODULE = "src/routes/shared/proxy-upstream-attempt.ts";
 const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
 const NON_STREAMING_HANDLER_MODULE = "src/routes/shared/non-streaming-handler.ts";
 
@@ -56,8 +57,11 @@ describe("proxy egress log boundary", () => {
 
   it("keeps log-store enqueue wiring out of the proxy orchestrator", () => {
     const proxyHandler = source(PROXY_HANDLER_MODULE);
+    const upstreamAttempt = source(UPSTREAM_ATTEMPT_MODULE);
 
-    expect(importsNamedBinding(proxyHandler, "proxy-egress-log.js", "recordProxyEgressLog", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-upstream-attempt.js", "sendProxyUpstreamAttempt", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-egress-log.js", "recordProxyEgressLog", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(upstreamAttempt, "proxy-egress-log.js", "recordProxyEgressLog", UPSTREAM_ATTEMPT_MODULE)).toBe(true);
     expect(importsNamedBinding(proxyHandler, "entry.js", "enqueueLogEntry", PROXY_HANDLER_MODULE)).toBe(false);
     expect(proxyHandler).not.toContain('path: "/codex/responses"');
   });

--- a/tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts
@@ -6,6 +6,7 @@ import { applyParsedRateLimits, applyRateLimitHeaders } from "@src/routes/shared
 
 const ROOT = process.cwd();
 const RATE_LIMIT_MODULE = "src/routes/shared/proxy-rate-limit.ts";
+const UPSTREAM_ATTEMPT_MODULE = "src/routes/shared/proxy-upstream-attempt.ts";
 const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
 
 function source(path: string): string {
@@ -64,8 +65,12 @@ describe("proxy rate-limit helper boundary", () => {
 
   it("keeps parsed rate-limit account-pool mutation out of the proxy orchestrator", () => {
     const proxyHandler = source(PROXY_HANDLER_MODULE);
+    const upstreamAttempt = source(UPSTREAM_ATTEMPT_MODULE);
 
-    expect(importsNamedBinding(proxyHandler, "proxy-rate-limit.js", "applyParsedRateLimits", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-upstream-attempt.js", "sendProxyUpstreamAttempt", PROXY_HANDLER_MODULE)).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "proxy-rate-limit.js", "applyParsedRateLimits", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(upstreamAttempt, "proxy-rate-limit.js", "applyParsedRateLimits", UPSTREAM_ATTEMPT_MODULE)).toBe(true);
+    expect(importsNamedBinding(upstreamAttempt, "proxy-rate-limit.js", "applyRateLimitHeaders", UPSTREAM_ATTEMPT_MODULE)).toBe(true);
     expect(importedModuleSpecifiers(proxyHandler, PROXY_HANDLER_MODULE)).not.toEqual(expect.arrayContaining([
       "../../proxy/rate-limit-headers.js",
     ]));

--- a/tests/unit/routes/shared/proxy-upstream-attempt-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-upstream-attempt-boundary.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as proxyUpstreamAttempt from "@src/routes/shared/proxy-upstream-attempt.js";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const ATTEMPT_MODULE = "src/routes/shared/proxy-upstream-attempt.ts";
+const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
+
+function source(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function parseSource(path: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleSpecifierText(node: ts.ImportDeclaration): string | null {
+  const moduleSpecifier = node.moduleSpecifier;
+  return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null;
+}
+
+function importsNamedBinding(content: string, moduleSuffix: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+    const specifier = moduleSpecifierText(statement);
+    if (!specifier?.endsWith(moduleSuffix)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importedModuleSpecifiers(content: string, path = "inline.ts"): string[] {
+  const file = parseSource(path, content);
+  return file.statements
+    .filter(ts.isImportDeclaration)
+    .map(moduleSpecifierText)
+    .filter((specifier): specifier is string => Boolean(specifier));
+}
+
+describe("proxy upstream attempt boundary", () => {
+  it("exports the upstream attempt helper from its own module", () => {
+    expect(proxyUpstreamAttempt.sendProxyUpstreamAttempt).toBeTypeOf("function");
+  });
+
+  it("keeps one upstream attempt's dump/retry/egress details out of the proxy orchestrator", () => {
+    const proxyHandler = source(PROXY_HANDLER_MODULE);
+
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-upstream-attempt.js",
+      "sendProxyUpstreamAttempt",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(proxyHandler).not.toContain("codexApi.createResponse(req.codexRequest");
+    expect(proxyHandler).not.toContain("recordProxyEgressLog({");
+    expect(proxyHandler).not.toContain("applyRateLimitHeaders({ accountPool, entryId, headers: rawResponse.headers })");
+  });
+
+  it("keeps account lifecycle, fallback, and response handling out of the upstream attempt helper", () => {
+    const helper = source(ATTEMPT_MODULE);
+
+    expect(importedModuleSpecifiers(helper, ATTEMPT_MODULE)).not.toEqual(expect.arrayContaining([
+      "./account-acquisition.js",
+      "./proxy-error-handler.js",
+      "./proxy-error-response.js",
+      "./proxy-fallback-retry-plan.js",
+      "./streaming-handler.js",
+      "./non-streaming-handler.js",
+      "./proxy-stagger.js",
+      "hono",
+    ]));
+  });
+});

--- a/tests/unit/routes/shared/proxy-upstream-attempt.test.ts
+++ b/tests/unit/routes/shared/proxy-upstream-attempt.test.ts
@@ -1,0 +1,244 @@
+import { CodexApiError } from "@src/proxy/codex-api.js";
+import {
+  sendProxyUpstreamAttempt,
+  type ProxyUpstreamAttemptApi,
+} from "@src/routes/shared/proxy-upstream-attempt.js";
+import type { ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
+import type { RateLimitAccountPool } from "@src/routes/shared/proxy-rate-limit.js";
+import type { ParsedRateLimit } from "@src/proxy/rate-limit-headers.js";
+import { WsConnectionPool } from "@src/proxy/ws-pool.js";
+import type { WsPoolContext } from "@src/proxy/codex-api.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@src/routes/shared/proxy-debug-dump.js", () => ({
+  dumpProxyRequest: vi.fn(),
+}));
+
+vi.mock("@src/routes/shared/proxy-egress-log.js", () => ({
+  recordProxyEgressLog: vi.fn(),
+}));
+
+const { dumpProxyRequest } = await import("@src/routes/shared/proxy-debug-dump.js");
+const { recordProxyEgressLog } = await import("@src/routes/shared/proxy-egress-log.js");
+
+function makeProxyRequest(): ProxyRequest {
+  return {
+    model: "gpt-5.4",
+    isStreaming: true,
+    codexRequest: {
+      model: "gpt-5.4",
+      input: [{ role: "user", content: "hello" }],
+      instructions: "system",
+      stream: true,
+      store: false,
+      prompt_cache_key: "conv-1",
+      useWebSocket: true,
+    },
+  };
+}
+
+function makeAccountPool(): RateLimitAccountPool {
+  return {
+    getEntry: vi.fn(() => ({ planType: "team" })),
+    updateCachedQuota: vi.fn(),
+    syncRateLimitWindow: vi.fn(),
+    applyRateLimit429: vi.fn(),
+  };
+}
+
+function makeApi(response: Response): ProxyUpstreamAttemptApi {
+  return {
+    createResponse: vi.fn(async () => response),
+  };
+}
+
+describe("sendProxyUpstreamAttempt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dumps the outbound request, sends it with retry wrapper inputs, and records egress", async () => {
+    const request = makeProxyRequest();
+    const response = new Response("ok", {
+      status: 202,
+      headers: {
+        "x-codex-turn-state": "turn-upstream",
+      },
+    });
+    const api = makeApi(response);
+    const abortController = new AbortController();
+    const poolCtx: WsPoolContext = {
+      pool: new WsConnectionPool({ enabled: false }, { startGc: false }),
+      poolKey: "entry-1:conv-1:vh",
+      entryId: "entry-1",
+    };
+
+    const result = await sendProxyUpstreamAttempt({
+      accountPool: makeAccountPool(),
+      api,
+      request,
+      entryId: "entry-1",
+      abortSignal: abortController.signal,
+      buildPoolCtx: () => poolCtx,
+      requestId: "request-123456",
+      tag: "Chat",
+      conversationId: "conv-1",
+      implicitResumeActive: true,
+      resumeReason: null,
+      nowMs: () => 1_000,
+      retryOptions: { maxRetries: 0, baseDelayMs: 1 },
+    });
+
+    expect(result).toEqual({
+      rawResponse: response,
+      upstreamTurnState: "turn-upstream",
+    });
+    expect(dumpProxyRequest).toHaveBeenCalledWith({
+      requestId: "request-123456",
+      tag: "Chat",
+      entryId: "entry-1",
+      conversationId: "conv-1",
+      implicitResumeActive: true,
+      resumeReason: null,
+      payload: request.codexRequest,
+    });
+    expect(api.createResponse).toHaveBeenCalledTimes(1);
+    const createResponseCall = vi.mocked(api.createResponse).mock.calls[0]!;
+    expect(createResponseCall[0]).toBe(request.codexRequest);
+    expect(createResponseCall[1]).toBe(abortController.signal);
+    expect(createResponseCall[2]).toBeTypeOf("function");
+    expect(createResponseCall[3]).toBe(poolCtx);
+    expect(recordProxyEgressLog).toHaveBeenCalledWith({
+      requestId: "request-123456",
+      request,
+      status: 202,
+      startMs: 1_000,
+    });
+  });
+
+  it("applies HTTP response rate-limit headers to the active entry", async () => {
+    const pool = makeAccountPool();
+    const response = new Response("ok", {
+      status: 200,
+      headers: {
+        "x-codex-primary-used-percent": "100",
+        "x-codex-primary-window-minutes": "60",
+        "x-codex-primary-reset-at": "2000000300",
+      },
+    });
+
+    await sendProxyUpstreamAttempt({
+      accountPool: pool,
+      api: makeApi(response),
+      request: makeProxyRequest(),
+      entryId: "entry-rate",
+      abortSignal: new AbortController().signal,
+      buildPoolCtx: () => undefined,
+      requestId: "request-123456",
+      tag: "Chat",
+      conversationId: "conv-1",
+      implicitResumeActive: false,
+      resumeReason: "no-prev",
+      nowMs: () => 1_000,
+      retryOptions: { maxRetries: 0, baseDelayMs: 1 },
+    });
+
+    expect(pool.updateCachedQuota).toHaveBeenCalledWith("entry-rate", expect.objectContaining({
+      rate_limit: expect.objectContaining({ used_percent: 100, limit_reached: true }),
+    }));
+    expect(pool.syncRateLimitWindow).toHaveBeenCalledWith("entry-rate", 2_000_000_300, 3_600);
+    expect(pool.applyRateLimit429).toHaveBeenCalledWith("entry-rate", { resetsAtSec: 2_000_000_300 });
+  });
+
+  it("applies WebSocket rate-limit callback updates to the active entry", async () => {
+    const pool = makeAccountPool();
+    const parsedRateLimit: ParsedRateLimit = {
+      primary: { used_percent: 42, window_minutes: 300, reset_at: 1_700_000_300 },
+      secondary: null,
+      code_review: null,
+    };
+    const api: ProxyUpstreamAttemptApi = {
+      createResponse: vi.fn(async (_request, _signal, onRateLimits) => {
+        onRateLimits?.(parsedRateLimit);
+        return new Response("ok", { status: 200 });
+      }),
+    };
+
+    await sendProxyUpstreamAttempt({
+      accountPool: pool,
+      api,
+      request: makeProxyRequest(),
+      entryId: "entry-ws",
+      abortSignal: new AbortController().signal,
+      buildPoolCtx: () => undefined,
+      requestId: "request-123456",
+      tag: "Chat",
+      conversationId: "conv-1",
+      implicitResumeActive: false,
+      resumeReason: "no-prev",
+      nowMs: () => 1_000,
+      retryOptions: { maxRetries: 0, baseDelayMs: 1 },
+    });
+
+    expect(pool.updateCachedQuota).toHaveBeenCalledWith("entry-ws", expect.objectContaining({
+      rate_limit: expect.objectContaining({ used_percent: 42 }),
+    }));
+  });
+
+  it("retries retryable upstream errors before recording successful egress once", async () => {
+    const response = new Response("ok", { status: 200 });
+    const api: ProxyUpstreamAttemptApi = {
+      createResponse: vi
+        .fn()
+        .mockRejectedValueOnce(new CodexApiError(500, "temporary"))
+        .mockResolvedValueOnce(response),
+    };
+
+    const result = await sendProxyUpstreamAttempt({
+      accountPool: makeAccountPool(),
+      api,
+      request: makeProxyRequest(),
+      entryId: "entry-retry",
+      abortSignal: new AbortController().signal,
+      buildPoolCtx: () => undefined,
+      requestId: "request-123456",
+      tag: "Chat",
+      conversationId: "conv-1",
+      implicitResumeActive: false,
+      resumeReason: "no-prev",
+      nowMs: () => 1_000,
+      retryOptions: { maxRetries: 1, baseDelayMs: 1 },
+    });
+
+    expect(result.rawResponse).toBe(response);
+    expect(api.createResponse).toHaveBeenCalledTimes(2);
+    expect(recordProxyEgressLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes terminal Codex API errors to the outer handler without recording success egress", async () => {
+    const err = new CodexApiError(400, "bad request");
+    const api: ProxyUpstreamAttemptApi = {
+      createResponse: vi.fn(async () => {
+        throw err;
+      }),
+    };
+
+    await expect(sendProxyUpstreamAttempt({
+      accountPool: makeAccountPool(),
+      api,
+      request: makeProxyRequest(),
+      entryId: "entry-error",
+      abortSignal: new AbortController().signal,
+      buildPoolCtx: () => undefined,
+      requestId: "request-123456",
+      tag: "Chat",
+      conversationId: "conv-1",
+      implicitResumeActive: false,
+      resumeReason: "no-prev",
+      retryOptions: { maxRetries: 1, baseDelayMs: 1 },
+    })).rejects.toBe(err);
+
+    expect(api.createResponse).toHaveBeenCalledTimes(1);
+    expect(recordProxyEgressLog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract one upstream attempt from `proxy-handler.ts` into `proxy-upstream-attempt.ts`
- Keep account lifecycle, fallback, error classification, and response formatting in the proxy orchestrator
- Add helper and boundary coverage for retry, egress logging, HTTP/WS rate-limit capture, and terminal error propagation

## Verification
- `npx vitest run tests/unit/routes/shared/proxy-upstream-attempt.test.ts tests/unit/routes/shared/proxy-upstream-attempt-boundary.test.ts tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts tests/unit/routes/shared/proxy-egress-log-boundary.test.ts tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts tests/integration/proxy-handler.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `rg -n "(\\bas\\s+any\\b|:\\s*any\\b|<any>)" src/routes/shared/proxy-handler.ts src/routes/shared/proxy-upstream-attempt.ts tests/unit/routes/shared/proxy-upstream-attempt.test.ts tests/unit/routes/shared/proxy-upstream-attempt-boundary.test.ts tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts tests/unit/routes/shared/proxy-egress-log-boundary.test.ts tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts tests/integration/proxy-handler.test.ts` (no matches)
- `npm run build`
- `npm test`
