### PR TITLE
fix: add Cloudflare challenge cooldown

### DIFF
--- a/src/auth/account-lifecycle.ts
+++ b/src/auth/account-lifecycle.ts
@@ -12,6 +12,7 @@ import { getRotationStrategy } from "./rotation-strategy.js";
 import type { RotationStrategy, RotationState, RotationStrategyName } from "./rotation-strategy.js";
 import type { AccountRegistry } from "./account-registry.js";
 import type { AccountEntry, AcquiredAccount } from "./types.js";
+import { isCfChallengeCooldownActive } from "./cf-challenge-cooldown.js";
 
 const ACQUIRE_LOCK_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -92,6 +93,7 @@ export class AccountLifecycle {
         a.status === "active" &&
         this.slotCount(a.id) < maxConcurrent &&
         (!excludeSet || !excludeSet.has(a.id)) &&
+        !isCfChallengeCooldownActive(a.id) &&
         (!skipExhausted || !hasReachedCachedQuota(a)),
     );
 
@@ -204,6 +206,7 @@ export class AccountLifecycle {
         a.status === "active" &&
         this.slotCount(a.id) < maxConcurrent &&
         a.planType &&
+        !isCfChallengeCooldownActive(a.id) &&
         (!skipExhausted || !hasReachedCachedQuota(a)),
     );
 

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -21,6 +21,7 @@ import type {
   CodexQuota,
 } from "./types.js";
 import { hasReachedCachedQuota } from "./quota-skip.js";
+import { isCfChallengeCooldownActive } from "./cf-challenge-cooldown.js";
 
 function safeEqual(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
@@ -318,6 +319,7 @@ export class AccountRegistry {
       // usable and we must report authenticated.
       if (
         entry.status === "active" &&
+        !isCfChallengeCooldownActive(entry.id) &&
         (!skipExhausted || !hasReachedCachedQuota(entry))
       ) {
         return true;
@@ -336,6 +338,7 @@ export class AccountRegistry {
       if (
         entry.status === "active" &&
         (!excludeSet || !excludeSet.has(entry.id)) &&
+        !isCfChallengeCooldownActive(entry.id) &&
         (!skipExhausted || !hasReachedCachedQuota(entry))
       ) {
         return true;

--- a/src/auth/cf-challenge-cooldown.ts
+++ b/src/auth/cf-challenge-cooldown.ts
@@ -1,0 +1,57 @@
+const BACKOFF_SECONDS = [10, 30, 90, 120] as const;
+const STALE_MS = 60 * 60 * 1000;
+
+export interface CfChallengeCooldown {
+  challengeCount: number;
+  delaySeconds: number;
+  cooldownUntilMs: number;
+  updatedAtMs: number;
+}
+
+const cooldowns = new Map<string, CfChallengeCooldown>();
+
+function delayForChallenge(challengeCount: number): number {
+  const index = Math.min(Math.max(challengeCount, 1), BACKOFF_SECONDS.length) - 1;
+  return BACKOFF_SECONDS[index];
+}
+
+export function recordCfChallengeCooldown(
+  entryId: string,
+  nowMs: number = Date.now(),
+): CfChallengeCooldown {
+  const previous = cooldowns.get(entryId);
+  const challengeCount =
+    !previous || nowMs - previous.updatedAtMs > STALE_MS
+      ? 1
+      : previous.challengeCount + 1;
+  const delaySeconds = delayForChallenge(challengeCount);
+  const state: CfChallengeCooldown = {
+    challengeCount,
+    delaySeconds,
+    cooldownUntilMs: nowMs + delaySeconds * 1000,
+    updatedAtMs: nowMs,
+  };
+  cooldowns.set(entryId, state);
+  return state;
+}
+
+export function getCfChallengeCooldown(entryId: string): CfChallengeCooldown | null {
+  return cooldowns.get(entryId) ?? null;
+}
+
+export function isCfChallengeCooldownActive(
+  entryId: string,
+  nowMs: number = Date.now(),
+): boolean {
+  const state = cooldowns.get(entryId);
+  return state != null && nowMs < state.cooldownUntilMs;
+}
+
+export function clearCfChallengeCooldown(entryId: string): void {
+  cooldowns.delete(entryId);
+}
+
+/** Visible for tests. */
+export function _resetAllCfChallengeCooldowns(): void {
+  cooldowns.clear();
+}

--- a/src/proxy/anthropic-upstream.ts
+++ b/src/proxy/anthropic-upstream.ts
@@ -59,7 +59,7 @@ export class AnthropicUpstream implements UpstreamAdapter {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);
-      throw new CodexApiError(response.status, errorText);
+      throw new CodexApiError(response.status, errorText, response.headers);
     }
 
     return response;

--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -427,7 +427,7 @@ export class CodexApi {
         }
       }
       const errorBody = Buffer.concat(chunks).toString("utf-8");
-      throw new CodexApiError(transportRes.status, errorBody);
+      throw new CodexApiError(transportRes.status, errorBody, transportRes.headers);
     }
 
     return new Response(transportRes.body, {
@@ -481,7 +481,7 @@ export class CodexApi {
     const responseBody = Buffer.concat(chunks).toString("utf-8");
 
     if (transportRes.status < 200 || transportRes.status >= 300) {
-      throw new CodexApiError(transportRes.status, responseBody);
+      throw new CodexApiError(transportRes.status, responseBody, transportRes.headers);
     }
 
     try {

--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -160,9 +160,12 @@ export interface CodexUsageResponse {
 }
 
 export class CodexApiError extends Error {
+  public readonly headers: Headers | undefined;
+
   constructor(
     public readonly status: number,
     public readonly body: string,
+    headers?: Headers,
   ) {
     let detail: string;
     try {
@@ -178,6 +181,7 @@ export class CodexApiError extends Error {
       detail = body;
     }
     super(`Codex API error (${status}): ${detail}`);
+    this.headers = headers ? new Headers(headers) : undefined;
   }
 }
 

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -42,15 +42,6 @@ export function isQuotaExhaustedError(err: unknown): boolean {
   return err.status === 402;
 }
 
-/** Check if an error indicates the account is banned/suspended (non-CF 403). */
-export function isBanError(err: unknown): boolean {
-  if (!isCodexLike(err)) return false;
-  if (err.status !== 403) return false;
-  const body = err.body.toLowerCase();
-  if (body.includes("cf_chl") || body.includes("<!doctype") || body.includes("<html")) return false;
-  return true;
-}
-
 /** Check if a 403 body is a Cloudflare challenge rather than an account ban. */
 export function isCfChallengeError(err: unknown): boolean {
   if (!isCodexLike(err)) return false;
@@ -64,6 +55,16 @@ export function isCfChallengeError(err: unknown): boolean {
     body.includes("attention required") ||
     body.includes("just a moment")
   );
+}
+
+/** Check if an error indicates the account is banned/suspended (non-CF 403). */
+export function isBanError(err: unknown): boolean {
+  if (!isCodexLike(err)) return false;
+  if (err.status !== 403) return false;
+  if (isCfChallengeError(err)) return false;
+  const body = err.body.toLowerCase();
+  if (body.includes("<!doctype") || body.includes("<html")) return false;
+  return true;
 }
 
 /** Check if an error is a 401 token invalidation (revoked/expired upstream). */

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -51,6 +51,21 @@ export function isBanError(err: unknown): boolean {
   return true;
 }
 
+/** Check if a 403 body is a Cloudflare challenge rather than an account ban. */
+export function isCfChallengeError(err: unknown): boolean {
+  if (!isCodexLike(err)) return false;
+  if (err.status !== 403) return false;
+  const body = err.body.toLowerCase();
+  return (
+    body.includes("cf-mitigated") ||
+    body.includes("cf-chl-bypass") ||
+    body.includes("_cf_chl") ||
+    body.includes("cf_chl") ||
+    body.includes("attention required") ||
+    body.includes("just a moment")
+  );
+}
+
 /** Check if an error is a 401 token invalidation (revoked/expired upstream). */
 export function isTokenInvalidError(err: unknown): boolean {
   if (!isCodexLike(err)) return false;

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -11,12 +11,22 @@ interface CodexLikeError {
   status: number;
   body: string;
   message: string;
+  headers?: unknown;
 }
 
 function isCodexLike(err: unknown): err is CodexLikeError {
   if (!(err instanceof Error)) return false;
   const rec = err as unknown as Record<string, unknown>;
   return typeof rec.status === "number" && typeof rec.body === "string";
+}
+
+function headersToLowerHaystack(headers: unknown): string {
+  if (!(headers instanceof Headers)) return "";
+  const parts: string[] = [];
+  headers.forEach((value, key) => {
+    parts.push(key, value);
+  });
+  return parts.join(" ").toLowerCase();
 }
 
 /** Extract the rate-limit reset duration from a 429 error body, if available. */
@@ -46,14 +56,14 @@ export function isQuotaExhaustedError(err: unknown): boolean {
 export function isCfChallengeError(err: unknown): boolean {
   if (!isCodexLike(err)) return false;
   if (err.status !== 403) return false;
-  const body = err.body.toLowerCase();
+  const haystack = `${err.body.toLowerCase()} ${headersToLowerHaystack(err.headers)}`;
   return (
-    body.includes("cf-mitigated") ||
-    body.includes("cf-chl-bypass") ||
-    body.includes("_cf_chl") ||
-    body.includes("cf_chl") ||
-    body.includes("attention required") ||
-    body.includes("just a moment")
+    haystack.includes("cf-mitigated") ||
+    haystack.includes("cf-chl-bypass") ||
+    haystack.includes("_cf_chl") ||
+    haystack.includes("cf_chl") ||
+    haystack.includes("attention required") ||
+    haystack.includes("just a moment")
   );
 }
 

--- a/src/proxy/gemini-upstream.ts
+++ b/src/proxy/gemini-upstream.ts
@@ -58,7 +58,7 @@ export class GeminiUpstream implements UpstreamAdapter {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);
-      throw new CodexApiError(response.status, errorText);
+      throw new CodexApiError(response.status, errorText, response.headers);
     }
 
     return response;

--- a/src/proxy/openai-upstream.ts
+++ b/src/proxy/openai-upstream.ts
@@ -52,7 +52,7 @@ export class OpenAIUpstream implements UpstreamAdapter {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);
-      throw new CodexApiError(response.status, errorText);
+      throw new CodexApiError(response.status, errorText, response.headers);
     }
 
     return response;

--- a/src/proxy/responses-upstream.ts
+++ b/src/proxy/responses-upstream.ts
@@ -111,7 +111,7 @@ export class ResponsesUpstream implements UpstreamAdapter {
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => `HTTP ${response.status}`);
-      throw new CodexApiError(response.status, errorText);
+      throw new CodexApiError(response.status, errorText, response.headers);
     }
 
     return response;

--- a/src/routes/responses-compact.ts
+++ b/src/routes/responses-compact.ts
@@ -5,6 +5,7 @@
 import type { Context } from "hono";
 import type { StatusCode } from "hono/utils/http-status";
 import type { AccountPool } from "../auth/account-pool.js";
+import { clearCfChallengeCooldown } from "../auth/cf-challenge-cooldown.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { CodexApi, CodexApiError } from "../proxy/codex-api.js";
@@ -146,6 +147,7 @@ export async function handleCompact(
         { tag: TAG },
       );
 
+      clearCfChallengeCooldown(entryId);
       releaseAccount(accountPool, entryId, compactImageFailedUsage, released);
       return c.json(result);
     } catch (err) {

--- a/src/routes/shared/non-streaming-helpers.ts
+++ b/src/routes/shared/non-streaming-helpers.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { StatusCode } from "hono/utils/http-status";
 import type { SessionAffinityMap } from "../../auth/session-affinity.js";
 import type { AccountPool } from "../../auth/account-pool.js";
+import { clearCfChallengeCooldown } from "../../auth/cf-challenge-cooldown.js";
 import type { CodexApi, WsPoolContext } from "../../proxy/codex-api.js";
 import { CodexApiError } from "../../proxy/codex-api.js";
 import type { CookieJar } from "../../proxy/cookie-jar.js";
@@ -396,6 +397,7 @@ export function releaseNonStreamingSuccessAccount(options: ReleaseNonStreamingSu
     released,
   } = options;
 
+  clearCfChallengeCooldown(entryId);
   releaseAccount(accountPool, entryId, annotateImageGenOutcome(usage, expectsImageGen), released);
 }
 

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -9,6 +9,7 @@ import type { AccountPool } from "../../auth/account-pool.js";
 import {
   extractRetryAfterSec,
   isBanError,
+  isCfChallengeError,
   isCfPathBlockError,
   isQuotaExhaustedError,
   isTokenInvalidError,
@@ -18,6 +19,7 @@ import type { CodexApiError } from "../../proxy/codex-types.js";
 import type { StatusCode } from "hono/utils/http-status";
 import type { CookieJar } from "../../proxy/cookie-jar.js";
 import { recordCfPathBlock } from "../../auth/cf-path-block-tracker.js";
+import { recordCfChallengeCooldown } from "../../auth/cf-challenge-cooldown.js";
 import { appendErrorLog } from "../../logs/error-log.js";
 
 /** Consecutive CF path-blocks before the account is auto-disabled. */
@@ -116,7 +118,22 @@ export function handleCodexApiError(
     return { action: "retry", status: 403, message: err.message };
   }
 
-  // 5. Token invalidated / account deactivated
+  // 5. Cloudflare challenge (403 HTML/challenge response) — cooldown, not ban.
+  if (isCfChallengeError(err)) {
+    const cooldown = recordCfChallengeCooldown(entryId);
+    console.warn(
+      `[${tag}] Account ${entryId} (${email}) | Cloudflare challenge 403, ` +
+        `cooling down for ${cooldown.delaySeconds}s and trying different account...`,
+    );
+    return {
+      action: "retry",
+      releaseBeforeRetry: true,
+      status: 502,
+      message: "Upstream blocked the request (Cloudflare challenge)",
+    };
+  }
+
+  // 6. Token invalidated / account deactivated
   if (isTokenInvalidError(err)) {
     const isDeactivated = err.message.toLowerCase().includes("deactivated");
     const newStatus = isDeactivated ? "banned" : "expired";
@@ -127,7 +144,7 @@ export function handleCodexApiError(
     return { action: "retry", status: 401, message: err.message };
   }
 
-  // 6. Cloudflare path block (empty-body 404). CF's Bot Management can
+  // 7. Cloudflare path block (empty-body 404). CF's Bot Management can
   //    "hide" the /codex/responses path by returning 404 with no body when
   //    the captured __cf_bm cookie no longer matches the request
   //    fingerprint. Clear the cookie jar (so the next attempt is a clean,
@@ -164,7 +181,7 @@ export function handleCodexApiError(
     };
   }
 
-  // 7. Generic error — return to client (preserve original body for passthrough)
+  // 8. Generic error — return to client (preserve original body for passthrough)
   const status = toErrorStatus(err.status);
   return { action: "respond", status, message: err.message, errorBody: err.body };
 }

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -109,16 +109,7 @@ export function handleCodexApiError(
     return { action: "retry", status: 402, message: err.message };
   }
 
-  // 4. Ban (non-Cloudflare 403)
-  if (isBanError(err)) {
-    pool.markStatus(entryId, "banned");
-    console.warn(
-      `[${tag}] Account ${entryId} (${email}) | 403 banned, trying different account...`,
-    );
-    return { action: "retry", status: 403, message: err.message };
-  }
-
-  // 5. Cloudflare challenge (403 HTML/challenge response) — cooldown, not ban.
+  // 4. Cloudflare challenge (403 HTML/challenge response) — cooldown, not ban.
   if (isCfChallengeError(err)) {
     const cooldown = recordCfChallengeCooldown(entryId);
     console.warn(
@@ -131,6 +122,15 @@ export function handleCodexApiError(
       status: 502,
       message: "Upstream blocked the request (Cloudflare challenge)",
     };
+  }
+
+  // 5. Ban (non-Cloudflare 403)
+  if (isBanError(err)) {
+    pool.markStatus(entryId, "banned");
+    console.warn(
+      `[${tag}] Account ${entryId} (${email}) | 403 banned, trying different account...`,
+    );
+    return { action: "retry", status: 403, message: err.message };
   }
 
   // 6. Token invalidated / account deactivated

--- a/src/routes/shared/streaming-handler.ts
+++ b/src/routes/shared/streaming-handler.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import { stream } from "hono/streaming";
 import type { AccountPool } from "../../auth/account-pool.js";
+import { clearCfChallengeCooldown } from "../../auth/cf-challenge-cooldown.js";
 import type { SessionAffinityMap } from "../../auth/session-affinity.js";
 import type { CodexApi } from "../../proxy/codex-api.js";
 import { recordStreamCloseEvent } from "../../logs/stream-close-event.js";
@@ -61,6 +62,7 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
   let usageInfo: UsageInfo | undefined;
   let capturedResponseId: string | null = null;
   let responseCompleted = false;
+  let streamCompletedWithoutError = false;
   const metadataCollector = createResponseMetadataCollector();
 
   return stream(c, async (s) => {
@@ -127,9 +129,11 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
           abortSignal: abortController.signal,
         },
       });
+      streamCompletedWithoutError = true;
     } finally {
       abortController.abort();
       recordStreamAffinity();
+      if (streamCompletedWithoutError) clearCfChallengeCooldown(capturedEntryId);
       if (usageInfo) {
         logProxyUsage({
           tag: fmt.tag,

--- a/tests/integration/proxy-handler.test.ts
+++ b/tests/integration/proxy-handler.test.ts
@@ -15,6 +15,10 @@ import { createMockFormatAdapter } from "@helpers/format-adapter.js";
 import { getSessionAffinityMap } from "@src/auth/session-affinity.js";
 import { buildVariantIdentity, resolvePromptCacheIdentity } from "@src/routes/shared/proxy-session-helpers.js";
 import { computeVariantHash } from "@src/routes/shared/variant-hash.js";
+import {
+  _resetAllCfChallengeCooldowns,
+  getCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
 
 // ── Module-level control for CodexApi.createResponse ──────────────────
 
@@ -34,7 +38,8 @@ vi.mock("@src/proxy/codex-api.js", () => {
   class CodexApiError extends Error {
     status: number;
     body: string;
-    constructor(status: number, body: string) {
+    headers: Headers | undefined;
+    constructor(status: number, body: string, headers?: Headers) {
       let detail: string;
       try {
         const parsed = JSON.parse(body);
@@ -45,6 +50,7 @@ vi.mock("@src/proxy/codex-api.js", () => {
       super(`Codex API error (${status}): ${detail}`);
       this.status = status;
       this.body = body;
+      this.headers = headers ? new Headers(headers) : undefined;
     }
   }
 
@@ -73,11 +79,22 @@ vi.mock("@src/proxy/codex-api.js", () => {
       if (mockCreateResponse) return mockCreateResponse(request, signal, onRateLimits, poolCtx);
       return Promise.resolve(new Response("data: {}\n\n"));
     }),
-    getUsage: vi.fn((): Promise<any> => {
+    getUsage: vi.fn((): Promise<CodexUsageResponse> => {
       if (mockGetUsage) return mockGetUsage();
       return Promise.resolve({
         plan_type: "plus",
-        rate_limit: { allowed: true, limit_reached: false, primary_window: { used_percent: 0, reset_at: Date.now() / 1000 + 3600, limit_window_seconds: 3600 } },
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 0,
+            reset_after_seconds: 3600,
+            reset_at: Date.now() / 1000 + 3600,
+            limit_window_seconds: 3600,
+          },
+          secondary_window: null,
+        },
+        code_review_rate_limit: null,
         additional_rate_limits: [],
       });
     }),
@@ -212,6 +229,7 @@ describe("proxy-handler integration", () => {
     mockCreateResponse = null;
     mockGetUsage = null;
     getSessionAffinityMap().dispose();
+    _resetAllCfChallengeCooldowns();
     vi.clearAllMocks();
   });
 
@@ -672,20 +690,39 @@ describe("proxy-handler integration", () => {
     expect(accountPool.release).not.toHaveBeenCalled();
   });
 
-  // 5c. CF 403 (Cloudflare challenge) → NOT treated as ban
-  it("handles CF 403 as regular error, not ban", async () => {
+  // 5c. CF 403 (Cloudflare challenge) → cooldown + fallback retry, NOT ban
+  it("handles CF 403 as cooldown retry, not ban", async () => {
     mockCreateResponse = () =>
-      Promise.reject(new CodexApiError(403, '<!DOCTYPE html><html>cf_chl_managed</html>'));
+      Promise.reject(new CodexApiError(
+        403,
+        "",
+        new Headers({ "cf-mitigated": "challenge" }),
+      ));
 
-    const accountPool = createMockAccountPool();
+    const accountPool = createMockAccountPool({
+      acquire: vi.fn()
+        .mockReturnValueOnce({ entryId: "e1", token: "tok1", accountId: "acc1" })
+        .mockReturnValueOnce(null),
+      hasAvailableAccounts: vi.fn(() => true),
+    });
     const fmt = createMockFormatAdapter();
     const { app } = buildTestApp({ accountPool, fmt });
 
     const res = await app.request("/test", { method: "POST" });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("api_error");
+    expect(body.message).toContain("Cloudflare challenge");
 
     expect(accountPool.markStatus).not.toHaveBeenCalled();
     expect(accountPool.release).toHaveBeenCalledWith("e1", undefined);
+    expect(accountPool.hasAvailableAccounts).toHaveBeenCalledWith(["e1"]);
+    expect(accountPool.acquire).toHaveBeenNthCalledWith(2, {
+      model: "codex",
+      excludeIds: ["e1"],
+      preferredEntryId: undefined,
+    });
+    expect(getCfChallengeCooldown("e1")?.delaySeconds).toBe(10);
   });
 
   // 6. CodexApiError 5xx → formatError with 502

--- a/tests/unit/auth/account-pool-has-available.test.ts
+++ b/tests/unit/auth/account-pool-has-available.test.ts
@@ -54,6 +54,10 @@ vi.mock("@src/models/model-store.js", () => ({
 import { AccountPool } from "@src/auth/account-pool.js";
 import { isTokenExpired } from "@src/auth/jwt-utils.js";
 import type { CodexQuota } from "@src/auth/types.js";
+import {
+  _resetAllCfChallengeCooldowns,
+  recordCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
 
 function makeQuota(overrides?: Partial<CodexQuota>): CodexQuota {
   return {
@@ -76,6 +80,7 @@ describe("AccountPool.hasAvailableAccounts", () => {
 
   beforeEach(() => {
     vi.mocked(isTokenExpired).mockReturnValue(false);
+    _resetAllCfChallengeCooldowns();
     pool = new AccountPool({ rotationStrategy: "least_used" });
   });
 
@@ -128,6 +133,12 @@ describe("AccountPool.hasAvailableAccounts", () => {
     const id1 = pool.addAccount("token-a");
     const id2 = pool.addAccount("token-b");
     expect(pool.hasAvailableAccounts([id1, id2])).toBe(false);
+  });
+
+  it("returns false when all active accounts are in Cloudflare challenge cooldown", () => {
+    const id = pool.addAccount("token-a");
+    recordCfChallengeCooldown(id);
+    expect(pool.hasAvailableAccounts()).toBe(false);
   });
 
   it("returns false when active accounts only have cached primary quota exhaustion", () => {
@@ -190,6 +201,7 @@ describe("AccountPool.isAuthenticated", () => {
 
   beforeEach(() => {
     vi.mocked(isTokenExpired).mockReturnValue(false);
+    _resetAllCfChallengeCooldowns();
     pool = new AccountPool({ rotationStrategy: "least_used" });
   });
 
@@ -244,6 +256,12 @@ describe("AccountPool.isAuthenticated", () => {
   it("returns false when only disabled accounts exist, regardless of skip_exhausted", () => {
     const id = pool.addAccount("token-a");
     pool.markStatus(id, "disabled");
+    expect(pool.isAuthenticated()).toBe(false);
+  });
+
+  it("returns false when only active accounts are in Cloudflare challenge cooldown", () => {
+    const id = pool.addAccount("token-a");
+    recordCfChallengeCooldown(id);
     expect(pool.isAuthenticated()).toBe(false);
   });
 });

--- a/tests/unit/auth/account-pool.test.ts
+++ b/tests/unit/auth/account-pool.test.ts
@@ -59,6 +59,10 @@ import { AccountPool } from "@src/auth/account-pool.js";
 import { getConfig } from "@src/config.js";
 import { isTokenExpired, extractUserProfile } from "@src/auth/jwt-utils.js";
 import { getModelPlanTypes } from "@src/models/model-store.js";
+import {
+  _resetAllCfChallengeCooldowns,
+  recordCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
 
 describe("AccountPool", () => {
   let pool: AccountPool;
@@ -76,6 +80,7 @@ describe("AccountPool", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as ReturnType<typeof getConfig>);
     vi.mocked(getModelPlanTypes).mockReturnValue([]);
+    _resetAllCfChallengeCooldowns();
     // extractUserProfile: derive plan from token name for test flexibility
     vi.mocked(extractUserProfile).mockImplementation((token: string) => {
       let plan = "free";
@@ -123,6 +128,17 @@ describe("AccountPool", () => {
       vi.mocked(isTokenExpired).mockReturnValue(true);
       pool.addAccount("token-expired");
       expect(pool.acquire()).toBeNull();
+    });
+
+    it("skips accounts with active Cloudflare challenge cooldown", () => {
+      const cooledDownId = pool.addAccount("token-aaa");
+      const availableId = pool.addAccount("token-bbb");
+      recordCfChallengeCooldown(cooledDownId);
+
+      const acquired = pool.acquire();
+
+      expect(acquired).not.toBeNull();
+      expect(acquired!.entryId).toBe(availableId);
     });
   });
 

--- a/tests/unit/auth/cf-challenge-cooldown-tracker.test.ts
+++ b/tests/unit/auth/cf-challenge-cooldown-tracker.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  _resetAllCfChallengeCooldowns,
+  clearCfChallengeCooldown,
+  getCfChallengeCooldown,
+  isCfChallengeCooldownActive,
+  recordCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
+
+describe("cf-challenge-cooldown", () => {
+  beforeEach(() => {
+    _resetAllCfChallengeCooldowns();
+  });
+
+  it("applies the progressive 10s, 30s, 90s, 120s backoff sequence", () => {
+    const t0 = 1_000_000;
+
+    expect(recordCfChallengeCooldown("entry-1", t0).delaySeconds).toBe(10);
+    expect(recordCfChallengeCooldown("entry-1", t0 + 10_001).delaySeconds).toBe(30);
+    expect(recordCfChallengeCooldown("entry-1", t0 + 40_002).delaySeconds).toBe(90);
+    expect(recordCfChallengeCooldown("entry-1", t0 + 130_003).delaySeconds).toBe(120);
+    expect(recordCfChallengeCooldown("entry-1", t0 + 250_004).delaySeconds).toBe(120);
+  });
+
+  it("tracks cooldowns independently per account", () => {
+    const t0 = 2_000_000;
+
+    expect(recordCfChallengeCooldown("entry-a", t0).delaySeconds).toBe(10);
+    expect(recordCfChallengeCooldown("entry-a", t0 + 10_001).delaySeconds).toBe(30);
+    expect(recordCfChallengeCooldown("entry-b", t0 + 10_001).delaySeconds).toBe(10);
+  });
+
+  it("reports active cooldown until the deadline passes", () => {
+    const t0 = 3_000_000;
+    const state = recordCfChallengeCooldown("entry-1", t0);
+
+    expect(state.cooldownUntilMs).toBe(t0 + 10_000);
+    expect(isCfChallengeCooldownActive("entry-1", t0 + 9_999)).toBe(true);
+    expect(isCfChallengeCooldownActive("entry-1", t0 + 10_000)).toBe(false);
+  });
+
+  it("clears progression after a successful non-challenge request", () => {
+    const t0 = 4_000_000;
+    recordCfChallengeCooldown("entry-1", t0);
+    recordCfChallengeCooldown("entry-1", t0 + 10_001);
+
+    clearCfChallengeCooldown("entry-1");
+
+    expect(getCfChallengeCooldown("entry-1")).toBeNull();
+    expect(recordCfChallengeCooldown("entry-1", t0 + 40_000).delaySeconds).toBe(10);
+  });
+});

--- a/tests/unit/proxy/codex-api.test.ts
+++ b/tests/unit/proxy/codex-api.test.ts
@@ -297,6 +297,48 @@ describe("CodexApi.createResponse", () => {
     }
   });
 
+  it("preserves response headers on non-2xx CodexApiError", async () => {
+    const errorBody = "";
+    const responseHeaders = new Headers({ "cf-mitigated": "challenge" });
+    const mockTransport = makeMockTransport({
+      post: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          status: 403,
+          body: new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(errorBody));
+              controller.close();
+            },
+          }),
+          headers: responseHeaders,
+          setCookieHeaders: [],
+        } satisfies TlsTransportResponse),
+      ),
+    });
+    vi.mocked(getTransport).mockReturnValue(mockTransport);
+
+    const api = new CodexApi("test-token", null);
+    const request = {
+      model: "gpt-5.4",
+      instructions: "test",
+      input: [{ role: "user" as const, content: "Hi" }],
+      stream: true as const,
+      store: false as const,
+    };
+
+    let caught: unknown;
+    try {
+      await api.createResponse(request);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(CodexApiError);
+    const err = caught as CodexApiError;
+    expect(err.status).toBe(403);
+    expect(err.headers?.get("cf-mitigated")).toBe("challenge");
+  });
+
   it("truncates error body exceeding 1MB", async () => {
     const largeBody = "x".repeat(2 * 1024 * 1024); // 2MB
     const mockTransport = makeMockTransport({

--- a/tests/unit/proxy/error-classification.test.ts
+++ b/tests/unit/proxy/error-classification.test.ts
@@ -3,6 +3,7 @@ import { CodexApiError } from "@src/proxy/codex-types.js";
 import {
   extractRetryAfterSec,
   isBanError,
+  isCfChallengeError,
   isCfPathBlockError,
   isQuotaExhaustedError,
   isTokenInvalidError,
@@ -86,6 +87,24 @@ describe("isBanError", () => {
     expect(isBanError(new Error("random"))).toBe(false);
     expect(isBanError("string")).toBe(false);
     expect(isBanError(null)).toBe(false);
+  });
+});
+
+describe("isCfChallengeError", () => {
+  it("returns true for Cloudflare challenge indicators", () => {
+    expect(isCfChallengeError(new CodexApiError(403, "<html>cf_chl challenge</html>"))).toBe(true);
+    expect(isCfChallengeError(new CodexApiError(403, "<html>Just a Moment</html>"))).toBe(true);
+    expect(isCfChallengeError(new CodexApiError(403, "cf-mitigated: challenge"))).toBe(true);
+  });
+
+  it("returns false for non-CF 403 bans", () => {
+    const err = new CodexApiError(403, '{"detail": "Your account has been flagged"}');
+    expect(isCfChallengeError(err)).toBe(false);
+  });
+
+  it("returns false for non-403 and non-Codex errors", () => {
+    expect(isCfChallengeError(new CodexApiError(404, "<html>cf_chl challenge</html>"))).toBe(false);
+    expect(isCfChallengeError(new Error("cf_chl"))).toBe(false);
   });
 });
 

--- a/tests/unit/proxy/error-classification.test.ts
+++ b/tests/unit/proxy/error-classification.test.ts
@@ -78,6 +78,11 @@ describe("isBanError", () => {
     expect(isBanError(err)).toBe(false);
   });
 
+  it("returns false for CF challenge 403 when the signal is only in response headers", () => {
+    const err = new CodexApiError(403, "", new Headers({ "cf-mitigated": "challenge" }));
+    expect(isBanError(err)).toBe(false);
+  });
+
   it("returns false for CF challenge 403 (HTML page)", () => {
     const err = new CodexApiError(403, '<!DOCTYPE html><html><head></head></html>');
     expect(isBanError(err)).toBe(false);
@@ -100,6 +105,7 @@ describe("isCfChallengeError", () => {
     expect(isCfChallengeError(new CodexApiError(403, "<html>cf_chl challenge</html>"))).toBe(true);
     expect(isCfChallengeError(new CodexApiError(403, "<html>Just a Moment</html>"))).toBe(true);
     expect(isCfChallengeError(new CodexApiError(403, "cf-mitigated: challenge"))).toBe(true);
+    expect(isCfChallengeError(new CodexApiError(403, "", new Headers({ "cf-chl-bypass": "managed" })))).toBe(true);
   });
 
   it("returns false for non-CF 403 bans", () => {

--- a/tests/unit/proxy/error-classification.test.ts
+++ b/tests/unit/proxy/error-classification.test.ts
@@ -73,6 +73,11 @@ describe("isBanError", () => {
     expect(isBanError(err)).toBe(false);
   });
 
+  it("returns false for CF challenge 403 (mitigation headers)", () => {
+    const err = new CodexApiError(403, "cf-mitigated: challenge; cf-chl-bypass: managed");
+    expect(isBanError(err)).toBe(false);
+  });
+
   it("returns false for CF challenge 403 (HTML page)", () => {
     const err = new CodexApiError(403, '<!DOCTYPE html><html><head></head></html>');
     expect(isBanError(err)).toBe(false);

--- a/tests/unit/routes/shared/non-streaming-success-release.test.ts
+++ b/tests/unit/routes/shared/non-streaming-success-release.test.ts
@@ -1,7 +1,12 @@
 import type { AccountPool } from "@src/auth/account-pool.js";
+import {
+  _resetAllCfChallengeCooldowns,
+  getCfChallengeCooldown,
+  recordCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
 import { releaseNonStreamingSuccessAccount } from "@src/routes/shared/non-streaming-helpers.js";
 import type { UsageInfo } from "@src/translation/codex-event-extractor.js";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function makePool(): AccountPool {
   return {
@@ -10,6 +15,10 @@ function makePool(): AccountPool {
 }
 
 describe("releaseNonStreamingSuccessAccount", () => {
+  beforeEach(() => {
+    _resetAllCfChallengeCooldowns();
+  });
+
   it("releases the successful account with collected usage", () => {
     const accountPool = makePool();
     const released = new Set<string>();
@@ -67,5 +76,20 @@ describe("releaseNonStreamingSuccessAccount", () => {
     });
 
     expect(accountPool.release).not.toHaveBeenCalled();
+  });
+
+  it("clears Cloudflare challenge cooldown after a successful release", () => {
+    const accountPool = makePool();
+    const usage: UsageInfo = { input_tokens: 1, output_tokens: 2 };
+    recordCfChallengeCooldown("entry-cf");
+
+    releaseNonStreamingSuccessAccount({
+      accountPool,
+      entryId: "entry-cf",
+      usage,
+      released: new Set<string>(),
+    });
+
+    expect(getCfChallengeCooldown("entry-cf")).toBeNull();
   });
 });

--- a/tests/unit/routes/shared/proxy-error-handler.test.ts
+++ b/tests/unit/routes/shared/proxy-error-handler.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handleCodexApiError, type ErrorAction } from "@src/routes/shared/proxy-error-handler.js";
 import { CodexApiError } from "@src/proxy/codex-types.js";
 import { _resetAllCfPathBlocks } from "@src/auth/cf-path-block-tracker.js";
+import {
+  _resetAllCfChallengeCooldowns,
+  getCfChallengeCooldown,
+} from "@src/auth/cf-challenge-cooldown.js";
 
 /* ── Minimal mock matching AccountPool subset used by error handler ── */
 interface MockPool {
@@ -38,6 +42,7 @@ describe("handleCodexApiError", () => {
 
   beforeEach(() => {
     pool = createMockPool();
+    _resetAllCfChallengeCooldowns();
   });
 
   // ── model-not-supported ──
@@ -147,14 +152,17 @@ describe("handleCodexApiError", () => {
       expect(pool.markStatus).toHaveBeenCalledWith(entryId, "banned");
     });
 
-    it("does not treat Cloudflare challenge as ban", () => {
+    it("records Cloudflare challenge cooldown and retries without banning", () => {
       const err = new CodexApiError(403, "<html>cf_chl challenge</html>");
 
       const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
 
-      // Cloudflare 403 is not a ban → generic error path
-      expect(result.action).toBe("respond");
+      expect(result.action).toBe("retry");
+      expect(result.releaseBeforeRetry).toBe(true);
+      expect(result.status).toBe(502);
+      expect(result.message).toContain("Cloudflare challenge");
       expect(pool.markStatus).not.toHaveBeenCalled();
+      expect(getCfChallengeCooldown(entryId)?.delaySeconds).toBe(10);
     });
   });
 

--- a/tests/unit/routes/shared/proxy-error-handler.test.ts
+++ b/tests/unit/routes/shared/proxy-error-handler.test.ts
@@ -164,6 +164,18 @@ describe("handleCodexApiError", () => {
       expect(pool.markStatus).not.toHaveBeenCalled();
       expect(getCfChallengeCooldown(entryId)?.delaySeconds).toBe(10);
     });
+
+    it("does not ban Cloudflare challenge responses that do not include HTML markers", () => {
+      const err = new CodexApiError(403, "cf-mitigated: challenge; cf-chl-bypass: managed");
+
+      const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      expect(result.action).toBe("retry");
+      expect(result.releaseBeforeRetry).toBe(true);
+      expect(result.status).toBe(502);
+      expect(pool.markStatus).not.toHaveBeenCalled();
+      expect(getCfChallengeCooldown(entryId)?.delaySeconds).toBe(10);
+    });
   });
 
   // ── 401 token-invalid ──


### PR DESCRIPTION
## Summary
- Refs #664.
- Adds an in-memory per-account Cloudflare challenge cooldown tracker with 10s, 30s, 90s, then 120s backoff.
- Treats CF challenge 403s as retryable cooldown events instead of bans, skips cooled-down accounts during acquisition/availability checks, and resets progression after successful responses.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/unit/proxy/error-classification.test.ts tests/unit/auth/cf-challenge-cooldown-tracker.test.ts tests/unit/routes/shared/proxy-error-handler.test.ts tests/unit/auth/account-pool.test.ts tests/unit/auth/account-pool-has-available.test.ts tests/unit/routes/shared/non-streaming-success-release.test.ts`
- [x] `./node_modules/.bin/vitest run tests/unit/auth/cf-challenge-cooldown-tracker.test.ts tests/unit/auth/cf-path-block-tracker.test.ts tests/unit/auth/account-pool.test.ts tests/unit/auth/account-pool-has-available.test.ts tests/unit/routes/shared/proxy-error-handler.test.ts tests/unit/routes/shared/proxy-error-retry-transition.test.ts tests/unit/routes/shared/non-streaming-success-release.test.ts tests/unit/routes/shared/streaming-handler.test.ts`
- [x] `git diff --check`
- [x] `npm run build`

## E2E
- [ ] Real Cloudflare challenge E2E was not run; this PR is validated by unit/build coverage only and should not be treated as a confirmed live-service fix until a real challenged-account scenario is verified.