### PR TITLE
Add conditional architecture detection for CODEX_ARCH environment variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 
+# Architecture: x64 or arm64
+# Only set CODEX_ARCH if it's not already set or is empty
+if [ -z "${CODEX_ARCH}" ]; then
+  UNAME_ARCH=$(uname -p)
+  if [ "$UNAME_ARCH" = "aarch64" ]; then
+    CODEX_ARCH="arm64"
+  elif [ "$UNAME_ARCH" = "x86_64" ]; then
+    CODEX_ARCH="x64"
+  else
+    CODEX_ARCH="$UNAME_ARCH"
+  fi
+  export CODEX_ARCH
+fi
+
 # Seed empty config bind mount with defaults from the image
 if [ -d /defaults ] && [ -z "$(ls -A /app/config 2>/dev/null)" ]; then
   echo "[Init] Config directory is empty — seeding from image defaults"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Architecture: x64 or arm64
 # Only set CODEX_ARCH if it's not already set or is empty
 if [ -z "${CODEX_ARCH}" ]; then
-  UNAME_ARCH=$(uname -p)
+  UNAME_ARCH=$(uname -m)
   if [ "$UNAME_ARCH" = "aarch64" ]; then
     CODEX_ARCH="arm64"
   elif [ "$UNAME_ARCH" = "x86_64" ]; then


### PR DESCRIPTION
### Summary
This PR adds architecture detection logic for the `CODEX_ARCH` environment variable in the Docker entrypoint script, but only when the variable is not already set or is empty. This change provides better flexibility for container deployments while maintaining backward compatibility. The main objective is for using the Docker image in multi-architecture Kubernetes environments.

### Changes Made
- **File Modified**: `docker-entrypoint.sh`
- **Lines Added**: 14 lines of conditional architecture detection logic

### Technical Details

#### Before
The script had no architecture detection, which could cause issues in environments where architecture-specific behavior was needed.

#### After
The script now includes conditional architecture detection that:
1. **Checks if CODEX_ARCH is already set**: Uses `[ -z "${CODEX_ARCH}" ]` to test if the variable is empty or unset
2. **Auto-detects architecture only when needed**: If CODEX_ARCH is not set, uses `uname -p` to detect the system architecture
3. **Maps common architectures**: Converts `aarch64` → `arm64` and `x86_64` → `x64` for consistency
4. **Preserves existing values**: If CODEX_ARCH is already set to a non-empty value, the script leaves it unchanged

### Architecture Mapping
- `aarch64` → `arm64`
- `x86_64` → `x64`
- Other architectures → raw `uname -p` output

### Benefits
1. **Flexibility**: Allows users to override the architecture detection by setting CODEX_ARCH in their environment
2. **Backward Compatibility**: Existing deployments without CODEX_ARCH set will continue to work with auto-detection
3. **Consistency**: Standardizes architecture names (arm64/x64) for easier handling in downstream code
4. **Debian Bookworm Support**: Specifically tested and working on Debian Bookworm systems

### Testing
The implementation has been tested with three scenarios:
1. **Unset variable**: Auto-detects and sets CODEX_ARCH appropriately
2. **Preset variable**: Preserves the existing CODEX_ARCH value
3. **Empty string**: Treats empty string as unset and auto-detects

### Use Cases
This change is particularly useful for:
- Multi-architecture Docker builds
- Multi-architecture Kubernetes environments
- CI/CD pipelines that need to override architecture detection
- Development environments with specific architecture requirements
- Cloud deployments where architecture needs to be explicitly controlled

### Impact
- **Breaking Changes**: None - fully backward compatible
- **Performance**: Negligible - adds one conditional check at startup
- **Dependencies**: None - uses standard shell commands (`uname`, `export`)

The change follows the principle of "convention over configuration" while still allowing explicit configuration when needed.