### PR TITLE
refactor(proxy): extract retry classifier as pure testable function

### DIFF
--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -53,6 +53,7 @@ import {
   applyCascadingBanDefense,
   buildProxyRetryRecoveryDecision,
 } from "./proxy-retry-recovery.js";
+import { classifyRetryAction } from "./proxy-retry-classifier.js";
 import { buildProxySessionContext } from "./proxy-session-context.js";
 import { staggerIfNeeded } from "./proxy-stagger.js";
 import { sendProxyUpstreamAttempt } from "./proxy-upstream-attempt.js";
@@ -298,68 +299,68 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         variantHash: sessionContext.variantHash,
       });
     } catch (err) {
-      if (!(err instanceof CodexApiError)) {
-        releaseAccount(accountPool, entryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
-        throw err;
-      }
-
-      if (implicitResume.replayFullInputAfterError(err)) {
-        continue;
-      }
-
-      const retryRecovery = buildProxyRetryRecoveryDecision({
+      const retryAction = classifyRetryAction(
         err,
-        tag: fmt.tag,
-        entryId,
-        stripAndRetryDone,
-        previousResponseId: req.codexRequest.previous_response_id,
-      });
-      if (retryRecovery.action === "retry") {
-        stripAndRetryDone = true;
-        applyProxyRetryRecoveryDecision({
-          decision: retryRecovery,
-          request: req,
-          affinityMap,
-          restoreImplicitResumeRequest: implicitResume.restore,
-        });
-        continue;
-      }
-
-      const decision = handleCodexApiError(
-        err, accountPool, entryId, req.codexRequest.model, fmt.tag, modelRetried, cookieJar,
+        { stripAndRetryDone, modelRetried, implicitResumeActive: implicitResume.isActive(), previousResponseId: req.codexRequest.previous_response_id },
+        (e) => implicitResume.canReplayAfterError(e),
       );
 
-      const errorRetryTransition = applyProxyErrorRetryTransition({
-        accountPool,
-        entryId,
-        model: req.codexRequest.model,
-        triedEntryIds,
-        tag: fmt.tag,
-        decision,
-        released,
-        restoreImplicitResumeRequest: implicitResume.restore,
-        modelRetried,
-        expectsImageGen: req.expectsImageGen,
-        cookieJar,
-        proxyPool,
-      });
-      if (errorRetryTransition.action === "respond") {
-        return respondWithProxyError({
-          c,
-          req,
-          fmt,
-          status: errorRetryTransition.status,
-          message: errorRetryTransition.message,
-          ...(errorRetryTransition.useFormat429 ? { useFormat429: true } : {}),
-        });
-      }
+      switch (retryAction.type) {
+        case "not_codex_error":
+          releaseAccount(accountPool, entryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
+          throw err;
 
-      modelRetried = errorRetryTransition.modelRetried;
-      entryId = errorRetryTransition.entryId;
-      triedEntryIds.push(errorRetryTransition.entryId);
-      codexApi = errorRetryTransition.api;
-      await staggerIfNeeded(errorRetryTransition.prevSlotMs);
-      continue;
+        case "implicit_resume_replay":
+          implicitResume.replayFullInputAfterError(err);
+          continue;
+
+        case "strip_and_retry": {
+          stripAndRetryDone = true;
+          const decision = buildProxyRetryRecoveryDecision({
+            err, tag: fmt.tag, entryId, stripAndRetryDone: false,
+            previousResponseId: req.codexRequest.previous_response_id,
+          });
+          applyProxyRetryRecoveryDecision({
+            decision,
+            request: req,
+            affinityMap,
+            restoreImplicitResumeRequest: implicitResume.restore,
+          });
+          continue;
+        }
+
+        case "error_handler_decides": {
+          const decision = handleCodexApiError(
+            err as CodexApiError, accountPool, entryId, req.codexRequest.model, fmt.tag, modelRetried, cookieJar,
+          );
+
+          const errorRetryTransition = applyProxyErrorRetryTransition({
+            accountPool, entryId,
+            model: req.codexRequest.model,
+            triedEntryIds, tag: fmt.tag,
+            decision, released,
+            restoreImplicitResumeRequest: implicitResume.restore,
+            modelRetried,
+            expectsImageGen: req.expectsImageGen,
+            cookieJar, proxyPool,
+          });
+          if (errorRetryTransition.action === "respond") {
+            return respondWithProxyError({
+              c, req, fmt,
+              status: errorRetryTransition.status,
+              message: errorRetryTransition.message,
+              ...(errorRetryTransition.useFormat429 ? { useFormat429: true } : {}),
+            });
+          }
+
+          modelRetried = errorRetryTransition.modelRetried;
+          entryId = errorRetryTransition.entryId;
+          triedEntryIds.push(errorRetryTransition.entryId);
+          codexApi = errorRetryTransition.api;
+          await staggerIfNeeded(errorRetryTransition.prevSlotMs);
+          continue;
+        }
+      }
     }
   }
 }

--- a/src/routes/shared/proxy-implicit-resume-lifecycle.ts
+++ b/src/routes/shared/proxy-implicit-resume-lifecycle.ts
@@ -31,6 +31,7 @@ export interface CreateImplicitResumeLifecycleOptions {
 export interface ImplicitResumeLifecycle {
   evaluation: ImplicitResumeEvaluation;
   activate(): void;
+  canReplayAfterError(err: unknown): boolean;
   getUsageHint(): UsageHint | undefined;
   isActive(): boolean;
   logSkippedWarnings(): void;
@@ -100,6 +101,9 @@ export function createImplicitResumeLifecycle(
           evaluation.unansweredCallIds.slice(0, 3).join(","),
         );
       }
+    },
+    canReplayAfterError(err: unknown): boolean {
+      return shouldReplayFullInputAfterImplicitResumeError(err, active);
     },
     replayFullInputAfterError(err: unknown): boolean {
       if (!shouldReplayFullInputAfterImplicitResumeError(err, active)) return false;

--- a/src/routes/shared/proxy-retry-classifier.ts
+++ b/src/routes/shared/proxy-retry-classifier.ts
@@ -1,0 +1,68 @@
+/**
+ * Retry classification — pure function that decides what to do after a
+ * CodexApiError, without performing side effects.
+ *
+ * Extracted from the proxy-handler for-loop to enable independent unit testing
+ * of each retry path and their priority interactions.
+ */
+
+import { CodexApiError } from "../../proxy/codex-api.js";
+import {
+  isPreviousResponseNotFoundError,
+  isUnansweredFunctionCallError,
+} from "../../proxy/error-classification.js";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface RetryState {
+  stripAndRetryDone: boolean;
+  modelRetried: boolean;
+  implicitResumeActive: boolean;
+  previousResponseId: string | undefined;
+}
+
+export type RetryAction =
+  | { type: "implicit_resume_replay" }
+  | { type: "strip_and_retry"; kind: "previous_response_not_found" | "unanswered_function_call" }
+  | { type: "error_handler_decides" }
+  | { type: "not_codex_error" };
+
+// ── Classifier ────────────────────────────────────────────────────
+
+/**
+ * Classify the retry action for a caught error during an upstream attempt.
+ *
+ * Priority order:
+ *   1. Implicit resume replay (WebSocket failures on resumed connections)
+ *   2. Strip previous_response_id (stale session references)
+ *   3. Error handler (429/4xx/5xx → fallback account or respond)
+ *
+ * This is a pure function — no side effects. The caller applies the decision.
+ */
+export function classifyRetryAction(
+  err: unknown,
+  state: RetryState,
+  isImplicitResumeReplayable: (err: unknown) => boolean,
+): RetryAction {
+  if (!(err instanceof CodexApiError)) {
+    return { type: "not_codex_error" };
+  }
+
+  // Priority 1: implicit resume can replay with full input
+  if (state.implicitResumeActive && isImplicitResumeReplayable(err)) {
+    return { type: "implicit_resume_replay" };
+  }
+
+  // Priority 2: strip stale previous_response_id (only once)
+  if (!state.stripAndRetryDone) {
+    if (isPreviousResponseNotFoundError(err)) {
+      return { type: "strip_and_retry", kind: "previous_response_not_found" };
+    }
+    if (isUnansweredFunctionCallError(err)) {
+      return { type: "strip_and_retry", kind: "unanswered_function_call" };
+    }
+  }
+
+  // Priority 3: delegate to error handler (429/ban/expired/5xx → fallback or respond)
+  return { type: "error_handler_decides" };
+}

--- a/tests/unit/routes/shared/proxy-retry-classifier.test.ts
+++ b/tests/unit/routes/shared/proxy-retry-classifier.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { classifyRetryAction, type RetryState } from "@src/routes/shared/proxy-retry-classifier.js";
+import { CodexApiError } from "@src/proxy/codex-api.js";
+
+function makeError(status: number, body: string): CodexApiError {
+  return new CodexApiError(status, body);
+}
+
+const prevRespNotFound = makeError(400, JSON.stringify({
+  error: { type: "invalid_request_error", code: "previous_response_not_found", message: "Not found" },
+}));
+
+const unansweredFn = makeError(400, JSON.stringify({
+  error: { type: "invalid_request_error", message: "No tool output found for function call call_abc." },
+}));
+
+const rateLimitErr = makeError(429, JSON.stringify({
+  error: { type: "rate_limit_error", message: "Rate limited" },
+}));
+
+const serverErr = makeError(502, "Bad Gateway");
+
+const defaultState: RetryState = {
+  stripAndRetryDone: false,
+  modelRetried: false,
+  implicitResumeActive: false,
+  previousResponseId: undefined,
+};
+
+const neverReplayable = () => false;
+const alwaysReplayable = () => true;
+
+describe("classifyRetryAction", () => {
+  describe("priority 1: implicit resume replay", () => {
+    it("returns implicit_resume_replay when active and error is replayable", () => {
+      const state: RetryState = { ...defaultState, implicitResumeActive: true };
+      const result = classifyRetryAction(rateLimitErr, state, alwaysReplayable);
+      expect(result).toEqual({ type: "implicit_resume_replay" });
+    });
+
+    it("skips replay when implicit resume is not active", () => {
+      const result = classifyRetryAction(rateLimitErr, defaultState, alwaysReplayable);
+      expect(result.type).not.toBe("implicit_resume_replay");
+    });
+
+    it("skips replay when error is not replayable", () => {
+      const state: RetryState = { ...defaultState, implicitResumeActive: true };
+      const result = classifyRetryAction(rateLimitErr, state, neverReplayable);
+      expect(result.type).toBe("error_handler_decides");
+    });
+  });
+
+  describe("priority 2: strip and retry", () => {
+    it("returns strip_and_retry for previous_response_not_found", () => {
+      const result = classifyRetryAction(prevRespNotFound, defaultState, neverReplayable);
+      expect(result).toEqual({ type: "strip_and_retry", kind: "previous_response_not_found" });
+    });
+
+    it("returns strip_and_retry for unanswered function call", () => {
+      const result = classifyRetryAction(unansweredFn, defaultState, neverReplayable);
+      expect(result).toEqual({ type: "strip_and_retry", kind: "unanswered_function_call" });
+    });
+
+    it("does NOT strip when stripAndRetryDone is true (loop guard)", () => {
+      const state: RetryState = { ...defaultState, stripAndRetryDone: true };
+      const result = classifyRetryAction(prevRespNotFound, state, neverReplayable);
+      expect(result.type).toBe("error_handler_decides");
+    });
+
+    it("does NOT strip when stripAndRetryDone even for unanswered", () => {
+      const state: RetryState = { ...defaultState, stripAndRetryDone: true };
+      const result = classifyRetryAction(unansweredFn, state, neverReplayable);
+      expect(result.type).toBe("error_handler_decides");
+    });
+  });
+
+  describe("priority 3: error handler", () => {
+    it("delegates 429 to error handler", () => {
+      const result = classifyRetryAction(rateLimitErr, defaultState, neverReplayable);
+      expect(result).toEqual({ type: "error_handler_decides" });
+    });
+
+    it("delegates 502 to error handler", () => {
+      const result = classifyRetryAction(serverErr, defaultState, neverReplayable);
+      expect(result).toEqual({ type: "error_handler_decides" });
+    });
+  });
+
+  describe("non-CodexApiError", () => {
+    it("returns not_codex_error for plain Error", () => {
+      const result = classifyRetryAction(new Error("boom"), defaultState, neverReplayable);
+      expect(result).toEqual({ type: "not_codex_error" });
+    });
+
+    it("returns not_codex_error for string throw", () => {
+      const result = classifyRetryAction("unexpected", defaultState, neverReplayable);
+      expect(result).toEqual({ type: "not_codex_error" });
+    });
+  });
+
+  describe("priority interactions", () => {
+    it("implicit resume takes priority over strip-retry for same error", () => {
+      const state: RetryState = { ...defaultState, implicitResumeActive: true };
+      const result = classifyRetryAction(prevRespNotFound, state, alwaysReplayable);
+      expect(result.type).toBe("implicit_resume_replay");
+    });
+
+    it("strip-retry takes priority over error handler for previous_response_not_found", () => {
+      const result = classifyRetryAction(prevRespNotFound, defaultState, neverReplayable);
+      expect(result.type).toBe("strip_and_retry");
+    });
+
+    it("after strip exhausted, falls through to error handler for same error", () => {
+      const state: RetryState = { ...defaultState, stripAndRetryDone: true };
+      const result = classifyRetryAction(prevRespNotFound, state, neverReplayable);
+      expect(result.type).toBe("error_handler_decides");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 (step 1) of tech debt reduction — make proxy-handler retry logic independently testable.

**Before:** catch block used if/else cascade mixing classification with side effects. 3 retry paths (implicit-resume replay, strip-and-retry, error-handler fallback) could only be tested through integration tests.

**After:**
- `proxy-retry-classifier.ts` (68 lines) — pure function `classifyRetryAction(error, state) → RetryAction`
- 14 unit tests covering every priority path and their interactions
- proxy-handler dispatches via `switch(retryAction.type)` — same behavior, explicit structure
- `ImplicitResumeLifecycle` gains `canReplayAfterError()` for pure checks

**Retry priority (explicit and documented):**
1. `implicit_resume_replay` — WebSocket failures on resumed connections
2. `strip_and_retry` — stale session references (previous_response_not_found, unanswered_function_call)
3. `error_handler_decides` — 429/4xx/5xx → fallback account or respond

## Test Plan

- [x] 14 new unit tests for classifier (priority paths + interactions)
- [x] 32 existing integration tests pass unchanged
- [x] 6 recovery integration tests pass unchanged
- [x] `npx tsc --noEmit` — 0 errors