### PR TITLE
fix(translation): preserve anthropic message roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Claude Messages 路径现在接受并保序透传 message-level system/developer role，未知 role 记录日志并降级为 user，避免新版 Claude Code 请求被 schema 拒绝或 role 顺序丢失（`src/types/anthropic.ts`、`src/translation/anthropic-to-codex.ts`）
 - `collectPassthrough` 在 `response.completed.response` 不含 `output` 字段时无法回填：条件从 `Array.isArray && length === 0` 改为 `!Array.isArray || length === 0`，覆盖 output 完全缺失的上游 shape。（#602，感谢 [@williamjameshandley](https://github.com/williamjameshandley)）
 - `/v1/chat/completions` 和 `/v1/messages` 路由在 `wantReasoning`/`wantThinking` 判断时现在读取翻译后的 `codexRequest.reasoning?.effort`，而非原始请求字段：此前仅当客户端显式传 `reasoning_effort` / `thinking.type` 时才向客户端透传推理摘要，通过 model suffix（如 `gpt-5.4-high`）或 `default_reasoning_effort` 配置注入的 effort 虽然正确发到上游，但 Codex 返回的 `response.reasoning_summary_text.delta` 被代理静默丢弃，导致客户端看不到任何推理内容、误以为 effort 无效（`src/routes/chat.ts`、`src/routes/messages.ts`、`tests/unit/translation/openai-to-codex.test.ts`）
 - 代理 host 字段粘贴完整 URL 时不再 double-prefix：`POST /api/proxies` body 的 `host` 如果是形如 `http://...` 或 `socks5://...` 的完整 URL，后端直接使用而不再拼接 protocol + port，避免生成 `http://http://...` 的畸形 URL；name 为空时自动回退到 URL 前，先去掉 username/password 防止凭证写入代理名称（`src/routes/proxies.ts`）

--- a/src/translation/anthropic-to-codex.ts
+++ b/src/translation/anthropic-to-codex.ts
@@ -26,6 +26,14 @@ function hasHostedWebSearchTool(tools: unknown[]): boolean {
   return tools.some((tool) => isRecord(tool) && tool.type === "web_search");
 }
 
+function normalizeMessageRole(role: string): "system" | "developer" | "user" | "assistant" {
+  if (role === "system" || role === "developer" || role === "user" || role === "assistant") {
+    return role;
+  }
+  console.warn("[anthropic-to-codex] Unknown message role, downgrading to user:", role);
+  return "user";
+}
+
 /**
  * Map Anthropic thinking budget_tokens to Codex reasoning effort.
  */
@@ -95,7 +103,7 @@ function extractMultimodalContent(
  * Handles text, image, tool_use, and tool_result blocks.
  */
 function contentToInputItems(
-  role: "user" | "assistant",
+  role: "system" | "developer" | "user" | "assistant",
   content: string | Array<Record<string, unknown>>,
 ): CodexInputItem[] {
   if (typeof content === "string") {
@@ -112,10 +120,9 @@ function contentToInputItems(
       items.push({ role: "user", content: extracted || "" });
     }
   } else {
-    // Assistant messages: text-only (Codex doesn't support structured assistant content)
     const text = extractTextContent(content);
     if (text || !hasToolBlocks) {
-      items.push({ role: "assistant", content: text });
+      items.push({ role, content: text });
     }
   }
 
@@ -216,7 +223,7 @@ export function translateAnthropicToCodexRequest(
   const input: CodexInputItem[] = [];
   for (const msg of req.messages) {
     const items = contentToInputItems(
-      msg.role as "user" | "assistant",
+      normalizeMessageRole(msg.role),
       msg.content as string | Array<Record<string, unknown>>,
     );
     input.push(...items);

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -76,7 +76,7 @@ const AnthropicContentSchema = z.union([
 ]);
 
 const AnthropicMessageSchema = z.object({
-  role: z.enum(["user", "assistant"]),
+  role: z.string().min(1),
   content: AnthropicContentSchema,
 });
 

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -315,7 +315,7 @@ describe("translateAnthropicToCodexRequest", () => {
       expect((outputItem as Record<string, unknown>).output).toBe(
         "Error: something went wrong",
       );
-    });
+
 
     it("preserves system and developer message roles in order", () => {
       const result = translateAnthropicToCodexRequest(
@@ -400,7 +400,7 @@ describe("translateAnthropicToCodexRequest", () => {
       } finally {
         warn.mockRestore();
       }
-    });
+    });   });
   });
 
   // ── Thinking → reasoning effort ──────────────────────────────────────

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -315,7 +315,7 @@ describe("translateAnthropicToCodexRequest", () => {
       expect((outputItem as Record<string, unknown>).output).toBe(
         "Error: something went wrong",
       );
-
+    });
 
     it("preserves system and developer message roles in order", () => {
       const result = translateAnthropicToCodexRequest(
@@ -400,7 +400,7 @@ describe("translateAnthropicToCodexRequest", () => {
       } finally {
         warn.mockRestore();
       }
-    });   });
+    });
   });
 
   // ── Thinking → reasoning effort ──────────────────────────────────────

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -316,6 +316,91 @@ describe("translateAnthropicToCodexRequest", () => {
         "Error: something went wrong",
       );
     });
+
+    it("preserves system and developer message roles in order", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          messages: [
+            { role: "system", content: "You are an expert engineer." },
+            { role: "developer", content: "Follow company coding standards." },
+            { role: "user", content: "hello" },
+          ],
+        } as Partial<AnthropicMessagesRequest>),
+      );
+      expect(result.instructions).toBe("You are a helpful assistant.");
+      expect(result.input).toEqual([
+        { role: "system", content: "You are an expert engineer." },
+        { role: "developer", content: "Follow company coding standards." },
+        { role: "user", content: "hello" },
+      ]);
+    });
+
+    it("keeps tool call items ordered around system and developer messages", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          messages: [
+            { role: "system", content: "You are an expert engineer." },
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool_use" as const,
+                  id: "toolu_01",
+                  name: "search",
+                  input: { query: "test" },
+                },
+              ],
+            },
+            {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result" as const,
+                  tool_use_id: "toolu_01",
+                  content: "result data",
+                },
+              ],
+            },
+            { role: "developer", content: "Keep coding standards." },
+            { role: "user", content: "continue" },
+          ],
+        } as Partial<AnthropicMessagesRequest>),
+      );
+      expect(result.input).toEqual([
+        { role: "system", content: "You are an expert engineer." },
+        {
+          type: "function_call",
+          call_id: "toolu_01",
+          name: "search",
+          arguments: '{"query":"test"}',
+        },
+        {
+          type: "function_call_output",
+          call_id: "toolu_01",
+          output: "result data",
+        },
+        { role: "developer", content: "Keep coding standards." },
+        { role: "user", content: "continue" },
+      ]);
+    });
+
+    it("downgrades unknown message roles to user", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            messages: [{ role: "future_role", content: "new role content" }],
+          } as Partial<AnthropicMessagesRequest>),
+        );
+        expect(result.input).toEqual([{ role: "user", content: "new role content" }]);
+        expect(warn).toHaveBeenCalledWith(
+          "[anthropic-to-codex] Unknown message role, downgrading to user:",
+          "future_role",
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 
   // ── Thinking → reasoning effort ──────────────────────────────────────

--- a/tests/unit/types/anthropic-schema.test.ts
+++ b/tests/unit/types/anthropic-schema.test.ts
@@ -78,4 +78,17 @@ describe("AnthropicMessagesRequestSchema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("accepts forward-compatible message roles", () => {
+    const result = AnthropicMessagesRequestSchema.safeParse({
+      ...BASE_REQUEST,
+      messages: [
+        { role: "system", content: "You are an expert engineer." },
+        { role: "developer", content: "Follow company coding standards." },
+        { role: "user", content: "hello" },
+        { role: "future_role", content: "new role content" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/tests/unit/update-checker.test.ts
+++ b/tests/unit/update-checker.test.ts
@@ -72,8 +72,14 @@ const APPCAST_XML = `<?xml version="1.0"?>
 
 type YamlMutator = (data: Record<string, unknown>) => void;
 
+function normalizeTestPath(path: unknown): string {
+  return String(path).replace(/\\/g, "/").replace(/^[A-Z]:/i, "");
+}
+
 function getClientYamlMutator(): YamlMutator {
-  const call = mockMutateYaml.mock.calls.find((entry) => entry[0] === "/fake/config/default.yaml");
+  const call = mockMutateYaml.mock.calls.find(
+    (entry) => normalizeTestPath(entry[0]) === "/fake/config/default.yaml",
+  );
   if (!call) {
     throw new Error("config/default.yaml mutator was not called");
   }
@@ -106,7 +112,7 @@ describe("update-checker syncs version state and config YAML", () => {
     );
     expect(versionWrites.length).toBeGreaterThanOrEqual(1);
     const writePath = versionWrites[0][0] as string;
-    expect(writePath).toBe("/fake/data/version-state.json");
+    expect(normalizeTestPath(writePath)).toBe("/fake/data/version-state.json");
 
     // Parse the written content
     const written = JSON.parse(versionWrites[0][1] as string) as {


### PR DESCRIPTION
## Summary

Claude Messages 入站现在接受并保序透传 message-level `system` / `developer` role，避免新版 Claude Code 请求因 schema 限制被拒绝，或在翻译到账号池 Codex 请求时丢失 role 顺序。未知 role 会记录 warning 并降级为 `user`，保持 forward-compatible。

## Changes

- 放宽 Anthropic Messages schema 的 message role 校验为非空字符串，允许未来 role 进入翻译层处理（`src/types/anthropic.ts`）。
- 在 Anthropic → Codex 翻译中集中规范 role：`system` / `developer` / `user` / `assistant` 保序透传，未知 role 记录日志并降级为 `user`（`src/translation/anthropic-to-codex.ts`）。
- 增加 schema、role 保序、tool call 顺序和未知 role 降级回归测试（`tests/unit/types/anthropic-schema.test.ts`、`tests/unit/translation/anthropic-to-codex.test.ts`）。
- 修正 update-checker 单测中的 fake path 比较，使其在 Windows 下不因 `path.resolve()` 盘符/反斜杠差异误失败（`tests/unit/update-checker.test.ts`）。
- 记录 CHANGELOG Fixed 条目（`CHANGELOG.md`）。

## Test Plan

- [x] `npx vitest run tests/unit/types/anthropic-schema.test.ts tests/unit/translation/anthropic-to-codex.test.ts tests/unit/update-checker.test.ts` — 3 files / 62 tests passed.
- [x] `npx tsc --noEmit` — passed.
- [ ] `npm test` — attempted on Windows; unrelated baseline/environment failures remain in `tests/unit/web/theme.test.ts`, shell-dependent `docker-entrypoint`/`electron-smoke` tests (`sh`/`bash` ENOENT), and several existing timeout-style tests. Targeted role/update-checker tests above pass.
- [ ] `npm run test:real` — not run; no live upstream credentials/session verification in this local pass.

## Notes

- PR is based on `dev`. `src/proxy/codex-types.ts` already contains `developer` role support on current `dev`, so this PR only changes Anthropic schema/translation handling and tests.