### PR TITLE
Expose account pool slot capacity in health response

### DIFF
--- a/src/auth/account-lifecycle.ts
+++ b/src/auth/account-lifecycle.ts
@@ -15,6 +15,13 @@ import type { AccountEntry, AcquiredAccount } from "./types.js";
 
 const ACQUIRE_LOCK_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+export interface AccountCapacitySummary {
+  max_concurrent_per_account: number;
+  total_slots: number;
+  used_slots: number;
+  available_slots: number;
+}
+
 export class AccountLifecycle {
   /** Per-account active slot timestamps. Each entry = one in-flight request. */
   private acquireLocks: Map<string, number[]> = new Map();
@@ -47,15 +54,7 @@ export class AccountLifecycle {
     if (slots.length === 0) this.acquireLocks.delete(entryId);
   }
 
-  acquire(options?: { model?: string; excludeIds?: string[]; preferredEntryId?: string }): AcquiredAccount | null {
-    const nowMs = Date.now();
-    const now = new Date(nowMs);
-
-    const entries = this.registry.getAllEntries();
-    for (const entry of entries) {
-      this.registry.refreshStatus(entry, now);
-    }
-
+  private cleanupStaleSlots(nowMs: number): void {
     // Auto-release stale slots (slots are chronological — if oldest is fresh, all are)
     for (const [id, slots] of this.acquireLocks) {
       if (nowMs - slots[0] <= ACQUIRE_LOCK_TTL_MS) continue;
@@ -70,6 +69,18 @@ export class AccountLifecycle {
         this.acquireLocks.set(id, fresh);
       }
     }
+  }
+
+  acquire(options?: { model?: string; excludeIds?: string[]; preferredEntryId?: string }): AcquiredAccount | null {
+    const nowMs = Date.now();
+    const now = new Date(nowMs);
+
+    const entries = this.registry.getAllEntries();
+    for (const entry of entries) {
+      this.registry.refreshStatus(entry, now);
+    }
+
+    this.cleanupStaleSlots(nowMs);
 
     const config = getConfig();
     const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
@@ -220,5 +231,40 @@ export class AccountLifecycle {
     }
 
     return result;
+  }
+
+  getCapacitySummary(): AccountCapacitySummary {
+    const nowMs = Date.now();
+    const now = new Date(nowMs);
+    const config = getConfig();
+    const maxConcurrent = config.auth.max_concurrent_per_account ?? 3;
+    const skipExhausted = config.quota?.skip_exhausted === true;
+
+    const entries = this.registry.getAllEntries();
+    for (const entry of entries) {
+      this.registry.refreshStatus(entry, now);
+    }
+    this.cleanupStaleSlots(nowMs);
+
+    let totalSlots = 0;
+    let usedSlots = 0;
+    let availableSlots = 0;
+
+    for (const entry of entries) {
+      if (entry.status !== "active") continue;
+      if (skipExhausted && hasReachedCachedQuota(entry)) continue;
+
+      const used = Math.min(this.slotCount(entry.id), maxConcurrent);
+      totalSlots += maxConcurrent;
+      usedSlots += used;
+      availableSlots += maxConcurrent - used;
+    }
+
+    return {
+      max_concurrent_per_account: maxConcurrent,
+      total_slots: totalSlots,
+      used_slots: usedSlots,
+      available_slots: availableSlots,
+    };
   }
 }

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -11,6 +11,7 @@ import { createFsPersistence } from "./account-persistence.js";
 import { AccountRegistry } from "./account-registry.js";
 import { AccountLifecycle } from "./account-lifecycle.js";
 import type { AccountPersistence, PersistenceLoadHealth } from "./account-persistence.js";
+import type { AccountCapacitySummary } from "./account-lifecycle.js";
 import type { RotationStrategyName } from "./rotation-strategy.js";
 import type {
   AccountEntry,
@@ -273,6 +274,10 @@ export class AccountPool {
     banned: number;
   } {
     return this.registry.getPoolSummary();
+  }
+
+  getCapacitySummary(): AccountCapacitySummary {
+    return this.lifecycle.getCapacitySummary();
   }
 
   // ── Persistence ───────────────────────────────────────────────────

--- a/src/routes/admin/health.ts
+++ b/src/routes/admin/health.ts
@@ -15,10 +15,15 @@ export function createHealthRoutes(accountPool: AccountPool): Hono {
   app.get("/health", async (c) => {
     const authenticated = accountPool.isAuthenticated();
     const poolSummary = accountPool.getPoolSummary();
+    const capacitySummary = accountPool.getCapacitySummary();
     return c.json({
       status: "ok",
       authenticated,
-      pool: { total: poolSummary.total, active: poolSummary.active },
+      pool: {
+        total: poolSummary.total,
+        active: poolSummary.active,
+        ...capacitySummary,
+      },
       timestamp: new Date().toISOString(),
     });
   });

--- a/tests/e2e/debug-routes.test.ts
+++ b/tests/e2e/debug-routes.test.ts
@@ -122,6 +122,36 @@ afterAll(() => {
   process.env.NODE_ENV = origEnv;
 });
 
+describe("GET /health", () => {
+  it("returns pool capacity without removing existing pool fields", async () => {
+    pool.addAccount("token-health");
+    const acquired = pool.acquire({});
+    expect(acquired).not.toBeNull();
+
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      authenticated: boolean;
+      pool: {
+        total: number;
+        active: number;
+        max_concurrent_per_account: number;
+        total_slots: number;
+        used_slots: number;
+        available_slots: number;
+      };
+    };
+
+    expect(body.authenticated).toBe(true);
+    expect(body.pool.total).toBe(1);
+    expect(body.pool.active).toBe(1);
+    expect(body.pool.max_concurrent_per_account).toBe(3);
+    expect(body.pool.total_slots).toBe(3);
+    expect(body.pool.used_slots).toBe(1);
+    expect(body.pool.available_slots).toBe(2);
+  });
+});
+
 describe("GET /debug/fingerprint", () => {
   it("returns fingerprint data from localhost", async () => {
     const res = await app.request("/debug/fingerprint");

--- a/tests/unit/auth/account-lifecycle-concurrency.test.ts
+++ b/tests/unit/auth/account-lifecycle-concurrency.test.ts
@@ -117,6 +117,29 @@ describe("per-account concurrent request slots", () => {
       expect(pool.acquire({})).toBeNull();
     });
 
+    it("reports slot capacity and in-flight usage", () => {
+      const { pool } = createPool(2);
+      expect(pool.getCapacitySummary()).toEqual({
+        max_concurrent_per_account: 3,
+        total_slots: 6,
+        used_slots: 0,
+        available_slots: 6,
+      });
+
+      const first = pool.acquire({})!;
+      const second = pool.acquire({})!;
+      expect(pool.getCapacitySummary()).toEqual({
+        max_concurrent_per_account: 3,
+        total_slots: 6,
+        used_slots: 2,
+        available_slots: 4,
+      });
+
+      pool.release(first.entryId);
+      pool.release(second.entryId);
+      expect(pool.getCapacitySummary().available_slots).toBe(6);
+    });
+
     it("release frees exactly one slot", () => {
       const { pool } = createPool(1);
       const acquired = [];
@@ -257,6 +280,27 @@ describe("per-account concurrent request slots", () => {
       expect(pool.acquire({})).not.toBeNull();
       expect(pool.acquire({})).not.toBeNull();
       expect(pool.acquire({})).toBeNull();
+
+      vi.useRealTimers();
+    });
+
+    it("capacity summary releases stale slots before counting availability", () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { pool } = createPool(1);
+
+      pool.acquire({});
+      pool.acquire({});
+      expect(pool.getCapacitySummary()).toMatchObject({
+        used_slots: 2,
+        available_slots: 1,
+      });
+
+      vi.advanceTimersByTime(6 * 60 * 1000);
+
+      expect(pool.getCapacitySummary()).toMatchObject({
+        used_slots: 0,
+        available_slots: 3,
+      });
 
       vi.useRealTimers();
     });


### PR DESCRIPTION
Summary: Adds read-only slot capacity metrics to /health so clients can distinguish active accounts from currently available acquire slots. Keeps pool.total and pool.active backward-compatible. Tests: npx tsc --noEmit; npx vitest run tests/unit/auth/account-lifecycle-concurrency.test.ts; npx vitest run tests/e2e/debug-routes.test.ts