### PR TITLE
fix(version+ci): 对齐版本到 2.0.76 + stable bump 改 tag-only

### DIFF
--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -77,7 +77,7 @@ jobs:
           echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
           echo "series=$SERIES" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version + tag
+      - name: Tag stable release (tag-only)
         id: bump
         if: steps.check.outputs.skip != 'true'
         run: |
@@ -101,63 +101,26 @@ jobs:
             exit 0
           fi
 
-          # Bump root/electron package versions and the workspace lock metadata.
-          node -e "
-            const fs = require('fs');
-            const NEW_VERSION = '${NEW_VERSION}';
-            for (const p of ['package.json', 'packages/electron/package.json']) {
-              const pkg = JSON.parse(fs.readFileSync(p, 'utf-8'));
-              pkg.version = NEW_VERSION;
-              fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
-            }
-            const lock = JSON.parse(fs.readFileSync('package-lock.json', 'utf-8'));
-            lock.version = NEW_VERSION;
-            lock.packages[''].version = NEW_VERSION;
-            lock.packages['packages/electron'].version = NEW_VERSION;
-            fs.writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
-          "
-
-          git add package.json packages/electron/package.json package-lock.json
-          # If version already matches (e.g. first tag in a new series), skip the commit
-          if git diff --cached --quiet; then
-            echo "package.json already at ${NEW_VERSION}, tagging without version commit"
-          else
-            git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
-          fi
+          # Tag-only: do NOT commit package.json onto master. The release
+          # version is read from the tag (release.yml extraMetadata.version),
+          # and a version-bump commit on master cannot FF back to an
+          # always-ahead dev — that drift is what kept breaking promote and
+          # made package.json regress on the next dev→master reconcile.
+          # major.minor (series) is maintained by developers on dev and flows
+          # in via promote; patch is owned entirely by the tag. This mirrors
+          # bump-electron-beta.yml, which has always been tag-only.
           git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"
-
-          # Retry push with rebase on conflict (other workflows may push concurrently)
           for i in 1 2 3; do
-            if git push origin master --follow-tags; then
-              echo "Bumped to $NEW_VERSION, tagged $NEW_TAG"
+            if git push origin "$NEW_TAG"; then
+              echo "Tagged $NEW_TAG (tag-only, no version commit)"
               echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Push failed (attempt $i/3), rebasing and retrying..."
-            git tag -d "$NEW_TAG"
-            git pull --rebase origin master
-            git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"
+            echo "Tag push failed (attempt $i/3), retrying..."
             sleep 2
           done
-          echo "::error::Push failed after 3 attempts"
+          echo "::error::Tag push failed after 3 attempts"
           exit 1
-
-      - name: Sync bump commit back to dev (FF)
-        if: steps.bump.outputs.new_tag
-        # Without this, every stable bump leaves dev behind master by one commit.
-        # The next promote run would then fail FF check ("manual rebase needed")
-        # and stay stuck until someone manually rebases dev.
-        run: |
-          if ! git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
-            echo "dev branch does not exist, skipping sync"
-            exit 0
-          fi
-          git fetch origin dev:refs/remotes/origin/dev
-          if git push origin master:dev; then
-            echo "Synced master ($(git rev-parse master)) to dev (FF)"
-          else
-            echo "::warning::FF push master:dev refused (dev moved during bump window). Manual sync needed."
-          fi
 
       - name: Trigger release workflow
         if: steps.bump.outputs.new_tag

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.75",
+  "version": "2.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.75",
+      "version": "2.0.76",
       "workspaces": [
         "packages/*"
       ],
@@ -7350,7 +7350,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.75",
+      "version": "2.0.76",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.75",
+  "version": "2.0.76",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "type": "module",
   "workspaces": [

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-proxy/electron",
-  "version": "2.0.75",
+  "version": "2.0.76",
   "description": "Codex Proxy desktop app (Electron shell)",
   "private": true,
   "main": "dist-electron/main.cjs",

--- a/tests/unit/ci/package-boundary.test.ts
+++ b/tests/unit/ci/package-boundary.test.ts
@@ -127,13 +127,19 @@ describe("root package boundary", () => {
     expect(asarLockPackage.dev).toBeUndefined();
   });
 
-  it("keeps the stable release bump workflow updating package-lock metadata", () => {
+  it("keeps the stable release bump workflow tag-only (no version commit onto master)", () => {
     const workflow = readFileSync(resolve(ROOT, ".github/workflows/bump-electron.yml"), "utf-8");
-    expect(workflow).toContain("'package-lock.json'");
-    expect(workflow).toContain("lock.version = NEW_VERSION");
-    expect(workflow).toContain("lock.packages[''].version = NEW_VERSION");
-    expect(workflow).toContain("lock.packages['packages/electron'].version = NEW_VERSION");
-    expect(workflow).toContain("git add package.json packages/electron/package.json package-lock.json");
+    // Tag-only contract: bump must NOT commit a version bump or push master.
+    // A version-bump commit on master can't FF back to an always-ahead dev,
+    // which kept breaking promote and regressed package.json on the next
+    // dev→master reconcile. Version ships from the tag (release.yml
+    // extraMetadata.version), mirroring bump-electron-beta.yml.
+    expect(workflow).not.toContain('git commit -m "chore: bump version');
+    expect(workflow).not.toContain("git push origin master");
+    expect(workflow).not.toContain("Sync bump commit back to dev");
+    // It must still create and push the release tag.
+    expect(workflow).toContain('git tag -a "$NEW_TAG"');
+    expect(workflow).toContain('git push origin "$NEW_TAG"');
   });
 
   it("keeps release-note workflow fixes from triggering app releases", () => {


### PR DESCRIPTION
## 问题

`package.json` version 字段倒退到 **2.0.75**,而 v2.0.76 一周前就已发布。根因:当年 `chore: bump version to 2.0.76` commit 只落在 master、从未回流 dev,今天 dev→master reconcile 把字段拉回了 75。这是 bump version 漂移技术债的直接症状。

## 改动(两部分,同一根因)

1. **修数值**:`package.json` / `package-lock.json` / `packages/electron/package.json` 对齐到 **2.0.76**(最新已发 stable tag)。
2. **根治**:`bump-electron.yml` 改 **tag-only** —— 不再 commit version、删掉注定失败的 FF sync-back 步骤,只创建并 push tag。发版版本号从 tag 读(`release.yml extraMetadata.version`),**对发布产物零功能变更**。对称 `bump-electron-beta.yml`(它一直是 tag-only),永久消除第二个 master 漂移源,package.json 再也不会因 promote 倒退。

major.minor(series)仍由开发者在 dev 维护;patch 由 tag 拥有。

## 验证

- YAML 校验通过;bump 步骤已确认:无 git commit、无 push master、只 push tag、sync-back 步骤已删。
- 模拟 bump check:仍从 v2.0.76 算出下一版 **2.0.77**,tag 不冲突。
- ⚠️ tag-only 是发版核心行为变更,合并后需真实跑一次 bump(明天 16:00 cron 或手动 dispatch)验证 v2.0.77 正常发布、master 不再产生 bump commit。

详见 `.github/guides/bump-version-drift-migration.md`(#619)。