### PR TITLE
refactor: extract proxy session context

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -9,6 +9,7 @@
  *   - proxy-fallback-retry-plan.ts — account fallback retry response planning
  *   - proxy-implicit-resume-request.ts — implicit-resume request apply/restore state
  *   - proxy-request-preparation.ts — request input/default forwarding fields
+ *   - proxy-session-context.ts — prompt cache / affinity / implicit-resume derived state
  *   - proxy-upstream-attempt.ts — one upstream request attempt + egress/rate-limit capture
  *   - proxy-debug-dump.ts     — opt-in request payload diagnostics
  *   - proxy-request-diagnostics.ts — request summary / large payload logs
@@ -32,7 +33,6 @@ import type {
 } from "./proxy-handler-types.js";
 import { getSessionAffinityMap } from "../../auth/session-affinity.js";
 import { randomUUID } from "crypto";
-import { computeVariantHash } from "./variant-hash.js";
 import {
   respondWithNoAccount,
   respondWithProxyError,
@@ -49,17 +49,12 @@ import {
 } from "./proxy-request-preparation.js";
 import { buildRequestDiagnostics } from "./proxy-request-diagnostics.js";
 import { buildProxyRetryRecoveryDecision } from "./proxy-retry-recovery.js";
+import { buildProxySessionContext } from "./proxy-session-context.js";
 import { staggerIfNeeded } from "./proxy-stagger.js";
 import { sendProxyUpstreamAttempt } from "./proxy-upstream-attempt.js";
 import { buildWsPoolContext } from "./proxy-ws-context.js";
 import {
-  buildVariantIdentity,
   evaluateImplicitResume,
-  getContinuationInputStartIndex,
-  getFunctionCallOutputIds,
-  IMPLICIT_RESUME_MAX_AGE_MS,
-  normalizeInstructions,
-  resolvePromptCacheIdentity,
   shouldReplayFullInputAfterImplicitResumeError,
 } from "./proxy-session-helpers.js";
 
@@ -71,65 +66,17 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   const requestId = c.get("requestId") ?? randomUUID().slice(0, 8);
   ensureProxyRequestInputArray(req);
   const originalRequestState = captureImplicitResumeRequestState(req);
-  const currentInstructions = req.codexRequest.instructions;
-  const explicitPrevRespId = req.codexRequest.previous_response_id;
-  const promptCacheIdentity = resolvePromptCacheIdentity(req.codexRequest, req.clientConversationId);
-  const promptCacheKey = promptCacheIdentity.promptCacheKey;
-  const continuationInputStart = explicitPrevRespId ? 0 : getContinuationInputStartIndex(req.codexRequest.input);
-  const explicitConversationId = explicitPrevRespId ? affinityMap.lookupConversationId(explicitPrevRespId) : null;
-  // effectiveConversationId follows the same identity used by prompt_cache_key:
-  // explicit key > client session > content hash > random fallback.
-  const effectiveConversationId = promptCacheIdentity.conversationId;
-  const chainConversationId = explicitConversationId ?? effectiveConversationId;
-  // Variant fingerprint isolates concurrent shapes of the same conversation
-  // (sub-agents, parallel tool calls) onto independent pool slots + prev_id
-  // chains. See `variant-hash.ts`. Cheap (sha256 over bytes already in memory)
-  // so we always compute it, even on routes that won't use it.
-  const variantIdentity = buildVariantIdentity(req.codexRequest, promptCacheIdentity);
-  const variantHash = computeVariantHash(
-    req.codexRequest.instructions,
-    req.codexRequest.tools,
-    variantIdentity,
-  );
-  const implicitPrevRespId =
-    !explicitPrevRespId &&
-    continuationInputStart > 0 &&
-    effectiveConversationId
-      ? affinityMap.lookupLatestResponseIdByConversationId(
-          effectiveConversationId,
-          IMPLICIT_RESUME_MAX_AGE_MS,
-          variantHash,
-        )
-      : null;
-  const prevRespId = explicitPrevRespId ?? implicitPrevRespId;
-  const implicitStoredInstructions = implicitPrevRespId
-    ? affinityMap.lookupInstructions(implicitPrevRespId)
-    : null;
-  const implicitContinuationInput = req.codexRequest.input.slice(continuationInputStart);
-  const requiredFunctionCallOutputIds = implicitPrevRespId
-    ? getFunctionCallOutputIds(implicitContinuationInput)
-    : [];
-  const implicitStoredFunctionCallIds = implicitPrevRespId
-    ? affinityMap.lookupFunctionCallIds(implicitPrevRespId)
-    : [];
-  // Session affinity: prefer the account that created the previous response
-  const preferredEntryId =
-    explicitPrevRespId
-      ? affinityMap.lookup(explicitPrevRespId)
-      : implicitPrevRespId && normalizeInstructions(currentInstructions) === normalizeInstructions(implicitStoredInstructions)
-        ? affinityMap.lookup(implicitPrevRespId)
-        : null;
+  const sessionContext = buildProxySessionContext({ request: req, affinityMap });
 
   // Turn state: sticky routing token from upstream, echoed back on subsequent requests
-  const explicitTurnState = explicitPrevRespId ? affinityMap.lookupTurnState(explicitPrevRespId) : null;
   applyProxyRequestForwardingDefaults({
     request: req,
-    promptCacheKey,
-    explicitTurnState,
+    promptCacheKey: sessionContext.promptCacheKey,
+    explicitTurnState: sessionContext.explicitTurnState,
   });
 
   // Single acquire call — preferredEntryId is a hint, not a hard requirement
-  const acquired = acquireAccount(accountPool, req.codexRequest.model, undefined, fmt.tag, preferredEntryId ?? undefined);
+  const acquired = acquireAccount(accountPool, req.codexRequest.model, undefined, fmt.tag, sessionContext.preferredEntryId ?? undefined);
   if (!acquired) {
     return respondWithNoAccount({ c, req, fmt });
   }
@@ -145,15 +92,8 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   const released = new Set<string>();
 
   const resumeEval = evaluateImplicitResume({
-    implicitPrevRespId,
-    continuationInputStart,
-    inputLength: req.codexRequest.input.length,
-    preferredEntryId,
+    ...sessionContext.resumeEvaluationInput,
     acquiredEntryId: entryId,
-    currentInstructions,
-    storedInstructions: implicitStoredInstructions,
-    requiredFunctionCallOutputIds,
-    storedFunctionCallIds: implicitStoredFunctionCallIds,
   });
   if (!resumeEval.active && resumeEval.missingCallIds && resumeEval.missingCallIds.length > 0) {
     console.warn(
@@ -170,8 +110,8 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   if (resumeEval.active) {
     activeUsageHint = applyImplicitResumeRequest({
       request: req,
-      implicitPrevRespId: implicitPrevRespId!,
-      continuationInputStart,
+      implicitPrevRespId: sessionContext.implicitPrevRespId!,
+      continuationInputStart: sessionContext.continuationInputStart,
       affinityMap,
     });
     implicitResumeActive = true;
@@ -190,15 +130,15 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
       entryId,
       requestId,
       request: req,
-      chainConversationId,
-      promptCacheKey,
-      variantHash,
-      explicitPrevRespId,
-      implicitPrevRespId,
-      prevRespId,
+      chainConversationId: sessionContext.chainConversationId,
+      promptCacheKey: sessionContext.promptCacheKey,
+      variantHash: sessionContext.variantHash,
+      explicitPrevRespId: sessionContext.explicitPrevRespId,
+      implicitPrevRespId: sessionContext.implicitPrevRespId,
+      prevRespId: sessionContext.prevRespId,
       resumeActive: resumeEval.active,
       resumeReason: resumeEval.reason,
-      preferredEntryId,
+      preferredEntryId: sessionContext.preferredEntryId,
     });
     console.log(diagnostics.summary);
     if (diagnostics.largePayloadWarning) console.warn(diagnostics.largePayloadWarning);
@@ -212,9 +152,9 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   const buildPoolCtx = (forEntryId: string = entryId) =>
     buildWsPoolContext({
       useWebSocket: req.codexRequest.useWebSocket,
-      conversationId: chainConversationId,
+      conversationId: sessionContext.chainConversationId,
       entryId: forEntryId,
-      variantHash,
+      variantHash: sessionContext.variantHash,
       requestId,
       tag: fmt.tag,
     });
@@ -230,7 +170,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         buildPoolCtx,
         requestId,
         tag: fmt.tag,
-        conversationId: chainConversationId,
+        conversationId: sessionContext.chainConversationId,
         implicitResumeActive,
         resumeReason: resumeEval.active ? null : resumeEval.reason,
       });
@@ -249,10 +189,10 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
           released,
           requestId,
           affinityMap,
-          conversationId: chainConversationId,
+          conversationId: sessionContext.chainConversationId,
           turnState: upstreamTurnState,
           usageHint: activeUsageHint,
-          variantHash,
+          variantHash: sessionContext.variantHash,
         });
       }
 
@@ -271,7 +211,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         released,
         requestId,
         affinityMap,
-        conversationId: chainConversationId,
+        conversationId: sessionContext.chainConversationId,
         turnState: upstreamTurnState,
         getUsageHint: () => activeUsageHint,
         restoreImplicitResumeRequest,
@@ -281,7 +221,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
           codexApi = nextApi;
           if (!triedEntryIds.includes(nextEntryId)) triedEntryIds.push(nextEntryId);
         },
-        variantHash,
+        variantHash: sessionContext.variantHash,
       });
     } catch (err) {
       if (!(err instanceof CodexApiError)) {

--- a/src/routes/shared/proxy-session-context.ts
+++ b/src/routes/shared/proxy-session-context.ts
@@ -1,0 +1,113 @@
+import type { SessionAffinityMap } from "../../auth/session-affinity.js";
+import type { ProxyRequest } from "./proxy-handler-types.js";
+import { computeVariantHash } from "./variant-hash.js";
+import {
+  buildVariantIdentity,
+  getContinuationInputStartIndex,
+  getFunctionCallOutputIds,
+  IMPLICIT_RESUME_MAX_AGE_MS,
+  normalizeInstructions,
+  resolvePromptCacheIdentity,
+  type ImplicitResumeOpts,
+} from "./proxy-session-helpers.js";
+
+export type ProxyResumeEvaluationInput = Omit<ImplicitResumeOpts, "acquiredEntryId">;
+
+export interface BuildProxySessionContextOptions {
+  request: ProxyRequest;
+  affinityMap: SessionAffinityMap;
+}
+
+export interface ProxySessionContext {
+  currentInstructions: string | null | undefined;
+  explicitPrevRespId: string | undefined;
+  promptCacheKey: string;
+  continuationInputStart: number;
+  explicitConversationId: string | null;
+  effectiveConversationId: string;
+  chainConversationId: string;
+  variantHash: string;
+  implicitPrevRespId: string | null;
+  prevRespId: string | null | undefined;
+  implicitStoredInstructions: string | null;
+  implicitContinuationInput: ProxyRequest["codexRequest"]["input"];
+  requiredFunctionCallOutputIds: string[];
+  implicitStoredFunctionCallIds: string[];
+  preferredEntryId: string | null;
+  explicitTurnState: string | null;
+  resumeEvaluationInput: ProxyResumeEvaluationInput;
+}
+
+export function buildProxySessionContext(
+  options: BuildProxySessionContextOptions,
+): ProxySessionContext {
+  const { request, affinityMap } = options;
+  const { codexRequest } = request;
+  const currentInstructions = codexRequest.instructions;
+  const explicitPrevRespId = codexRequest.previous_response_id;
+  const promptCacheIdentity = resolvePromptCacheIdentity(codexRequest, request.clientConversationId);
+  const promptCacheKey = promptCacheIdentity.promptCacheKey;
+  const continuationInputStart = explicitPrevRespId ? 0 : getContinuationInputStartIndex(codexRequest.input);
+  const explicitConversationId = explicitPrevRespId ? affinityMap.lookupConversationId(explicitPrevRespId) : null;
+  const effectiveConversationId = promptCacheIdentity.conversationId;
+  const chainConversationId = explicitConversationId ?? effectiveConversationId;
+  const variantIdentity = buildVariantIdentity(codexRequest, promptCacheIdentity);
+  const variantHash = computeVariantHash(codexRequest.instructions, codexRequest.tools, variantIdentity);
+  const implicitPrevRespId =
+    !explicitPrevRespId &&
+    continuationInputStart > 0 &&
+    effectiveConversationId
+      ? affinityMap.lookupLatestResponseIdByConversationId(
+          effectiveConversationId,
+          IMPLICIT_RESUME_MAX_AGE_MS,
+          variantHash,
+        )
+      : null;
+  const prevRespId = explicitPrevRespId ?? implicitPrevRespId;
+  const implicitStoredInstructions = implicitPrevRespId
+    ? affinityMap.lookupInstructions(implicitPrevRespId)
+    : null;
+  const implicitContinuationInput = codexRequest.input.slice(continuationInputStart);
+  const requiredFunctionCallOutputIds = implicitPrevRespId
+    ? getFunctionCallOutputIds(implicitContinuationInput)
+    : [];
+  const implicitStoredFunctionCallIds = implicitPrevRespId
+    ? affinityMap.lookupFunctionCallIds(implicitPrevRespId)
+    : [];
+  const preferredEntryId =
+    explicitPrevRespId
+      ? affinityMap.lookup(explicitPrevRespId)
+      : implicitPrevRespId && normalizeInstructions(currentInstructions) === normalizeInstructions(implicitStoredInstructions)
+        ? affinityMap.lookup(implicitPrevRespId)
+        : null;
+  const explicitTurnState = explicitPrevRespId ? affinityMap.lookupTurnState(explicitPrevRespId) : null;
+
+  return {
+    currentInstructions,
+    explicitPrevRespId,
+    promptCacheKey,
+    continuationInputStart,
+    explicitConversationId,
+    effectiveConversationId,
+    chainConversationId,
+    variantHash,
+    implicitPrevRespId,
+    prevRespId,
+    implicitStoredInstructions,
+    implicitContinuationInput,
+    requiredFunctionCallOutputIds,
+    implicitStoredFunctionCallIds,
+    preferredEntryId,
+    explicitTurnState,
+    resumeEvaluationInput: {
+      implicitPrevRespId,
+      continuationInputStart,
+      inputLength: codexRequest.input.length,
+      preferredEntryId,
+      currentInstructions,
+      storedInstructions: implicitStoredInstructions,
+      requiredFunctionCallOutputIds,
+      storedFunctionCallIds: implicitStoredFunctionCallIds,
+    },
+  };
+}

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -13,6 +13,8 @@ import type { CodexResponsesRequest } from "@src/proxy/codex-types.js";
 import type { ParsedRateLimit } from "@src/proxy/rate-limit-headers.js";
 import { createMockFormatAdapter } from "@helpers/format-adapter.js";
 import { getSessionAffinityMap } from "@src/auth/session-affinity.js";
+import { buildVariantIdentity, resolvePromptCacheIdentity } from "@src/routes/shared/proxy-session-helpers.js";
+import { computeVariantHash } from "@src/routes/shared/variant-hash.js";
 
 // ── Module-level control for CodexApi.createResponse ──────────────────
 
@@ -43,6 +45,21 @@ vi.mock("@src/proxy/codex-api.js", () => {
     }
   }
 
+  class PreviousResponseWebSocketError extends CodexApiError {
+    causeMessage: string;
+    constructor(causeMessage: string) {
+      super(0, JSON.stringify({
+        error: {
+          message:
+            "WebSocket failed while using previous_response_id; HTTP SSE fallback would drop server-side history: " +
+            causeMessage,
+        },
+      }));
+      this.name = "PreviousResponseWebSocketError";
+      this.causeMessage = causeMessage;
+    }
+  }
+
   const CodexApi = vi.fn().mockImplementation(() => ({
     createResponse: vi.fn((
       request: CodexResponsesRequest,
@@ -55,7 +72,7 @@ vi.mock("@src/proxy/codex-api.js", () => {
     }),
   }));
 
-  return { CodexApi, CodexApiError };
+  return { CodexApi, CodexApiError, PreviousResponseWebSocketError };
 });
 
 vi.mock("@src/config.js", () => ({
@@ -105,7 +122,7 @@ vi.mock("@src/translation/codex-event-extractor.js", () => {
 
 // Import after mocks are set up
 import { handleProxyRequest } from "@src/routes/shared/proxy-handler.js";
-import { CodexApiError } from "@src/proxy/codex-api.js";
+import { CodexApiError, PreviousResponseWebSocketError } from "@src/proxy/codex-api.js";
 import { EmptyResponseError, UpstreamPrematureCloseError } from "@src/translation/codex-event-extractor.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -936,6 +953,92 @@ describe("proxy-handler integration", () => {
     expect(createCount).toBe(2);
     expect(seenPrevIds[0]).toBe("resp_0e2e6e7917486cfd0069eec8532d988194a3da6379c70abe68");
     expect(seenPrevIds[1]).toBeUndefined();
+  });
+
+  it("replays full original input after implicit previous-response WebSocket failure", async () => {
+    const req: ProxyRequest = {
+      ...createDefaultRequest(),
+      codexRequest: {
+        ...createDefaultRequest().codexRequest,
+        prompt_cache_key: "thread-implicit-ws",
+        input: [
+          { role: "user", content: "first" },
+          { role: "assistant", content: "ok" },
+          { role: "user", content: "continue" },
+        ],
+        turnState: "turn-original",
+        useWebSocket: false,
+      },
+    };
+    const affinityMap = getSessionAffinityMap();
+    const promptCacheIdentity = resolvePromptCacheIdentity(req.codexRequest, req.clientConversationId);
+    const variantHash = computeVariantHash(
+      req.codexRequest.instructions,
+      req.codexRequest.tools,
+      buildVariantIdentity(req.codexRequest, promptCacheIdentity),
+    );
+    affinityMap.record(
+      "resp_implicit_ws",
+      "e1",
+      "thread-implicit-ws",
+      "turn-implicit",
+      "You are helpful",
+      undefined,
+      undefined,
+      variantHash,
+    );
+
+    const seenRequests: Array<{
+      input: CodexResponsesRequest["input"];
+      previousResponseId: string | undefined;
+      turnState: string | undefined;
+      useWebSocket: boolean | undefined;
+    }> = [];
+    let createCount = 0;
+    mockCreateResponse = (request) => {
+      createCount++;
+      seenRequests.push({
+        input: [...request.input],
+        previousResponseId: request.previous_response_id,
+        turnState: request.turnState,
+        useWebSocket: request.useWebSocket,
+      });
+      if (createCount === 1) {
+        return Promise.reject(new PreviousResponseWebSocketError("ws down"));
+      }
+      return Promise.resolve(new Response("data: {}\n\n"));
+    };
+
+    const accountPool = createMockAccountPool();
+    const fmt = createMockFormatAdapter();
+    const { app } = buildTestApp({ accountPool, fmt, req });
+
+    const res = await app.request("/test", { method: "POST" });
+    expect(res.status).toBe(200);
+
+    expect(seenRequests).toEqual([
+      {
+        input: [{ role: "user", content: "continue" }],
+        previousResponseId: "resp_implicit_ws",
+        turnState: "turn-implicit",
+        useWebSocket: true,
+      },
+      {
+        input: [
+          { role: "user", content: "first" },
+          { role: "assistant", content: "ok" },
+          { role: "user", content: "continue" },
+        ],
+        previousResponseId: undefined,
+        turnState: "turn-original",
+        useWebSocket: false,
+      },
+    ]);
+    expect(accountPool.acquire).toHaveBeenCalledTimes(1);
+    expect(accountPool.release).toHaveBeenCalledWith("e1", {
+      input_tokens: 10,
+      output_tokens: 20,
+    });
   });
 
   it("recovers when collectTranslator raises previous_response_not_found", async () => {

--- a/tests/unit/routes/shared/proxy-session-context-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-session-context-boundary.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as proxySessionContext from "@src/routes/shared/proxy-session-context.js";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const SESSION_CONTEXT_MODULE = "src/routes/shared/proxy-session-context.ts";
+const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
+
+function source(path: string): string {
+  return readFileSync(resolve(ROOT, path), "utf-8");
+}
+
+function parseSource(path: string, content: string): ts.SourceFile {
+  return ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleSpecifierText(node: ts.ImportDeclaration): string | null {
+  const moduleSpecifier = node.moduleSpecifier;
+  return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null;
+}
+
+function importsNamedBinding(content: string, moduleSuffix: string, bindingName: string, path = "inline.ts"): boolean {
+  const file = parseSource(path, content);
+  for (const statement of file.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = moduleSpecifierText(statement);
+    if (!specifier?.endsWith(moduleSuffix)) continue;
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
+    if (namedBindings.elements.some((element) => {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      return importedName === bindingName || element.name.text === bindingName;
+    })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importedModuleSpecifiers(content: string, path = "inline.ts"): string[] {
+  const file = parseSource(path, content);
+  return file.statements
+    .filter(ts.isImportDeclaration)
+    .map(moduleSpecifierText)
+    .filter((specifier): specifier is string => Boolean(specifier));
+}
+
+describe("proxy session context boundary", () => {
+  it("exports the session context builder from its own module", () => {
+    expect(proxySessionContext.buildProxySessionContext).toBeTypeOf("function");
+  });
+
+  it("keeps prompt-cache, affinity, and variant derivation out of the proxy orchestrator", () => {
+    const proxyHandler = source(PROXY_HANDLER_MODULE);
+
+    expect(importsNamedBinding(
+      proxyHandler,
+      "proxy-session-context.js",
+      "buildProxySessionContext",
+      PROXY_HANDLER_MODULE,
+    )).toBe(true);
+    expect(importsNamedBinding(proxyHandler, "variant-hash.js", "computeVariantHash", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(proxyHandler, "proxy-session-helpers.js", "resolvePromptCacheIdentity", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(proxyHandler, "proxy-session-helpers.js", "buildVariantIdentity", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(proxyHandler, "proxy-session-helpers.js", "getContinuationInputStartIndex", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(proxyHandler, "proxy-session-helpers.js", "getFunctionCallOutputIds", PROXY_HANDLER_MODULE)).toBe(false);
+    expect(importsNamedBinding(proxyHandler, "proxy-session-helpers.js", "IMPLICIT_RESUME_MAX_AGE_MS", PROXY_HANDLER_MODULE)).toBe(false);
+  });
+
+  it("keeps request mutation, account acquisition, and response handling out of the session context helper", () => {
+    const helper = source(SESSION_CONTEXT_MODULE);
+
+    expect(importedModuleSpecifiers(helper, SESSION_CONTEXT_MODULE)).not.toEqual(expect.arrayContaining([
+      "./account-acquisition.js",
+      "./proxy-request-preparation.js",
+      "./proxy-implicit-resume-request.js",
+      "./streaming-handler.js",
+      "./non-streaming-handler.js",
+      "./proxy-upstream-attempt.js",
+      "hono",
+    ]));
+  });
+});

--- a/tests/unit/routes/shared/proxy-session-context.test.ts
+++ b/tests/unit/routes/shared/proxy-session-context.test.ts
@@ -1,0 +1,166 @@
+import { SessionAffinityMap } from "@src/auth/session-affinity.js";
+import type { CodexResponsesRequest } from "@src/proxy/codex-types.js";
+import { buildProxySessionContext } from "@src/routes/shared/proxy-session-context.js";
+import { buildVariantIdentity, resolvePromptCacheIdentity } from "@src/routes/shared/proxy-session-helpers.js";
+import type { ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
+import { computeVariantHash } from "@src/routes/shared/variant-hash.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+const affinityMaps: SessionAffinityMap[] = [];
+
+function makeAffinityMap(): SessionAffinityMap {
+  const affinityMap = new SessionAffinityMap();
+  affinityMaps.push(affinityMap);
+  return affinityMap;
+}
+
+function makeCodexRequest(overrides: Partial<CodexResponsesRequest> = {}): CodexResponsesRequest {
+  return {
+    model: "gpt-5.4",
+    instructions: "system",
+    input: [{ role: "user", content: "hello" }],
+    stream: true,
+    store: false,
+    ...overrides,
+  };
+}
+
+function makeProxyRequest(overrides: Partial<ProxyRequest> = {}): ProxyRequest {
+  const codexRequest = overrides.codexRequest ?? makeCodexRequest();
+  return {
+    model: codexRequest.model,
+    isStreaming: true,
+    codexRequest,
+    ...overrides,
+  };
+}
+
+function variantHashFor(request: ProxyRequest): string {
+  const identity = resolvePromptCacheIdentity(request.codexRequest, request.clientConversationId);
+  return computeVariantHash(
+    request.codexRequest.instructions,
+    request.codexRequest.tools,
+    buildVariantIdentity(request.codexRequest, identity),
+  );
+}
+
+describe("buildProxySessionContext", () => {
+  afterEach(() => {
+    for (const affinityMap of affinityMaps) affinityMap.dispose();
+    affinityMaps.length = 0;
+  });
+
+  it("derives explicit previous-response affinity before account acquisition", () => {
+    const affinityMap = makeAffinityMap();
+    affinityMap.record(
+      "resp_prev",
+      "entry-prev",
+      "conversation-prev",
+      "turn-prev",
+      "system",
+      33,
+      ["call_prev"],
+      "variant-prev",
+    );
+    const request = makeProxyRequest({
+      codexRequest: makeCodexRequest({
+        previous_response_id: "resp_prev",
+        prompt_cache_key: "explicit-cache",
+      }),
+    });
+
+    const context = buildProxySessionContext({ request, affinityMap });
+
+    expect(context.explicitPrevRespId).toBe("resp_prev");
+    expect(context.promptCacheKey).toBe("explicit-cache");
+    expect(context.effectiveConversationId).toBe("explicit-cache");
+    expect(context.explicitConversationId).toBe("conversation-prev");
+    expect(context.chainConversationId).toBe("conversation-prev");
+    expect(context.implicitPrevRespId).toBeNull();
+    expect(context.prevRespId).toBe("resp_prev");
+    expect(context.preferredEntryId).toBe("entry-prev");
+    expect(context.explicitTurnState).toBe("turn-prev");
+    expect(context.continuationInputStart).toBe(0);
+    expect(context.resumeEvaluationInput.implicitPrevRespId).toBeNull();
+  });
+
+  it("ignores blank prompt cache and client conversation ids", () => {
+    const affinityMap = makeAffinityMap();
+    const request = makeProxyRequest({
+      clientConversationId: " ",
+      codexRequest: makeCodexRequest({
+        prompt_cache_key: " ",
+      }),
+    });
+
+    const context = buildProxySessionContext({ request, affinityMap });
+
+    expect(context.promptCacheKey).not.toBe("");
+    expect(context.promptCacheKey).not.toBe(" ");
+    expect(context.effectiveConversationId).toBe(context.promptCacheKey);
+  });
+
+  it("derives an implicit previous response for the matching conversation variant", () => {
+    const affinityMap = makeAffinityMap();
+    const request = makeProxyRequest({
+      clientConversationId: "client-thread",
+      codexRequest: makeCodexRequest({
+        input: [
+          { role: "user", content: "call the tool" },
+          { type: "function_call", call_id: "call_a", name: "lookup", arguments: "{}" },
+          { type: "function_call_output", call_id: "call_a", output: "done" },
+        ],
+        tools: [{ type: "function", name: "lookup" }],
+        codexWindowId: "window-1",
+      }),
+    });
+    const variantHash = variantHashFor(request);
+    affinityMap.record(
+      "resp_implicit",
+      "entry-implicit",
+      "client-thread",
+      "turn-implicit",
+      "system",
+      55,
+      ["call_a"],
+      variantHash,
+    );
+    affinityMap.record(
+      "resp_wrong_variant",
+      "entry-wrong",
+      "client-thread",
+      "turn-wrong",
+      "system",
+      55,
+      ["call_a"],
+      "other-variant",
+    );
+
+    const context = buildProxySessionContext({ request, affinityMap });
+
+    expect(context.promptCacheKey).toBe("client-thread");
+    expect(context.explicitConversationId).toBeNull();
+    expect(context.chainConversationId).toBe("client-thread");
+    expect(context.variantHash).toBe(variantHash);
+    expect(context.implicitPrevRespId).toBe("resp_implicit");
+    expect(context.prevRespId).toBe("resp_implicit");
+    expect(context.preferredEntryId).toBe("entry-implicit");
+    expect(context.explicitTurnState).toBeNull();
+    expect(context.implicitStoredInstructions).toBe("system");
+    expect(context.implicitStoredFunctionCallIds).toEqual(["call_a"]);
+    expect(context.requiredFunctionCallOutputIds).toEqual(["call_a"]);
+    expect(context.implicitContinuationInput).toEqual([
+      { type: "function_call_output", call_id: "call_a", output: "done" },
+    ]);
+    expect(context.resumeEvaluationInput).toEqual({
+      implicitPrevRespId: "resp_implicit",
+      continuationInputStart: 2,
+      inputLength: 3,
+      preferredEntryId: "entry-implicit",
+      currentInstructions: "system",
+      storedInstructions: "system",
+      requiredFunctionCallOutputIds: ["call_a"],
+      storedFunctionCallIds: ["call_a"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract prompt-cache, affinity, variant hash, and implicit-resume derived state into `proxy-session-context.ts`
- Keep request mutation, account acquisition, rollback, fallback, and response handling in `proxy-handler.ts`
- Add helper/boundary coverage plus an integration regression for implicit-resume WebSocket rollback restoring the original request

## Verification
- `npx vitest run tests/unit/routes/shared/proxy-session-context.test.ts tests/unit/routes/shared/proxy-session-context-boundary.test.ts tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts tests/integration/proxy-handler.test.ts`
- `npx vitest run tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/unit/routes/shared/proxy-session-context.test.ts tests/unit/routes/shared/proxy-session-context-boundary.test.ts tests/unit/routes/shared/proxy-session-helpers-boundary.test.ts tests/unit/routes/shared/proxy-request-diagnostics.test.ts tests/integration/proxy-handler.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `rg -n "(\\bas\\s+any\\b|:\\s*any\\b|<any>)" src/routes/shared/proxy-handler.ts src/routes/shared/proxy-session-context.ts tests/unit/routes/shared/proxy-session-context.test.ts tests/unit/routes/shared/proxy-session-context-boundary.test.ts tests/integration/proxy-handler.test.ts` (no matches)
- `npm run build`
- `npm test`
