### PR TITLE
fix(auth): prevent apiKeyAuth middleware pollution in sub-routes

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,8 +3,8 @@ api:
   timeout_seconds: 600
 client:
   originator: Codex Desktop
-  app_version: 26.519.81530
-  build_number: "3178"
+  app_version: 26.602.40724
+  build_number: "3593"
   platform: darwin
   arch: arm64
   chromium_version: "146"

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -81,9 +81,7 @@ export function createChatRoutes(
   upstreamRouter?: UpstreamRouter,
 ): Hono {
   const app = new Hono();
-  app.use("*", apiKeyAuth(accountPool));
-
-  app.post("/v1/chat/completions", async (c) => {
+  app.post("/v1/chat/completions", apiKeyAuth(accountPool), async (c) => {
     // Parse request
     const body = await c.req.json();
     const parsed = ChatCompletionRequestSchema.safeParse(body);

--- a/src/routes/embeddings.ts
+++ b/src/routes/embeddings.ts
@@ -98,9 +98,7 @@ function copyResponseHeaders(upstream: Response): Headers {
 
 export function createEmbeddingsRoutes(accountPool: AccountPool, apiKeyPool: ApiKeyPool): Hono {
   const app = new Hono();
-  app.use("*", apiKeyAuth(accountPool));
-
-  app.post("/v1/embeddings", async (c) => {
+  app.post("/v1/embeddings", apiKeyAuth(accountPool), async (c) => {
     const body = await c.req.json();
     const parsed = EmbeddingsRequestSchema.safeParse(body);
     if (!parsed.success) {

--- a/src/routes/gemini.ts
+++ b/src/routes/gemini.ts
@@ -83,10 +83,8 @@ export function createGeminiRoutes(
   upstreamRouter?: UpstreamRouter,
 ): Hono {
   const app = new Hono();
-  app.use("*", apiKeyAuth(accountPool));
-
   // Handle both generateContent and streamGenerateContent
-  app.post("/v1beta/models/:modelAction", async (c) => {
+  app.post("/v1beta/models/:modelAction", apiKeyAuth(accountPool), async (c) => {
     const modelActionParam = c.req.param("modelAction");
     const parsed = parseModelAction(modelActionParam);
 

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -134,9 +134,9 @@ export function createMessagesRoutes(
   upstreamRouter?: UpstreamRouter,
 ): Hono {
   const app = new Hono();
-  app.use("*", apiKeyAuth(accountPool));
+  const auth = apiKeyAuth(accountPool);
 
-  app.post("/v1/messages/count_tokens", async (c) => {
+  app.post("/v1/messages/count_tokens", auth, async (c) => {
     const body = await c.req.json();
 
     const parsed = AnthropicCountTokensRequestSchema.safeParse(body);
@@ -150,7 +150,7 @@ export function createMessagesRoutes(
     return c.json({ input_tokens: estimateCountTokens(parsed.data) });
   });
 
-  app.post("/v1/messages", async (c) => {
+  app.post("/v1/messages", auth, async (c) => {
     // Parse request
     const body = await c.req.json();
     const parsed = AnthropicMessagesRequestSchema.safeParse(body);

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -100,7 +100,7 @@ export function createResponsesRoutes(
   // Register errorHandler locally so that when testing this router in isolation (e.g. unit tests),
   // uncaught errors are still handled and formatted appropriately.
   app.onError(errorHandler);
-  app.use("*", apiKeyAuth(accountPool));
+  const auth = apiKeyAuth(accountPool);
 
   const responsesHandler = async (c: Context) => {
     const rawBody = await c.req.json();
@@ -297,11 +297,11 @@ export function createResponsesRoutes(
     return handleCompact(c, accountPool, cookieJar, proxyPool, body, upstreamRouter);
   };
 
-  app.post("/v1/responses", responsesHandler);
-  app.post("/v1/responses/review", responsesHandler);
-  app.post("/responses", responsesHandler);
-  app.post("/responses/review", responsesHandler);
-  app.post("/v1/responses/compact", compactHandler);
+  app.post("/v1/responses", auth, responsesHandler);
+  app.post("/v1/responses/review", auth, responsesHandler);
+  app.post("/responses", auth, responsesHandler);
+  app.post("/responses/review", auth, responsesHandler);
+  app.post("/v1/responses/compact", auth, compactHandler);
 
   return app;
 }

--- a/tests/unit/routes/api-key-auth-scoping.test.ts
+++ b/tests/unit/routes/api-key-auth-scoping.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests that apiKeyAuth middleware is scoped to the correct endpoints only.
+ * Regression for: https://github.com/icebear0828/codex-proxy/pull/647
+ *
+ * Before the fix, `app.use("*", apiKeyAuth(...))` in sub-routes caused the
+ * middleware to apply globally when sub-routers were mounted at root, leaking
+ * 401s onto routes like /v1/models that should be publicly accessible.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { AccountPool } from "@src/auth/account-pool.js";
+
+// ── Mocks (before route imports) ────────────────────────────────────────────
+
+const mockConfig = {
+  server: { proxy_api_key: "test-secret-key" },
+  tls: { proxy_url: null as string | null },
+  model: { default: "gpt-5.3-codex" },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/models/model-fetcher.js", () => ({
+  triggerImmediateRefresh: vi.fn(),
+  startModelRefresh: vi.fn(),
+  stopModelRefresh: vi.fn(),
+}));
+
+vi.mock("@src/proxy/cookie-jar.js", () => ({
+  CookieJar: vi.fn().mockImplementation(() => ({})),
+}));
+
+// ── Imports ──────────────────────────────────────────────────────────────────
+
+import { createChatRoutes } from "@src/routes/chat.js";
+import { createMessagesRoutes } from "@src/routes/messages.js";
+import { createGeminiRoutes } from "@src/routes/gemini.js";
+import { createModelRoutes } from "@src/routes/models.js";
+import { createResponsesRoutes } from "@src/routes/responses.js";
+import { loadStaticModels } from "@src/models/model-store.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createAccountPool(validates = false): AccountPool {
+  return {
+    validateProxyApiKey: vi.fn(() => validates),
+  } as unknown as AccountPool;
+}
+
+async function noKeyPost(
+  app: { request: (path: string, init?: RequestInit) => Promise<Response> },
+  path: string,
+) {
+  return app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+}
+
+async function noKeyGet(
+  app: { request: (path: string, init?: RequestInit) => Promise<Response> },
+  path: string,
+) {
+  return app.request(path, { method: "GET" });
+}
+
+// ── Protected routes: must return 401 without key ────────────────────────────
+
+describe("chat routes — apiKeyAuth scoped to POST /v1/chat/completions", () => {
+  it("returns 401 on POST /v1/chat/completions without key", async () => {
+    const app = createChatRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1/chat/completions");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("messages routes — apiKeyAuth scoped to POST /v1/messages", () => {
+  it("returns 401 on POST /v1/messages without key", async () => {
+    const app = createMessagesRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1/messages");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 on POST /v1/messages/count_tokens without key", async () => {
+    const app = createMessagesRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1/messages/count_tokens");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("gemini routes — apiKeyAuth scoped to POST /v1beta/models/:modelAction", () => {
+  it("returns 401 on POST /v1beta/models/gpt-5.5:generateContent without key", async () => {
+    const app = createGeminiRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1beta/models/gpt-5.5:generateContent");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("responses routes — apiKeyAuth scoped to response endpoints", () => {
+  it("returns 401 on POST /v1/responses without key", async () => {
+    const app = createResponsesRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1/responses");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 on POST /v1/responses/compact without key", async () => {
+    const app = createResponsesRoutes(createAccountPool(false));
+    const res = await noKeyPost(app, "/v1/responses/compact");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Public routes: must NOT return 401 even with proxy_api_key set ───────────
+
+describe("model routes — GET /v1/models is publicly accessible (no auth required)", () => {
+  it("returns 200 on GET /v1/models without Authorization header", async () => {
+    loadStaticModels();
+    const app = createModelRoutes();
+    const res = await noKeyGet(app, "/v1/models");
+    // Must NOT be 401 — model listing should be public
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
This PR fixes the apiKeyAuth middleware issue where mounting sub-routes to Hono under root path elevated the middleware to act globally, causing 401 leaks on non-API routes. Precised endpoint bindings are applied to replace global use("*") matches in routes/chat.ts, embeddings.ts, gemini.ts, messages.ts, and responses.ts.

Closes #653