### PR TITLE
fix: extend mac x64 packaged smoke timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,9 @@ jobs:
         env:
           RELEASE_DIR: packages/electron/release
           MAC_ARCH: x64
+          # x64 app startup runs through Rosetta on macOS runners and can
+          # legitimately take just over the default 90s smoke timeout.
+          SMOKE_TIMEOUT: 180
           SMOKE_LOG: ${{ runner.temp }}/electron-smoke.log
         run: bash .github/scripts/electron-smoke.sh
 

--- a/tests/unit/ci/electron-smoke-script.test.ts
+++ b/tests/unit/ci/electron-smoke-script.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { execFileSync } from "child_process";
-import { existsSync, statSync } from "fs";
+import { existsSync, readFileSync, statSync } from "fs";
 import { resolve } from "path";
 
 const SCRIPT = resolve(__dirname, "..", "..", "..", ".github", "scripts", "electron-smoke.sh");
@@ -112,5 +112,18 @@ describe("electron-smoke.sh script", () => {
     });
     expect(result.status).not.toBe(0);
     expect(result.stderr + result.stdout).toContain("Unsupported RUNNER_OS");
+  });
+
+  it("gives mac x64 packaged smoke extra startup time", () => {
+    const workflow = readFileSync(
+      resolve(__dirname, "..", "..", "..", ".github", "workflows", "release.yml"),
+      "utf-8",
+    );
+    const block = workflow.match(
+      /- name: Smoke test packaged binary \(mac-x64\)[\s\S]*?run: bash \.github\/scripts\/electron-smoke\.sh/,
+    )?.[0] ?? "";
+
+    expect(block).toContain("MAC_ARCH: x64");
+    expect(block).toContain("SMOKE_TIMEOUT: 180");
   });
 });


### PR DESCRIPTION
## Summary
- give mac x64 packaged smoke 180s startup timeout for Rosetta on GitHub macOS runners
- add a workflow regression test for the mac-x64 smoke timeout env

## Tests
- npx vitest run tests/unit/ci/electron-smoke-script.test.ts
- git diff --check -- .github/workflows/release.yml tests/unit/ci/electron-smoke-script.test.ts

## Notes
- Does not touch local restart scripts or package.json changes.
