### PR TITLE
chore(web): allow dev proxy target override

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
 import path from "path";
 
+const proxyTarget = process.env.VITE_PROXY_TARGET ?? "http://localhost:8080";
+
 export default defineConfig({
   plugins: [preact()],
   resolve: {
@@ -25,11 +27,11 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/v1": "http://localhost:8080",
-      "/auth": "http://localhost:8080",
-      "/health": "http://localhost:8080",
-      "/debug": "http://localhost:8080",
-      "/admin": "http://localhost:8080",
+      "/v1": proxyTarget,
+      "/auth": proxyTarget,
+      "/health": proxyTarget,
+      "/debug": proxyTarget,
+      "/admin": proxyTarget,
     },
   },
 });


### PR DESCRIPTION
## Summary / 摘要
- Allow Vite dev proxy target override via `VITE_PROXY_TARGET`.
- Default behavior remains unchanged: proxy still targets `http://localhost:8080` unless the env var is set.
- This makes it possible to test a branch backend on another port, e.g. 18080, while keeping the installed app on 8080 running.

- 新增 `VITE_PROXY_TARGET`，允许覆盖 Vite dev proxy 目标。
- 默认行为不变：未设置环境变量时仍代理到 `http://localhost:8080`。
- 这样可以在 18080 等其他端口测试分支后端，同时保留 8080 上的安装版运行。

## Verification / 验证
- `npm run build`