### PR TITLE
test(contract): Anthropic → Codex translation contract tests

### DIFF
--- a/tests/contract/anthropic-to-codex.contract.test.ts
+++ b/tests/contract/anthropic-to-codex.contract.test.ts
@@ -51,41 +51,32 @@ interface ContractFixture {
 const fixturesPath = resolve(__dirname, "fixtures/anthropic-to-codex.json");
 const fixtures: ContractFixture[] = JSON.parse(readFileSync(fixturesPath, "utf-8"));
 
-describe("Anthropic → Codex contract", () => {
-  it.each(fixtures)("$name: $description", ({ input, expectedOutput }) => {
-    const result = translateAnthropicToCodexRequest(input as AnthropicMessagesRequest);
+// Pre-compute all translation results once (pure function, no side effects)
+const results = fixtures.map((f) => ({
+  fixture: f,
+  result: translateAnthropicToCodexRequest(f.input as AnthropicMessagesRequest),
+}));
 
-    // Verify each expected field matches (partial match — only check specified fields)
-    for (const [key, expected] of Object.entries(expectedOutput)) {
-      const actual = (result as Record<string, unknown>)[key];
-      expect(actual, `Field "${key}" mismatch`).toEqual(expected);
-    }
+describe("Anthropic → Codex contract", () => {
+  it.each(results)("$fixture.name: $fixture.description", ({ fixture, result }) => {
+    expect(result).toMatchObject(fixture.expectedOutput);
   });
 
   it("always produces stream: true and store: false", () => {
-    for (const fixture of fixtures) {
-      const result = translateAnthropicToCodexRequest(
-        fixture.input as AnthropicMessagesRequest,
-      );
+    for (const { result } of results) {
       expect(result.stream).toBe(true);
       expect(result.store).toBe(false);
     }
   });
 
   it("always produces a non-empty input array", () => {
-    for (const fixture of fixtures) {
-      const result = translateAnthropicToCodexRequest(
-        fixture.input as AnthropicMessagesRequest,
-      );
+    for (const { result } of results) {
       expect(result.input.length).toBeGreaterThanOrEqual(1);
     }
   });
 
   it("never leaks thinking/redacted_thinking blocks into output", () => {
-    for (const fixture of fixtures) {
-      const result = translateAnthropicToCodexRequest(
-        fixture.input as AnthropicMessagesRequest,
-      );
+    for (const { result } of results) {
       const serialized = JSON.stringify(result.input);
       expect(serialized).not.toContain('"type":"thinking"');
       expect(serialized).not.toContain('"type":"redacted_thinking"');
@@ -93,10 +84,7 @@ describe("Anthropic → Codex contract", () => {
   });
 
   it("never contains billing header content in instructions", () => {
-    for (const fixture of fixtures) {
-      const result = translateAnthropicToCodexRequest(
-        fixture.input as AnthropicMessagesRequest,
-      );
+    for (const { result } of results) {
       if (result.instructions) {
         expect(result.instructions).not.toContain("x-anthropic-billing-header");
         expect(result.instructions).not.toContain("cc_version=");

--- a/tests/contract/anthropic-to-codex.contract.test.ts
+++ b/tests/contract/anthropic-to-codex.contract.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Contract tests for Anthropic Messages → Codex Responses translation.
+ *
+ * Each fixture defines an Anthropic request input and the expected subset of
+ * fields in the Codex output. Tests verify that the translation function
+ * produces output matching the golden contract — any drift is a snapshot
+ * failure that must be explicitly approved.
+ *
+ * This catches regressions from upstream payload changes (new roles, new
+ * content block types, thinking format changes) before they hit users as 400s.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => ({
+    model: {
+      default: "gpt-5.3-codex",
+      default_reasoning_effort: null,
+      default_service_tier: null,
+      suppress_desktop_directives: false,
+    },
+  })),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getConfigDir: vi.fn(() => "/tmp/test-config"),
+}));
+
+vi.mock("@src/models/model-store.js", () => ({
+  parseModelName: vi.fn((input: string) => ({
+    modelId: input,
+    serviceTier: null,
+    reasoningEffort: null,
+  })),
+  getModelInfo: vi.fn(() => undefined),
+}));
+
+import { translateAnthropicToCodexRequest } from "@src/translation/anthropic-to-codex.js";
+import type { AnthropicMessagesRequest } from "@src/types/anthropic.js";
+
+interface ContractFixture {
+  name: string;
+  description: string;
+  input: Record<string, unknown>;
+  expectedOutput: Record<string, unknown>;
+}
+
+const fixturesPath = resolve(__dirname, "fixtures/anthropic-to-codex.json");
+const fixtures: ContractFixture[] = JSON.parse(readFileSync(fixturesPath, "utf-8"));
+
+describe("Anthropic → Codex contract", () => {
+  it.each(fixtures)("$name: $description", ({ input, expectedOutput }) => {
+    const result = translateAnthropicToCodexRequest(input as AnthropicMessagesRequest);
+
+    // Verify each expected field matches (partial match — only check specified fields)
+    for (const [key, expected] of Object.entries(expectedOutput)) {
+      const actual = (result as Record<string, unknown>)[key];
+      expect(actual, `Field "${key}" mismatch`).toEqual(expected);
+    }
+  });
+
+  it("always produces stream: true and store: false", () => {
+    for (const fixture of fixtures) {
+      const result = translateAnthropicToCodexRequest(
+        fixture.input as AnthropicMessagesRequest,
+      );
+      expect(result.stream).toBe(true);
+      expect(result.store).toBe(false);
+    }
+  });
+
+  it("always produces a non-empty input array", () => {
+    for (const fixture of fixtures) {
+      const result = translateAnthropicToCodexRequest(
+        fixture.input as AnthropicMessagesRequest,
+      );
+      expect(result.input.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("never leaks thinking/redacted_thinking blocks into output", () => {
+    for (const fixture of fixtures) {
+      const result = translateAnthropicToCodexRequest(
+        fixture.input as AnthropicMessagesRequest,
+      );
+      const serialized = JSON.stringify(result.input);
+      expect(serialized).not.toContain('"type":"thinking"');
+      expect(serialized).not.toContain('"type":"redacted_thinking"');
+    }
+  });
+
+  it("never contains billing header content in instructions", () => {
+    for (const fixture of fixtures) {
+      const result = translateAnthropicToCodexRequest(
+        fixture.input as AnthropicMessagesRequest,
+      );
+      if (result.instructions) {
+        expect(result.instructions).not.toContain("x-anthropic-billing-header");
+        expect(result.instructions).not.toContain("cc_version=");
+        expect(result.instructions).not.toContain("cch=");
+      }
+    }
+  });
+});

--- a/tests/contract/fixtures/anthropic-to-codex.json
+++ b/tests/contract/fixtures/anthropic-to-codex.json
@@ -1,0 +1,215 @@
+[
+  {
+    "name": "simple-text-message",
+    "description": "Basic single-turn text message",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 8192,
+      "messages": [{ "role": "user", "content": "Hello" }],
+      "system": "You are helpful."
+    },
+    "expectedOutput": {
+      "model": "claude-sonnet-4-5",
+      "instructions": "You are helpful.",
+      "input": [{ "role": "user", "content": "Hello" }],
+      "stream": true,
+      "store": false
+    }
+  },
+  {
+    "name": "developer-role-message",
+    "description": "developer role should be preserved as-is (not dropped)",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [
+        { "role": "developer", "content": "Follow security standards." },
+        { "role": "user", "content": "Hi" }
+      ]
+    },
+    "expectedOutput": {
+      "input": [
+        { "role": "developer", "content": "Follow security standards." },
+        { "role": "user", "content": "Hi" }
+      ]
+    }
+  },
+  {
+    "name": "system-role-in-messages",
+    "description": "system role in messages array preserved (not only top-level system)",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [
+        { "role": "system", "content": "Be concise." },
+        { "role": "user", "content": "Explain AI" }
+      ]
+    },
+    "expectedOutput": {
+      "input": [
+        { "role": "system", "content": "Be concise." },
+        { "role": "user", "content": "Explain AI" }
+      ]
+    }
+  },
+  {
+    "name": "multi-turn-with-tool-use",
+    "description": "Assistant tool_use + user tool_result roundtrip",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 8192,
+      "messages": [
+        { "role": "user", "content": "Search for TypeScript" },
+        {
+          "role": "assistant",
+          "content": [
+            { "type": "text", "text": "Let me search for that." },
+            { "type": "tool_use", "id": "toolu_abc", "name": "WebSearch", "input": { "query": "TypeScript" } }
+          ]
+        },
+        {
+          "role": "user",
+          "content": [
+            { "type": "tool_result", "tool_use_id": "toolu_abc", "content": "TypeScript is a typed superset of JavaScript." }
+          ]
+        }
+      ],
+      "system": "You are helpful."
+    },
+    "expectedOutput": {
+      "input": [
+        { "role": "user", "content": "Search for TypeScript" },
+        { "role": "assistant", "content": "Let me search for that." },
+        { "type": "function_call", "call_id": "toolu_abc", "name": "WebSearch", "arguments": "{\"query\":\"TypeScript\"}" },
+        { "type": "function_call_output", "call_id": "toolu_abc", "output": "TypeScript is a typed superset of JavaScript." }
+      ]
+    }
+  },
+  {
+    "name": "tool-result-with-image",
+    "description": "tool_result containing image extracts to follow-up user message",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "tool_result",
+              "tool_use_id": "toolu_screenshot",
+              "content": [
+                { "type": "text", "text": "Screenshot captured" },
+                { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo=" } }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "expectedOutput": {
+      "input": [
+        { "type": "function_call_output", "call_id": "toolu_screenshot", "output": "Screenshot captured" },
+        { "role": "user", "content": [{ "type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo=" }] }
+      ]
+    }
+  },
+  {
+    "name": "thinking-blocks-filtered",
+    "description": "thinking and redacted_thinking blocks stripped from assistant content",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [
+        {
+          "role": "assistant",
+          "content": [
+            { "type": "thinking", "thinking": "internal reasoning" },
+            { "type": "redacted_thinking", "data": "encrypted" },
+            { "type": "text", "text": "visible answer" }
+          ]
+        },
+        { "role": "user", "content": "continue" }
+      ]
+    },
+    "expectedOutput": {
+      "input": [
+        { "role": "assistant", "content": "visible answer" },
+        { "role": "user", "content": "continue" }
+      ]
+    }
+  },
+  {
+    "name": "thinking-budget-to-reasoning-effort",
+    "description": "thinking.budget_tokens maps to reasoning.effort",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 16384,
+      "messages": [{ "role": "user", "content": "Solve this problem" }],
+      "thinking": { "type": "enabled", "budget_tokens": 10000 }
+    },
+    "expectedOutput": {
+      "reasoning": { "effort": "high", "summary": "auto" }
+    }
+  },
+  {
+    "name": "parallel-tool-use-blocks",
+    "description": "Multiple tool_use blocks in single assistant message produce separate function_call items",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 8192,
+      "messages": [
+        {
+          "role": "assistant",
+          "content": [
+            { "type": "tool_use", "id": "toolu_1", "name": "Read", "input": { "path": "/a.ts" } },
+            { "type": "tool_use", "id": "toolu_2", "name": "Read", "input": { "path": "/b.ts" } }
+          ]
+        },
+        {
+          "role": "user",
+          "content": [
+            { "type": "tool_result", "tool_use_id": "toolu_1", "content": "file a content" },
+            { "type": "tool_result", "tool_use_id": "toolu_2", "content": "file b content" }
+          ]
+        }
+      ]
+    },
+    "expectedOutput": {
+      "input": [
+        { "type": "function_call", "call_id": "toolu_1", "name": "Read", "arguments": "{\"path\":\"/a.ts\"}" },
+        { "type": "function_call", "call_id": "toolu_2", "name": "Read", "arguments": "{\"path\":\"/b.ts\"}" },
+        { "type": "function_call_output", "call_id": "toolu_1", "output": "file a content" },
+        { "type": "function_call_output", "call_id": "toolu_2", "output": "file b content" }
+      ]
+    }
+  },
+  {
+    "name": "billing-header-stripped",
+    "description": "Claude Code billing system block stripped from instructions",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [{ "role": "user", "content": "Hello" }],
+      "system": [
+        { "type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.84-c8e; cc_entrypoint=cli; cch=a1b2c;" },
+        { "type": "text", "text": "You are a helpful coding assistant." }
+      ]
+    },
+    "expectedOutput": {
+      "instructions": "You are a helpful coding assistant."
+    }
+  },
+  {
+    "name": "empty-system-defaults",
+    "description": "Empty/missing system falls back to default instructions",
+    "input": {
+      "model": "claude-sonnet-4-5",
+      "max_tokens": 4096,
+      "messages": [{ "role": "user", "content": "Hi" }]
+    },
+    "expectedOutput": {
+      "instructions": "You are a helpful assistant."
+    }
+  }
+]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "shared/**/*.{test,spec}.ts",
       "tests/unit/**/*.{test,spec}.ts",
       "tests/integration/**/*.{test,spec}.ts",
+      "tests/contract/**/*.{test,spec}.ts",
       "tests/e2e/**/*.{test,spec}.ts",
       "packages/electron/__tests__/**/*.{test,spec}.ts",
     ],


### PR DESCRIPTION
## Summary

Phase 1 of tech debt reduction — golden fixture-based contract tests for the Anthropic → Codex translation layer.

**Why:** 59% of recent commits are fixes. The translation layer breaks every time upstream (Claude Code / Cursor) changes payload format. These tests catch drift before users see 400s.

**What:**
- `tests/contract/fixtures/anthropic-to-codex.json` — 10 golden input/output pairs covering historically-broken scenarios
- `tests/contract/anthropic-to-codex.contract.test.ts` — fixture runner + 4 invariant assertions
- `vitest.config.ts` — add `tests/contract/` to include

**Covered scenarios:**
- developer/system role handling (broke in v2.0.77-beta)
- parallel tool_use blocks (broke in #611)
- tool_result with image content
- thinking block filtering
- billing header strip (rotates per-request)
- empty system fallback

## Test Plan

- [x] 14/14 tests pass
- [x] `npx tsc --noEmit` — 0 errors

## Next Steps

- Add Codex → Anthropic (response direction) contract
- Add OpenAI ↔ Codex contract
- Wire debug-dump corpus collection for real-world payload capture