### PR TITLE
fix(test): update stale assertions after responses split and tag-only bump

### DIFF
--- a/packages/electron/__tests__/release-pipeline.test.ts
+++ b/packages/electron/__tests__/release-pipeline.test.ts
@@ -114,8 +114,7 @@ describe("release pipeline", () => {
     expect(existsSync(bumpYml)).toBe(true);
 
     const content = readFileSync(bumpYml, "utf-8");
-    // Must bump both root and electron package versions
+    // Must reference root package.json for version series
     expect(content).toContain("package.json");
-    expect(content).toContain("packages/electron/package.json");
   });
 });

--- a/tests/unit/routes/shared/proxy-stagger-boundary.test.ts
+++ b/tests/unit/routes/shared/proxy-stagger-boundary.test.ts
@@ -8,6 +8,7 @@ const ROOT = process.cwd();
 const STAGGER_MODULE = "src/routes/shared/proxy-stagger.ts";
 const PROXY_HANDLER_MODULE = "src/routes/shared/proxy-handler.ts";
 const RESPONSES_MODULE = "src/routes/responses.ts";
+const RESPONSES_COMPACT_MODULE = "src/routes/responses-compact.ts";
 
 function source(path: string): string {
   return readFileSync(resolve(ROOT, path), "utf-8");
@@ -64,10 +65,10 @@ describe("proxy stagger helper boundary", () => {
   });
 
   it("keeps compact responses from importing utility functions from the runtime handler", () => {
-    const responses = source(RESPONSES_MODULE);
+    const compact = source(RESPONSES_COMPACT_MODULE);
 
-    expect(importsNamedBinding(responses, "shared/proxy-stagger.js", "staggerIfNeeded", RESPONSES_MODULE)).toBe(true);
-    expect(importsNamedBinding(responses, "shared/proxy-handler.js", "handleProxyRequest", RESPONSES_MODULE)).toBe(true);
-    expect(importsNamedBinding(responses, "shared/proxy-handler.js", "staggerIfNeeded", RESPONSES_MODULE)).toBe(false);
+    expect(importsNamedBinding(compact, "shared/proxy-stagger.js", "staggerIfNeeded", RESPONSES_COMPACT_MODULE)).toBe(true);
+    expect(importsNamedBinding(compact, "shared/proxy-handler.js", "handleProxyRequest", RESPONSES_COMPACT_MODULE)).toBe(false);
+    expect(importsNamedBinding(compact, "shared/proxy-handler.js", "staggerIfNeeded", RESPONSES_COMPACT_MODULE)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two tests were broken by prior changes but only caught by the pre-push hook (not CI):

- `release-pipeline.test.ts`: asserted `packages/electron/package.json` in `bump-electron.yml`, but the workflow switched to tag-only mode
- `proxy-stagger-boundary.test.ts`: checked `responses.ts` for `staggerIfNeeded` import, but #630 moved it to `responses-compact.ts`

## Test Plan

- [x] `npm test` — 251 files, 2449 tests, 0 failures