### PR TITLE
fix(messages): add Anthropic count tokens endpoint

### DIFF
--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -3,10 +3,10 @@
  * POST /v1/messages — compatible with Claude Code CLI and other Anthropic clients.
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import type { StatusCode } from "hono/utils/http-status";
-import { AnthropicMessagesRequestSchema } from "../types/anthropic.js";
-import type { AnthropicErrorBody, AnthropicErrorType } from "../types/anthropic.js";
+import { AnthropicCountTokensRequestSchema, AnthropicMessagesRequestSchema } from "../types/anthropic.js";
+import type { AnthropicCountTokensRequest, AnthropicErrorBody, AnthropicErrorType, AnthropicMessagesRequest } from "../types/anthropic.js";
 import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
@@ -34,6 +34,78 @@ function makeError(
   message: string,
 ): AnthropicErrorBody {
   return { type: "error", error: { type, message } };
+}
+
+function checkProxyApiKey(c: Context, accountPool: AccountPool): Response | null {
+  const config = getConfig();
+  if (!config.server.proxy_api_key) return null;
+
+  const xApiKey = c.req.header("x-api-key");
+  const authHeader = c.req.header("Authorization");
+  const bearerKey = authHeader?.replace("Bearer ", "");
+  const providedKey = xApiKey ?? bearerKey;
+
+  if (!providedKey || !accountPool.validateProxyApiKey(providedKey)) {
+    c.status(401);
+    return c.json(makeError("authentication_error", "Invalid API key"));
+  }
+
+  return null;
+}
+
+function estimateTextTokens(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+
+  const cjkMatches = trimmed.match(/[\u3400-\u9fff\uf900-\ufaff]/g);
+  const cjkCount = cjkMatches?.length ?? 0;
+  const nonCjkCount = Math.max(0, trimmed.length - cjkCount);
+
+  return Math.ceil(nonCjkCount / 4) + cjkCount;
+}
+
+function estimateUnknownTokens(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "string") return estimateTextTokens(value);
+  if (typeof value === "number" || typeof value === "boolean") {
+    return estimateTextTokens(String(value));
+  }
+  if (Array.isArray(value)) {
+    return value.reduce((sum, item) => sum + estimateUnknownTokens(item), 0) + value.length;
+  }
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).reduce(
+      (sum, [key, item]) => sum + estimateTextTokens(key) + estimateUnknownTokens(item),
+      2,
+    );
+  }
+  return estimateTextTokens(String(value));
+}
+
+function estimateMessageContentTokens(content: AnthropicMessagesRequest["messages"][number]["content"]): number {
+  if (typeof content === "string") return estimateTextTokens(content);
+  return content.reduce((sum, block) => sum + estimateUnknownTokens(block), 0);
+}
+
+function estimateCountTokens(req: AnthropicCountTokensRequest): number {
+  const modelTokens = estimateTextTokens(req.model);
+  const systemTokens = req.system ? estimateUnknownTokens(req.system) + 4 : 0;
+  const messageTokens = req.messages.reduce(
+    (sum, message) =>
+      sum +
+      4 +
+      estimateTextTokens(message.role) +
+      estimateMessageContentTokens(message.content),
+    0,
+  );
+  const toolTokens = (req.tools ?? []).reduce(
+    (sum, tool) => sum + 16 + estimateUnknownTokens(tool),
+    0,
+  );
+  const toolChoiceTokens = req.tool_choice ? estimateUnknownTokens(req.tool_choice) : 0;
+  const thinkingTokens = req.thinking ? estimateUnknownTokens(req.thinking) : 0;
+
+  return Math.max(1, modelTokens + systemTokens + messageTokens + toolTokens + toolChoiceTokens + thinkingTokens + 3);
 }
 
 function makeAnthropicFormat(wantThinking: boolean): FormatAdapter {
@@ -77,6 +149,31 @@ export function createMessagesRoutes(
 ): Hono {
   const app = new Hono();
 
+  app.post("/v1/messages/count_tokens", async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      c.status(400);
+      return c.json(
+        makeError("invalid_request_error", "Invalid JSON in request body"),
+      );
+    }
+
+    const parsed = AnthropicCountTokensRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      c.status(400);
+      return c.json(
+        makeError("invalid_request_error", `Invalid request: ${parsed.error.message}`),
+      );
+    }
+
+    const authError = checkProxyApiKey(c, accountPool);
+    if (authError) return authError;
+
+    return c.json({ input_tokens: estimateCountTokens(parsed.data) });
+  });
+
   app.post("/v1/messages", async (c) => {
     // Parse request
     let body: unknown;
@@ -108,19 +205,8 @@ export function createMessagesRoutes(
       );
     }
 
-    // Optional proxy API key check (x-api-key or Bearer token)
-    const config = getConfig();
-    if (config.server.proxy_api_key) {
-      const xApiKey = c.req.header("x-api-key");
-      const authHeader = c.req.header("Authorization");
-      const bearerKey = authHeader?.replace("Bearer ", "");
-      const providedKey = xApiKey ?? bearerKey;
-
-      if (!providedKey || !accountPool.validateProxyApiKey(providedKey)) {
-        c.status(401);
-        return c.json(makeError("authentication_error", "Invalid API key"));
-      }
-    }
+    const authError = checkProxyApiKey(c, accountPool);
+    if (authError) return authError;
 
     const clientConversationId = extractAnthropicClientConversationId(
       req,

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -146,6 +146,22 @@ export type AnthropicMessagesRequest = z.infer<
   typeof AnthropicMessagesRequestSchema
 >;
 
+export const AnthropicCountTokensRequestSchema = z.object({
+  model: z.string(),
+  messages: z.array(AnthropicMessageSchema).min(1),
+  system: z
+    .union([z.string(), z.array(AnthropicTextContentSchema)])
+    .optional(),
+  tools: AnthropicMessagesRequestSchema.shape.tools,
+  tool_choice: AnthropicMessagesRequestSchema.shape.tool_choice,
+  thinking: AnthropicMessagesRequestSchema.shape.thinking,
+  betas: z.array(z.string()).optional(),
+});
+
+export type AnthropicCountTokensRequest = z.infer<
+  typeof AnthropicCountTokensRequestSchema
+>;
+
 // --- Response ---
 
 export interface AnthropicContentBlock {

--- a/tests/e2e/messages.test.ts
+++ b/tests/e2e/messages.test.ts
@@ -88,6 +88,14 @@ function messagesRequest(body: unknown) {
   });
 }
 
+function countTokensRequest(body: unknown) {
+  return ctx.app.request("/v1/messages/count_tokens?beta=true", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 function defaultBody(overrides?: Record<string, unknown>) {
   return {
     model: "codex",
@@ -115,6 +123,67 @@ function parseAnthropicSSE(text: string): Array<{ event: string; data: unknown }
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("E2E: POST /v1/messages", () => {
+  it("count_tokens: returns local Anthropic-compatible token estimate without upstream call", async () => {
+    const res = await countTokensRequest({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hello from Claude Code" }],
+      tools: [{
+        name: "Read",
+        description: "Read a file from the local workspace",
+        input_schema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+          },
+          required: ["file_path"],
+        },
+      }],
+      betas: ["token-efficient-tools-2025-02-19"],
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { input_tokens?: unknown };
+    expect(typeof body.input_tokens).toBe("number");
+    expect(body.input_tokens).toBeGreaterThan(0);
+    expect(body.input_tokens).toBeLessThan(500);
+    expect(getMockTransport().post).not.toHaveBeenCalled();
+  });
+
+  it("count_tokens: works without an authenticated Codex account", async () => {
+    const noAuth = buildApp({ noAccount: true });
+    try {
+      const res = await noAuth.app.request("/v1/messages/count_tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.5",
+          messages: [{ role: "user", content: "count only" }],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { input_tokens?: unknown };
+      expect(typeof body.input_tokens).toBe("number");
+      expect(body.input_tokens).toBeGreaterThan(0);
+    } finally {
+      noAuth.cookieJar.destroy();
+      noAuth.proxyPool.destroy();
+      noAuth.accountPool.destroy();
+    }
+  });
+
+  it("count_tokens: invalid requests return Anthropic error shape", async () => {
+    const res = await countTokensRequest({
+      model: "gpt-5.5",
+      messages: [],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { type: string; error: { type: string } };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
   // ── Anthropic SSE format ───────────────────────────────────────
 
   it("streaming: full Anthropic SSE event sequence", async () => {

--- a/tests/unit/routes/messages-count-tokens.test.ts
+++ b/tests/unit/routes/messages-count-tokens.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConfig = {
+  server: { proxy_api_key: null as string | null },
+  auth: {
+    rotation_strategy: "least_used" as const,
+    rate_limit_backoff_seconds: 60,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+import { AccountPool } from "@src/auth/account-pool.js";
+import { createMessagesRoutes } from "@src/routes/messages.js";
+
+function countTokensBody() {
+  return {
+    model: "gpt-5.5",
+    messages: [{ role: "user", content: "count only" }],
+  };
+}
+
+describe("messages count_tokens route", () => {
+  beforeEach(() => {
+    mockConfig.server.proxy_api_key = null;
+  });
+
+  it("requires proxy API key when configured", async () => {
+    mockConfig.server.proxy_api_key = "proxy-secret";
+    const pool = new AccountPool();
+    const app = createMessagesRoutes(pool);
+
+    try {
+      const rejected = await app.request("/v1/messages/count_tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(countTokensBody()),
+      });
+      expect(rejected.status).toBe(401);
+
+      const accepted = await app.request("/v1/messages/count_tokens?beta=true", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer proxy-secret",
+        },
+        body: JSON.stringify(countTokensBody()),
+      });
+      expect(accepted.status).toBe(200);
+
+      const body = await accepted.json() as { input_tokens?: unknown };
+      expect(typeof body.input_tokens).toBe("number");
+    } finally {
+      pool.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add `POST /v1/messages/count_tokens` for Anthropic-compatible clients
- validate the count-tokens request shape and return `{ input_tokens }`
- keep the endpoint local-only so it does not require an authenticated Codex account or an upstream request
- reuse the configured proxy API key check when `server.proxy_api_key` is set

## Why

Claude Code calls Anthropic SDK `beta.messages.countTokens(...)`, which maps to `/v1/messages/count_tokens?beta=true`. Without this endpoint, `/context` token accounting can fall back to inaccurate estimates and significantly over-report categories such as custom agents.

## Testing

- `npm test -- tests/e2e/messages.test.ts tests/unit/routes/messages-count-tokens.test.ts`
- `npx tsc --noEmit`
- `npm run build`