### PR TITLE
chore(version): bump to 2.0.77 (next release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.76",
+  "version": "2.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.0.76",
+      "version": "2.0.77",
       "workspaces": [
         "packages/*"
       ],
@@ -7350,7 +7350,7 @@
     },
     "packages/electron": {
       "name": "@codex-proxy/electron",
-      "version": "2.0.76",
+      "version": "2.0.77",
       "dependencies": {
         "electron-updater": "^6.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "2.0.76",
+  "version": "2.0.77",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "type": "module",
   "workspaces": [

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-proxy/electron",
-  "version": "2.0.76",
+  "version": "2.0.77",
   "description": "Codex Proxy desktop app (Electron shell)",
   "private": true,
   "main": "dist-electron/main.cjs",


### PR DESCRIPTION
把 package.json / package-lock.json / packages/electron/package.json 从 2.0.76 推进到 **2.0.77**(下一个待发版本),让版本号反映'代码已超过上周发的 76、正在开发 77',不再停在旧值。

明天的 tag-only bump 会从 v2.0.76 tag 算出并打 tag **v2.0.77**,正好与此字段对上。三处 version 已验证一致。