### PR TITLE
fix: support image generation in chat completions route

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -109,6 +109,12 @@ export function createChatRoutes(
     }
 
     const { codexRequest, tupleSchema } = translateToCodexRequest(req);
+    const expectsImageGen = Array.isArray(codexRequest.tools)
+      && codexRequest.tools.some((t) => {
+        if (typeof t !== "object" || t === null) return false;
+        const record = t as Record<string, unknown>;
+        return record.type === "image_generation";
+      });
     // Check after translation so suffix-parsed and config-default effort are included.
     const wantReasoning = !!codexRequest.reasoning?.effort;
     const fmt = makeOpenAIFormat(wantReasoning);
@@ -119,6 +125,7 @@ export function createChatRoutes(
       isStreaming: req.stream ?? false,
       clientConversationId: req.user,
       tupleSchema,
+      expectsImageGen,
     };
 
     const requestId = c.get("requestId") ?? randomUUID().slice(0, 8);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -5,6 +5,7 @@ import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { translateToCodexRequest } from "../translation/openai-to-codex.js";
+import { isRecord } from "../translation/shared-utils.js";
 import {
   streamCodexToOpenAI,
   collectCodexResponse,
@@ -110,11 +111,7 @@ export function createChatRoutes(
 
     const { codexRequest, tupleSchema } = translateToCodexRequest(req);
     const expectsImageGen = Array.isArray(codexRequest.tools)
-      && codexRequest.tools.some((t) => {
-        if (typeof t !== "object" || t === null) return false;
-        const record = t as Record<string, unknown>;
-        return record.type === "image_generation";
-      });
+      && codexRequest.tools.some((t): t is Record<string, unknown> => isRecord(t) && t.type === "image_generation");
     // Check after translation so suffix-parsed and config-default effort are included.
     const wantReasoning = !!codexRequest.reasoning?.effort;
     const fmt = makeOpenAIFormat(wantReasoning);

--- a/src/translation/codex-event-extractor.ts
+++ b/src/translation/codex-event-extractor.ts
@@ -89,6 +89,11 @@ export interface ExtractedEvent {
   functionCallStart?: FunctionCallStart;
   functionCallDelta?: FunctionCallDelta;
   functionCallDone?: FunctionCallDone;
+  imageGenerationDone?: {
+    id: string;
+    result: string;
+    revised_prompt?: string;
+  };
 }
 
 /**
@@ -162,6 +167,15 @@ export async function* iterateCodexEvents(
       }
 
       case "response.output_item.done":
+        if (typed.item.type === "image_generation_call") {
+          extracted.imageGenerationDone = {
+            id: typed.item.id || "",
+            result: typed.item.result || "",
+            revised_prompt: typed.item.revised_prompt,
+          };
+        }
+        break;
+
       case "response.content_part.added":
       case "response.content_part.done":
       case "response.output_text.annotation.added":

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -83,6 +83,38 @@ export async function* streamCodexToOpenAI(
       throw codexApiErrorFromEvent(evt.error);
     }
 
+    if (evt.imageGenerationDone) {
+      hasToolCalls = true;
+      hasContent = true;
+      const idx = nextToolCallIndex++;
+      const toolCall: ChatCompletionChunkToolCall = {
+        index: idx,
+        id: evt.imageGenerationDone.id,
+        type: "function",
+        function: {
+          name: "image_generation",
+          arguments: JSON.stringify({
+            result: evt.imageGenerationDone.result,
+            revised_prompt: evt.imageGenerationDone.revised_prompt,
+          }),
+        },
+      };
+      yield formatSSE({
+        id: chunkId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [toolCall] },
+            finish_reason: null,
+          },
+        ],
+      });
+      continue;
+    }
+
     // Handle function call events
     if (evt.functionCallStart) {
       hasToolCalls = true;
@@ -359,6 +391,19 @@ export async function collectCodexResponse(
         function: {
           name: evt.functionCallDone.name,
           arguments: evt.functionCallDone.arguments,
+        },
+      });
+    }
+    if (evt.imageGenerationDone) {
+      toolCalls.push({
+        id: evt.imageGenerationDone.id,
+        type: "function",
+        function: {
+          name: "image_generation",
+          arguments: JSON.stringify({
+            result: evt.imageGenerationDone.result,
+            revised_prompt: evt.imageGenerationDone.revised_prompt,
+          }),
         },
       });
     }

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -87,18 +87,13 @@ export async function* streamCodexToOpenAI(
       hasToolCalls = true;
       hasContent = true;
       const idx = nextToolCallIndex++;
-      const toolCall: ChatCompletionChunkToolCall = {
-        index: idx,
-        id: evt.imageGenerationDone.id,
-        type: "function",
-        function: {
-          name: "image_generation",
-          arguments: JSON.stringify({
-            result: evt.imageGenerationDone.result,
-            revised_prompt: evt.imageGenerationDone.revised_prompt,
-          }),
-        },
-      };
+      const argsJson = JSON.stringify({
+        result: evt.imageGenerationDone.result,
+        ...(evt.imageGenerationDone.revised_prompt !== undefined
+          ? { revised_prompt: evt.imageGenerationDone.revised_prompt }
+          : {}),
+      });
+      // Start chunk: id + type + name (arguments empty per OpenAI streaming spec)
       yield formatSSE({
         id: chunkId,
         object: "chat.completion.chunk",
@@ -107,7 +102,32 @@ export async function* streamCodexToOpenAI(
         choices: [
           {
             index: 0,
-            delta: { tool_calls: [toolCall] },
+            delta: {
+              tool_calls: [
+                {
+                  index: idx,
+                  id: evt.imageGenerationDone.id,
+                  type: "function",
+                  function: { name: "image_generation", arguments: "" },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      });
+      // Arguments chunk: arguments content (no id/type per OpenAI streaming spec)
+      yield formatSSE({
+        id: chunkId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: idx, function: { arguments: argsJson } }],
+            },
             finish_reason: null,
           },
         ],
@@ -402,7 +422,9 @@ export async function collectCodexResponse(
           name: "image_generation",
           arguments: JSON.stringify({
             result: evt.imageGenerationDone.result,
-            revised_prompt: evt.imageGenerationDone.revised_prompt,
+            ...(evt.imageGenerationDone.revised_prompt !== undefined
+              ? { revised_prompt: evt.imageGenerationDone.revised_prompt }
+              : {}),
           }),
         },
       });

--- a/src/types/codex-events.ts
+++ b/src/types/codex-events.ts
@@ -128,6 +128,8 @@ export interface CodexOutputItemDoneEvent {
     arguments?: string;
     content?: unknown[];
     actions?: unknown[];
+    result?: string;
+    revised_prompt?: string;
     [key: string]: unknown;
   };
 }
@@ -490,6 +492,8 @@ export function parseCodexEvent(evt: CodexSSEEvent): TypedCodexEvent {
             ...(typeof data.item.arguments === "string" ? { arguments: data.item.arguments } : {}),
             ...(Array.isArray(data.item.content) ? { content: data.item.content } : {}),
             ...(Array.isArray(data.item.actions) ? { actions: data.item.actions } : {}),
+            ...(typeof data.item.result === "string" ? { result: data.item.result } : {}),
+            ...(typeof data.item.revised_prompt === "string" ? { revised_prompt: data.item.revised_prompt } : {}),
           },
         };
       }

--- a/tests/_helpers/sse.ts
+++ b/tests/_helpers/sse.ts
@@ -201,3 +201,35 @@ export function buildMultiToolCallStreamChunks(
 
   return sse;
 }
+
+/** Build an image generation SSE stream. */
+export function buildImageGenStreamChunks(
+  responseId: string,
+  itemId: string,
+  result: string,
+  revisedPrompt: string,
+  usage?: { input_tokens: number; output_tokens: number },
+): string {
+  return (
+    sseChunk("response.created", { response: { id: responseId } }) +
+    sseChunk("response.in_progress", { response: { id: responseId } }) +
+    sseChunk("response.output_item.done", {
+      outputIndex: 0,
+      item: {
+        type: "image_generation_call",
+        id: itemId,
+        result,
+        revised_prompt: revisedPrompt,
+      },
+    }) +
+    sseChunk("response.completed", {
+      response: {
+        id: responseId,
+        usage: usage ?? { input_tokens: 10, output_tokens: 10 },
+        tool_usage: {
+          image_gen: { input_tokens: 1, output_tokens: 1 }
+        }
+      },
+    })
+  );
+}

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -444,19 +444,27 @@ describe("E2E: POST /v1/chat/completions", () => {
       return choices?.[0]?.delta?.tool_calls;
     });
 
-    expect(toolCallChunks).toHaveLength(1);
-    const choices = toolCallChunks[0].choices as Array<{
-      delta?: {
-        tool_calls?: Array<{
-          id: string;
-          function: { name: string; arguments: string };
-        }>;
-      };
+    // Per OpenAI streaming spec: start chunk (id+name+empty args) + arguments chunk
+    expect(toolCallChunks).toHaveLength(2);
+
+    type ToolCallChunk = Array<{
+      index: number;
+      id?: string;
+      type?: string;
+      function?: { name?: string; arguments?: string };
     }>;
-    const tc = choices[0].delta!.tool_calls![0];
-    expect(tc.id).toBe("item_img_e2e_2");
-    expect(tc.function.name).toBe("image_generation");
-    const args = JSON.parse(tc.function.arguments);
+
+    const startChunkChoices = toolCallChunks[0].choices as Array<{ delta?: { tool_calls?: ToolCallChunk } }>;
+    const startTc = startChunkChoices[0].delta!.tool_calls![0];
+    expect(startTc.id).toBe("item_img_e2e_2");
+    expect(startTc.type).toBe("function");
+    expect(startTc.function?.name).toBe("image_generation");
+    expect(startTc.function?.arguments).toBe("");
+
+    const argsChunkChoices = toolCallChunks[1].choices as Array<{ delta?: { tool_calls?: ToolCallChunk } }>;
+    const argsTc = argsChunkChoices[0].delta!.tool_calls![0];
+    expect(argsTc.id).toBeUndefined();
+    const args = JSON.parse(argsTc.function!.arguments!);
     expect(args.result).toBe("fake_b64_data_stream");
     expect(args.revised_prompt).toBe("blue square");
   });

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -25,6 +25,7 @@ import {
   buildTextStreamChunks,
   buildToolCallStreamChunks,
   buildReasoningStreamChunks,
+  buildImageGenStreamChunks,
 } from "@helpers/sse.js";
 import { createValidJwt } from "@helpers/jwt.js";
 
@@ -390,5 +391,73 @@ describe("E2E: POST /v1/chat/completions", () => {
     const sentBody = JSON.parse(getLastTransportBody()!);
     expect(sentBody.model).toBe("gpt-5.4");
     expect(sentBody.reasoning?.effort).toBe("high");
+  });
+
+  // ── Image generation ──────────────────────────────────────────
+
+  it("non-streaming image generation: translates image_generation_call to tool_calls", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildImageGenStreamChunks("resp_chat_img_ns", "item_img_e2e_1", "fake_b64_data", "red circle"),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      tools: [{ type: "image_generation", size: "1024x1024" }],
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as Record<string, unknown>;
+    const choices = body.choices as Array<{
+      message: { tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }> };
+      finish_reason: string;
+    }>;
+
+    expect(choices[0].message.tool_calls).toBeDefined();
+    expect(choices[0].message.tool_calls!.length).toBe(1);
+    const tc = choices[0].message.tool_calls![0];
+    expect(tc.id).toBe("item_img_e2e_1");
+    expect(tc.function.name).toBe("image_generation");
+    const args = JSON.parse(tc.function.arguments);
+    expect(args.result).toBe("fake_b64_data");
+    expect(args.revised_prompt).toBe("red circle");
+  });
+
+  it("streaming image generation: translates image_generation_call to tool_calls", async () => {
+    setTransportPost(async () =>
+      makeTransportResponse(
+        buildImageGenStreamChunks("resp_chat_img_s", "item_img_e2e_2", "fake_b64_data_stream", "blue square"),
+      ),
+    );
+
+    const res = await chatRequest(defaultBody({
+      stream: true,
+      tools: [{ type: "image_generation", size: "1024x1024" }],
+    }));
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const chunks = parseOpenAISSE(text);
+
+    const toolCallChunks = chunks.filter((c) => {
+      const choices = c.choices as Array<{ delta?: { tool_calls?: unknown } }> | undefined;
+      return choices?.[0]?.delta?.tool_calls;
+    });
+
+    expect(toolCallChunks).toHaveLength(1);
+    const choices = toolCallChunks[0].choices as Array<{
+      delta?: {
+        tool_calls?: Array<{
+          id: string;
+          function: { name: string; arguments: string };
+        }>;
+      };
+    }>;
+    const tc = choices[0].delta!.tool_calls![0];
+    expect(tc.id).toBe("item_img_e2e_2");
+    expect(tc.function.name).toBe("image_generation");
+    const args = JSON.parse(tc.function.arguments);
+    expect(args.result).toBe("fake_b64_data_stream");
+    expect(args.revised_prompt).toBe("blue square");
   });
 });

--- a/tests/unit/translation/codex-to-openai.test.ts
+++ b/tests/unit/translation/codex-to-openai.test.ts
@@ -373,10 +373,18 @@ describe("image generation translation", () => {
       .filter((c) => c.startsWith("data: {"))
       .map((c) => JSON.parse(c.replace("data: ", "")));
     const toolCallChunks = parsedChunks.filter((p) => p.choices[0].delta?.tool_calls);
-    expect(toolCallChunks).toHaveLength(1);
-    const toolCall = toolCallChunks[0].choices[0].delta.tool_calls[0];
-    expect(toolCall.function.name).toBe("image_generation");
-    const args = JSON.parse(toolCall.function.arguments);
+    // Per OpenAI streaming spec: start chunk (id+name+empty args) + arguments chunk
+    expect(toolCallChunks).toHaveLength(2);
+
+    const startTc = toolCallChunks[0].choices[0].delta.tool_calls[0];
+    expect(startTc.id).toBe("item_img_123");
+    expect(startTc.type).toBe("function");
+    expect(startTc.function.name).toBe("image_generation");
+    expect(startTc.function.arguments).toBe("");
+
+    const argsTc = toolCallChunks[1].choices[0].delta.tool_calls[0];
+    expect(argsTc.id).toBeUndefined();
+    const args = JSON.parse(argsTc.function.arguments);
     expect(args.result).toBe("fake_base64_image_content");
     expect(args.revised_prompt).toBe("a beautiful red circle on white background");
   });

--- a/tests/unit/translation/codex-to-openai.test.ts
+++ b/tests/unit/translation/codex-to-openai.test.ts
@@ -342,3 +342,53 @@ describe("streamCodexToOpenAI — onResponseId callback", () => {
     expect(receivedId).toBe("resp_1");
   });
 });
+
+describe("image generation translation", () => {
+  const imgEvents: ExtractedEvent[] = [
+    createCreated("resp_img"),
+    createInProgress("resp_img"),
+    {
+      typed: {
+        type: "response.output_item.done",
+        outputIndex: 0,
+        item: {
+          type: "image_generation_call",
+          id: "item_img_123",
+          result: "fake_base64_image_content",
+          revised_prompt: "a beautiful red circle on white background",
+        }
+      },
+      imageGenerationDone: {
+        id: "item_img_123",
+        result: "fake_base64_image_content",
+        revised_prompt: "a beautiful red circle on white background",
+      }
+    },
+    createCompleted("resp_img", { input_tokens: 10, output_tokens: 10 }),
+  ];
+
+  it("streamCodexToOpenAI translates imageGenerationDone event into tool_calls", async () => {
+    const chunks = await collectStreamOutput(imgEvents);
+    const parsedChunks = chunks
+      .filter((c) => c.startsWith("data: {"))
+      .map((c) => JSON.parse(c.replace("data: ", "")));
+    const toolCallChunks = parsedChunks.filter((p) => p.choices[0].delta?.tool_calls);
+    expect(toolCallChunks).toHaveLength(1);
+    const toolCall = toolCallChunks[0].choices[0].delta.tool_calls[0];
+    expect(toolCall.function.name).toBe("image_generation");
+    const args = JSON.parse(toolCall.function.arguments);
+    expect(args.result).toBe("fake_base64_image_content");
+    expect(args.revised_prompt).toBe("a beautiful red circle on white background");
+  });
+
+  it("collectCodexResponse translates imageGenerationDone event into tool_calls", async () => {
+    mockEvents = imgEvents;
+    const { response } = await collectCodexResponse(fakeCodexApi, fakeResponse, "gpt-5.4");
+    expect(response.choices[0].message.tool_calls).toBeDefined();
+    const toolCall = response.choices[0].message.tool_calls![0];
+    expect(toolCall.function.name).toBe("image_generation");
+    const args = JSON.parse(toolCall.function.arguments);
+    expect(args.result).toBe("fake_base64_image_content");
+    expect(args.revised_prompt).toBe("a beautiful red circle on white background");
+  });
+});


### PR DESCRIPTION
This PR fixes a bug where image generation results (image_generation_call events) were not translated to OpenAI completions format, and restores expectsImageGen in chat route to track usage.