### PR TITLE
ci: alert on promote-dev→master fast-forward failure

### DIFF
--- a/.github/workflows/promote-dev-to-master.yml
+++ b/.github/workflows/promote-dev-to-master.yml
@@ -144,3 +144,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run docker-publish.yml --ref master
+
+  # If the promote job fails (most commonly the ff-precondition check exiting 1
+  # because master drifted ahead of dev), open a tracking issue so the breakage
+  # is visible instead of silently piling up for weeks. Soak/CI-not-green are
+  # normal skips that keep the job green, so they do not trigger this.
+  notify-ff-failure:
+    needs: promote
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open tracking issue on promote failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TITLE="⚠️ promote-dev→master 卡住：fast-forward 前提被破坏"
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Already tracked in #$EXISTING, not duplicating"
+            exit 0
+          fi
+          gh issue create --repo "$REPO" --title "$TITLE" --body \
+          "\`promote-dev-to-master.yml\` 失败：master 有 dev 没有的提交，ff-promote 链路中断，dev 无法晋升到 master。
+
+          常见近因：master 侧自动产物（changelog→README sync、version bump、promote merge commit）未回流 dev，逐周漂移。
+
+          恢复方法：\`git merge -s ours origin/master\` 把 master 记为已合并（树取 dev），走 PR 进 dev，即可恢复 ff 前提。
+
+          失败 run：$RUN_URL"


### PR DESCRIPTION
## 背景

`promote-dev-to-master.yml` 的 fast-forward 前提被 master 侧 sync-back 漂移破坏后,**连续 ~3 周每天失败却无人察觉**(只有一封被淹没的 Actions 失败邮件)。本次靠手动 `-s ours` reconcile(#616)才发现。

## 改动

新增 `notify-ff-failure` job:
- `needs: promote` + `if: failure()` —— 仅在 promote job **真正失败**(最常见是 ff 前提检查 exit 1)时触发
- soak 未满 / CI 未绿是正常 skip,保持 job green,**不会误报**
- 失败时开一个 tracking issue(对已存在的 open issue 去重,不刷屏),issue 正文附带 `-s ours` 恢复步骤
- job 级 `permissions: issues: write`,不影响 promote job 的权限

## 限制

schedule workflow 跑的是默认分支(master)上的版本,故本告警需随下次 promote 进入 master 后才对运行时生效。

## 测试计划

- `uv run --with pyyaml` 校验 YAML:jobs=[promote, notify-ff-failure],notify needs/if/permissions 均符合预期 ✅
- 合并并 promote 到 master 后,下次若 ff 失败将自动开 issue 验证

## 注意

未根治 sync-back 漂移本身(`sync-changelog.yml` 缺 sync-back + `bump-electron.yml` 的 FF push 对领先 dev 无效)—— 这是告警,不是修复,根治方案待单独评估。