### PR TITLE
feat: migrate account persistence to SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- 账号持久化从 `accounts.json` 主存储迁移到 `accounts.sqlite`，启动时自动从旧 JSON 迁移并继续保留 `accounts.json` 镜像用于降级/回滚；批量导入改为持久化批处理，避免每个账号同步重写整份 JSON 导致大批量导入卡死。（#657）
 - 重构：消除类型守卫 `isRecord` 的多处重复声明（收拢翻译层与路由层到 `shared-utils.ts`）
 - 重构：合并推理预算映射表 `REASONING_EFFORT_BUDGET`（提取为 `shared-utils.ts` 的公共常量）
 - 重构：精简别名（删除 `gemini-to-codex.ts` 里的 `flattenParts` 别名）

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,9 @@ ENV CODEX_PROXY_HOST=0.0.0.0
 # curl: needed by full-update.ts
 # unzip: needed by full-update.ts to extract Codex.app
 # gosu: needed by entrypoint to drop from root to node user
+# build-essential/python3: needed when better-sqlite3 falls back to node-gyp
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl unzip ca-certificates gosu && \
+    apt-get install -y --no-install-recommends curl unzip ca-certificates gosu build-essential python3 && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "dependencies": {
         "@electron/asar": "^3.2.0",
         "@hono/node-server": "^1.0.0",
+        "better-sqlite3": "^12.10.0",
         "hono": "^4.0.0",
         "https-proxy-agent": "^8.0.0",
         "js-yaml": "^4.1.0",
@@ -21,6 +22,7 @@
         "zod": "^3.23.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
@@ -1596,6 +1598,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -2310,7 +2322,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2327,11 +2338,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -2362,7 +2395,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3061,7 +3093,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -3077,7 +3108,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3094,6 +3124,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defaults": {
@@ -3171,7 +3210,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3669,7 +3707,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3832,6 +3869,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3923,6 +3969,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -3989,6 +4041,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -4126,6 +4184,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4438,7 +4502,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4486,7 +4549,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -5028,7 +5090,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5201,6 +5262,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5225,6 +5292,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -5682,6 +5755,45 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -5746,7 +5858,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -5776,6 +5887,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -5793,7 +5919,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -5976,7 +6101,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6097,6 +6221,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -6276,7 +6445,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6386,6 +6554,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -6440,6 +6617,40 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/temp": {
@@ -6752,6 +6963,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -6853,7 +7076,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@electron/asar": "^3.2.0",
     "@hono/node-server": "^1.0.0",
+    "better-sqlite3": "^12.10.0",
     "hono": "^4.0.0",
     "https-proxy-agent": "^8.0.0",
     "js-yaml": "^4.1.0",
@@ -39,6 +40,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",

--- a/src/auth/account-persistence.ts
+++ b/src/auth/account-persistence.ts
@@ -10,6 +10,7 @@ import {
   existsSync,
   mkdirSync,
 } from "fs";
+import { createRequire } from "module";
 import { resolve, dirname } from "path";
 import { randomBytes } from "crypto";
 import { getDataDir } from "../paths.js";
@@ -20,6 +21,8 @@ import {
   isTokenExpired,
 } from "./jwt-utils.js";
 import type { AccountEntry, AccountsFile, CodexQuota } from "./types.js";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Migrate a legacy entry to the new schema:
@@ -114,8 +117,42 @@ export interface AccountPersistence {
   save(accounts: AccountEntry[]): void;
 }
 
+interface PersistenceLoadResult {
+  entries: AccountEntry[];
+  needsPersist: boolean;
+  loadFailed?: boolean;
+  health?: PersistenceLoadHealth;
+}
+
+interface SqliteRunResult {
+  changes: number;
+  lastInsertRowid: number | bigint;
+}
+
+interface SqliteStatement {
+  all(...params: unknown[]): unknown[];
+  run(...params: unknown[]): SqliteRunResult;
+}
+
+interface SqliteDatabase {
+  exec(sql: string): void;
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+}
+
+type SqliteDatabaseConstructor = new (filename: string) => SqliteDatabase;
+
+type SqliteLoadResult =
+  | { ok: true; entries: AccountEntry[]; needsPersist: boolean }
+  | { ok: false; error: unknown };
+
+type PersistenceBackend = "sqlite" | "json" | null;
+
 function getAccountsFile(): string {
   return resolve(getDataDir(), "accounts.json");
+}
+function getAccountsSqliteFile(): string {
+  return resolve(getDataDir(), "accounts.sqlite");
 }
 function getLegacyAuthFile(): string {
   return resolve(getDataDir(), "auth.json");
@@ -131,30 +168,89 @@ export function createFsPersistence(): AccountPersistence {
   // latch is the second line of defense.
   let quarantineActive = false;
   let quarantineHealth: PersistenceLoadHealth | null = null;
+  let activeBackend: PersistenceBackend = null;
 
   const persistence: AccountPersistence = {
     load() {
       // Migrate from legacy auth.json if needed
       const migrated = migrateFromLegacy();
 
-      // Load from accounts.json
-      const { entries: loaded, needsPersist, loadFailed, health } = loadPersisted();
-      if (loadFailed) {
-        quarantineActive = true;
-        quarantineHealth = health ?? { quarantined: false, backupPath: null };
+      const sqliteFile = getAccountsSqliteFile();
+      if (existsSync(sqliteFile)) {
+        const sqliteLoad = loadSqlitePersisted(sqliteFile);
+        if (sqliteLoad.ok) {
+          if (sqliteLoad.entries.length > 0 || !existsSync(getAccountsFile())) {
+            activeBackend = "sqlite";
+            if (sqliteLoad.needsPersist) {
+              persistence.save(sqliteLoad.entries);
+            }
+            return {
+              entries: sqliteLoad.entries,
+              needsPersist: sqliteLoad.needsPersist,
+            };
+          }
+
+          const jsonLoad = loadJsonOrQuarantine();
+          if (jsonLoad.loadFailed) return jsonLoad;
+          if (jsonLoad.entries.length > 0) {
+            if (tryPromoteJsonToSqlite(jsonLoad.entries)) {
+              activeBackend = "sqlite";
+              if (jsonLoad.needsPersist) {
+                trySaveJsonMirror(jsonLoad.entries);
+              }
+            } else {
+              activeBackend = "json";
+              if (jsonLoad.needsPersist) {
+                trySaveJsonMirror(jsonLoad.entries);
+              }
+            }
+            return jsonLoad;
+          }
+
+          activeBackend = "sqlite";
+          return { entries: [], needsPersist: false };
+        }
+
+        console.warn(
+          "[AccountPool] Failed to load accounts.sqlite; falling back to accounts.json:",
+          sqliteLoad.error instanceof Error ? sqliteLoad.error.message : sqliteLoad.error,
+        );
       }
 
-      const entries = migrated.length > 0 && loaded.length === 0 ? migrated : loaded;
+      const jsonLoad = loadJsonOrQuarantine();
+      if (jsonLoad.loadFailed) return jsonLoad;
 
-      // Auto-persist when backfill was applied (preserves original behavior).
-      // Suppressed when loadFailed — the registry will be put into a
-      // persist-disabled state by AccountPool, and we must not write the
-      // partially-recovered map back over the (now quarantined) original.
-      if (needsPersist && loaded.length > 0 && !loadFailed) {
-        persistence.save(loaded);
+      const entries = migrated.length > 0 && jsonLoad.entries.length === 0
+        ? migrated
+        : jsonLoad.entries;
+
+      if (entries.length > 0) {
+        if (tryPromoteJsonToSqlite(entries)) {
+          activeBackend = "sqlite";
+          if (jsonLoad.needsPersist) {
+            trySaveJsonMirror(entries);
+          }
+        } else {
+          activeBackend = "json";
+          if (jsonLoad.needsPersist) {
+            trySaveJsonMirror(entries);
+          }
+        }
+        return { entries, needsPersist: jsonLoad.needsPersist };
       }
 
-      return { entries, needsPersist, loadFailed, health };
+      activeBackend = "sqlite";
+      return { entries, needsPersist: jsonLoad.needsPersist };
+
+      function loadJsonOrQuarantine(): PersistenceLoadResult {
+        const loaded = loadPersisted();
+        if (loaded.loadFailed) {
+          quarantineActive = true;
+          quarantineHealth = loaded.health ?? { quarantined: false, backupPath: null };
+          activeBackend = "json";
+        }
+        return loaded;
+      }
     },
 
     save(accounts: AccountEntry[]): void {
@@ -166,20 +262,298 @@ export function createFsPersistence(): AccountPersistence {
         );
         return;
       }
-      try {
-        const accountsFile = getAccountsFile();
-        const dir = dirname(accountsFile);
-        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-        const data: AccountsFile = { accounts };
-        const tmpFile = accountsFile + ".tmp";
-        writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
-        renameSync(tmpFile, accountsFile);
-      } catch (err) {
-        console.error("[AccountPool] Failed to persist accounts:", err instanceof Error ? err.message : err);
+
+      if (activeBackend !== "json") {
+        try {
+          saveSqliteAccounts(getAccountsSqliteFile(), accounts);
+          activeBackend = "sqlite";
+          trySaveJsonMirror(accounts);
+          return;
+        } catch (err) {
+          console.warn(
+            "[AccountPool] Failed to persist accounts.sqlite; falling back to accounts.json:",
+            err instanceof Error ? err.message : err,
+          );
+          activeBackend = "json";
+        }
       }
+
+      trySaveJsonMirror(accounts);
     },
   };
   return persistence;
+}
+
+function tryPromoteJsonToSqlite(entries: AccountEntry[]): boolean {
+  try {
+    saveSqliteAccounts(getAccountsSqliteFile(), entries);
+    return true;
+  } catch (err) {
+    console.warn(
+      "[AccountPool] Failed to migrate accounts.json to accounts.sqlite; continuing with JSON persistence:",
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
+function trySaveJsonMirror(accounts: AccountEntry[]): void {
+  try {
+    saveJsonAccounts(accounts);
+  } catch (err) {
+    console.error("[AccountPool] Failed to persist accounts.json:", err instanceof Error ? err.message : err);
+  }
+}
+
+function saveJsonAccounts(accounts: AccountEntry[]): void {
+  const accountsFile = getAccountsFile();
+  const dir = dirname(accountsFile);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const data: AccountsFile = { accounts };
+  const tmpFile = accountsFile + ".tmp";
+  writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
+  renameSync(tmpFile, accountsFile);
+}
+
+function loadSqliteConstructor(): SqliteDatabaseConstructor {
+  const nodeSqlite = loadNodeSqliteConstructor();
+  if (nodeSqlite) return nodeSqlite;
+
+  const loaded = require("better-sqlite3") as unknown;
+  if (typeof loaded !== "function") {
+    throw new Error("better-sqlite3 did not export a database constructor");
+  }
+  return loaded as SqliteDatabaseConstructor;
+}
+
+function loadNodeSqliteConstructor(): SqliteDatabaseConstructor | null {
+  try {
+    const loaded = require("node:sqlite") as unknown;
+    if (isNodeSqliteModule(loaded)) {
+      return loaded.DatabaseSync;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function isNodeSqliteModule(value: unknown): value is { DatabaseSync: SqliteDatabaseConstructor } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { DatabaseSync?: unknown }).DatabaseSync === "function"
+  );
+}
+
+function openSqliteDatabase(sqliteFile: string): SqliteDatabase {
+  const Database = loadSqliteConstructor();
+  return new Database(sqliteFile);
+}
+
+function initSqliteSchema(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS accounts (
+      id TEXT PRIMARY KEY,
+      token TEXT NOT NULL,
+      refresh_token TEXT,
+      email TEXT,
+      account_id TEXT,
+      user_id TEXT,
+      label TEXT,
+      plan_type TEXT,
+      proxy_api_key TEXT NOT NULL,
+      status TEXT NOT NULL,
+      entry_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  db.exec("PRAGMA user_version = 1");
+}
+
+function saveSqliteAccounts(sqliteFile: string, accounts: AccountEntry[]): void {
+  const dir = dirname(sqliteFile);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const db = openSqliteDatabase(sqliteFile);
+  try {
+    initSqliteSchema(db);
+    const deleteAll = db.prepare("DELETE FROM accounts");
+    const insert = db.prepare(`
+      INSERT INTO accounts (
+        id,
+        token,
+        refresh_token,
+        email,
+        account_id,
+        user_id,
+        label,
+        plan_type,
+        proxy_api_key,
+        status,
+        entry_json,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      deleteAll.run();
+      const updatedAt = new Date().toISOString();
+      for (const entry of accounts) {
+        insert.run(
+          entry.id,
+          entry.token,
+          entry.refreshToken,
+          entry.email,
+          entry.accountId,
+          entry.userId,
+          entry.label,
+          entry.planType,
+          entry.proxyApiKey,
+          entry.status,
+          JSON.stringify(entry),
+          updatedAt,
+        );
+      }
+      db.exec("COMMIT");
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // Ignore rollback failures; rethrow the original write error.
+      }
+      throw err;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function loadSqlitePersisted(sqliteFile: string): SqliteLoadResult {
+  try {
+    const db = openSqliteDatabase(sqliteFile);
+    try {
+      initSqliteSchema(db);
+      const rows = db.prepare("SELECT entry_json FROM accounts ORDER BY rowid").all();
+      const rawEntries = rows.map((row) => {
+        if (!isAccountSqliteRow(row)) {
+          throw new Error("accounts.sqlite row is missing entry_json");
+        }
+        return JSON.parse(row.entry_json) as unknown;
+      });
+      const normalized = normalizeAccountEntries(rawEntries);
+      return { ok: true, ...normalized };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function isAccountSqliteRow(value: unknown): value is { entry_json: string } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { entry_json?: unknown }).entry_json === "string"
+  );
+}
+
+function normalizeAccountEntries(rawEntries: unknown[]): {
+  entries: AccountEntry[];
+  needsPersist: boolean;
+} {
+  const entries: AccountEntry[] = [];
+  let needsPersist = false;
+
+  for (const rawEntry of rawEntries) {
+    if (rawEntry === null || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+      continue;
+    }
+    const entry = rawEntry as AccountEntry;
+    if (!entry.id || !entry.token) continue;
+
+    // Backfill missing fields from JWT
+    if (!entry.planType || !entry.email || !entry.accountId || !entry.userId) {
+      const profile = extractUserProfile(entry.token);
+      const accountId = extractChatGptAccountId(entry.token);
+      if (!entry.planType && profile?.chatgpt_plan_type) {
+        entry.planType = profile.chatgpt_plan_type;
+        needsPersist = true;
+      }
+      if (!entry.email && profile?.email) {
+        entry.email = profile.email;
+        needsPersist = true;
+      }
+      if (!entry.accountId && accountId) {
+        entry.accountId = accountId;
+        needsPersist = true;
+      }
+      if (!entry.userId && profile?.chatgpt_user_id) {
+        entry.userId = profile.chatgpt_user_id;
+        needsPersist = true;
+      }
+    }
+    // Backfill userId for entries missing it (pre-v1.0.68)
+    if (entry.userId === undefined) {
+      entry.userId = null;
+      needsPersist = true;
+    }
+    // Backfill empty_response_count
+    if (entry.usage.empty_response_count == null) {
+      entry.usage.empty_response_count = 0;
+      needsPersist = true;
+    }
+    // Backfill window counter fields
+    if (entry.usage.window_request_count == null) {
+      entry.usage.window_request_count = 0;
+      entry.usage.window_input_tokens = 0;
+      entry.usage.window_output_tokens = 0;
+      entry.usage.window_counters_reset_at = null;
+      entry.usage.limit_window_seconds = null;
+      needsPersist = true;
+    }
+    // Backfill cached_tokens fields (added in cache-hit-rate stats)
+    if (entry.usage.cached_tokens == null) {
+      entry.usage.cached_tokens = 0;
+      needsPersist = true;
+    }
+    if (entry.usage.window_cached_tokens == null) {
+      entry.usage.window_cached_tokens = 0;
+      needsPersist = true;
+    }
+    // Backfill window_reset_at (missing causes NaN in refreshStatus)
+    if (!("window_reset_at" in entry.usage)) {
+      entry.usage.window_reset_at = null;
+      needsPersist = true;
+    }
+    // Backfill label field
+    if ((entry as unknown as Record<string, unknown>).label === undefined) {
+      entry.label = null;
+      needsPersist = true;
+    }
+    // Backfill cachedQuota fields
+    if (entry.cachedQuota === undefined) {
+      entry.cachedQuota = null;
+      entry.quotaFetchedAt = null;
+      needsPersist = true;
+    }
+    // Backfill quotaVerifyRequired (added in cascading-ban-defense)
+    // If absent (pre-existing disk entry), default to false so old entries
+    // don't trigger unnecessary upstream verification.
+    if (entry.quotaVerifyRequired === undefined) {
+      entry.quotaVerifyRequired = false;
+      needsPersist = true;
+    }
+    // Migrate legacy rate_limit_until + status="rate_limited" → cachedQuota
+    if (migrateLegacyRateLimit(entry)) {
+      needsPersist = true;
+    }
+    entries.push(entry);
+  }
+
+  return { entries, needsPersist };
 }
 
 function migrateFromLegacy(): AccountEntry[] {
@@ -247,12 +621,7 @@ function migrateFromLegacy(): AccountEntry[] {
   }
 }
 
-function loadPersisted(): {
-  entries: AccountEntry[];
-  needsPersist: boolean;
-  loadFailed?: boolean;
-  health?: PersistenceLoadHealth;
-} {
+function loadPersisted(): PersistenceLoadResult {
   const accountsFile = getAccountsFile();
   if (!existsSync(accountsFile)) return { entries: [], needsPersist: false };
 
@@ -293,92 +662,7 @@ function loadPersisted(): {
   }
 
   try {
-    const entries: AccountEntry[] = [];
-    let needsPersist = false;
-
-    for (const entry of data.accounts) {
-      if (!entry.id || !entry.token) continue;
-
-      // Backfill missing fields from JWT
-      if (!entry.planType || !entry.email || !entry.accountId || !entry.userId) {
-        const profile = extractUserProfile(entry.token);
-        const accountId = extractChatGptAccountId(entry.token);
-        if (!entry.planType && profile?.chatgpt_plan_type) {
-          entry.planType = profile.chatgpt_plan_type;
-          needsPersist = true;
-        }
-        if (!entry.email && profile?.email) {
-          entry.email = profile.email;
-          needsPersist = true;
-        }
-        if (!entry.accountId && accountId) {
-          entry.accountId = accountId;
-          needsPersist = true;
-        }
-        if (!entry.userId && profile?.chatgpt_user_id) {
-          entry.userId = profile.chatgpt_user_id;
-          needsPersist = true;
-        }
-      }
-      // Backfill userId for entries missing it (pre-v1.0.68)
-      if (entry.userId === undefined) {
-        entry.userId = null;
-        needsPersist = true;
-      }
-      // Backfill empty_response_count
-      if (entry.usage.empty_response_count == null) {
-        entry.usage.empty_response_count = 0;
-        needsPersist = true;
-      }
-      // Backfill window counter fields
-      if (entry.usage.window_request_count == null) {
-        entry.usage.window_request_count = 0;
-        entry.usage.window_input_tokens = 0;
-        entry.usage.window_output_tokens = 0;
-        entry.usage.window_counters_reset_at = null;
-        entry.usage.limit_window_seconds = null;
-        needsPersist = true;
-      }
-      // Backfill cached_tokens fields (added in cache-hit-rate stats)
-      if (entry.usage.cached_tokens == null) {
-        entry.usage.cached_tokens = 0;
-        needsPersist = true;
-      }
-      if (entry.usage.window_cached_tokens == null) {
-        entry.usage.window_cached_tokens = 0;
-        needsPersist = true;
-      }
-      // Backfill window_reset_at (missing causes NaN in refreshStatus)
-      if (!("window_reset_at" in entry.usage)) {
-        entry.usage.window_reset_at = null;
-        needsPersist = true;
-      }
-      // Backfill label field
-      if ((entry as unknown as Record<string, unknown>).label === undefined) {
-        entry.label = null;
-        needsPersist = true;
-      }
-      // Backfill cachedQuota fields
-      if (entry.cachedQuota === undefined) {
-        entry.cachedQuota = null;
-        entry.quotaFetchedAt = null;
-        needsPersist = true;
-      }
-      // Backfill quotaVerifyRequired (added in cascading-ban-defense)
-      // If absent (pre-existing disk entry), default to false so old entries
-      // don't trigger unnecessary upstream verification.
-      if (entry.quotaVerifyRequired === undefined) {
-        entry.quotaVerifyRequired = false;
-        needsPersist = true;
-      }
-      // Migrate legacy rate_limit_until + status="rate_limited" → cachedQuota
-      if (migrateLegacyRateLimit(entry)) {
-        needsPersist = true;
-      }
-      entries.push(entry);
-    }
-
-    return { entries, needsPersist };
+    return normalizeAccountEntries(data.accounts);
   } catch (err) {
     // The per-entry migration/backfill loop threw. Treat as corruption.
     return quarantineCorruptFile(accountsFile, raw, err, "entry_processing_failed");

--- a/src/auth/account-persistence.ts
+++ b/src/auth/account-persistence.ts
@@ -96,7 +96,7 @@ export function migrateLegacyRateLimit(entry: AccountEntry): boolean {
 
 export interface PersistenceLoadHealth {
   /**
-   * Whether the corrupt `accounts.json` was successfully renamed aside.
+   * Whether the corrupt account persistence file was successfully renamed aside.
    * False means the rename itself failed — the original file is still
    * on disk and the user-facing message must NOT instruct recovery
    * from a `.bak` that does not exist.
@@ -104,6 +104,8 @@ export interface PersistenceLoadHealth {
   quarantined: boolean;
   /** Absolute path of the `.bak` file if quarantine succeeded. */
   backupPath: string | null;
+  /** The account persistence file that failed to load. */
+  store?: "accounts.json" | "accounts.sqlite";
 }
 
 export interface AccountPersistence {
@@ -115,6 +117,7 @@ export interface AccountPersistence {
     health?: PersistenceLoadHealth;
   };
   save(accounts: AccountEntry[]): void;
+  readRefreshToken?(entryId: string): string | null;
 }
 
 interface PersistenceLoadResult {
@@ -144,6 +147,10 @@ type SqliteDatabaseConstructor = new (filename: string) => SqliteDatabase;
 
 type SqliteLoadResult =
   | { ok: true; entries: AccountEntry[]; needsPersist: boolean }
+  | { ok: false; error: unknown };
+
+type SqliteRefreshTokenResult =
+  | { ok: true; value: string | null }
   | { ok: false; error: unknown };
 
 type PersistenceBackend = "sqlite" | "json" | null;
@@ -176,6 +183,7 @@ export function createFsPersistence(): AccountPersistence {
       const migrated = migrateFromLegacy();
 
       const sqliteFile = getAccountsSqliteFile();
+      let sqliteLoadError: unknown = null;
       if (existsSync(sqliteFile)) {
         const sqliteLoad = loadSqlitePersisted(sqliteFile);
         if (sqliteLoad.ok) {
@@ -211,6 +219,7 @@ export function createFsPersistence(): AccountPersistence {
           return { entries: [], needsPersist: false };
         }
 
+        sqliteLoadError = sqliteLoad.error;
         console.warn(
           "[AccountPool] Failed to load accounts.sqlite; falling back to accounts.json:",
           sqliteLoad.error instanceof Error ? sqliteLoad.error.message : sqliteLoad.error,
@@ -223,6 +232,14 @@ export function createFsPersistence(): AccountPersistence {
       const entries = migrated.length > 0 && jsonLoad.entries.length === 0
         ? migrated
         : jsonLoad.entries;
+
+      if (sqliteLoadError != null && entries.length === 0) {
+        const failed = quarantineCorruptFile(sqliteFile, null, sqliteLoadError, "sqlite_load_failed");
+        quarantineActive = true;
+        quarantineHealth = failed.health;
+        activeBackend = "sqlite";
+        return failed;
+      }
 
       if (entries.length > 0) {
         if (tryPromoteJsonToSqlite(entries)) {
@@ -255,8 +272,9 @@ export function createFsPersistence(): AccountPersistence {
 
     save(accounts: AccountEntry[]): void {
       if (quarantineActive) {
+        const store = quarantineHealth?.store ?? "accounts.json";
         console.warn(
-          "[AccountPool] save() refused: accounts.json was quarantined this session" +
+          `[AccountPool] save() refused: ${store} was quarantined this session` +
             (quarantineHealth?.backupPath ? ` (backup: ${quarantineHealth.backupPath})` : "") +
             ". Restore a healthy file and restart the process to resume auto-save.",
         );
@@ -279,6 +297,24 @@ export function createFsPersistence(): AccountPersistence {
       }
 
       trySaveJsonMirror(accounts);
+    },
+
+    readRefreshToken(entryId: string): string | null {
+      if (activeBackend === "json") {
+        return readJsonRefreshToken(entryId);
+      }
+
+      const sqliteFile = getAccountsSqliteFile();
+      if (existsSync(sqliteFile)) {
+        const sqliteResult = readSqliteRefreshToken(sqliteFile, entryId);
+        if (sqliteResult.ok) return sqliteResult.value;
+        console.warn(
+          "[AccountPool] Failed to read refresh token from accounts.sqlite; falling back to accounts.json:",
+          sqliteResult.error instanceof Error ? sqliteResult.error.message : sqliteResult.error,
+        );
+      }
+
+      return readJsonRefreshToken(entryId);
     },
   };
   return persistence;
@@ -403,12 +439,12 @@ function saveSqliteAccounts(sqliteFile: string, accounts: AccountEntry[]): void 
         insert.run(
           entry.id,
           entry.token,
-          entry.refreshToken,
-          entry.email,
-          entry.accountId,
-          entry.userId,
-          entry.label,
-          entry.planType,
+          entry.refreshToken ?? null,
+          entry.email ?? null,
+          entry.accountId ?? null,
+          entry.userId ?? null,
+          entry.label ?? null,
+          entry.planType ?? null,
           entry.proxyApiKey,
           entry.status,
           JSON.stringify(entry),
@@ -451,6 +487,52 @@ function loadSqlitePersisted(sqliteFile: string): SqliteLoadResult {
   }
 }
 
+function readSqliteRefreshToken(sqliteFile: string, entryId: string): SqliteRefreshTokenResult {
+  try {
+    const db = openSqliteDatabase(sqliteFile);
+    try {
+      initSqliteSchema(db);
+      const rows = db
+        .prepare("SELECT refresh_token FROM accounts WHERE id = ? LIMIT 1")
+        .all(entryId);
+      if (rows.length === 0) return { ok: true, value: null };
+      const row = rows[0];
+      if (row === null || typeof row !== "object" || Array.isArray(row)) {
+        throw new Error("accounts.sqlite refresh token row is not an object");
+      }
+      const refreshToken = (row as { refresh_token?: unknown }).refresh_token;
+      if (refreshToken !== null && refreshToken !== undefined && typeof refreshToken !== "string") {
+        throw new Error("accounts.sqlite refresh_token is not a string or null");
+      }
+      return { ok: true, value: refreshToken ?? null };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function readJsonRefreshToken(entryId: string): string | null {
+  try {
+    const raw = readFileSync(getAccountsFile(), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const accounts = (parsed as { accounts?: unknown }).accounts;
+    if (!Array.isArray(accounts)) return null;
+    for (const account of accounts) {
+      if (account === null || typeof account !== "object" || Array.isArray(account)) continue;
+      const record = account as { id?: unknown; refreshToken?: unknown };
+      if (record.id === entryId) {
+        return typeof record.refreshToken === "string" ? record.refreshToken : null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function isAccountSqliteRow(value: unknown): value is { entry_json: string } {
   return (
     value !== null &&
@@ -474,6 +556,11 @@ function normalizeAccountEntries(rawEntries: unknown[]): {
     const entry = rawEntry as AccountEntry;
     if (!entry.id || !entry.token) continue;
 
+    if (entry.refreshToken === undefined) {
+      entry.refreshToken = null;
+      needsPersist = true;
+    }
+
     // Backfill missing fields from JWT
     if (!entry.planType || !entry.email || !entry.accountId || !entry.userId) {
       const profile = extractUserProfile(entry.token);
@@ -495,9 +582,21 @@ function normalizeAccountEntries(rawEntries: unknown[]): {
         needsPersist = true;
       }
     }
+    if (entry.email === undefined) {
+      entry.email = null;
+      needsPersist = true;
+    }
+    if (entry.accountId === undefined) {
+      entry.accountId = null;
+      needsPersist = true;
+    }
     // Backfill userId for entries missing it (pre-v1.0.68)
     if (entry.userId === undefined) {
       entry.userId = null;
+      needsPersist = true;
+    }
+    if (entry.planType === undefined) {
+      entry.planType = null;
       needsPersist = true;
     }
     // Backfill empty_response_count
@@ -536,6 +635,10 @@ function normalizeAccountEntries(rawEntries: unknown[]): {
     // Backfill cachedQuota fields
     if (entry.cachedQuota === undefined) {
       entry.cachedQuota = null;
+      entry.quotaFetchedAt = null;
+      needsPersist = true;
+    }
+    if (entry.quotaFetchedAt === undefined) {
       entry.quotaFetchedAt = null;
       needsPersist = true;
     }
@@ -738,6 +841,10 @@ function quarantineCorruptFile(
     entries: [],
     needsPersist: false,
     loadFailed: true,
-    health: { quarantined, backupPath: quarantined ? backupPath : null },
+    health: {
+      quarantined,
+      backupPath: quarantined ? backupPath : null,
+      store: accountsFile.endsWith(".sqlite") ? "accounts.sqlite" : "accounts.json",
+    },
   };
 }

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -62,7 +62,7 @@ export class AccountPool {
       // Default to assuming quarantine succeeded if the persistence
       // implementation didn't report — older/mocked impls predate the
       // health field. The file-based createFsPersistence always reports.
-      this.persistenceHealth = loaded.health ?? { quarantined: true, backupPath: null };
+      this.persistenceHealth = loaded.health ?? { quarantined: true, backupPath: null, store: "accounts.json" };
     }
     this.registry = new AccountRegistry(persistence, loaded.entries, {
       persistDisabled: loaded.loadFailed === true,
@@ -296,7 +296,7 @@ export class AccountPool {
   }
 
   /**
-   * True when the on-disk `accounts.json` failed to load at startup and
+   * True when account persistence failed to load at startup and
    * was quarantined. While disabled, all schedulePersist/persistNow calls
    * are no-ops — in-memory CRUD still works for the running session, but
    * nothing reaches disk until the user restores a healthy file and
@@ -317,6 +317,7 @@ export class AccountPool {
   getPersistenceHealth(): PersistenceHealth {
     if (!this.isPersistDisabled()) return { ok: true };
     const health = this.persistenceHealth;
+    const store = health?.store ?? "accounts.json";
     if (health?.quarantined === false) {
       return {
         ok: false,
@@ -324,8 +325,8 @@ export class AccountPool {
         quarantined: false,
         backupPath: null,
         message:
-          "accounts.json failed to load at startup. The proxy tried to move it aside but the rename failed — the original file is still on disk. " +
-          "Auto-save is paused for this session. Inspect data/accounts.json manually and restart the app once it parses cleanly.",
+          `${store} failed to load at startup. The proxy tried to move it aside but the rename failed — the original file is still on disk. ` +
+          `Auto-save is paused for this session. Inspect data/${store} manually and restart the app once it parses cleanly.`,
       };
     }
     return {
@@ -334,13 +335,13 @@ export class AccountPool {
       quarantined: true,
       backupPath: health?.backupPath ?? null,
       message:
-        "accounts.json failed to load at startup and was quarantined (see data/ for accounts.json.corrupt-*.bak). " +
+        `${store} failed to load at startup and was quarantined (see data/ for ${store}.corrupt-*.bak). ` +
         "Auto-save is paused until you restore the file and restart the app. Imports in this session live in memory only.",
     };
   }
 
   /**
-   * Read a single account's refresh token directly from disk (accounts.json).
+   * Read a single account's refresh token directly from the active persistence backend.
    * Used by RefreshScheduler to detect cross-process RT updates before refreshing.
    * Returns null if not found or on read error.
    */

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -134,6 +134,15 @@ export class AccountPool {
     return this.registry.addAccount(token, refreshToken);
   }
 
+  async withPersistenceBatch<T>(fn: () => Promise<T>): Promise<T> {
+    this.registry.beginPersistenceBatch();
+    try {
+      return await fn();
+    } finally {
+      this.registry.endPersistenceBatch();
+    }
+  }
+
   removeAccount(id: string): boolean {
     this.lifecycle.clearLock(id);
     this.evictWsPool(id);

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -62,6 +62,8 @@ export class AccountRegistry {
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
   private persistence: AccountPersistence;
   private persistDisabled: boolean;
+  private persistBatchDepth = 0;
+  private persistDirty = false;
 
   constructor(
     persistence: AccountPersistence,
@@ -84,6 +86,19 @@ export class AccountRegistry {
    */
   isPersistDisabled(): boolean {
     return this.persistDisabled;
+  }
+
+  beginPersistenceBatch(): void {
+    this.persistBatchDepth++;
+  }
+
+  endPersistenceBatch(): void {
+    if (this.persistBatchDepth === 0) return;
+    this.persistBatchDepth--;
+    if (this.persistBatchDepth === 0 && this.persistDirty) {
+      this.persistDirty = false;
+      this.persistNow();
+    }
   }
 
   // ── CRUD ──────────────────────────────────────────────────────────
@@ -607,6 +622,10 @@ export class AccountRegistry {
 
   schedulePersist(): void {
     if (this.persistDisabled) return;
+    if (this.persistBatchDepth > 0) {
+      this.persistDirty = true;
+      return;
+    }
     if (this.persistTimer) return;
     this.persistTimer = setTimeout(() => {
       this.persistTimer = null;
@@ -620,6 +639,10 @@ export class AccountRegistry {
       this.persistTimer = null;
     }
     if (this.persistDisabled) return;
+    if (this.persistBatchDepth > 0) {
+      this.persistDirty = true;
+      return;
+    }
     this.persistence.save([...this.accounts.values()]);
   }
 

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -6,10 +6,7 @@
  */
 
 import { randomBytes, timingSafeEqual } from "crypto";
-import { readFileSync } from "fs";
-import { resolve } from "path";
 import { getConfig } from "../config.js";
-import { getDataDir } from "../paths.js";
 import { jitter } from "../utils/jitter.js";
 import {
   decodeJwtPayload,
@@ -190,18 +187,11 @@ export class AccountRegistry {
   }
 
   /**
-   * Read a single account's RT from the persisted file on disk.
+   * Read a single account's RT from the active persistence backend.
    * Used to detect cross-process updates before consuming a one-time RT.
    */
   readEntryRTFromDisk(entryId: string): string | null {
-    try {
-      const raw = readFileSync(resolve(getDataDir(), "accounts.json"), "utf-8");
-      const data = JSON.parse(raw) as { accounts?: Array<{ id: string; refreshToken?: string | null }> };
-      const entry = data.accounts?.find((a) => a.id === entryId);
-      return entry?.refreshToken ?? null;
-    } catch {
-      return null;
-    }
+    return this.persistence.readRefreshToken?.(entryId) ?? null;
   }
 
   setLabel(entryId: string, label: string | null): boolean {

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -54,49 +54,51 @@ export class AccountImportService {
   ) {}
 
   async importMany(entries: ImportEntry[]): Promise<ImportResult> {
-    let added = 0;
-    let updated = 0;
-    let failed = 0;
-    const errors: string[] = [];
-    const existingIds = new Set(this.pool.getAccounts().map((a) => a.id));
+    return this.pool.withPersistenceBatch(async () => {
+      let added = 0;
+      let updated = 0;
+      let failed = 0;
+      const errors: string[] = [];
+      const existingIds = new Set(this.pool.getAccounts().map((a) => a.id));
 
-    for (const entry of entries) {
-      const resolved = await this.resolveToken(
-        entry.token,
-        entry.refreshToken ?? null,
-      );
-      if (!resolved.ok) {
-        failed++;
-        errors.push(resolved.error);
-        continue;
-      }
+      for (const entry of entries) {
+        const resolved = await this.resolveToken(
+          entry.token,
+          entry.refreshToken ?? null,
+        );
+        if (!resolved.ok) {
+          failed++;
+          errors.push(resolved.error);
+          continue;
+        }
 
-      const entryId = this.pool.addAccount(resolved.token, resolved.rt);
-      this.scheduler.scheduleOne(entryId, resolved.token);
+        const entryId = this.pool.addAccount(resolved.token, resolved.rt);
+        this.scheduler.scheduleOne(entryId, resolved.token);
 
-      if (entry.label) {
-        this.pool.setLabel(entryId, entry.label);
-      }
+        if (entry.label) {
+          this.pool.setLabel(entryId, entry.label);
+        }
 
-      // Warmup: establish session cookies to avoid cold-start detection
-      if (this.deps.warmup) {
-        const accountId = extractChatGptAccountId(resolved.token);
-        try {
-          await this.deps.warmup(entryId, resolved.token, accountId);
-        } catch (err) {
-          console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
+        // Warmup: establish session cookies to avoid cold-start detection
+        if (this.deps.warmup) {
+          const accountId = extractChatGptAccountId(resolved.token);
+          try {
+            await this.deps.warmup(entryId, resolved.token, accountId);
+          } catch (err) {
+            console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
+          }
+        }
+
+        if (existingIds.has(entryId)) {
+          updated++;
+        } else {
+          added++;
+          existingIds.add(entryId);
         }
       }
 
-      if (existingIds.has(entryId)) {
-        updated++;
-      } else {
-        added++;
-        existingIds.add(entryId);
-      }
-    }
-
-    return { added, updated, failed, errors };
+      return { added, updated, failed, errors };
+    });
   }
 
   async importOne(

--- a/tests/e2e/accounts-sqlite-persistence.test.ts
+++ b/tests/e2e/accounts-sqlite-persistence.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { Hono } from "hono";
+import { createValidJwt } from "@helpers/jwt.js";
+import { createMockConfig } from "@helpers/config.js";
+
+let tmpData: string;
+
+vi.mock("@src/paths.js", () => ({
+  getConfigDir: () => resolve(tmpData, "config"),
+  getDataDir: () => tmpData,
+  getBinDir: () => resolve(tmpData, "bin"),
+  getPublicDir: () => resolve(tmpData, "public"),
+  getDesktopPublicDir: () => resolve(tmpData, "public-desktop"),
+  isEmbedded: () => false,
+}));
+
+vi.mock("@src/models/model-store.js", () => ({
+  getModelPlanTypes: vi.fn(() => []),
+  isPlanFetched: vi.fn(() => true),
+}));
+
+import { setConfigForTesting, resetConfigForTesting } from "@src/config.js";
+import { AccountPool } from "@src/auth/account-pool.js";
+import { RefreshScheduler } from "@src/auth/refresh-scheduler.js";
+import { createAccountRoutes } from "@src/routes/accounts.js";
+
+function accountsJsonPath(): string {
+  return resolve(tmpData, "accounts.json");
+}
+
+function accountsSqlitePath(): string {
+  return resolve(tmpData, "accounts.sqlite");
+}
+
+function buildApp(pool: AccountPool, scheduler: RefreshScheduler): Hono {
+  const app = new Hono();
+  app.route("/", createAccountRoutes(pool, scheduler));
+  return app;
+}
+
+describe("accounts SQLite persistence E2E", () => {
+  beforeEach(() => {
+    tmpData = mkdtempSync(resolve(tmpdir(), "codex-accounts-sqlite-e2e-"));
+    setConfigForTesting(createMockConfig({
+      auth: {
+        refresh_enabled: false,
+        jwt_token: null,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    resetConfigForTesting();
+    rmSync(tmpData, { recursive: true, force: true });
+  });
+
+  it("imports accounts through HTTP, reloads from SQLite, then falls back to mirrored JSON", async () => {
+    const pool = new AccountPool();
+    const scheduler = new RefreshScheduler(pool);
+    const app = buildApp(pool, scheduler);
+
+    const res = await app.request("/auth/accounts/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        accounts: [
+          {
+            token: createValidJwt({ accountId: "sqlite-e2e-1", email: "e2e1@test.com" }),
+            label: "E2E 1",
+          },
+          {
+            token: createValidJwt({ accountId: "sqlite-e2e-2", email: "e2e2@test.com" }),
+            label: "E2E 2",
+          },
+          {
+            token: createValidJwt({ accountId: "sqlite-e2e-3", email: "e2e3@test.com" }),
+            label: "E2E 3",
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      added: 3,
+      updated: 0,
+      failed: 0,
+    });
+    scheduler.destroy();
+    pool.destroy();
+
+    expect(existsSync(accountsSqlitePath())).toBe(true);
+    expect(existsSync(accountsJsonPath())).toBe(true);
+
+    const sqliteReload = new AccountPool();
+    expect(sqliteReload.getAccounts().map((account) => account.label).sort()).toEqual([
+      "E2E 1",
+      "E2E 2",
+      "E2E 3",
+    ]);
+    sqliteReload.destroy();
+
+    rmSync(accountsSqlitePath());
+
+    const jsonFallback = new AccountPool();
+    expect(jsonFallback.getAccounts().map((account) => account.label).sort()).toEqual([
+      "E2E 1",
+      "E2E 2",
+      "E2E 3",
+    ]);
+    jsonFallback.destroy();
+
+    const mirrored = JSON.parse(readFileSync(accountsJsonPath(), "utf-8")) as {
+      accounts: Array<{ label: string | null }>;
+    };
+    expect(mirrored.accounts.map((account) => account.label).sort()).toEqual([
+      "E2E 1",
+      "E2E 2",
+      "E2E 3",
+    ]);
+  });
+});

--- a/tests/e2e/accounts-sqlite-persistence.test.ts
+++ b/tests/e2e/accounts-sqlite-persistence.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
 import { Hono } from "hono";
@@ -184,6 +184,32 @@ describe("accounts SQLite persistence E2E", () => {
     });
     expect(keep?.cachedQuota?.rate_limit.used_percent).toBe(42);
     expect(reloaded.getEntry(deleteId)).toBeUndefined();
+    reloaded.destroy();
+  });
+
+  it("reads refresh tokens from SQLite before a stale JSON mirror", () => {
+    const pool = new AccountPool();
+    const entryId = pool.addAccount(
+      createValidJwt({ accountId: "sqlite-rt-read", email: "rt@test.com", planType: "plus" }),
+      "rt-original",
+    );
+    pool.updateToken(
+      entryId,
+      createValidJwt({ accountId: "sqlite-rt-read", email: "rt@test.com", planType: "plus" }),
+      "rt-sqlite-new",
+    );
+    pool.destroy();
+
+    const mirrored = JSON.parse(readFileSync(accountsJsonPath(), "utf-8")) as {
+      accounts: Array<{ id: string; refreshToken?: string | null }>;
+    };
+    const staleMirrorEntry = mirrored.accounts.find((account) => account.id === entryId);
+    expect(staleMirrorEntry).toBeDefined();
+    staleMirrorEntry!.refreshToken = "rt-json-stale";
+    writeFileSync(accountsJsonPath(), JSON.stringify(mirrored, null, 2), "utf-8");
+
+    const reloaded = new AccountPool();
+    expect(reloaded.readEntryRTFromDisk(entryId)).toBe("rt-sqlite-new");
     reloaded.destroy();
   });
 });

--- a/tests/e2e/accounts-sqlite-persistence.test.ts
+++ b/tests/e2e/accounts-sqlite-persistence.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "path";
 import { Hono } from "hono";
 import { createValidJwt } from "@helpers/jwt.js";
 import { createMockConfig } from "@helpers/config.js";
+import type { CodexQuota } from "@src/auth/types.js";
 
 let tmpData: string;
 
@@ -39,6 +40,21 @@ function buildApp(pool: AccountPool, scheduler: RefreshScheduler): Hono {
   const app = new Hono();
   app.route("/", createAccountRoutes(pool, scheduler));
   return app;
+}
+
+function makeQuota(): CodexQuota {
+  return {
+    plan_type: "plus",
+    rate_limit: {
+      allowed: true,
+      limit_reached: false,
+      used_percent: 42,
+      reset_at: Math.floor(Date.now() / 1000) + 3600,
+      limit_window_seconds: 3600,
+    },
+    secondary_rate_limit: null,
+    code_review_rate_limit: null,
+  };
 }
 
 describe("accounts SQLite persistence E2E", () => {
@@ -122,5 +138,52 @@ describe("accounts SQLite persistence E2E", () => {
       "E2E 2",
       "E2E 3",
     ]);
+  });
+
+  it("persists existing account mutation paths through SQLite reload", () => {
+    const pool = new AccountPool();
+    const keepId = pool.addAccount(
+      createValidJwt({ accountId: "sqlite-mutation-keep", email: "keep@test.com", planType: "plus" }),
+      "rt-keep",
+    );
+
+    pool.setLabel(keepId, "Mutation Label");
+    pool.markStatus(keepId, "disabled");
+    pool.markStatus(keepId, "active");
+    pool.updateCachedQuota(keepId, makeQuota());
+
+    const acquired = pool.acquire({ preferredEntryId: keepId });
+    expect(acquired?.entryId).toBe(keepId);
+    pool.release(keepId, { input_tokens: 123, output_tokens: 45, cached_tokens: 12 });
+
+    const deleteId = pool.addAccount(
+      createValidJwt({ accountId: "sqlite-mutation-delete", email: "delete@test.com", planType: "plus" }),
+      "rt-delete",
+    );
+    expect(pool.removeAccount(deleteId)).toBe(true);
+    pool.destroy();
+
+    const reloaded = new AccountPool();
+    const keep = reloaded.getEntry(keepId);
+
+    expect(keep).toMatchObject({
+      id: keepId,
+      label: "Mutation Label",
+      status: "active",
+      refreshToken: "rt-keep",
+      usage: {
+        request_count: 1,
+        input_tokens: 123,
+        output_tokens: 45,
+        cached_tokens: 12,
+        window_request_count: 1,
+        window_input_tokens: 123,
+        window_output_tokens: 45,
+        window_cached_tokens: 12,
+      },
+    });
+    expect(keep?.cachedQuota?.rate_limit.used_percent).toBe(42);
+    expect(reloaded.getEntry(deleteId)).toBeUndefined();
+    reloaded.destroy();
   });
 });

--- a/tests/unit/auth/account-sqlite-persistence.test.ts
+++ b/tests/unit/auth/account-sqlite-persistence.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import type { AccountEntry, AccountsFile } from "@src/auth/types.js";
+
+let tmpData: string;
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: () => tmpData,
+}));
+
+vi.mock("@src/config.js", () => ({
+  getConfig: () => ({
+    observability: { local_error_log: true, max_log_bytes: 10 * 1024 * 1024 },
+    client: { app_version: "test" },
+  }),
+}));
+
+async function freshModule() {
+  vi.resetModules();
+  return import("@src/auth/account-persistence.js");
+}
+
+function accountsJsonPath(): string {
+  return resolve(tmpData, "accounts.json");
+}
+
+function accountsSqlitePath(): string {
+  return resolve(tmpData, "accounts.sqlite");
+}
+
+function makeEntry(id: string, label: string | null = null): AccountEntry {
+  return {
+    id,
+    token: `token-${id}`,
+    refreshToken: `rt-${id}`,
+    email: `${id}@test.com`,
+    accountId: `acct-${id}`,
+    userId: `user-${id}`,
+    label,
+    planType: "plus",
+    proxyApiKey: `codex-proxy-${id}`,
+    status: "active",
+    usage: {
+      request_count: 2,
+      input_tokens: 30,
+      output_tokens: 40,
+      cached_tokens: 10,
+      empty_response_count: 1,
+      last_used: "2026-01-02T03:04:05.000Z",
+      rate_limit_until: null,
+      window_request_count: 2,
+      window_input_tokens: 30,
+      window_output_tokens: 40,
+      window_cached_tokens: 10,
+      window_counters_reset_at: "2026-01-02T00:00:00.000Z",
+      limit_window_seconds: 18_000,
+    },
+    addedAt: "2026-01-01T00:00:00.000Z",
+    cachedQuota: {
+      plan_type: "plus",
+      rate_limit: {
+        allowed: true,
+        limit_reached: false,
+        used_percent: 12,
+        reset_at: 1_767_222_000,
+        limit_window_seconds: 18_000,
+      },
+      secondary_rate_limit: null,
+      code_review_rate_limit: null,
+    },
+    quotaFetchedAt: "2026-01-02T03:00:00.000Z",
+  };
+}
+
+function writeAccountsJson(entries: AccountEntry[]): void {
+  writeFileSync(accountsJsonPath(), JSON.stringify({ accounts: entries }, null, 2), "utf-8");
+}
+
+function readAccountsJson(): AccountsFile {
+  return JSON.parse(readFileSync(accountsJsonPath(), "utf-8")) as AccountsFile;
+}
+
+describe("SQLite account persistence", () => {
+  beforeEach(() => {
+    tmpData = mkdtempSync(resolve(tmpdir(), "codex-accounts-sqlite-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpData, { recursive: true, force: true });
+  });
+
+  it("migrates existing accounts.json to accounts.sqlite without deleting the JSON fallback", async () => {
+    const entry = makeEntry("legacy", "Legacy Label");
+    writeAccountsJson([entry]);
+
+    const { createFsPersistence } = await freshModule();
+    const firstLoad = createFsPersistence().load();
+
+    expect(firstLoad.loadFailed).toBeFalsy();
+    expect(firstLoad.entries).toHaveLength(1);
+    expect(firstLoad.entries[0]).toMatchObject({
+      id: "legacy",
+      label: "Legacy Label",
+      refreshToken: "rt-legacy",
+      cachedQuota: entry.cachedQuota,
+    });
+    expect(existsSync(accountsSqlitePath())).toBe(true);
+    expect(existsSync(accountsJsonPath())).toBe(true);
+
+    rmSync(accountsJsonPath());
+
+    const secondLoad = createFsPersistence().load();
+    expect(secondLoad.loadFailed).toBeFalsy();
+    expect(secondLoad.entries).toHaveLength(1);
+    expect(secondLoad.entries[0].id).toBe("legacy");
+    expect(secondLoad.entries[0].label).toBe("Legacy Label");
+  });
+
+  it("keeps accounts.json mirrored after SQLite saves so downgrade fallback remains usable", async () => {
+    const entry = makeEntry("mirror", "Before");
+    writeAccountsJson([entry]);
+
+    const { createFsPersistence } = await freshModule();
+    const persistence = createFsPersistence();
+    const loaded = persistence.load();
+
+    expect(existsSync(accountsSqlitePath())).toBe(true);
+
+    const updated = loaded.entries.map((account) => (
+      account.id === "mirror" ? { ...account, label: "After" } : account
+    ));
+    persistence.save(updated);
+
+    expect(readAccountsJson().accounts).toHaveLength(1);
+    expect(readAccountsJson().accounts[0].label).toBe("After");
+
+    rmSync(accountsSqlitePath());
+
+    const fallbackLoad = createFsPersistence().load();
+    expect(fallbackLoad.entries).toHaveLength(1);
+    expect(fallbackLoad.entries[0].label).toBe("After");
+  });
+
+  it("falls back to healthy accounts.json when SQLite is unavailable", async () => {
+    const entry = makeEntry("fallback", "Fallback");
+    writeAccountsJson([entry]);
+    writeFileSync(accountsSqlitePath(), "not a sqlite database", "utf-8");
+
+    const { createFsPersistence } = await freshModule();
+    const persistence = createFsPersistence();
+    const result = persistence.load();
+
+    expect(result.loadFailed).toBeFalsy();
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].id).toBe("fallback");
+
+    persistence.save([{ ...result.entries[0], label: "Fallback Saved" }]);
+    expect(readAccountsJson().accounts[0].label).toBe("Fallback Saved");
+  });
+});

--- a/tests/unit/auth/account-sqlite-persistence.test.ts
+++ b/tests/unit/auth/account-sqlite-persistence.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
 import type { AccountEntry, AccountsFile } from "@src/auth/types.js";
@@ -158,5 +158,86 @@ describe("SQLite account persistence", () => {
 
     persistence.save([{ ...result.entries[0], label: "Fallback Saved" }]);
     expect(readAccountsJson().accounts[0].label).toBe("Fallback Saved");
+  });
+
+  it("reports load failure when SQLite is corrupt and no JSON fallback exists", async () => {
+    writeFileSync(accountsSqlitePath(), "not a sqlite database", "utf-8");
+
+    const { createFsPersistence } = await freshModule();
+    const result = createFsPersistence().load();
+
+    expect(result.loadFailed).toBe(true);
+    expect(result.health).toMatchObject({
+      quarantined: true,
+      store: "accounts.sqlite",
+    });
+    expect(existsSync(accountsSqlitePath())).toBe(false);
+    expect(
+      readdirSync(tmpData).some((name) => (
+        name.startsWith("accounts.sqlite.corrupt-") && name.endsWith(".bak")
+      )),
+    ).toBe(true);
+  });
+
+  it("migrates legacy JSON entries that omit nullable fields into SQLite", async () => {
+    const legacy = makeEntry("missing-nullables", null);
+    const rawLegacy = { ...legacy } as Record<string, unknown>;
+    delete rawLegacy.refreshToken;
+    delete rawLegacy.email;
+    delete rawLegacy.accountId;
+    delete rawLegacy.userId;
+    delete rawLegacy.label;
+    delete rawLegacy.planType;
+    writeFileSync(
+      accountsJsonPath(),
+      JSON.stringify({ accounts: [rawLegacy] }, null, 2),
+      "utf-8",
+    );
+
+    const { createFsPersistence } = await freshModule();
+    const firstLoad = createFsPersistence().load();
+
+    expect(firstLoad.loadFailed).toBeFalsy();
+    expect(firstLoad.entries[0]).toMatchObject({
+      id: "missing-nullables",
+      refreshToken: null,
+      email: null,
+      accountId: null,
+      userId: null,
+      label: null,
+      planType: null,
+    });
+    expect(existsSync(accountsSqlitePath())).toBe(true);
+
+    rmSync(accountsJsonPath());
+
+    const sqliteReload = createFsPersistence().load();
+    expect(sqliteReload.loadFailed).toBeFalsy();
+    expect(sqliteReload.entries[0]).toMatchObject({
+      id: "missing-nullables",
+      refreshToken: null,
+      email: null,
+      accountId: null,
+      userId: null,
+      label: null,
+      planType: null,
+    });
+  });
+
+  it("reads refresh tokens from SQLite before a stale JSON mirror", async () => {
+    const entry = makeEntry("rt-source", "rt-json-original");
+    writeAccountsJson([entry]);
+
+    const { createFsPersistence } = await freshModule();
+    const persistence = createFsPersistence();
+    const loaded = persistence.load();
+    persistence.save([{ ...loaded.entries[0], refreshToken: "rt-sqlite-new" }]);
+
+    writeAccountsJson([{ ...entry, refreshToken: "rt-json-stale" }]);
+
+    const readablePersistence = persistence as {
+      readRefreshToken?: (entryId: string) => string | null;
+    };
+    expect(readablePersistence.readRefreshToken?.("rt-source")).toBe("rt-sqlite-new");
   });
 });

--- a/tests/unit/services/account-import.test.ts
+++ b/tests/unit/services/account-import.test.ts
@@ -3,7 +3,7 @@
  * All deps injected via constructor.
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
 import { createValidJwt } from "@helpers/jwt.js";
 import { setConfigForTesting, resetConfigForTesting } from "@src/config.js";
@@ -181,6 +181,41 @@ describe("AccountImportService", () => {
       ]);
 
       expect(pool.getAccounts()[0].label).toBe("Team Alpha");
+    });
+
+    it("persists once after bulk import instead of once per account", async () => {
+      const persistence = createMemoryPersistence();
+      const saveSpy = vi.spyOn(persistence, "save");
+      const pool = new AccountPool({
+        persistence,
+        rotationStrategy: "least_used",
+        initialToken: null,
+        rateLimitBackoffSeconds: 300,
+      });
+      const svc = new AccountImportService(
+        pool,
+        makeScheduler(),
+        makeDeps(),
+      );
+
+      const entries = Array.from({ length: 200 }, (_, index) => {
+        const number = index + 1;
+        return {
+          token: createValidJwt({
+            accountId: `batch-${number}`,
+            email: `b${number}@test.com`,
+          }),
+          label: `Batch ${number}`,
+        };
+      });
+
+      const result = await svc.importMany(entries);
+
+      expect(result).toMatchObject({ added: 200, updated: 0, failed: 0 });
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(persistence._store).toHaveLength(200);
+      expect(persistence._store.at(0)?.label).toBe("Batch 1");
+      expect(persistence._store.at(-1)?.label).toBe("Batch 200");
     });
 
     it("counts updated for duplicate accounts", async () => {


### PR DESCRIPTION
## Summary
- Migrate account persistence to `data/accounts.sqlite` while keeping `accounts.json` as a downgrade/fallback mirror.
- Add JSON-to-SQLite migration and fallback behavior so healthy JSON survives SQLite load/write failures.
- Batch bulk account import through a single persistence flush to avoid repeated full JSON rewrites.

Closes #657

## Test plan
- [x] `node node_modules/vitest/vitest.mjs run tests/unit/services/account-import.test.ts tests/unit/auth/account-sqlite-persistence.test.ts`
- [x] `node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
- [x] `node node_modules/vitest/vitest.mjs run tests/unit/auth tests/unit/services/account-import.test.ts tests/unit/services/account-query.test.ts tests/unit/services/account-mutation.test.ts tests/unit/routes/accounts-import-export.test.ts tests/unit/routes/accounts-batch.test.ts tests/unit/routes/account-label.test.ts tests/unit/routes/accounts-persistence-health.test.ts tests/e2e/accounts-sqlite-persistence.test.ts`
- [x] `node node_modules/vitest/vitest.mjs run tests/e2e/accounts-sqlite-persistence.test.ts` (3 consecutive local filesystem/HTTP-route E2E passes)
- [x] `node electron/build.mjs` from `packages/electron/`
- [x] `node -e "import('./packages/electron/dist-electron/server.mjs').then(m=>console.log(Boolean(m.startServer), Boolean(m.setPaths))).catch(e=>{console.error(e); process.exit(1)})"`
- [x] `node node_modules/vitest/vitest.mjs run packages/electron/__tests__/build.test.ts packages/electron/__tests__/builder-config.test.ts packages/electron/__tests__/prepare-pack.test.ts packages/electron/__tests__/release-pipeline.test.ts`
- [x] `git diff --check`