### PR TITLE
feat: add CORS configuration via environment variable or server.cors …

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ for await (const chunk of stream) {
 通过环境变量 `CORS_ALLOWED_HOSTS` 可以配置允许跨域访问的主机列表，对应配置文件中的 `server.cors` 字段。多个主机名用逗号分隔：
 
 ```bash
-export CORS_ALLOWED_HOSTS="https://example.com,https://another-domain.com"
+export CORS_ALLOWED_HOSTS="example.com,another-domain.com"
 ```
 
 或在 `data/local.yaml` 中配置：

--- a/README.md
+++ b/README.md
@@ -505,6 +505,23 @@ for await (const chunk of stream) {
 
 > **重要**：不要直接修改 `config/default.yaml`，该文件会在版本更新时被覆盖。自定义配置请通过 Dashboard 设置面板修改（自动保存到 `data/local.yaml`），或手动创建 `data/local.yaml` 写入需要覆盖的字段。`data/` 目录不受更新影响。
 
+### CORS 允许主机
+
+通过环境变量 `CORS_ALLOWED_HOSTS` 可以配置允许跨域访问的主机列表，对应配置文件中的 `server.cors` 字段。多个主机名用逗号分隔：
+
+```bash
+export CORS_ALLOWED_HOSTS="https://example.com,https://another-domain.com"
+```
+
+或在 `data/local.yaml` 中配置：
+
+```yaml
+server:
+  cors:
+    - "https://example.com"
+    - "https://another-domain.com"
+```
+
 默认配置位于 `config/default.yaml`：
 
 | 分类 | 关键配置 | 说明 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -456,6 +456,23 @@ for await (const chunk of stream) {
 
 All configuration in `config/default.yaml`:
 
+### CORS Allowed Hosts
+
+Configure allowed CORS origins via the `CORS_ALLOWED_HOSTS` environment variable, which maps to the `server.cors` field in the config file. Separate multiple hosts with commas:
+
+```bash
+export CORS_ALLOWED_HOSTS="https://example.com,https://another-domain.com"
+```
+
+Or in `data/local.yaml`:
+
+```yaml
+server:
+  cors:
+    - "https://example.com"
+    - "https://another-domain.com"
+```
+
 | Section | Key Settings | Description |
 |---------|-------------|-------------|
 | `server` | `host`, `port`, `proxy_api_key` | Listen address and API key |

--- a/README_EN.md
+++ b/README_EN.md
@@ -461,7 +461,7 @@ All configuration in `config/default.yaml`:
 Configure allowed CORS origins via the `CORS_ALLOWED_HOSTS` environment variable, which maps to the `server.cors` field in the config file. Separate multiple hosts with commas:
 
 ```bash
-export CORS_ALLOWED_HOSTS="https://example.com,https://another-domain.com"
+export CORS_ALLOWED_HOSTS="example.com,another-domain.com"
 ```
 
 Or in `data/local.yaml`:

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -193,6 +193,14 @@ export function applyEnvOverrides(
       (raw.server as Record<string, unknown>).port = parsed;
     }
   }
+  const corsAllowedHosts = process.env.CORS_ALLOWED_HOSTS?.trim();
+  if (corsAllowedHosts) {
+    if (!raw.server) raw.server = {};
+    (raw.server as Record<string, unknown>).cors = corsAllowedHosts
+      .split(",")
+      .map((h: string) => h.trim())
+      .filter((h: string) => h.length > 0);
+  }
   const serverHostEnv = process.env.CODEX_PROXY_HOST?.trim();
   const localServer = localOverrides?.server as Record<string, unknown> | undefined;
   const localHasServerHost = localServer !== undefined && "host" in localServer;

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -194,7 +194,9 @@ export function applyEnvOverrides(
     }
   }
   const corsAllowedHosts = process.env.CORS_ALLOWED_HOSTS?.trim();
-  if (corsAllowedHosts) {
+  const localServerCors = localOverrides?.server as Record<string, unknown> | undefined;
+  const localHasServerCors = localServerCors !== undefined && "cors" in localServerCors;
+  if (corsAllowedHosts && !localHasServerCors) {
     if (!raw.server) raw.server = {};
     (raw.server as Record<string, unknown>).cors = corsAllowedHosts
       .split(",")
@@ -202,8 +204,8 @@ export function applyEnvOverrides(
       .filter((h: string) => h.length > 0);
   }
   const serverHostEnv = process.env.CODEX_PROXY_HOST?.trim();
-  const localServer = localOverrides?.server as Record<string, unknown> | undefined;
-  const localHasServerHost = localServer !== undefined && "host" in localServer;
+  const localServerHost = localOverrides?.server as Record<string, unknown> | undefined;
+  const localHasServerHost = localServerHost !== undefined && "host" in localServerHost;
   if (serverHostEnv && !localHasServerHost) {
     if (!raw.server) raw.server = {};
     (raw.server as Record<string, unknown>).host = serverHostEnv;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -108,6 +108,7 @@ export const ConfigSchema = z.object({
     port: z.number().min(1).max(65535).default(8080),
     proxy_api_key: z.string().nullable().default(null),
     trust_proxy: z.boolean().default(false),
+    cors: z.array(z.string()).default([]),
   }),
   logs: z.object({
     enabled: z.boolean().default(false),

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -108,7 +108,17 @@ export const ConfigSchema = z.object({
     port: z.number().min(1).max(65535).default(8080),
     proxy_api_key: z.string().nullable().default(null),
     trust_proxy: z.boolean().default(false),
-    cors: z.array(z.string()).default([]),
+    cors: z.array(z.string().trim().min(1).refine((val) => {
+      // Strip scheme if present and validate it's a valid hostname
+      const hostname = val.replace(/^https?:\/\//, '').trim();
+      if (!hostname) return false;
+      // Basic hostname validation - allow hostnames, IP addresses, and localhost
+      return /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/.test(hostname) ||
+             /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname) ||
+             hostname === "localhost";
+    }, {
+      message: "Invalid hostname format. Use bare hostnames like 'example.com' or '192.168.1.1'",
+    })).default([]),
   }),
   logs: z.object({
     enabled: z.boolean().default(false),

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,11 +1,12 @@
 import type { MiddlewareHandler } from "hono";
-import { isLoopbackHostname } from "../utils/host.js";
+import { getConfig } from "../config.js";
+import { isLoopbackHostname, normalizeHostname } from "../utils/host.js";
 
 /**
- * CORS middleware — allows requests from loopback origins only.
+ * CORS middleware — allows requests from loopback origins and configured hosts.
  * Handles OPTIONS preflight and sets response headers for API routes only.
  */
-export const cors: MiddlewareHandler = async (c, next) => {
+export const cors: MiddlewareHandler = async (c: any, next: any) => {
   const origin = c.req.header("Origin");
   const corsEnabled = isCorsEnabledPath(c.req.path);
   const allowedOrigin = corsEnabled ? getAllowedOrigin(origin) : null;
@@ -47,7 +48,21 @@ function getAllowedOrigin(origin: string | undefined): string | null {
   try {
     const url = new URL(origin);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
-    return isLoopbackHostname(url.hostname) ? url.origin : null;
+
+    if (isLoopbackHostname(url.hostname)) {
+      return url.origin;
+    }
+
+    const config = getConfig();
+    const allowedHosts = config.server.cors;
+    if (allowedHosts.length > 0) {
+      const normalizedHost = normalizeHostname(url.hostname);
+      if (allowedHosts.some((h: string) => normalizeHostname(h) === normalizedHost)) {
+        return url.origin;
+      }
+    }
+
+    return null;
   } catch {
     return null;
   }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -43,7 +43,7 @@ function isCorsEnabledPath(path: string): boolean {
     path.startsWith("/official-agent/");
 }
 
-function getAllowedOrigin(origin: string | undefined): string | null {
+export function getAllowedOrigin(origin: string | undefined): string | null {
   if (!origin) return null;
   try {
     const url = new URL(origin);
@@ -57,7 +57,11 @@ function getAllowedOrigin(origin: string | undefined): string | null {
     const allowedHosts = config.server.cors;
     if (allowedHosts.length > 0) {
       const normalizedHost = normalizeHostname(url.hostname);
-      if (allowedHosts.some((h: string) => normalizeHostname(h) === normalizedHost)) {
+      if (allowedHosts.some((h: string) => {
+        // Strip scheme from config entry before normalizing
+        const configHost = h.replace(/^https?:\/\//, '');
+        return normalizeHostname(configHost) === normalizedHost;
+      })) {
         return url.origin;
       }
     }

--- a/tests/unit/middleware/cors.test.ts
+++ b/tests/unit/middleware/cors.test.ts
@@ -96,7 +96,7 @@ describe("cors middleware", () => {
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
     });
 
-    it("accepts allowlisted origins with scheme prefix", async () => {
+    it("accepts allowlisted origins with https:// scheme prefix", async () => {
       mocks.getConfig.mockReturnValue({ server: { cors: ["https://example.com"] } });
 
       const app = createApp();
@@ -111,6 +111,23 @@ describe("cors middleware", () => {
 
       expect(res.status).toBe(204);
       expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+    });
+
+    it("accepts allowlisted origins with http:// scheme prefix", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: ["http://example.com"] } });
+
+      const app = createApp();
+
+      const res = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "http://example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://example.com");
     });
 
     it("rejects non-allowlisted non-loopback origins", async () => {

--- a/tests/unit/middleware/cors.test.ts
+++ b/tests/unit/middleware/cors.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from "vitest";
 import { Hono } from "hono";
 import { cors } from "@src/middleware/cors.js";
+
+const mocks = vi.hoisted(() => ({
+  getConfig: vi.fn(() => ({ server: { cors: [] as string[] } })),
+}));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: mocks.getConfig,
+}));
 
 function createApp(): Hono {
   const app = new Hono();
@@ -10,6 +18,9 @@ function createApp(): Hono {
 }
 
 describe("cors middleware", () => {
+  beforeEach(() => {
+    mocks.getConfig.mockClear();
+  });
   it("allows loopback origins on API compatibility routes", async () => {
     const app = createApp();
 
@@ -65,5 +76,108 @@ describe("cors middleware", () => {
 
     expect(res.status).toBe(403);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+
+  describe("CORS allowlist", () => {
+    it("accepts allowlisted origins", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: ["example.com"] } });
+
+      const app = createApp();
+
+      const res = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+    });
+
+    it("accepts allowlisted origins with scheme prefix", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: ["https://example.com"] } });
+
+      const app = createApp();
+
+      const res = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://example.com");
+    });
+
+    it("rejects non-allowlisted non-loopback origins", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: ["allowed.com"] } });
+
+      const app = createApp();
+
+      const res = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+  });
+});
+
+describe("CORS_ALLOWED_HOSTS env var parsing", () => {
+  const originalEnv = process.env.CORS_ALLOWED_HOSTS;
+
+  afterEach(() => {
+    delete process.env.CORS_ALLOWED_HOSTS;
+  });
+
+  afterAll(() => {
+    process.env.CORS_ALLOWED_HOSTS = originalEnv;
+  });
+
+  it("parses comma-separated hosts", async () => {
+    process.env.CORS_ALLOWED_HOSTS = "example.com, test.com";
+
+    // This would normally be tested through the config loading system
+    // For now, we'll test the parsing logic directly
+    const corsAllowedHosts = process.env.CORS_ALLOWED_HOSTS?.trim();
+    const result = corsAllowedHosts
+      ?.split(",")
+      .map((h: string) => h.trim())
+      .filter((h: string) => h.length > 0);
+
+    expect(result).toEqual(["example.com", "test.com"]);
+  });
+
+  it("trims whitespace from hosts", async () => {
+    process.env.CORS_ALLOWED_HOSTS = " example.com , test.com ";
+
+    const corsAllowedHosts = process.env.CORS_ALLOWED_HOSTS?.trim();
+    const result = corsAllowedHosts
+      ?.split(",")
+      .map((h: string) => h.trim())
+      .filter((h: string) => h.length > 0);
+
+    expect(result).toEqual(["example.com", "test.com"]);
+  });
+
+  it("filters out empty entries", async () => {
+    process.env.CORS_ALLOWED_HOSTS = "example.com,, test.com";
+
+    const corsAllowedHosts = process.env.CORS_ALLOWED_HOSTS?.trim();
+    const result = corsAllowedHosts
+      ?.split(",")
+      .map((h: string) => h.trim())
+      .filter((h: string) => h.length > 0);
+
+    expect(result).toEqual(["example.com", "test.com"]);
   });
 });


### PR DESCRIPTION
## Description

Added CORS configuration via environment variable `CORS_ALLOWED_HOSTS`. This allows configuring allowed CORS origins through environment variables or the configuration file.

## Files Modified

- `README.md`: Added documentation for CORS configuration
- `README_EN.md`: Added documentation for CORS configuration
- `src/config-loader.ts`: Load CORS configuration from environment variable
- `src/config-schema.ts`: Added CORS configuration to server schema
- `src/middleware/cors.ts`: Use CORS configuration from config file

## Changes Made

1. Added documentation for configuring CORS allowed hosts in both Chinese and English README files.
2. Modified `config-loader.ts` to load CORS configuration from the `CORS_ALLOWED_HOSTS` environment variable.
3. Added `cors` field to the server configuration schema in `config-schema.ts`.
4. Updated the CORS middleware to use the configuration from the config file and allow requests from configured hosts.

## Usage

To configure allowed CORS origins, set the `CORS_ALLOWED_HOSTS` environment variable:

```bash
export CORS_ALLOWED_HOSTS="example.com,another-domain.com"
```

Or configure in `data/local.yaml`:

```yaml
server:
  cors:
    - "example.com"
    - "another-domain.com"
```

## Additional Context

This change allows for more flexible configuration of CORS settings without modifying the source code.  

If variable is not set or it is empty the actual behavior remains for avoiding regression.