### PR TITLE
fix(responses): backfill output[] when missing, not only when empty

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -406,8 +406,8 @@ export async function collectPassthrough(
           onResponseMetadata?.({ functionCallIds: [...collectFunctionCallIds] });
         }
         // Codex hosted search 经常完整流出 output_item.done/text delta，
-        // 但 completed.response.output 为空。这里用流式事件回填最终 JSON。
-        if (Array.isArray(resp.output) && resp.output.length === 0) {
+        // 但 completed.response.output 为空或缺失。这里用流式事件回填最终 JSON。
+        if (!Array.isArray(resp.output) || resp.output.length === 0) {
           if (outputItems.length > 0) {
             resp.output = outputItems;
           } else if (textDeltas) {


### PR DESCRIPTION
## Summary

The non-streaming `/v1/responses` collector (`collectPassthrough` in `src/routes/responses.ts`) backfills `response.output` from accumulated stream events when the upstream `response.completed` event omits it. The current guard only matches the *empty array* case:

```ts
if (Array.isArray(resp.output) && resp.output.length === 0) {
```

But upstream (observed on `gpt-5.5` via ChatGPT subscription, 2026-05-27) frequently emits `response.completed` with the `output` field **missing entirely**, not as `[]`. `Array.isArray(undefined)` returns `false`, the backfill is skipped, and the final non-stream JSON returned to the client has no `output` field at all.

## Symptom

Clients using the official `openai` Python SDK get `TypeError: 'NoneType' object is not iterable` when their code accesses `response.output_text` — the SDK's `@property` iterates `self.output` without a None check:

```python
File "openai/types/responses/response.py", line 315, in output_text
    for output in self.output:
TypeError: 'NoneType' object is not iterable
```

## Fix

One-line: loosen the guard to also fire when `output` is missing:

```diff
-        if (Array.isArray(resp.output) && resp.output.length === 0) {
+        if (!Array.isArray(resp.output) || resp.output.length === 0) {
```

The body of the branch is unchanged — it only runs when there's no upstream `output` to copy through, so widening the trigger is safe.

## Verification

End-to-end on lovelace (Arch Linux, codex-proxy 2.0.76 with this patch applied):

```bash
curl -sS http://localhost:8080/v1/responses \
  -H 'Authorization: Bearer pwd' \
  -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.5","input":[{"role":"user","content":[{"type":"input_text","text":"Reply ok"}]}],"max_output_tokens":50,"stream":false}'
```

Before: response JSON has no `output` field (33 top-level keys, `output` absent). `usage.output_tokens=5` but generated text is dropped.

After: response JSON contains
```json
"output": [{"id":"msg_...","type":"message","status":"completed",
            "content":[{"type":"output_text","text":"ok"}],
            "role":"assistant"}],
"output_text": "ok"
```

mcp-handley-lab's openai adapter (which calls `responses.create(stream=False)`) recovers from the `'NoneType' is not iterable` crash and returns normal text.

## Notes

- The accompanying Chinese comment also updated to reflect the new condition ("为空" → "为空或缺失").
- No tests added — this is a one-line guard change in a code path already covered by existing non-stream collect tests; the upstream-shape variation is the trigger, which would need a separate fixture to reproduce.