### PR TITLE
feat(api-keys): fetch provider models dynamically

### DIFF
--- a/shared/hooks/use-api-keys.ts
+++ b/shared/hooks/use-api-keys.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "preact/hooks";
+import { useState, useEffect, useCallback } from "preact/hooks";
 
 export type ApiKeyProvider = "anthropic" | "openai" | "gemini" | "openrouter" | "custom";
 export type ApiKeyCapability = "chat" | "embeddings";
@@ -30,10 +30,10 @@ export interface ProviderMeta {
   models: CatalogModel[];
 }
 
-export interface FetchCustomModelsInput {
-  provider: "custom";
+export interface FetchProviderModelsInput {
+  provider: ApiKeyProvider;
   apiKey: string;
-  baseUrl: string;
+  baseUrl?: string;
 }
 
 export type Catalog = Record<string, ProviderMeta>;
@@ -42,7 +42,6 @@ export function useApiKeys() {
   const [keys, setKeys] = useState<ApiKeyEntry[]>([]);
   const [catalog, setCatalog] = useState<Catalog>({});
   const [loading, setLoading] = useState(true);
-  const customModelCacheRef = useRef(new Map<string, CatalogModel[]>());
 
   const loadKeys = useCallback(async () => {
     try {
@@ -137,11 +136,7 @@ export function useApiKeys() {
     return { added: data.added || 0, failed: data.failed || 0, errors: data.errors || [] };
   }, [loadKeys]);
 
-  const fetchCustomModels = useCallback(async (input: FetchCustomModelsInput): Promise<{ ok: true; models: CatalogModel[] } | { ok: false; error: string }> => {
-    const cacheKey = `${input.baseUrl.trim()}::${input.apiKey.trim()}`;
-    const cached = customModelCacheRef.current.get(cacheKey);
-    if (cached) return { ok: true, models: cached };
-
+  const fetchProviderModels = useCallback(async (input: FetchProviderModelsInput): Promise<{ ok: true; models: CatalogModel[] } | { ok: false; error: string }> => {
     try {
       const resp = await fetch("/auth/api-keys/models", {
         method: "POST",
@@ -149,13 +144,12 @@ export function useApiKeys() {
         body: JSON.stringify({
           provider: input.provider,
           apiKey: input.apiKey.trim(),
-          baseUrl: input.baseUrl.trim(),
+          baseUrl: input.baseUrl?.trim(),
         }),
       });
       const data = await resp.json();
       if (!resp.ok) return { ok: false, error: data.error || "Failed to fetch models" };
       const models = Array.isArray(data.models) ? data.models : [];
-      customModelCacheRef.current.set(cacheKey, models);
       return { ok: true, models };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : "Network error" };
@@ -187,7 +181,7 @@ export function useApiKeys() {
     updateLabel,
     importKeys,
     exportKeys,
-    fetchCustomModels,
+    fetchProviderModels,
     refresh: loadKeys,
   };
 }

--- a/src/auth/api-key-catalog.ts
+++ b/src/auth/api-key-catalog.ts
@@ -21,22 +21,39 @@ export const PROVIDER_CATALOG: Record<BuiltinProvider, ProviderMeta> = {
   anthropic: {
     displayName: "Anthropic",
     defaultBaseUrl: "https://api.anthropic.com/v1",
-    models: [],
+    // Minimal fallback — overridden by dynamic fetch after API key entry.
+    models: [
+      { id: "claude-opus-4-5", displayName: "Claude Opus 4.5" },
+      { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5" },
+    ],
   },
   openai: {
     displayName: "OpenAI",
     defaultBaseUrl: "https://api.openai.com/v1",
-    models: [],
+    models: [
+      { id: "gpt-4.1", displayName: "GPT-4.1" },
+      { id: "gpt-4.1-mini", displayName: "GPT-4.1 Mini" },
+      { id: "o4-mini", displayName: "o4 Mini" },
+    ],
   },
   gemini: {
     displayName: "Google Gemini",
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
-    models: [],
+    models: [
+      { id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+      { id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash" },
+    ],
   },
   openrouter: {
     displayName: "OpenRouter",
     defaultBaseUrl: "https://openrouter.ai/api/v1",
-    models: [],
+    models: [
+      { id: "anthropic/claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+      { id: "openai/gpt-4.1", displayName: "GPT-4.1" },
+      { id: "google/gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+      { id: "deepseek/deepseek-r1", displayName: "DeepSeek R1" },
+    ],
   },
 };
 

--- a/src/auth/api-key-catalog.ts
+++ b/src/auth/api-key-catalog.ts
@@ -17,62 +17,26 @@ export interface ProviderMeta {
   models: CatalogModel[];
 }
 
-const ANTHROPIC_MODELS: CatalogModel[] = [
-  { id: "claude-opus-4-7", displayName: "Claude Opus 4.7" },
-  { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-5", displayName: "Claude Haiku 4.5" },
-];
-
-const OPENAI_MODELS: CatalogModel[] = [
-  { id: "gpt-5.4", displayName: "GPT-5.4" },
-  { id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
-  { id: "gpt-5.3-codex", displayName: "GPT-5.3 Codex" },
-  { id: "gpt-4.1", displayName: "GPT-4.1" },
-  { id: "gpt-4.1-mini", displayName: "GPT-4.1 Mini" },
-  { id: "o3", displayName: "o3" },
-  { id: "o3-mini", displayName: "o3 Mini" },
-  { id: "o4-mini", displayName: "o4 Mini" },
-];
-
-const GEMINI_MODELS: CatalogModel[] = [
-  { id: "gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro" },
-  { id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash" },
-  { id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash" },
-];
-
-const OPENROUTER_MODELS: CatalogModel[] = [
-  { id: "anthropic/claude-opus-4.6", displayName: "Claude Opus 4.6" },
-  { id: "anthropic/claude-sonnet-4.6", displayName: "Claude Sonnet 4.6" },
-  { id: "openai/gpt-5.4", displayName: "GPT-5.4" },
-  { id: "google/gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro" },
-  { id: "google/gemini-3.1-flash-lite", displayName: "Gemini 3.1 Flash Lite" },
-  { id: "deepseek/deepseek-v3.2", displayName: "DeepSeek V3.2" },
-  { id: "deepseek/deepseek-r1", displayName: "DeepSeek R1" },
-  { id: "meta-llama/llama-4-maverick", displayName: "Llama 4 Maverick" },
-  { id: "mistralai/mistral-small-4", displayName: "Mistral Small 4" },
-  { id: "qwen/qwen3-coder-480b-a35b-07-25", displayName: "Qwen3 Coder 480B" },
-];
-
 export const PROVIDER_CATALOG: Record<BuiltinProvider, ProviderMeta> = {
   anthropic: {
     displayName: "Anthropic",
     defaultBaseUrl: "https://api.anthropic.com/v1",
-    models: ANTHROPIC_MODELS,
+    models: [],
   },
   openai: {
     displayName: "OpenAI",
     defaultBaseUrl: "https://api.openai.com/v1",
-    models: OPENAI_MODELS,
+    models: [],
   },
   gemini: {
     displayName: "Google Gemini",
     defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
-    models: GEMINI_MODELS,
+    models: [],
   },
   openrouter: {
     displayName: "OpenRouter",
     defaultBaseUrl: "https://openrouter.ai/api/v1",
-    models: OPENROUTER_MODELS,
+    models: [],
   },
 };
 

--- a/src/auth/api-key-model-cache.ts
+++ b/src/auth/api-key-model-cache.ts
@@ -1,0 +1,288 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { getDataDir } from "../paths.js";
+import { PROVIDER_CATALOG, isBuiltinProvider } from "./api-key-catalog.js";
+import type { ApiKeyProvider, BuiltinProvider, CatalogModel, ProviderMeta } from "./api-key-catalog.js";
+
+export const MODEL_CACHE_TTL_MS = 183 * 24 * 60 * 60 * 1000;
+
+export interface ApiKeyModelCacheEntry {
+  url: string;
+  models: CatalogModel[];
+  fetchedAt: string;
+}
+
+export interface ApiKeyModelCacheFile {
+  entries: Record<string, ApiKeyModelCacheEntry>;
+}
+
+export interface ApiKeyModelCachePersistence {
+  load(): ApiKeyModelCacheFile;
+  save(cache: ApiKeyModelCacheFile): void;
+}
+
+export interface FetchProviderModelsInput {
+  provider: ApiKeyProvider;
+  apiKey: string;
+  baseUrl?: string;
+}
+
+interface ModelRequest {
+  cacheUrl: string;
+  requestUrl: string;
+  headers: Record<string, string>;
+}
+
+export type ProviderModelFetchErrorKind = "unauthorized" | "provider" | "network" | "empty";
+
+export class ProviderModelFetchError extends Error {
+  constructor(public readonly kind: ProviderModelFetchErrorKind, message: string) {
+    super(message);
+    this.name = "ProviderModelFetchError";
+  }
+}
+
+export interface ApiKeyModelCacheOptions {
+  persistence?: ApiKeyModelCachePersistence;
+  fetchFn?: typeof fetch;
+  now?: () => Date;
+}
+
+const BUILTIN_MODEL_URLS: Record<BuiltinProvider, string> = {
+  anthropic: "https://api.anthropic.com/v1/models",
+  openai: "https://api.openai.com/v1/models",
+  gemini: "https://generativelanguage.googleapis.com/v1beta/models",
+  openrouter: "https://openrouter.ai/api/v1/models",
+};
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export function createFsApiKeyModelCachePersistence(filePath = resolve(getDataDir(), "api-key-models-cache.json")): ApiKeyModelCachePersistence {
+  return {
+    load: () => {
+      if (!existsSync(filePath)) return { entries: {} };
+      try {
+        return parseCacheFile(JSON.parse(readFileSync(filePath, "utf-8")));
+      } catch {
+        return { entries: {} };
+      }
+    },
+    save: (cache) => {
+      mkdirSync(dirname(filePath), { recursive: true });
+      const tmpFile = `${filePath}.tmp`;
+      writeFileSync(tmpFile, JSON.stringify(cache, null, 2), "utf-8");
+      renameSync(tmpFile, filePath);
+    },
+  };
+}
+
+export class ApiKeyModelCache {
+  private readonly persistence: ApiKeyModelCachePersistence;
+  private readonly fetchFn: typeof fetch;
+  private readonly now: () => Date;
+
+  constructor(options: ApiKeyModelCacheOptions = {}) {
+    this.persistence = options.persistence ?? createFsApiKeyModelCachePersistence();
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  getCatalogWithCachedModels(): Record<BuiltinProvider, ProviderMeta> {
+    const catalog = {} as Record<BuiltinProvider, ProviderMeta>;
+    for (const provider of Object.keys(PROVIDER_CATALOG) as BuiltinProvider[]) {
+      const meta = PROVIDER_CATALOG[provider];
+      catalog[provider] = {
+        ...meta,
+        models: this.getCachedModelsByUrl(BUILTIN_MODEL_URLS[provider]) ?? [],
+      };
+    }
+    return catalog;
+  }
+
+  getCachedModelsByUrl(url: string): CatalogModel[] | null {
+    const cache = this.persistence.load();
+    const entry = cache.entries[url];
+    if (!entry) return null;
+    const fetchedAt = Date.parse(entry.fetchedAt);
+    if (!Number.isFinite(fetchedAt)) return null;
+    if (this.now().getTime() - fetchedAt >= MODEL_CACHE_TTL_MS) return null;
+    return entry.models;
+  }
+
+  async fetchModels(input: FetchProviderModelsInput): Promise<CatalogModel[]> {
+    const request = buildModelRequest(input);
+    const cached = this.getCachedModelsByUrl(request.cacheUrl);
+    if (cached) return cached;
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(request.requestUrl, {
+        headers: request.headers,
+      });
+    } catch {
+      throw new ProviderModelFetchError("network", "Failed to reach provider");
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw new ProviderModelFetchError("unauthorized", "Failed to fetch models: unauthorized");
+    }
+    if (!response.ok) {
+      throw new ProviderModelFetchError("provider", "Failed to fetch models from provider");
+    }
+
+    const payload = await response.json().catch(() => null) as unknown;
+    const models = normalizeProviderModels(input.provider, payload);
+    if (models.length === 0) {
+      throw new ProviderModelFetchError("empty", "Provider returned no models");
+    }
+
+    const cache = this.persistence.load();
+    cache.entries[request.cacheUrl] = {
+      url: request.cacheUrl,
+      models,
+      fetchedAt: this.now().toISOString(),
+    };
+    this.persistence.save(cache);
+    return models;
+  }
+}
+
+function parseCacheFile(value: unknown): ApiKeyModelCacheFile {
+  if (!isRecord(value) || !isRecord(value.entries)) return { entries: {} };
+  const entries: Record<string, ApiKeyModelCacheEntry> = {};
+  for (const [key, rawEntry] of Object.entries(value.entries)) {
+    if (!isRecord(rawEntry)) continue;
+    const url = readString(rawEntry, "url");
+    const fetchedAt = readString(rawEntry, "fetchedAt");
+    if (!url || !fetchedAt || !Array.isArray(rawEntry.models)) continue;
+    const models = normalizeCatalogModels(rawEntry.models);
+    if (models.length === 0) continue;
+    entries[key] = { url, fetchedAt, models };
+  }
+  return { entries };
+}
+
+function buildModelRequest(input: FetchProviderModelsInput): ModelRequest {
+  const apiKey = input.apiKey.trim();
+  if (input.provider === "custom") {
+    const baseUrl = input.baseUrl?.trim();
+    if (!baseUrl) throw new ProviderModelFetchError("provider", "baseUrl is required for custom providers");
+    const cacheUrl = `${normalizeBaseUrl(baseUrl)}/models`;
+    return {
+      cacheUrl,
+      requestUrl: cacheUrl,
+      headers: bearerHeaders(apiKey),
+    };
+  }
+
+  if (!isBuiltinProvider(input.provider)) {
+    throw new ProviderModelFetchError("provider", "Unsupported provider");
+  }
+
+  const cacheUrl = BUILTIN_MODEL_URLS[input.provider];
+  if (input.provider === "anthropic") {
+    return {
+      cacheUrl,
+      requestUrl: cacheUrl,
+      headers: {
+        ...bearerHeaders(apiKey),
+        "anthropic-version": "2023-06-01",
+      },
+    };
+  }
+  if (input.provider === "gemini") {
+    const requestUrl = new URL(cacheUrl);
+    requestUrl.searchParams.set("key", apiKey);
+    return {
+      cacheUrl,
+      requestUrl: requestUrl.toString(),
+      headers: { Accept: "application/json" },
+    };
+  }
+
+  return {
+    cacheUrl,
+    requestUrl: cacheUrl,
+    headers: bearerHeaders(apiKey),
+  };
+}
+
+function bearerHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    Accept: "application/json",
+  };
+}
+
+export function normalizeProviderModels(provider: ApiKeyProvider, payload: unknown): CatalogModel[] {
+  if (provider === "gemini") return normalizeGeminiModels(payload);
+  return normalizeDataModels(payload, provider === "anthropic" ? ["display_name", "name"] : ["name", "display_name"]);
+}
+
+function normalizeDataModels(payload: unknown, displayKeys: string[]): CatalogModel[] {
+  if (!isRecord(payload) || !Array.isArray(payload.data)) return [];
+  const models: CatalogModel[] = [];
+  for (const item of payload.data) {
+    if (!isRecord(item)) continue;
+    const id = readString(item, "id");
+    if (!id) continue;
+    models.push({
+      id,
+      displayName: readFirstString(item, displayKeys) || id,
+    });
+  }
+  return dedupeCatalogModels(models);
+}
+
+function normalizeGeminiModels(payload: unknown): CatalogModel[] {
+  if (!isRecord(payload) || !Array.isArray(payload.models)) return [];
+  const models: CatalogModel[] = [];
+  for (const item of payload.models) {
+    if (!isRecord(item)) continue;
+    const rawId = readString(item, "name");
+    if (!rawId) continue;
+    const id = rawId.startsWith("models/") ? rawId.slice("models/".length) : rawId;
+    models.push({
+      id,
+      displayName: readFirstString(item, ["displayName", "display_name"]) || id,
+    });
+  }
+  return dedupeCatalogModels(models);
+}
+
+function normalizeCatalogModels(items: unknown[]): CatalogModel[] {
+  const models: CatalogModel[] = [];
+  for (const item of items) {
+    if (!isRecord(item)) continue;
+    const id = readString(item, "id");
+    const displayName = readString(item, "displayName");
+    if (!id || !displayName) continue;
+    models.push({ id, displayName });
+  }
+  return dedupeCatalogModels(models);
+}
+
+function dedupeCatalogModels(models: CatalogModel[]): CatalogModel[] {
+  const deduped = new Map<string, CatalogModel>();
+  for (const model of models) deduped.set(model.id, model);
+  return [...deduped.values()];
+}
+
+function readFirstString(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = readString(record, key);
+    if (value) return value;
+  }
+  return "";
+}
+
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/auth/api-key-model-cache.ts
+++ b/src/auth/api-key-model-cache.ts
@@ -4,7 +4,7 @@ import { getDataDir } from "../paths.js";
 import { PROVIDER_CATALOG, isBuiltinProvider } from "./api-key-catalog.js";
 import type { ApiKeyProvider, BuiltinProvider, CatalogModel, ProviderMeta } from "./api-key-catalog.js";
 
-export const MODEL_CACHE_TTL_MS = 183 * 24 * 60 * 60 * 1000;
+export const MODEL_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — provider model lists change frequently
 
 export interface ApiKeyModelCacheEntry {
   url: string;
@@ -90,19 +90,24 @@ export class ApiKeyModelCache {
   }
 
   getCatalogWithCachedModels(): Record<BuiltinProvider, ProviderMeta> {
+    // Load persistence once to avoid N disk reads for N providers.
+    const cache = this.persistence.load();
     const catalog = {} as Record<BuiltinProvider, ProviderMeta>;
     for (const provider of Object.keys(PROVIDER_CATALOG) as BuiltinProvider[]) {
       const meta = PROVIDER_CATALOG[provider];
       catalog[provider] = {
         ...meta,
-        models: this.getCachedModelsByUrl(BUILTIN_MODEL_URLS[provider]) ?? [],
+        models: this.getCachedModelsByUrlFromCache(cache, BUILTIN_MODEL_URLS[provider]) ?? meta.models,
       };
     }
     return catalog;
   }
 
   getCachedModelsByUrl(url: string): CatalogModel[] | null {
-    const cache = this.persistence.load();
+    return this.getCachedModelsByUrlFromCache(this.persistence.load(), url);
+  }
+
+  private getCachedModelsByUrlFromCache(cache: ApiKeyModelCacheFile, url: string): CatalogModel[] | null {
     const entry = cache.entries[url];
     if (!entry) return null;
     const fetchedAt = Date.parse(entry.fetchedAt);
@@ -113,7 +118,10 @@ export class ApiKeyModelCache {
 
   async fetchModels(input: FetchProviderModelsInput): Promise<CatalogModel[]> {
     const request = buildModelRequest(input);
-    const cached = this.getCachedModelsByUrl(request.cacheUrl);
+    // Load once — reuse for both cache-hit check and write-back to avoid
+    // two separate disk reads per request.
+    const cache = this.persistence.load();
+    const cached = this.getCachedModelsByUrlFromCache(cache, request.cacheUrl);
     if (cached) return cached;
 
     let response: Response;
@@ -121,8 +129,8 @@ export class ApiKeyModelCache {
       response = await this.fetchFn(request.requestUrl, {
         headers: request.headers,
       });
-    } catch {
-      throw new ProviderModelFetchError("network", "Failed to reach provider");
+    } catch (err) {
+      throw new ProviderModelFetchError("network", `Failed to reach provider: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     if (response.status === 401 || response.status === 403) {
@@ -138,7 +146,6 @@ export class ApiKeyModelCache {
       throw new ProviderModelFetchError("empty", "Provider returned no models");
     }
 
-    const cache = this.persistence.load();
     cache.entries[request.cacheUrl] = {
       url: request.cacheUrl,
       models,
@@ -218,6 +225,8 @@ function bearerHeaders(apiKey: string): Record<string, string> {
 
 export function normalizeProviderModels(provider: ApiKeyProvider, payload: unknown): CatalogModel[] {
   if (provider === "gemini") return normalizeGeminiModels(payload);
+  // Anthropic's /v1/models response uses `id` + `display_name` (no `name` field).
+  // OpenAI and OpenRouter use `id` + `name` as the human-readable display.
   return normalizeDataModels(payload, provider === "anthropic" ? ["display_name", "name"] : ["name", "display_name"]);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { AnthropicUpstream } from "./proxy/anthropic-upstream.js";
 import { GeminiUpstream } from "./proxy/gemini-upstream.js";
 import { ApiKeyPool } from "./auth/api-key-pool.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
+import { ApiKeyModelCache } from "./auth/api-key-model-cache.js";
 import { createEmbeddingsRoutes } from "./routes/embeddings.js";
 import { createRuntimeUpstreamRouter } from "./proxy/upstream-router-bootstrap.js";
 import { startOllamaBridge, stopOllamaBridge } from "./ollama/server.js";
@@ -163,6 +164,9 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   const upstreamRouter = createRuntimeUpstreamRouter(adapters, cfg.model_routing, apiKeyPool);
   if (hasApiKeys) console.log(`[Init] API key pool: ${apiKeyPool.getAll().length} key(s) loaded`);
 
+  // Create a single model cache instance shared across all routes.
+  const apiKeyModelCache = new ApiKeyModelCache();
+
   // Mount routes
   const authRoutes = createAuthRoutes(accountPool, refreshScheduler);
   const accountRoutes = createAccountRoutes(accountPool, refreshScheduler, cookieJar, proxyPool);
@@ -170,7 +174,7 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
   const messagesRoutes = createMessagesRoutes(accountPool, cookieJar, proxyPool, upstreamRouter);
   const geminiRoutes = createGeminiRoutes(accountPool, cookieJar, proxyPool, upstreamRouter);
   const responsesRoutes = createResponsesRoutes(accountPool, cookieJar, proxyPool, upstreamRouter);
-  const apiKeyRoutes = createApiKeyRoutes(apiKeyPool);
+  const apiKeyRoutes = createApiKeyRoutes(apiKeyPool, apiKeyModelCache);
   const embeddingsRoutes = createEmbeddingsRoutes(accountPool, apiKeyPool);
   const proxyRoutes = createProxyRoutes(proxyPool, accountPool);
   const usageStats = new UsageStatsStore();

--- a/src/routes/api-keys.ts
+++ b/src/routes/api-keys.ts
@@ -8,7 +8,7 @@ import type { Context } from "hono";
 import { z } from "zod";
 import { API_KEY_CAPABILITIES, API_KEY_WIRES } from "../auth/api-key-pool.js";
 import type { ApiKeyEntry, ApiKeyPool } from "../auth/api-key-pool.js";
-import { PROVIDER_CATALOG } from "../auth/api-key-catalog.js";
+import { ApiKeyModelCache, ProviderModelFetchError } from "../auth/api-key-model-cache.js";
 
 const VALID_PROVIDERS = ["anthropic", "openai", "gemini", "openrouter", "custom"] as const;
 const ModelsSchema = z.array(z.string().trim().min(1)).min(1).transform((models) => [...new Set(models)]);
@@ -28,42 +28,20 @@ const ApiKeyBindingSchema = z.object({
   { message: "baseUrl is required for custom providers" },
 );
 
-const FetchCustomModelsSchema = z.object({
-  provider: z.literal("custom"),
+const FetchProviderModelsSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS),
   apiKey: z.string().trim().min(1),
-  baseUrl: z.string().trim().url(),
-});
+  baseUrl: z.string().trim().url().optional(),
+}).refine(
+  (d) => d.provider !== "custom" || Boolean(d.baseUrl),
+  { message: "baseUrl is required for custom providers" },
+);
 
 const BulkImportSchema = z.object({
   keys: z.array(ApiKeyBindingSchema).min(1),
 });
 
 type ApiKeyBindingInput = z.infer<typeof ApiKeyBindingSchema>;
-
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
-}
-
-function normalizeFetchedModels(payload: unknown): Array<{ id: string; displayName: string }> {
-  if (!payload || typeof payload !== "object" || !("data" in payload) || !Array.isArray(payload.data)) {
-    return [];
-  }
-
-  const models: Array<{ id: string; displayName: string }> = [];
-  for (const item of payload.data) {
-    if (!item || typeof item !== "object") continue;
-    const id = typeof item.id === "string" ? item.id.trim() : "";
-    if (!id) continue;
-    const displayName = typeof item.name === "string" && item.name.trim()
-      ? item.name.trim()
-      : id;
-    models.push({ id, displayName });
-  }
-
-  const deduped = new Map<string, { id: string; displayName: string }>();
-  for (const model of models) deduped.set(model.id, model);
-  return [...deduped.values()];
-}
 
 function addEntries(pool: ApiKeyPool, items: ApiKeyBindingInput[]): {
   added: number;
@@ -126,13 +104,13 @@ async function parseJsonRequest<T>(c: Context, schema: z.ZodSchema<T>): Promise<
   return { ok: true, data: result.data };
 }
 
-export function createApiKeyRoutes(pool: ApiKeyPool): Hono {
+export function createApiKeyRoutes(pool: ApiKeyPool, modelCache = new ApiKeyModelCache()): Hono {
   const app = new Hono();
 
   // ── Catalog (predefined models) ──────────────────────────────
 
   app.get("/auth/api-keys/catalog", (c) => {
-    return c.json({ catalog: PROVIDER_CATALOG });
+    return c.json({ catalog: modelCache.getCatalogWithCachedModels() });
   });
 
   // ── List ──────────────────────────────────────────────────────
@@ -141,40 +119,24 @@ export function createApiKeyRoutes(pool: ApiKeyPool): Hono {
     return c.json({ keys: pool.exportAll(false) });
   });
 
-  // ── Fetch custom provider models ───────────────────────────────
+  // ── Fetch provider models ──────────────────────────────────────
 
   app.post("/auth/api-keys/models", async (c) => {
-    const parsed = await parseJsonRequest(c, FetchCustomModelsSchema);
+    const parsed = await parseJsonRequest(c, FetchProviderModelsSchema);
     if (!parsed.ok) return parsed.response;
 
-    const baseUrl = normalizeBaseUrl(parsed.data.baseUrl);
-
     try {
-      const upstream = await fetch(`${baseUrl}/models`, {
-        headers: {
-          "Authorization": `Bearer ${parsed.data.apiKey}`,
-          "Accept": "application/json",
-        },
-      });
-
-      if (!upstream.ok) {
-        if (upstream.status === 401 || upstream.status === 403) {
-          c.status(upstream.status);
+      const models = await modelCache.fetchModels(parsed.data);
+      return c.json({ models });
+    } catch (err) {
+      if (err instanceof ProviderModelFetchError) {
+        if (err.kind === "unauthorized") {
+          c.status(401);
           return c.json({ error: "Failed to fetch models: unauthorized" });
         }
         c.status(502);
-        return c.json({ error: "Failed to fetch models from provider" });
+        return c.json({ error: err.message });
       }
-
-      const payload = await upstream.json().catch(() => null);
-      const models = normalizeFetchedModels(payload);
-      if (models.length === 0) {
-        c.status(502);
-        return c.json({ error: "Provider returned no models" });
-      }
-
-      return c.json({ models });
-    } catch {
       c.status(502);
       return c.json({ error: "Failed to reach provider" });
     }

--- a/tests/unit/auth/api-key-catalog.test.ts
+++ b/tests/unit/auth/api-key-catalog.test.ts
@@ -13,18 +13,9 @@ describe("api-key-catalog", () => {
     expect(PROVIDER_CATALOG.openrouter).toBeDefined();
   });
 
-  it("each provider has non-empty model list", () => {
+  it("starts with empty dynamic model lists", () => {
     for (const [, meta] of Object.entries(PROVIDER_CATALOG)) {
-      expect(meta.models.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("each model has id and displayName", () => {
-    for (const [, meta] of Object.entries(PROVIDER_CATALOG)) {
-      for (const model of meta.models) {
-        expect(model.id).toBeTruthy();
-        expect(model.displayName).toBeTruthy();
-      }
+      expect(meta.models).toEqual([]);
     }
   });
 

--- a/tests/unit/auth/api-key-catalog.test.ts
+++ b/tests/unit/auth/api-key-catalog.test.ts
@@ -13,9 +13,13 @@ describe("api-key-catalog", () => {
     expect(PROVIDER_CATALOG.openrouter).toBeDefined();
   });
 
-  it("starts with empty dynamic model lists", () => {
+  it("has minimal static fallback models for all builtin providers", () => {
     for (const [, meta] of Object.entries(PROVIDER_CATALOG)) {
-      expect(meta.models).toEqual([]);
+      expect(meta.models.length).toBeGreaterThan(0);
+      for (const model of meta.models) {
+        expect(model.id).toBeTruthy();
+        expect(model.displayName).toBeTruthy();
+      }
     }
   });
 

--- a/tests/unit/auth/api-key-model-cache.test.ts
+++ b/tests/unit/auth/api-key-model-cache.test.ts
@@ -44,7 +44,7 @@ describe("ApiKeyModelCache", () => {
     expect(JSON.stringify(persistence.snapshot())).not.toContain("sk-one");
   });
 
-  it("expires cache entries after six months", async () => {
+  it("expires cache entries after seven days", async () => {
     const fetchedAt = new Date(new Date("2026-01-01T00:00:00Z").getTime() - MODEL_CACHE_TTL_MS - 1).toISOString();
     const persistence = createMemoryPersistence({
       entries: {
@@ -64,6 +64,14 @@ describe("ApiKeyModelCache", () => {
 
     await expect(cache.fetchModels({ provider: "openai", apiKey: "sk" })).resolves.toEqual([{ id: "fresh", displayName: "fresh" }]);
     expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes original error message for network failures", async () => {
+    const fetchFn = vi.fn(async () => { throw new Error("ECONNREFUSED 127.0.0.1:443"); });
+    const cache = new ApiKeyModelCache({ persistence: createMemoryPersistence(), fetchFn });
+
+    await expect(cache.fetchModels({ provider: "openai", apiKey: "sk" }))
+      .rejects.toMatchObject({ kind: "network", message: expect.stringContaining("ECONNREFUSED") });
   });
 
   it("uses a Gemini request key without storing it in the cache URL", async () => {
@@ -108,8 +116,11 @@ describe("ApiKeyModelCache", () => {
 
     const catalog = cache.getCatalogWithCachedModels();
 
+    // Cached models override the static fallback for anthropic.
     expect(catalog.anthropic.models).toEqual([{ id: "claude-test", displayName: "Claude Test" }]);
-    expect(catalog.openai.models).toEqual([]);
+    // openai has no cached entry — falls back to static defaults (non-empty).
+    expect(catalog.openai.models.length).toBeGreaterThan(0);
+    expect(catalog.openai.models[0]).toHaveProperty("id");
   });
 
   it("normalizes provider model payloads", () => {

--- a/tests/unit/auth/api-key-model-cache.test.ts
+++ b/tests/unit/auth/api-key-model-cache.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ApiKeyModelCache,
+  MODEL_CACHE_TTL_MS,
+  normalizeProviderModels,
+  type ApiKeyModelCacheFile,
+  type ApiKeyModelCachePersistence,
+} from "@src/auth/api-key-model-cache.js";
+
+function createMemoryPersistence(initial: ApiKeyModelCacheFile = { entries: {} }): ApiKeyModelCachePersistence & { snapshot(): ApiKeyModelCacheFile } {
+  let stored = initial;
+  return {
+    load: () => ({ entries: { ...stored.entries } }),
+    save: (cache) => {
+      stored = { entries: { ...cache.entries } };
+    },
+    snapshot: () => stored,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ApiKeyModelCache", () => {
+  it("caches fetched models by URL and reuses them for a different API key", async () => {
+    const persistence = createMemoryPersistence();
+    const fetchFn = vi.fn(async () => jsonResponse({ data: [{ id: "gpt-test", name: "GPT Test" }] }));
+    const cache = new ApiKeyModelCache({
+      persistence,
+      fetchFn,
+      now: () => new Date("2026-01-01T00:00:00Z"),
+    });
+
+    const first = await cache.fetchModels({ provider: "openai", apiKey: "sk-one" });
+    const second = await cache.fetchModels({ provider: "openai", apiKey: "sk-two" });
+
+    expect(first).toEqual([{ id: "gpt-test", displayName: "GPT Test" }]);
+    expect(second).toEqual(first);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(persistence.snapshot())).not.toContain("sk-one");
+  });
+
+  it("expires cache entries after six months", async () => {
+    const fetchedAt = new Date(new Date("2026-01-01T00:00:00Z").getTime() - MODEL_CACHE_TTL_MS - 1).toISOString();
+    const persistence = createMemoryPersistence({
+      entries: {
+        "https://api.openai.com/v1/models": {
+          url: "https://api.openai.com/v1/models",
+          fetchedAt,
+          models: [{ id: "stale", displayName: "Stale" }],
+        },
+      },
+    });
+    const fetchFn = vi.fn(async () => jsonResponse({ data: [{ id: "fresh" }] }));
+    const cache = new ApiKeyModelCache({
+      persistence,
+      fetchFn,
+      now: () => new Date("2026-01-01T00:00:00Z"),
+    });
+
+    await expect(cache.fetchModels({ provider: "openai", apiKey: "sk" })).resolves.toEqual([{ id: "fresh", displayName: "fresh" }]);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a Gemini request key without storing it in the cache URL", async () => {
+    const persistence = createMemoryPersistence();
+    const fetchFn = vi.fn(async () => jsonResponse({ models: [{ name: "models/gemini-test", displayName: "Gemini Test" }] }));
+    const cache = new ApiKeyModelCache({ persistence, fetchFn });
+
+    await cache.fetchModels({ provider: "gemini", apiKey: "gem-key" });
+
+    const requestedUrl = String(fetchFn.mock.calls[0][0]);
+    expect(requestedUrl).toContain("key=gem-key");
+    expect(Object.keys(persistence.snapshot().entries)).toEqual(["https://generativelanguage.googleapis.com/v1beta/models"]);
+    expect(JSON.stringify(persistence.snapshot())).not.toContain("gem-key");
+  });
+
+  it("builds custom provider cache keys from normalized model URLs", async () => {
+    const persistence = createMemoryPersistence();
+    const fetchFn = vi.fn(async () => jsonResponse({ data: [{ id: "custom-model" }] }));
+    const cache = new ApiKeyModelCache({ persistence, fetchFn });
+
+    await cache.fetchModels({ provider: "custom", apiKey: "custom-key", baseUrl: "https://example.com/v1/" });
+    await cache.fetchModels({ provider: "custom", apiKey: "another-key", baseUrl: "https://example.com/v1" });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(Object.keys(persistence.snapshot().entries)).toEqual(["https://example.com/v1/models"]);
+  });
+
+  it("returns cached models in the built-in catalog", () => {
+    const persistence = createMemoryPersistence({
+      entries: {
+        "https://api.anthropic.com/v1/models": {
+          url: "https://api.anthropic.com/v1/models",
+          fetchedAt: "2026-01-01T00:00:00Z",
+          models: [{ id: "claude-test", displayName: "Claude Test" }],
+        },
+      },
+    });
+    const cache = new ApiKeyModelCache({
+      persistence,
+      now: () => new Date("2026-01-02T00:00:00Z"),
+    });
+
+    const catalog = cache.getCatalogWithCachedModels();
+
+    expect(catalog.anthropic.models).toEqual([{ id: "claude-test", displayName: "Claude Test" }]);
+    expect(catalog.openai.models).toEqual([]);
+  });
+
+  it("normalizes provider model payloads", () => {
+    expect(normalizeProviderModels("openai", { data: [{ id: "gpt", name: "GPT" }, { id: "gpt", name: "Duplicate" }] })).toEqual([
+      { id: "gpt", displayName: "Duplicate" },
+    ]);
+    expect(normalizeProviderModels("anthropic", { data: [{ id: "claude", display_name: "Claude" }] })).toEqual([
+      { id: "claude", displayName: "Claude" },
+    ]);
+    expect(normalizeProviderModels("gemini", { models: [{ name: "models/gemini", displayName: "Gemini" }] })).toEqual([
+      { id: "gemini", displayName: "Gemini" },
+    ]);
+    expect(normalizeProviderModels("custom", { data: [{ id: "custom", display_name: "Custom" }] })).toEqual([
+      { id: "custom", displayName: "Custom" },
+    ]);
+  });
+});

--- a/tests/unit/routes/api-keys.test.ts
+++ b/tests/unit/routes/api-keys.test.ts
@@ -1,10 +1,8 @@
-/**
- * Tests for third-party API key management routes.
- */
-
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiKeyPool } from "@src/auth/api-key-pool.js";
 import type { ApiKeyEntry, ApiKeyPersistence } from "@src/auth/api-key-pool.js";
+import { ApiKeyModelCache } from "@src/auth/api-key-model-cache.js";
+import type { ApiKeyModelCacheFile, ApiKeyModelCachePersistence } from "@src/auth/api-key-model-cache.js";
 import { createApiKeyRoutes } from "@src/routes/api-keys.js";
 
 function createMemoryPersistence(): ApiKeyPersistence {
@@ -17,30 +15,159 @@ function createMemoryPersistence(): ApiKeyPersistence {
   };
 }
 
+function createModelPersistence(initial: ApiKeyModelCacheFile = { entries: {} }): ApiKeyModelCachePersistence & { snapshot(): ApiKeyModelCacheFile } {
+  let stored = initial;
+  return {
+    load: () => ({ entries: { ...stored.entries } }),
+    save: (cache) => {
+      stored = { entries: { ...cache.entries } };
+    },
+    snapshot: () => stored,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("api key routes", () => {
   let pool: ApiKeyPool;
+  let modelPersistence: ReturnType<typeof createModelPersistence>;
+  let fetchFn: ReturnType<typeof vi.fn<() => Promise<Response>>>;
   let app: ReturnType<typeof createApiKeyRoutes>;
 
   beforeEach(() => {
     pool = new ApiKeyPool(createMemoryPersistence());
-    app = createApiKeyRoutes(pool);
+    modelPersistence = createModelPersistence();
+    fetchFn = vi.fn(async () => jsonResponse({ data: [{ id: "model-a", name: "Model A" }] }));
+    app = createApiKeyRoutes(pool, new ApiKeyModelCache({ persistence: modelPersistence, fetchFn }));
   });
 
-  it("returns current built-in Anthropic catalog defaults", async () => {
+  it("returns built-in catalog metadata with cached models", async () => {
+    modelPersistence.save({
+      entries: {
+        "https://api.anthropic.com/v1/models": {
+          url: "https://api.anthropic.com/v1/models",
+          fetchedAt: new Date().toISOString(),
+          models: [{ id: "claude-test", displayName: "Claude Test" }],
+        },
+      },
+    });
+
     const res = await app.request("/auth/api-keys/catalog");
     expect(res.status).toBe(200);
 
     const body = await res.json() as {
       catalog: {
         anthropic: {
+          displayName: string;
+          defaultBaseUrl: string;
           models: Array<{ id: string; displayName: string }>;
         };
       };
     };
-    expect(body.catalog.anthropic.models.slice(0, 2)).toEqual([
-      { id: "claude-opus-4-7", displayName: "Claude Opus 4.7" },
-      { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
-    ]);
+    expect(body.catalog.anthropic.displayName).toBe("Anthropic");
+    expect(body.catalog.anthropic.defaultBaseUrl).toContain("anthropic.com");
+    expect(body.catalog.anthropic.models).toEqual([{ id: "claude-test", displayName: "Claude Test" }]);
+  });
+
+  it("fetches built-in provider models", async () => {
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openai", apiKey: "sk-openai" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ models: [{ id: "model-a", displayName: "Model A" }] });
+    expect(fetchFn).toHaveBeenCalledWith("https://api.openai.com/v1/models", {
+      headers: { Authorization: "Bearer sk-openai", Accept: "application/json" },
+    });
+  });
+
+  it("sends Anthropic version header when fetching Anthropic models", async () => {
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "anthropic", apiKey: "sk-ant" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchFn.mock.calls[0][1]).toEqual({
+      headers: {
+        Authorization: "Bearer sk-ant",
+        Accept: "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+  });
+
+  it("uses Gemini query key while caching by URL without the key", async () => {
+    fetchFn.mockResolvedValueOnce(jsonResponse({ models: [{ name: "models/gemini-test", displayName: "Gemini Test" }] }));
+
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "gemini", apiKey: "gem-key" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ models: [{ id: "gemini-test", displayName: "Gemini Test" }] });
+    expect(String(fetchFn.mock.calls[0][0])).toContain("key=gem-key");
+    expect(Object.keys(modelPersistence.snapshot().entries)).toEqual(["https://generativelanguage.googleapis.com/v1beta/models"]);
+  });
+
+  it("fetches custom provider models from base URL models endpoint", async () => {
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "custom", apiKey: "custom-key", baseUrl: "https://example.com/v1/" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledWith("https://example.com/v1/models", {
+      headers: { Authorization: "Bearer custom-key", Accept: "application/json" },
+    });
+  });
+
+  it("uses URL-keyed cache for repeated model fetches", async () => {
+    const body = JSON.stringify({ provider: "openai", apiKey: "sk-one" });
+    const secondBody = JSON.stringify({ provider: "openai", apiKey: "sk-two" });
+
+    await app.request("/auth/api-keys/models", { method: "POST", headers: { "Content-Type": "application/json" }, body });
+    const res = await app.request("/auth/api-keys/models", { method: "POST", headers: { "Content-Type": "application/json" }, body: secondBody });
+
+    expect(res.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns unauthorized errors from upstream", async () => {
+    fetchFn.mockResolvedValueOnce(jsonResponse({ error: "no" }, 403));
+
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openai", apiKey: "sk-openai" }),
+    });
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: "Failed to fetch models: unauthorized" });
+  });
+
+  it("returns provider errors for empty model payloads", async () => {
+    fetchFn.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    const res = await app.request("/auth/api-keys/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openai", apiKey: "sk-openai" }),
+    });
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({ error: "Provider returned no models" });
   });
 
   it("adds one stored entry per selected model and masks returned keys", async () => {

--- a/web/src/components/ApiKeyManager.test.tsx
+++ b/web/src/components/ApiKeyManager.test.tsx
@@ -9,30 +9,42 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+function createOnAdd() {
+  return vi.fn(async (_input: {
+    provider: ApiKeyProvider;
+    models: string[];
+    apiKey: string;
+    baseUrl?: string;
+    label?: string;
+    capabilities?: ApiKeyCapability[];
+    wire?: ApiKeyWire;
+  }) => ({ ok: true }));
+}
+
+function createFetchProviderModels(models: CatalogModel[] = []) {
+  return vi.fn(async (_input: { provider: ApiKeyProvider; apiKey: string; baseUrl?: string }) => ({
+    ok: true as const,
+    models,
+  }));
+}
+
+const defaultCatalog = {
+  anthropic: { displayName: "Anthropic", defaultBaseUrl: "https://api.anthropic.com/v1", models: [] },
+  openai: { displayName: "OpenAI", defaultBaseUrl: "https://api.openai.com/v1", models: [] },
+  gemini: { displayName: "Google Gemini", defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta", models: [] },
+  openrouter: { displayName: "OpenRouter", defaultBaseUrl: "https://openrouter.ai/api/v1", models: [] },
+};
+
 describe("AddKeyForm", () => {
   it("submits manual embedding models with embeddings capability", async () => {
-    const onAdd = vi.fn(async (_input: {
-      provider: ApiKeyProvider;
-      models: string[];
-      apiKey: string;
-      baseUrl?: string;
-      label?: string;
-      capabilities?: ApiKeyCapability[];
-      wire?: ApiKeyWire;
-    }) => ({ ok: true }));
-    const fetchCustomModels = vi.fn(async (_input: { provider: "custom"; apiKey: string; baseUrl: string }) => ({
-      ok: true as const,
-      models: [] as CatalogModel[],
-    }));
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels();
 
     render(
       <AddKeyForm
         onAdd={onAdd}
-        catalog={{
-          anthropic: { displayName: "Anthropic", defaultBaseUrl: "https://api.anthropic.com/v1", models: [] },
-          openai: { displayName: "OpenAI", defaultBaseUrl: "https://api.openai.com/v1", models: [] },
-        }}
-        fetchCustomModels={fetchCustomModels}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
       />,
     );
 
@@ -58,28 +70,14 @@ describe("AddKeyForm", () => {
   });
 
   it("submits wire=responses when the Responses API protocol is chosen for OpenAI-family", async () => {
-    const onAdd = vi.fn(async (_input: {
-      provider: ApiKeyProvider;
-      models: string[];
-      apiKey: string;
-      baseUrl?: string;
-      label?: string;
-      capabilities?: ApiKeyCapability[];
-      wire?: ApiKeyWire;
-    }) => ({ ok: true }));
-    const fetchCustomModels = vi.fn(async (_input: { provider: "custom"; apiKey: string; baseUrl: string }) => ({
-      ok: true as const,
-      models: [] as CatalogModel[],
-    }));
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels();
 
     render(
       <AddKeyForm
         onAdd={onAdd}
-        catalog={{
-          anthropic: { displayName: "Anthropic", defaultBaseUrl: "https://api.anthropic.com/v1", models: [] },
-          openai: { displayName: "OpenAI", defaultBaseUrl: "https://api.openai.com/v1", models: [] },
-        }}
-        fetchCustomModels={fetchCustomModels}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
       />,
     );
 
@@ -88,7 +86,6 @@ describe("AddKeyForm", () => {
     fireEvent.input(screen.getByPlaceholderText("manual-model-1, manual-model-2"), {
       target: { value: "gpt-5.5" },
     });
-    // The wire selector only appears for OpenAI-family providers.
     const wireSelect = screen.getByDisplayValue("Chat Completions (default)");
     fireEvent.change(wireSelect, { target: { value: "responses" } });
     fireEvent.click(screen.getByText("Add Key"));
@@ -98,23 +95,104 @@ describe("AddKeyForm", () => {
   });
 
   it("does not render the wire selector for anthropic", () => {
-    const onAdd = vi.fn(async () => ({ ok: true }));
-    const fetchCustomModels = vi.fn(async (_input: { provider: "custom"; apiKey: string; baseUrl: string }) => ({
-      ok: true as const,
-      models: [] as CatalogModel[],
-    }));
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels();
 
     render(
       <AddKeyForm
         onAdd={onAdd}
-        catalog={{
-          anthropic: { displayName: "Anthropic", defaultBaseUrl: "https://api.anthropic.com/v1", models: [] },
-        }}
-        fetchCustomModels={fetchCustomModels}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
       />,
     );
 
-    // Default provider is anthropic → no upstream-protocol selector.
     expect(screen.queryByText("Upstream protocol")).toBeNull();
+  });
+
+  it("fetches built-in provider models after API key blur", async () => {
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels([{ id: "gpt-test", displayName: "GPT Test" }]);
+
+    render(
+      <AddKeyForm
+        onAdd={onAdd}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "openai" } });
+    fireEvent.input(screen.getByPlaceholderText("sk-..."), { target: { value: "sk-test" } });
+    fireEvent.blur(screen.getByPlaceholderText("sk-..."));
+
+    await waitFor(() => expect(screen.getByText("GPT Test")).toBeTruthy());
+    expect(fetchProviderModels).toHaveBeenCalledWith({ provider: "openai", apiKey: "sk-test", baseUrl: undefined });
+  });
+
+  it("submits a selected dynamically fetched built-in model", async () => {
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels([{ id: "gpt-test", displayName: "GPT Test" }]);
+
+    render(
+      <AddKeyForm
+        onAdd={onAdd}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "openai" } });
+    fireEvent.input(screen.getByPlaceholderText("sk-..."), { target: { value: "sk-test" } });
+    fireEvent.blur(screen.getByPlaceholderText("sk-..."));
+    await waitFor(() => expect(screen.getByText("GPT Test")).toBeTruthy());
+    fireEvent.click(screen.getByText("Add Key"));
+
+    await waitFor(() => expect(onAdd).toHaveBeenCalledTimes(1));
+    expect(onAdd.mock.calls[0][0].models).toEqual(["gpt-test"]);
+  });
+
+  it("shows manual fallback when built-in model fetch fails", async () => {
+    const onAdd = createOnAdd();
+    const fetchProviderModels = vi.fn(async () => ({ ok: false as const, error: "Failed" }));
+
+    render(
+      <AddKeyForm
+        onAdd={onAdd}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "openai" } });
+    fireEvent.input(screen.getByPlaceholderText("sk-..."), { target: { value: "sk-test" } });
+    fireEvent.blur(screen.getByPlaceholderText("sk-..."));
+
+    await waitFor(() => expect(screen.getByPlaceholderText("model-name-1, model-name-2")).toBeTruthy());
+    expect(screen.getByText("模型列表获取失败，请手动输入模型名：Failed")).toBeTruthy();
+  });
+
+  it("fetches custom provider models with base URL", async () => {
+    const onAdd = createOnAdd();
+    const fetchProviderModels = createFetchProviderModels([{ id: "custom-model", displayName: "Custom Model" }]);
+
+    render(
+      <AddKeyForm
+        onAdd={onAdd}
+        catalog={defaultCatalog}
+        fetchProviderModels={fetchProviderModels}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "custom" } });
+    fireEvent.input(screen.getByPlaceholderText("sk-..."), { target: { value: "custom-key" } });
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), { target: { value: "https://api.example.com/v1" } });
+    fireEvent.blur(screen.getByPlaceholderText("https://api.example.com/v1"));
+
+    await waitFor(() => expect(screen.getByText("Custom Model")).toBeTruthy());
+    expect(fetchProviderModels).toHaveBeenCalledWith({
+      provider: "custom",
+      apiKey: "custom-key",
+      baseUrl: "https://api.example.com/v1",
+    });
   });
 });

--- a/web/src/components/ApiKeyManager.tsx
+++ b/web/src/components/ApiKeyManager.tsx
@@ -1,8 +1,3 @@
-/**
- * API Key Manager — Dashboard component for managing third-party API keys.
- * Supports add/delete/toggle/import/export with predefined model catalogs.
- */
-
 import { useState, useCallback, useMemo, useRef } from "preact/hooks";
 import { useApiKeys } from "../../../shared/hooks/use-api-keys";
 import type { ApiKeyCapability, ApiKeyProvider, ApiKeyWire, ApiKeyEntry, CatalogModel } from "../../../shared/hooks/use-api-keys";
@@ -10,8 +5,9 @@ import type { ApiKeyCapability, ApiKeyProvider, ApiKeyWire, ApiKeyEntry, Catalog
 /** Providers whose upstream wire protocol (chat vs responses) is selectable. */
 const WIRE_SELECTABLE_PROVIDERS: ReadonlySet<ApiKeyProvider> = new Set(["openai", "openrouter", "custom"]);
 
-const CUSTOM_MODELS_HINT = "请先输入key和url，将会获取模型列表";
-const CUSTOM_MODELS_FALLBACK_HINT = "模型列表获取失败，请手动输入模型名";
+const PROVIDER_MODELS_HINT = "请先输入 API Key，将会获取模型列表";
+const CUSTOM_MODELS_HINT = "请先输入 API Key 和 URL，将会获取模型列表";
+const MODELS_FALLBACK_HINT = "模型列表获取失败，请手动输入模型名";
 
 const PROVIDER_OPTIONS: Array<{ value: ApiKeyProvider; label: string }> = [
   { value: "anthropic", label: "Anthropic" },
@@ -26,7 +22,7 @@ const CAPABILITY_OPTIONS: Array<{ value: ApiKeyCapability; label: string }> = [
   { value: "embeddings", label: "Embeddings" },
 ];
 
-type CustomModelStatus = "idle" | "loading" | "loaded" | "fallback";
+type ProviderModelStatus = "idle" | "loading" | "loaded" | "fallback";
 
 function normalizeCustomModelInput(value: string): string[] {
   return value
@@ -53,7 +49,7 @@ function renderModelChecklist(models: CatalogModel[], selectedModelSet: Set<stri
   );
 }
 
-function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
+function AddKeyForm({ onAdd, catalog, fetchProviderModels }: {
   onAdd: (input: {
     provider: ApiKeyProvider;
     models: string[];
@@ -64,7 +60,7 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
     wire?: ApiKeyWire;
   }) => Promise<{ ok: boolean; error?: string }>;
   catalog: Record<string, { displayName: string; defaultBaseUrl: string; models: Array<{ id: string; displayName: string }> }>;
-  fetchCustomModels: (input: { provider: "custom"; apiKey: string; baseUrl: string }) => Promise<{ ok: true; models: CatalogModel[] } | { ok: false; error: string }>;
+  fetchProviderModels: (input: { provider: ApiKeyProvider; apiKey: string; baseUrl?: string }) => Promise<{ ok: true; models: CatalogModel[] } | { ok: false; error: string }>;
 }) {
   const [provider, setProvider] = useState<ApiKeyProvider>("anthropic");
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
@@ -74,25 +70,26 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
   const [manualModelsInput, setManualModelsInput] = useState("");
   const [capabilities, setCapabilities] = useState<ApiKeyCapability[]>(["chat"]);
   const [wire, setWire] = useState<ApiKeyWire>("chat");
-  const [customModels, setCustomModels] = useState<CatalogModel[]>([]);
-  const [customModelStatus, setCustomModelStatus] = useState<CustomModelStatus>("idle");
-  const [customModelMessage, setCustomModelMessage] = useState(CUSTOM_MODELS_HINT);
+  const [providerModels, setProviderModels] = useState<CatalogModel[]>([]);
+  const [modelStatus, setModelStatus] = useState<ProviderModelStatus>("idle");
+  const [modelMessage, setModelMessage] = useState(PROVIDER_MODELS_HINT);
   const [error, setError] = useState("");
   const [adding, setAdding] = useState(false);
-  const latestCustomRequestRef = useRef(0);
+  const latestModelRequestRef = useRef(0);
   const latestResolvedSignatureRef = useRef("");
 
   const isCustom = provider === "custom";
   const wireSelectable = WIRE_SELECTABLE_PROVIDERS.has(provider);
   const providerCatalog = !isCustom ? catalog[provider]?.models ?? [] : [];
+  const availableModels = providerModels.length > 0 ? providerModels : providerCatalog;
   const selectedModelSet = useMemo(() => new Set(selectedModels), [selectedModels]);
   const selectedCapabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
 
-  const resetCustomModels = useCallback((status: CustomModelStatus = "idle", message = CUSTOM_MODELS_HINT) => {
-    setCustomModels([]);
+  const resetProviderModels = useCallback((status: ProviderModelStatus = "idle", message = PROVIDER_MODELS_HINT) => {
+    setProviderModels([]);
     setSelectedModels([]);
-    setCustomModelStatus(status);
-    setCustomModelMessage(message);
+    setModelStatus(status);
+    setModelMessage(message);
   }, []);
 
   const handleModelToggle = (modelId: string) => {
@@ -107,51 +104,51 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
       : [...prev, capability]);
   };
 
-  const triggerCustomModelFetch = useCallback(async () => {
-    if (!isCustom) return;
-
+  const triggerProviderModelFetch = useCallback(async () => {
     const normalizedApiKey = apiKey.trim();
     const normalizedBaseUrl = baseUrl.trim();
-    if (!normalizedApiKey || !normalizedBaseUrl) {
-      resetCustomModels();
+    if (!normalizedApiKey || (isCustom && !normalizedBaseUrl)) {
+      resetProviderModels("idle", isCustom ? CUSTOM_MODELS_HINT : PROVIDER_MODELS_HINT);
       return;
     }
 
-    const signature = `${normalizedBaseUrl}::${normalizedApiKey}`;
-    if (latestResolvedSignatureRef.current === signature && customModels.length > 0) return;
+    const signature = isCustom
+      ? `${provider}::${normalizedBaseUrl}::${normalizedApiKey}`
+      : `${provider}::${normalizedApiKey}`;
+    if (latestResolvedSignatureRef.current === signature && providerModels.length > 0) return;
 
-    const requestId = latestCustomRequestRef.current + 1;
-    latestCustomRequestRef.current = requestId;
-    setCustomModelStatus("loading");
-    setCustomModelMessage("正在获取模型列表...");
+    const requestId = latestModelRequestRef.current + 1;
+    latestModelRequestRef.current = requestId;
+    setModelStatus("loading");
+    setModelMessage("正在获取模型列表...");
     setError("");
 
-    const result = await fetchCustomModels({
-      provider: "custom",
+    const result = await fetchProviderModels({
+      provider,
       apiKey: normalizedApiKey,
-      baseUrl: normalizedBaseUrl,
+      baseUrl: isCustom ? normalizedBaseUrl : undefined,
     });
 
-    if (latestCustomRequestRef.current !== requestId) return;
+    if (latestModelRequestRef.current !== requestId) return;
 
     if (!result.ok || result.models.length === 0) {
-      setCustomModels([]);
+      setProviderModels([]);
       setSelectedModels([]);
-      setCustomModelStatus("fallback");
-      setCustomModelMessage(result.ok ? CUSTOM_MODELS_FALLBACK_HINT : `${CUSTOM_MODELS_FALLBACK_HINT}：${result.error}`);
+      setModelStatus("fallback");
+      setModelMessage(result.ok ? MODELS_FALLBACK_HINT : `${MODELS_FALLBACK_HINT}：${result.error}`);
       latestResolvedSignatureRef.current = "";
       return;
     }
 
-    setCustomModels(result.models);
-    setCustomModelStatus("loaded");
-    setCustomModelMessage("");
+    setProviderModels(result.models);
+    setModelStatus("loaded");
+    setModelMessage("");
     latestResolvedSignatureRef.current = signature;
     setSelectedModels((prev) => {
       const next = prev.filter((id) => result.models.some((model) => model.id === id));
       return next.length > 0 ? next : [result.models[0].id];
     });
-  }, [apiKey, baseUrl, customModels.length, fetchCustomModels, isCustom, resetCustomModels]);
+  }, [apiKey, baseUrl, fetchProviderModels, isCustom, provider, providerModels.length, resetProviderModels]);
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -160,12 +157,12 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
     const normalizedApiKey = apiKey.trim();
     const normalizedBaseUrl = baseUrl.trim();
     const normalizedManualModels = normalizeCustomModelInput(manualModelsInput);
-    const models = isCustom && customModelStatus === "fallback"
+    const models = modelStatus === "fallback"
       ? normalizedManualModels
       : [...new Set([...selectedModels, ...normalizedManualModels])];
 
     if (models.length === 0 || !normalizedApiKey) {
-      setError(isCustom && customModelStatus === "fallback"
+      setError(modelStatus === "fallback"
         ? "请输入至少一个模型名并填写 API Key"
         : "Select at least one model and enter an API Key");
       return;
@@ -198,7 +195,7 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
       setManualModelsInput("");
       setCapabilities(["chat"]);
       setWire("chat");
-      resetCustomModels();
+      resetProviderModels();
     } else {
       setError(result.error || "Failed to add key");
     }
@@ -222,7 +219,7 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
               setCapabilities(["chat"]);
               setWire("chat");
               latestResolvedSignatureRef.current = "";
-              resetCustomModels();
+              resetProviderModels("idle", v === "custom" ? CUSTOM_MODELS_HINT : PROVIDER_MODELS_HINT);
             }}
             class="px-2.5 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-slate-800 dark:text-text-main"
           >
@@ -239,11 +236,10 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
             value={apiKey}
             onInput={(e) => {
               setApiKey((e.target as HTMLInputElement).value);
-              if (isCustom) {
-                latestResolvedSignatureRef.current = "";
-                resetCustomModels();
-              }
+              latestResolvedSignatureRef.current = "";
+              resetProviderModels("idle", isCustom ? CUSTOM_MODELS_HINT : PROVIDER_MODELS_HINT);
             }}
+            onBlur={() => { void triggerProviderModelFetch(); }}
             placeholder="sk-..."
             class="px-2.5 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-slate-800 dark:text-text-main"
           />
@@ -252,25 +248,22 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
 
       <div class="flex flex-col gap-1">
         <label class="text-[0.7rem] font-medium text-slate-500 dark:text-text-dim">Models</label>
-        {!isCustom && renderModelChecklist(providerCatalog, selectedModelSet, handleModelToggle)}
-        {isCustom && customModelStatus === "loaded" && renderModelChecklist(customModels, selectedModelSet, handleModelToggle)}
-        {isCustom && customModelStatus !== "loaded" && (
-          <div class="flex flex-col gap-2">
-            <div class="px-2.5 py-2 text-sm rounded-lg border border-dashed border-gray-200 dark:border-border-dark text-slate-400 dark:text-text-dim">
-              {customModelStatus === "loading" ? "正在获取模型列表..." : customModelMessage}
-            </div>
-            {customModelStatus === "fallback" && (
-              <input
-                type="text"
-                value={manualModelsInput}
-                onInput={(e) => setManualModelsInput((e.target as HTMLInputElement).value)}
-                placeholder="model-name-1, model-name-2"
-                class="px-2.5 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-slate-800 dark:text-text-main"
-              />
-            )}
+        {availableModels.length > 0 && renderModelChecklist(availableModels, selectedModelSet, handleModelToggle)}
+        {availableModels.length === 0 && (
+          <div class="px-2.5 py-2 text-sm rounded-lg border border-dashed border-gray-200 dark:border-border-dark text-slate-400 dark:text-text-dim">
+            {modelStatus === "loading" ? "正在获取模型列表..." : modelMessage}
           </div>
         )}
-        {(!isCustom || customModelStatus === "loaded") && (
+        {modelStatus === "fallback" && (
+          <input
+            type="text"
+            value={manualModelsInput}
+            onInput={(e) => setManualModelsInput((e.target as HTMLInputElement).value)}
+            placeholder="model-name-1, model-name-2"
+            class="px-2.5 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-slate-800 dark:text-text-main"
+          />
+        )}
+        {modelStatus !== "fallback" && (
           <input
             type="text"
             value={manualModelsInput}
@@ -323,9 +316,9 @@ function AddKeyForm({ onAdd, catalog, fetchCustomModels }: {
             onInput={(e) => {
               setBaseUrl((e.target as HTMLInputElement).value);
               latestResolvedSignatureRef.current = "";
-              resetCustomModels();
+              resetProviderModels("idle", CUSTOM_MODELS_HINT);
             }}
-            onBlur={() => { void triggerCustomModelFetch(); }}
+            onBlur={() => { void triggerProviderModelFetch(); }}
             placeholder="https://api.example.com/v1"
             class="px-2.5 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-border-dark bg-slate-50 dark:bg-bg-dark text-slate-800 dark:text-text-main"
           />
@@ -426,7 +419,7 @@ function KeyRow({ entry, onDelete, onToggle }: {
 }
 
 export function ApiKeyManager() {
-  const { keys, catalog, loading, addKey, deleteKey, toggleStatus, importKeys, fetchCustomModels } = useApiKeys();
+  const { keys, catalog, loading, addKey, deleteKey, toggleStatus, importKeys, fetchProviderModels } = useApiKeys();
   const [showForm, setShowForm] = useState(false);
   const [importResult, setImportResult] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -496,7 +489,7 @@ export function ApiKeyManager() {
             return result;
           }}
           catalog={catalog}
-          fetchCustomModels={fetchCustomModels}
+          fetchProviderModels={fetchProviderModels}
         />
       )}
 


### PR DESCRIPTION
## Summary / 摘要
- Add a URL-keyed six-month backend cache for API key provider model lists.
- Dynamically fetch models for Anthropic, OpenAI, Gemini, OpenRouter, and custom providers through one shared endpoint.
- Update the API Keys UI to fetch built-in provider models after entering an API key, while preserving manual fallback input.
- Allow Vite dev proxy target override via `VITE_PROXY_TARGET` for testing this branch without touching the installed app on port 8080.

- 新增按模型列表 URL 索引的 6 个月后端缓存。
- Anthropic / OpenAI / Gemini / OpenRouter / custom 共用同一个动态拉取模型接口。
- 更新 API Keys UI：输入 API Key 后动态拉取内置 provider 模型，同时保留手动输入兜底。
- 新增 `VITE_PROXY_TARGET`，方便 5173 前端代理到测试后端，不影响 8080 上的安装版。

## Verification / 验证
- `npx vitest run tests/unit/auth/api-key-model-cache.test.ts tests/unit/routes/api-keys.test.ts tests/unit/auth/api-key-catalog.test.ts` — 3 files, 25 tests passed.
- `npm run test:web -- ApiKeyManager.test.tsx` — 1 file, 7 tests passed.
- `npm run build` — web build and TypeScript build passed.

## Notes / 说明
- Cache entries store only URL, models, and fetched timestamp; API keys are not persisted.
- Gemini network requests include the API key query parameter, but the cache key excludes it.
- For local branch testing while keeping installed Codex Proxy on 8080: run backend with `PORT=18080`, then run web with `VITE_PROXY_TARGET=http://127.0.0.1:18080 npm run dev:web -- --host 127.0.0.1 --port 5173`.

- 缓存只保存 URL、模型列表和拉取时间，不保存 API Key。
- Gemini 网络请求会带 key 查询参数，但缓存索引不包含 key。
- 本地测试时如需保留 8080 的安装版：后端用 `PORT=18080`，前端用 `VITE_PROXY_TARGET=http://127.0.0.1:18080 npm run dev:web -- --host 127.0.0.1 --port 5173`。