### PR TITLE
fix(observability): optimize error-logs read performance for large files

### DIFF
--- a/src/logs/error-log.ts
+++ b/src/logs/error-log.ts
@@ -22,9 +22,12 @@
 
 import {
   appendFileSync,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   renameSync,
   statSync,
   unlinkSync,
@@ -200,19 +203,215 @@ function readJsonlFile(path: string): ErrorLogEntry[] {
   return out;
 }
 
+function readJsonlFileTail(path: string, limit: number): ErrorLogEntry[] {
+  if (!existsSync(path)) return [];
+  const size = statSync(path).size;
+  if (size === 0) return [];
+
+  const fd = openSync(path, "r");
+  try {
+    const out: ErrorLogEntry[] = [];
+    const chunkSize = 64 * 1024;
+    let position = size;
+    let leftover = "";
+
+    while (position > 0 && out.length < limit) {
+      const readLength = Math.min(position, chunkSize);
+      position -= readLength;
+
+      const buffer = Buffer.alloc(readLength);
+      readSync(fd, buffer, 0, readLength, position);
+
+      const chunkStr = buffer.toString("utf-8") + leftover;
+      const lines = chunkStr.split("\n");
+
+      if (position > 0) {
+        leftover = lines.shift() || "";
+      } else {
+        leftover = "";
+      }
+
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        try {
+          out.push(JSON.parse(line) as ErrorLogEntry);
+          if (out.length >= limit) break;
+        } catch {
+          // ignore corrupted
+        }
+      }
+    }
+
+    if (leftover.trim() && out.length < limit) {
+      try {
+        out.push(JSON.parse(leftover.trim()) as ErrorLogEntry);
+      } catch {
+        // ignore
+      }
+    }
+
+    return out;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function countLines(path: string): number {
+  if (!existsSync(path)) return 0;
+  const fd = openSync(path, "r");
+  try {
+    const size = statSync(path).size;
+    if (size === 0) return 0;
+    let count = 0;
+    const chunkSize = 64 * 1024;
+    let position = 0;
+    while (position < size) {
+      const readLength = Math.min(size - position, chunkSize);
+      const buffer = Buffer.alloc(readLength);
+      readSync(fd, buffer, 0, readLength, position);
+      position += readLength;
+      for (let i = 0; i < readLength; i++) {
+        if (buffer[i] === 0x0a) {
+          count++;
+        }
+      }
+    }
+    return count;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function countUnreadSince(cursor: string): number {
+  const path = logPath();
+  if (!existsSync(path)) return 0;
+  const size = statSync(path).size;
+  if (size === 0) return 0;
+
+  const fd = openSync(path, "r");
+  try {
+    let unreadCount = 0;
+    const chunkSize = 64 * 1024;
+    let position = size;
+    let leftover = "";
+    let stop = false;
+
+    while (position > 0 && !stop) {
+      const readLength = Math.min(position, chunkSize);
+      position -= readLength;
+
+      const buffer = Buffer.alloc(readLength);
+      readSync(fd, buffer, 0, readLength, position);
+
+      const chunkStr = buffer.toString("utf-8") + leftover;
+      const lines = chunkStr.split("\n");
+
+      if (position > 0) {
+        leftover = lines.shift() || "";
+      } else {
+        leftover = "";
+      }
+
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        try {
+          const entry = JSON.parse(line) as ErrorLogEntry;
+          if (entry.ts > cursor) {
+            unreadCount++;
+          } else {
+            stop = true;
+            break;
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    if (!stop && leftover.trim()) {
+      try {
+        const entry = JSON.parse(leftover.trim()) as ErrorLogEntry;
+        if (entry.ts > cursor) {
+          unreadCount++;
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    if (!stop) {
+      const backup = backupPath();
+      if (existsSync(backup)) {
+        const backupFd = openSync(backup, "r");
+        try {
+          let backupPosition = statSync(backup).size;
+          let backupLeftover = "";
+          while (backupPosition > 0 && !stop) {
+            const readLength = Math.min(backupPosition, chunkSize);
+            backupPosition -= readLength;
+            const buffer = Buffer.alloc(readLength);
+            readSync(backupFd, buffer, 0, readLength, backupPosition);
+            const chunkStr = buffer.toString("utf-8") + backupLeftover;
+            const lines = chunkStr.split("\n");
+            if (backupPosition > 0) {
+              backupLeftover = lines.shift() || "";
+            } else {
+              backupLeftover = "";
+            }
+            for (let i = lines.length - 1; i >= 0; i--) {
+              const line = lines[i].trim();
+              if (!line) continue;
+              try {
+                const entry = JSON.parse(line) as ErrorLogEntry;
+                if (entry.ts > cursor) {
+                  unreadCount++;
+                } else {
+                  stop = true;
+                  break;
+                }
+              } catch {
+                // ignore
+              }
+            }
+          }
+          if (!stop && backupLeftover.trim()) {
+            try {
+              const entry = JSON.parse(backupLeftover.trim()) as ErrorLogEntry;
+              if (entry.ts > cursor) {
+                unreadCount++;
+              }
+            } catch {
+              // ignore
+            }
+          }
+        } finally {
+          closeSync(backupFd);
+        }
+      }
+    }
+
+    return unreadCount;
+  } finally {
+    closeSync(fd);
+  }
+}
+
 /**
  * Read entries from current + backup files, newest first.
  * `limit`, when given, caps the number of returned entries.
+ * Defaults to 1000 to prevent OOM / CPU lock when logs are huge.
  */
 export function readErrorLog(limit?: number): ErrorLogEntry[] {
-  // Backup is older; current is newer. Concatenate then reverse so
-  // the newest entries appear first.
-  const oldest = readJsonlFile(backupPath());
-  const newest = readJsonlFile(logPath());
-  const combined = [...oldest, ...newest];
-  combined.reverse();
-  if (limit !== undefined) return combined.slice(0, limit);
-  return combined;
+  const targetLimit = limit ?? 1000;
+  const newest = readJsonlFileTail(logPath(), targetLimit);
+  const remaining = targetLimit - newest.length;
+  if (remaining > 0) {
+    const oldest = readJsonlFileTail(backupPath(), remaining);
+    return [...newest, ...oldest];
+  }
+  return newest;
 }
 
 /** Remove all persisted error log entries and the read cursor. */
@@ -303,13 +502,22 @@ export function setReadCursor(ts: string): void {
  */
 export function getUnreadCount(entries?: ErrorLogEntry[]): number {
   const cursor = getReadCursor();
-  const list = entries ?? readErrorLog();
-  if (cursor === null) return list.length;
-  let count = 0;
-  for (const e of list) {
-    if (e.ts > cursor) count += 1;
+  if (entries !== undefined) {
+    if (cursor === null) return entries.length;
+    let count = 0;
+    for (const e of entries) {
+      if (e.ts > cursor) count += 1;
+    }
+    return count;
   }
-  return count;
+  if (cursor === null) {
+    return countLines(logPath()) + countLines(backupPath());
+  }
+  return countUnreadSince(cursor);
+}
+
+export function getTotalCount(): number {
+  return countLines(logPath()) + countLines(backupPath());
 }
 
 // ── Process-level handlers ──────────────────────────────────────────

--- a/src/logs/error-log.ts
+++ b/src/logs/error-log.ts
@@ -257,6 +257,12 @@ function readJsonlFileTail(path: string, limit: number): ErrorLogEntry[] {
   }
 }
 
+/**
+ * Count newline characters in a file as a proxy for the number of JSONL entries.
+ * Assumes each entry is written as exactly one line terminated by '\n' with no
+ * trailing blank lines.  appendErrorLog() always appends `JSON.stringify(e)+"\n"`,
+ * so this invariant holds under normal operation.
+ */
 function countLines(path: string): number {
   if (!existsSync(path)) return 0;
   const fd = openSync(path, "r");
@@ -283,6 +289,18 @@ function countLines(path: string): number {
   }
 }
 
+/**
+ * Count log entries whose `ts` field is strictly greater than `cursor` by
+ * scanning both files backwards from the tail.
+ *
+ * INVARIANT: Entries within each file are assumed to be written in
+ * monotonically non-decreasing `ts` order.  appendErrorLog() always appends
+ * to the tail, and callers use Date.now() / new Date().toISOString(), so this
+ * holds under normal operation.  If entries were ever written out-of-order
+ * (e.g. concurrent writers with clock skew), the early-stop heuristic could
+ * under-count unread entries.  In practice the Electron main process is the
+ * sole writer, so the invariant is safe.
+ */
 function countUnreadSince(cursor: string): number {
   const path = logPath();
   if (!existsSync(path)) return 0;

--- a/src/routes/admin/error-logs.ts
+++ b/src/routes/admin/error-logs.ts
@@ -5,6 +5,7 @@ import {
   clearErrorLog,
   groupErrorLog,
   getUnreadCount,
+  getTotalCount,
   readErrorLog,
   setReadCursor,
   type ErrorSource,
@@ -47,8 +48,7 @@ export function createErrorLogRoutes(): Hono {
   });
 
   app.get("/admin/error-logs/count", (c) => {
-    const entries = readErrorLog();
-    return c.json({ total: entries.length, unread: getUnreadCount(entries) });
+    return c.json({ total: getTotalCount(), unread: getUnreadCount() });
   });
 
   app.post("/admin/error-logs/seen", (c) => {

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -45,6 +45,10 @@ export function createSettingsRoutes(): Hono {
   const app = new Hono();
 
   app.use("/admin/*", async (c, next) => {
+    const path = c.req.path;
+    if (path.startsWith("/admin/error-logs")) {
+      return next();
+    }
     if (c.req.method !== "POST" && c.req.method !== "PUT" && c.req.method !== "PATCH" && c.req.method !== "DELETE") {
       return next();
     }

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -46,7 +46,10 @@ export function createSettingsRoutes(): Hono {
 
   app.use("/admin/*", async (c, next) => {
     const path = c.req.path;
-    if (path.startsWith("/admin/error-logs")) {
+    // Error-log routes use dashboard session auth (dashboardAuth middleware).
+    // Only skip this Bearer-token gate for read-only GET requests; mutating
+    // operations (POST seen, DELETE) still need to pass through.
+    if (path.startsWith("/admin/error-logs") && c.req.method === "GET") {
       return next();
     }
     if (c.req.method !== "POST" && c.req.method !== "PUT" && c.req.method !== "PATCH" && c.req.method !== "DELETE") {

--- a/tests/integration/error-logs-e2e.ts
+++ b/tests/integration/error-logs-e2e.ts
@@ -1,0 +1,145 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { setPaths } from "../../src/paths.js";
+import { loadConfig } from "../../src/config.js";
+import { dashboardAuth } from "../../src/middleware/dashboard-auth.js";
+import { createErrorLogRoutes } from "../../src/routes/admin/error-logs.js";
+import { createDashboardAuthRoutes } from "../../src/routes/dashboard-login.js";
+
+// 1. 初始化物理临时目录并使用 setPaths 重定向 dataDir
+const tmpDataDir = mkdtempSync(resolve(tmpdir(), "e2e-errlogs-"));
+setPaths({
+  rootDir: process.cwd(),
+  configDir: resolve(process.cwd(), "config"),
+  dataDir: tmpDataDir,
+  binDir: resolve(process.cwd(), "bin"),
+  publicDir: resolve(process.cwd(), "public"),
+});
+
+// 2. 覆盖全局配置以启用 proxy_api_key（强制 cookie 鉴权）并模拟非 localhost (设置 trust_proxy = true 并注入 proxy 请求头)
+const config = loadConfig();
+config.server.proxy_api_key = "testkey";
+config.server.trust_proxy = true;
+config.session.ttl_minutes = 60;
+
+// 3. 构建 Hono 实例
+const app = new Hono();
+
+// 挂载鉴权中间件和路由
+app.use("*", dashboardAuth);
+app.route("/", createDashboardAuthRoutes());
+app.route("/", createErrorLogRoutes());
+
+// 4. 写入 16000 条大日志
+const currentFile = resolve(tmpDataDir, "error-log.jsonl");
+let currentContent = "";
+const now = Date.now();
+for (let i = 0; i < 16000; i++) {
+  const ts = new Date(now - 100000 + i * 10).toISOString();
+  currentContent += JSON.stringify({
+    ts,
+    version: "0.0.0-test",
+    platform: "darwin",
+    source: "main",
+    error: { name: "CurrentError", message: `err ${i}`, stack: "at current.js:1" }
+  }) + "\n";
+}
+writeFileSync(currentFile, currentContent, "utf-8");
+
+// 5. 物理启动 TCP 服务监听在 8082
+const server = serve({ fetch: app.fetch, port: 8082 }, async () => {
+  console.log("E2E Test server is listening on port 8082");
+
+  try {
+    // ----------------------------------------------------
+    // 执行连续 3 轮完整端到端测试以证明全流程走通
+    // ----------------------------------------------------
+    for (let round = 1; round <= 3; round++) {
+      console.log(`\n--- Round ${round} E2E Test ---`);
+
+      // 1) 登录并获得 Cookie _codex_session
+      const loginRes = await fetch("http://127.0.0.1:8082/auth/dashboard-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1" },
+        body: JSON.stringify({ password: "testkey" }),
+      });
+      if (loginRes.status !== 200) {
+        throw new Error(`Login failed with status ${loginRes.status}`);
+      }
+      const setCookie = loginRes.headers.get("Set-Cookie") || "";
+      const cookieMatch = setCookie.match(/_codex_session=[^;]+/);
+      if (!cookieMatch) {
+        throw new Error("Failed to extract _codex_session cookie");
+      }
+      const cookie = cookieMatch[0];
+      console.log(`Successfully logged in. Session cookie: ${cookie}`);
+
+      // 2) 物理调用 count 获取未读数和总数 (预期 16000)
+      const countStart = performance.now();
+      const countRes = await fetch("http://127.0.0.1:8082/admin/error-logs/count", {
+        headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
+      });
+      const countEnd = performance.now();
+      if (countRes.status !== 200) {
+        throw new Error(`Count request failed with status ${countRes.status}`);
+      }
+      const countBody = await countRes.json() as { total: number; unread: number };
+      console.log(`[Count Result] total: ${countBody.total}, unread: ${countBody.unread}, ms: ${(countEnd - countStart).toFixed(2)}`);
+      if (countBody.total !== 16000 || countBody.unread !== 16000) {
+        throw new Error(`Unexpected count body: ${JSON.stringify(countBody)}`);
+      }
+
+      // 3) 物理调用 seen 接口更新 cursor
+      const seenStart = performance.now();
+      const seenRes = await fetch("http://127.0.0.1:8082/admin/error-logs/seen", {
+        method: "POST",
+        headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
+      });
+      const seenEnd = performance.now();
+      if (seenRes.status !== 200) {
+        throw new Error(`Seen request failed with status ${seenRes.status}`);
+      }
+      const seenBody = await seenRes.json() as { ok: boolean };
+      console.log(`[Seen Result] ok: ${seenBody.ok}, ms: ${(seenEnd - seenStart).toFixed(2)}`);
+
+      // 4) 再次物理调用 count 验证未读数变 0
+      const afterRes = await fetch("http://127.0.0.1:8082/admin/error-logs/count", {
+        headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
+      });
+      if (afterRes.status !== 200) {
+        throw new Error(`After Count request failed with status ${afterRes.status}`);
+      }
+      const afterBody = await afterRes.json() as { unread: number };
+      console.log(`[After Count Result] unread: ${afterBody.unread}`);
+      if (afterBody.unread !== 0) {
+        throw new Error(`Expected unread to be 0, got ${afterBody.unread}`);
+      }
+
+      // 5) 清空日志
+      const clearRes = await fetch("http://127.0.0.1:8082/admin/error-logs", {
+        method: "DELETE",
+        headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
+      });
+      if (clearRes.status !== 200) {
+        throw new Error(`Clear request failed with status ${clearRes.status}`);
+      }
+      console.log("[Clear Result] Logs cleared successfully.");
+
+      // 6) 重新写回 16000 条日志供下一轮测试使用
+      writeFileSync(currentFile, currentContent, "utf-8");
+    }
+
+    console.log("\nE2E VERIFICATION COMPLETED SUCCESSFULLY!");
+    console.log("All 3 rounds of Seen, Count, and Clear full flows completed successfully!");
+  } catch (err) {
+    console.error("E2E VERIFICATION FAILED:", err);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+    rmSync(tmpDataDir, { recursive: true, force: true });
+    process.exit();
+  }
+});

--- a/tests/integration/error-logs-e2e.ts
+++ b/tests/integration/error-logs-e2e.ts
@@ -19,7 +19,7 @@ setPaths({
   publicDir: resolve(process.cwd(), "public"),
 });
 
-// 2. 覆盖全局配置以启用 proxy_api_key（强制 cookie 鉴权）并模拟非 localhost (设置 trust_proxy = true 并注入 proxy 请求头)
+// 2. 覆盖全局配置以启用 proxy_api_key（强制 cookie 鉴权）并模拟非 localhost
 const config = loadConfig();
 config.server.proxy_api_key = "testkey";
 config.server.trust_proxy = true;
@@ -27,8 +27,6 @@ config.session.ttl_minutes = 60;
 
 // 3. 构建 Hono 实例
 const app = new Hono();
-
-// 挂载鉴权中间件和路由
 app.use("*", dashboardAuth);
 app.route("/", createDashboardAuthRoutes());
 app.route("/", createErrorLogRoutes());
@@ -49,19 +47,20 @@ for (let i = 0; i < 16000; i++) {
 }
 writeFileSync(currentFile, currentContent, "utf-8");
 
-// 5. 物理启动 TCP 服务监听在 8082
-const server = serve({ fetch: app.fetch, port: 8082 }, async () => {
-  console.log("E2E Test server is listening on port 8082");
+// 5. 物理启动 TCP 服务，port:0 让 OS 分配空闲端口，避免 CI 端口冲突
+const server = serve({ fetch: app.fetch, port: 0 }, async () => {
+  const addr = server.address();
+  const port = typeof addr === "object" && addr !== null ? addr.port : 8082;
+  const base = `http://127.0.0.1:${port}`;
+  console.log(`E2E Test server is listening on port ${port}`);
 
   try {
-    // ----------------------------------------------------
     // 执行连续 3 轮完整端到端测试以证明全流程走通
-    // ----------------------------------------------------
     for (let round = 1; round <= 3; round++) {
       console.log(`\n--- Round ${round} E2E Test ---`);
 
       // 1) 登录并获得 Cookie _codex_session
-      const loginRes = await fetch("http://127.0.0.1:8082/auth/dashboard-login", {
+      const loginRes = await fetch(`${base}/auth/dashboard-login`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1" },
         body: JSON.stringify({ password: "testkey" }),
@@ -71,21 +70,17 @@ const server = serve({ fetch: app.fetch, port: 8082 }, async () => {
       }
       const setCookie = loginRes.headers.get("Set-Cookie") || "";
       const cookieMatch = setCookie.match(/_codex_session=[^;]+/);
-      if (!cookieMatch) {
-        throw new Error("Failed to extract _codex_session cookie");
-      }
+      if (!cookieMatch) throw new Error("Failed to extract _codex_session cookie");
       const cookie = cookieMatch[0];
       console.log(`Successfully logged in. Session cookie: ${cookie}`);
 
       // 2) 物理调用 count 获取未读数和总数 (预期 16000)
       const countStart = performance.now();
-      const countRes = await fetch("http://127.0.0.1:8082/admin/error-logs/count", {
+      const countRes = await fetch(`${base}/admin/error-logs/count`, {
         headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
       });
       const countEnd = performance.now();
-      if (countRes.status !== 200) {
-        throw new Error(`Count request failed with status ${countRes.status}`);
-      }
+      if (countRes.status !== 200) throw new Error(`Count request failed with status ${countRes.status}`);
       const countBody = await countRes.json() as { total: number; unread: number };
       console.log(`[Count Result] total: ${countBody.total}, unread: ${countBody.unread}, ms: ${(countEnd - countStart).toFixed(2)}`);
       if (countBody.total !== 16000 || countBody.unread !== 16000) {
@@ -94,38 +89,30 @@ const server = serve({ fetch: app.fetch, port: 8082 }, async () => {
 
       // 3) 物理调用 seen 接口更新 cursor
       const seenStart = performance.now();
-      const seenRes = await fetch("http://127.0.0.1:8082/admin/error-logs/seen", {
+      const seenRes = await fetch(`${base}/admin/error-logs/seen`, {
         method: "POST",
         headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
       });
       const seenEnd = performance.now();
-      if (seenRes.status !== 200) {
-        throw new Error(`Seen request failed with status ${seenRes.status}`);
-      }
+      if (seenRes.status !== 200) throw new Error(`Seen request failed with status ${seenRes.status}`);
       const seenBody = await seenRes.json() as { ok: boolean };
       console.log(`[Seen Result] ok: ${seenBody.ok}, ms: ${(seenEnd - seenStart).toFixed(2)}`);
 
       // 4) 再次物理调用 count 验证未读数变 0
-      const afterRes = await fetch("http://127.0.0.1:8082/admin/error-logs/count", {
+      const afterRes = await fetch(`${base}/admin/error-logs/count`, {
         headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
       });
-      if (afterRes.status !== 200) {
-        throw new Error(`After Count request failed with status ${afterRes.status}`);
-      }
+      if (afterRes.status !== 200) throw new Error(`After Count request failed with status ${afterRes.status}`);
       const afterBody = await afterRes.json() as { unread: number };
       console.log(`[After Count Result] unread: ${afterBody.unread}`);
-      if (afterBody.unread !== 0) {
-        throw new Error(`Expected unread to be 0, got ${afterBody.unread}`);
-      }
+      if (afterBody.unread !== 0) throw new Error(`Expected unread to be 0, got ${afterBody.unread}`);
 
       // 5) 清空日志
-      const clearRes = await fetch("http://127.0.0.1:8082/admin/error-logs", {
+      const clearRes = await fetch(`${base}/admin/error-logs`, {
         method: "DELETE",
         headers: { Cookie: cookie, "X-Forwarded-For": "1.1.1.1" },
       });
-      if (clearRes.status !== 200) {
-        throw new Error(`Clear request failed with status ${clearRes.status}`);
-      }
+      if (clearRes.status !== 200) throw new Error(`Clear request failed with status ${clearRes.status}`);
       console.log("[Clear Result] Logs cleared successfully.");
 
       // 6) 重新写回 16000 条日志供下一轮测试使用

--- a/tests/unit/routes/admin/error-logs.test.ts
+++ b/tests/unit/routes/admin/error-logs.test.ts
@@ -283,3 +283,80 @@ describe("POST /admin/error-logs/report", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("large log performance and limit tests", () => {
+  it("processes seen, count, and lists efficiently with 15,000+ entries", async () => {
+    // Generate a large log file with 8000 entries and a backup file with 8000 entries
+    const backupFile = resolve(tmpDataDir, "error-log.1.jsonl");
+    const currentFile = resolve(tmpDataDir, "error-log.jsonl");
+
+    let backupContent = "";
+    let currentContent = "";
+
+    const now = Date.now();
+    for (let i = 0; i < 8000; i++) {
+      const ts = new Date(now - 200000 + i * 10).toISOString();
+      backupContent += JSON.stringify({
+        ts,
+        version: "0.0.0-test",
+        platform: "darwin",
+        source: "server",
+        error: { name: "BackupError", message: `err ${i}`, stack: "at backup.js:1" }
+      }) + "\n";
+    }
+
+    for (let i = 0; i < 8000; i++) {
+      const ts = new Date(now - 100000 + i * 10).toISOString();
+      currentContent += JSON.stringify({
+        ts,
+        version: "0.0.0-test",
+        platform: "darwin",
+        source: "main",
+        error: { name: "CurrentError", message: `err ${i}`, stack: "at current.js:1" }
+      }) + "\n";
+    }
+
+    writeFileSync(backupFile, backupContent, "utf-8");
+    writeFileSync(currentFile, currentContent, "utf-8");
+
+    const app = await buildApp();
+
+    // 1. Check count performance and correctness
+    const startCount = performance.now();
+    const countRes = await app.request("/admin/error-logs/count");
+    const endCount = performance.now();
+    expect(countRes.status).toBe(200);
+    const countBody = await countRes.json() as { total: number; unread: number };
+    expect(countBody.total).toBe(16000);
+    expect(countBody.unread).toBe(16000);
+    expect(endCount - startCount).toBeLessThan(100); // Should be very fast (under 100ms)
+
+    // 2. Check seen performance and correctness
+    const startSeen = performance.now();
+    const seenRes = await app.request("/admin/error-logs/seen", { method: "POST" });
+    const endSeen = performance.now();
+    expect(seenRes.status).toBe(200);
+    const seenBody = await seenRes.json() as { ok: boolean; cursor: string };
+    expect(seenBody.ok).toBe(true);
+    expect(seenBody.cursor).toBeTruthy();
+    expect(endSeen - startSeen).toBeLessThan(100); // Should be very fast (under 100ms)
+
+    // Verify unread becomes 0
+    const countAfterRes = await app.request("/admin/error-logs/count");
+    const countAfterBody = await countAfterRes.json() as { unread: number };
+    expect(countAfterBody.unread).toBe(0);
+
+    // 3. Check grouped errors list limit (should default to processing at most 1000 items)
+    const startGrouped = performance.now();
+    const groupedRes = await app.request("/admin/error-logs");
+    const endGrouped = performance.now();
+    expect(groupedRes.status).toBe(200);
+    const groupedBody = await groupedRes.json() as { groups: Array<{ name: string; count: number }> };
+    
+    // Default limit should apply. The total count across groups should sum to the limit (1000)
+    const totalGroupedCount = groupedBody.groups.reduce((acc, g) => acc + g.count, 0);
+    expect(totalGroupedCount).toBe(1000);
+    expect(endGrouped - startGrouped).toBeLessThan(100);
+  });
+});
+


### PR DESCRIPTION
Closes #658. This PR optimizes reading and counting logic for admin error-logs. Instead of reading and parsing the entire JSONL file on each request (which causes high CPU/RAM and OOM crashes leading to session losses), it now counts lines directly and scans the file tail from backwards using native node FS blocks.