### PR TITLE
fix: sanitize reasoning input items

### DIFF
--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -101,10 +101,10 @@ export interface CodexReasoningTextPart {
 
 export interface CodexReasoningItem {
   type: "reasoning";
-  id?: string;
+  id: string;
   status?: CodexReasoningStatus;
   encrypted_content?: string;
-  summary?: CodexReasoningSummaryPart[];
+  summary: CodexReasoningSummaryPart[];
   content?: CodexReasoningTextPart[];
 }
 

--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -87,13 +87,43 @@ export type CodexContentPart =
   | { type: "input_text"; text: string }
   | { type: "input_image"; image_url: string };
 
+export type CodexReasoningStatus = "in_progress" | "completed" | "incomplete";
+
+export interface CodexReasoningSummaryPart {
+  type: "summary_text";
+  text: string;
+}
+
+export interface CodexReasoningTextPart {
+  type: "reasoning_text";
+  text: string;
+}
+
+export interface CodexReasoningItem {
+  type: "reasoning";
+  id?: string;
+  status?: CodexReasoningStatus;
+  encrypted_content?: string;
+  summary?: CodexReasoningSummaryPart[];
+  content?: CodexReasoningTextPart[];
+}
+
+export interface CodexCompactionItem {
+  type: "compaction";
+  id?: string;
+  encrypted_content: string;
+  created_by?: string;
+}
+
 export type CodexInputItem =
   | { role: "user"; content: string | CodexContentPart[] }
   | { role: "assistant"; content: string }
   | { role: "system"; content: string }
   | { role: "developer"; content: string }
   | { type: "function_call"; id?: string; call_id: string; name: string; arguments: string }
-  | { type: "function_call_output"; call_id: string; output: string };
+  | { type: "function_call_output"; call_id: string; output: string }
+  | CodexReasoningItem
+  | CodexCompactionItem;
 
 /** Parsed SSE event from the Codex Responses stream */
 export interface CodexSSEEvent {

--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -112,7 +112,6 @@ export interface CodexCompactionItem {
   type: "compaction";
   id?: string;
   encrypted_content: string;
-  created_by?: string;
 }
 
 export type CodexInputItem =

--- a/src/proxy/reasoning-input-sanitizer.ts
+++ b/src/proxy/reasoning-input-sanitizer.ts
@@ -23,13 +23,12 @@ function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
 
 function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+  return value.flatMap((part): CodexReasoningSummaryPart[] => {
     if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
       return [];
     }
     return [{ type: "summary_text", text: part.text }];
   });
-  return parts.length > 0 ? parts : undefined;
 }
 
 function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
@@ -43,15 +42,15 @@ function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
   return parts.length > 0 ? parts : undefined;
 }
 
-function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem {
-  const sanitized: CodexReasoningItem = { type: "reasoning" };
+function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem | null {
   const id = nonEmptyString(item.id);
-  if (id) sanitized.id = id;
+  const summary = sanitizeSummary(item.summary);
+  if (!id || summary === undefined) return null;
+
+  const sanitized: CodexReasoningItem = { type: "reasoning", id, summary };
   if (isReasoningStatus(item.status)) sanitized.status = item.status;
   const encryptedContent = nonEmptyString(item.encrypted_content);
   if (encryptedContent) sanitized.encrypted_content = encryptedContent;
-  const summary = sanitizeSummary(item.summary);
-  if (summary) sanitized.summary = summary;
   const content = sanitizeContent(item.content);
   if (content) sanitized.content = content;
   return sanitized;
@@ -63,15 +62,16 @@ function sanitizeCompactionItem(item: Record<string, unknown>): CodexCompactionI
   const sanitized: CodexCompactionItem = { type: "compaction", encrypted_content: encryptedContent };
   const id = nonEmptyString(item.id);
   if (id) sanitized.id = id;
-  const createdBy = nonEmptyString(item.created_by);
-  if (createdBy) sanitized.created_by = createdBy;
   return sanitized;
 }
 
 export function sanitizeCodexInputItems(input: unknown[]): CodexInputItem[] {
   return input.flatMap((item): CodexInputItem[] => {
     if (!isRecord(item)) return [item as CodexInputItem];
-    if (item.type === "reasoning") return [sanitizeReasoningItem(item)];
+    if (item.type === "reasoning") {
+      const sanitized = sanitizeReasoningItem(item);
+      return sanitized ? [sanitized] : [];
+    }
     if (item.type === "compaction") {
       const sanitized = sanitizeCompactionItem(item);
       return sanitized ? [sanitized] : [];

--- a/src/proxy/reasoning-input-sanitizer.ts
+++ b/src/proxy/reasoning-input-sanitizer.ts
@@ -1,0 +1,81 @@
+import type {
+  CodexCompactionItem,
+  CodexInputItem,
+  CodexReasoningItem,
+  CodexReasoningStatus,
+  CodexReasoningSummaryPart,
+  CodexReasoningTextPart,
+} from "./codex-types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? value : undefined;
+}
+
+function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
+  return value === "in_progress" || value === "completed" || value === "incomplete";
+}
+
+function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+    if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "summary_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningTextPart[] => {
+    if (!isRecord(part) || part.type !== "reasoning_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "reasoning_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem {
+  const sanitized: CodexReasoningItem = { type: "reasoning" };
+  const id = nonEmptyString(item.id);
+  if (id) sanitized.id = id;
+  if (isReasoningStatus(item.status)) sanitized.status = item.status;
+  const encryptedContent = nonEmptyString(item.encrypted_content);
+  if (encryptedContent) sanitized.encrypted_content = encryptedContent;
+  const summary = sanitizeSummary(item.summary);
+  if (summary) sanitized.summary = summary;
+  const content = sanitizeContent(item.content);
+  if (content) sanitized.content = content;
+  return sanitized;
+}
+
+function sanitizeCompactionItem(item: Record<string, unknown>): CodexCompactionItem | null {
+  const encryptedContent = nonEmptyString(item.encrypted_content);
+  if (!encryptedContent) return null;
+  const sanitized: CodexCompactionItem = { type: "compaction", encrypted_content: encryptedContent };
+  const id = nonEmptyString(item.id);
+  if (id) sanitized.id = id;
+  const createdBy = nonEmptyString(item.created_by);
+  if (createdBy) sanitized.created_by = createdBy;
+  return sanitized;
+}
+
+export function sanitizeCodexInputItems(input: unknown[]): CodexInputItem[] {
+  return input.flatMap((item): CodexInputItem[] => {
+    if (!isRecord(item)) return [item as CodexInputItem];
+    if (item.type === "reasoning") return [sanitizeReasoningItem(item)];
+    if (item.type === "compaction") {
+      const sanitized = sanitizeCompactionItem(item);
+      return sanitized ? [sanitized] : [];
+    }
+    return [item as CodexInputItem];
+  });
+}

--- a/src/routes/responses-compact.ts
+++ b/src/routes/responses-compact.ts
@@ -8,7 +8,8 @@ import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { CodexApi, CodexApiError } from "../proxy/codex-api.js";
-import type { CodexCompactRequest, CodexInputItem } from "../proxy/codex-api.js";
+import type { CodexCompactRequest } from "../proxy/codex-api.js";
+import { sanitizeCodexInputItems } from "../proxy/reasoning-input-sanitizer.js";
 import type { UsageInfo } from "../translation/codex-event-extractor.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
 import { parseModelName, resolveModelId } from "../models/model-store.js";
@@ -60,7 +61,7 @@ export async function handleCompact(
 
   const compactRequest: CodexCompactRequest = {
     model: modelId,
-    input: Array.isArray(body.input) ? (body.input as CodexInputItem[]) : [],
+    input: Array.isArray(body.input) ? sanitizeCodexInputItems(body.input) : [],
     instructions: typeof body.instructions === "string" ? body.instructions : "",
   };
   if (Array.isArray(body.tools) && body.tools.length > 0) {

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -10,7 +10,8 @@ import { Hono, type Context } from "hono";
 import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
-import type { CodexResponsesRequest, CodexInputItem } from "../proxy/codex-api.js";
+import type { CodexResponsesRequest } from "../proxy/codex-api.js";
+import { sanitizeCodexInputItems } from "../proxy/reasoning-input-sanitizer.js";
 import { enqueueLogEntry } from "../logs/entry.js";
 import { summarizeRequestForLog } from "../logs/request-summary.js";
 import { getRealClientIp } from "../utils/get-real-client-ip.js";
@@ -121,7 +122,7 @@ export function createResponsesRoutes(
     const codexRequest: CodexResponsesRequest = {
       model: modelId,
       instructions: typeof body.instructions === "string" ? body.instructions : "",
-      input: Array.isArray(body.input) ? (body.input as CodexInputItem[]) : [],
+      input: Array.isArray(body.input) ? sanitizeCodexInputItems(body.input) : [],
       stream: true,
       store: false,
     };

--- a/tests/unit/proxy/reasoning-input-sanitizer.test.ts
+++ b/tests/unit/proxy/reasoning-input-sanitizer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCodexInputItems } from "@src/proxy/reasoning-input-sanitizer.js";
+
+describe("sanitizeCodexInputItems", () => {
+  it("preserves valid reasoning items and removes unsupported signature fields", () => {
+    const input = [{
+      type: "reasoning",
+      id: "rs_1",
+      status: "completed",
+      encrypted_content: "enc_valid",
+      summary: [{ type: "summary_text", text: "brief" }],
+      content: [{ type: "reasoning_text", text: "hidden" }],
+      signature: "anthropic-style-signature",
+      extra: "drop-me",
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      id: "rs_1",
+      status: "completed",
+      encrypted_content: "enc_valid",
+      summary: [{ type: "summary_text", text: "brief" }],
+      content: [{ type: "reasoning_text", text: "hidden" }],
+    }]);
+  });
+
+  it("drops invalid encrypted_content values instead of forwarding them", () => {
+    const input = [
+      { type: "reasoning", id: "rs_empty", encrypted_content: "" },
+      { type: "reasoning", id: "rs_number", encrypted_content: 123 },
+      { type: "reasoning", id: "rs_spaces", encrypted_content: "   " },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([
+      { type: "reasoning", id: "rs_empty" },
+      { type: "reasoning", id: "rs_number" },
+      { type: "reasoning", id: "rs_spaces" },
+    ]);
+  });
+
+  it("filters malformed reasoning summary and content parts", () => {
+    const input = [{
+      type: "reasoning",
+      summary: [
+        { type: "summary_text", text: "keep" },
+        { type: "summary_text", text: 42 },
+        { type: "text", text: "drop" },
+      ],
+      content: [
+        { type: "reasoning_text", text: "keep reasoning" },
+        { type: "reasoning_text" },
+        { type: "output_text", text: "drop" },
+      ],
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      summary: [{ type: "summary_text", text: "keep" }],
+      content: [{ type: "reasoning_text", text: "keep reasoning" }],
+    }]);
+  });
+
+  it("drops compaction items with invalid encrypted_content", () => {
+    const input = [
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+      { type: "compaction", encrypted_content: "" },
+      { type: "compaction", encrypted_content: 7 },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+    ]);
+  });
+
+  it("keeps non-reasoning input items unchanged in mixed arrays", () => {
+    const user = { role: "user", content: "Hello" };
+    const callOutput = { type: "function_call_output", call_id: "call_1", output: "ok" };
+
+    expect(sanitizeCodexInputItems([
+      user,
+      { type: "reasoning", encrypted_content: "" },
+      callOutput,
+    ])).toEqual([
+      user,
+      { type: "reasoning" },
+      callOutput,
+    ]);
+  });
+});

--- a/tests/unit/proxy/reasoning-input-sanitizer.test.ts
+++ b/tests/unit/proxy/reasoning-input-sanitizer.test.ts
@@ -24,23 +24,40 @@ describe("sanitizeCodexInputItems", () => {
     }]);
   });
 
+  it("preserves reasoning items with an empty summary array", () => {
+    const input = [{
+      type: "reasoning",
+      id: "rs_empty_summary",
+      summary: [],
+      encrypted_content: "enc_valid",
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      id: "rs_empty_summary",
+      summary: [],
+      encrypted_content: "enc_valid",
+    }]);
+  });
+
   it("drops invalid encrypted_content values instead of forwarding them", () => {
     const input = [
-      { type: "reasoning", id: "rs_empty", encrypted_content: "" },
-      { type: "reasoning", id: "rs_number", encrypted_content: 123 },
-      { type: "reasoning", id: "rs_spaces", encrypted_content: "   " },
+      { type: "reasoning", id: "rs_empty", summary: [], encrypted_content: "" },
+      { type: "reasoning", id: "rs_number", summary: [], encrypted_content: 123 },
+      { type: "reasoning", id: "rs_spaces", summary: [], encrypted_content: "   " },
     ];
 
     expect(sanitizeCodexInputItems(input)).toEqual([
-      { type: "reasoning", id: "rs_empty" },
-      { type: "reasoning", id: "rs_number" },
-      { type: "reasoning", id: "rs_spaces" },
+      { type: "reasoning", id: "rs_empty", summary: [] },
+      { type: "reasoning", id: "rs_number", summary: [] },
+      { type: "reasoning", id: "rs_spaces", summary: [] },
     ]);
   });
 
   it("filters malformed reasoning summary and content parts", () => {
     const input = [{
       type: "reasoning",
+      id: "rs_filtered",
       summary: [
         { type: "summary_text", text: "keep" },
         { type: "summary_text", text: 42 },
@@ -55,9 +72,20 @@ describe("sanitizeCodexInputItems", () => {
 
     expect(sanitizeCodexInputItems(input)).toEqual([{
       type: "reasoning",
+      id: "rs_filtered",
       summary: [{ type: "summary_text", text: "keep" }],
       content: [{ type: "reasoning_text", text: "keep reasoning" }],
     }]);
+  });
+
+  it("drops malformed reasoning items that are missing required identity fields", () => {
+    const input = [
+      { type: "reasoning", summary: [], encrypted_content: "enc_missing_id" },
+      { type: "reasoning", id: "rs_missing_summary", encrypted_content: "enc_missing_summary" },
+      { type: "reasoning", id: "", summary: [], encrypted_content: "enc_empty_id" },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([]);
   });
 
   it("drops compaction items with invalid encrypted_content", () => {
@@ -68,7 +96,7 @@ describe("sanitizeCodexInputItems", () => {
     ];
 
     expect(sanitizeCodexInputItems(input)).toEqual([
-      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact" },
     ]);
   });
 
@@ -82,7 +110,6 @@ describe("sanitizeCodexInputItems", () => {
       callOutput,
     ])).toEqual([
       user,
-      { type: "reasoning" },
       callOutput,
     ]);
   });

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -251,6 +251,38 @@ describe("POST /v1/responses/compact", () => {
     expect(format.strict).toBe(true);
   });
 
+  it("sanitizes reasoning input items before compact forwarding", async () => {
+    await app.request("/v1/responses/compact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "codex",
+        input: [
+          {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "",
+            signature: "unsupported",
+            content: [{ type: "reasoning_text", text: "kept" }],
+          },
+          { type: "compaction", encrypted_content: 123 },
+          { role: "user", content: "Hello" },
+        ],
+        instructions: "",
+      }),
+    });
+
+    const req = capturedCompactRequest as Record<string, unknown>;
+    expect(req.input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        content: [{ type: "reasoning_text", text: "kept" }],
+      },
+      { role: "user", content: "Hello" },
+    ]);
+  });
+
   it("defaults instructions to empty string when omitted", async () => {
     await app.request("/v1/responses/compact", {
       method: "POST",

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -261,6 +261,7 @@ describe("POST /v1/responses/compact", () => {
           {
             type: "reasoning",
             id: "rs_1",
+            summary: [],
             encrypted_content: "",
             signature: "unsupported",
             content: [{ type: "reasoning_text", text: "kept" }],
@@ -277,6 +278,7 @@ describe("POST /v1/responses/compact", () => {
       {
         type: "reasoning",
         id: "rs_1",
+        summary: [],
         content: [{ type: "reasoning_text", text: "kept" }],
       },
       { role: "user", content: "Hello" },

--- a/tests/unit/routes/responses-optional-instructions.test.ts
+++ b/tests/unit/routes/responses-optional-instructions.test.ts
@@ -268,6 +268,38 @@ describe("/v1/responses — optional instructions", () => {
     expect(req.version).toBe("26.318.11754");
   });
 
+  it("sanitizes reasoning input items before proxy forwarding", async () => {
+    await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "codex",
+        input: [
+          {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "",
+            signature: "unsupported",
+            summary: [{ type: "summary_text", text: "kept" }],
+          },
+          { type: "compaction", encrypted_content: 123 },
+          { role: "user", content: "Hello" },
+        ],
+        stream: true,
+      }),
+    });
+
+    const req = capturedCodexRequest as Record<string, unknown>;
+    expect(req.input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        summary: [{ type: "summary_text", text: "kept" }],
+      },
+      { role: "user", content: "Hello" },
+    ]);
+  });
+
   it("still rejects non-object body", async () => {
     const res = await app.request("/v1/responses", {
       method: "POST",


### PR DESCRIPTION
## Summary
- Refs #662.
- Adds an allowlisted Responses reasoning/compaction input sanitizer before upstream forwarding.
- Strips unsupported reasoning `signature`/unknown fields, removes empty or non-string `encrypted_content`, filters malformed reasoning parts, and drops invalid compaction items for both `/v1/responses` and `/v1/responses/compact`.
- The allowlist follows the Responses API input item shape documented in the OpenAI API reference: https://platform.openai.com/docs/api-reference/responses/create

## Test plan
- [x] `./node_modules/.bin/vitest run tests/unit/proxy/reasoning-input-sanitizer.test.ts tests/unit/routes/responses-optional-instructions.test.ts tests/unit/routes/responses-compact.test.ts`
- [x] `git diff --check`
- [x] `rg -n "as any|: any|<any>" src/proxy/reasoning-input-sanitizer.ts src/proxy/codex-types.ts src/routes/responses.ts src/routes/responses-compact.ts tests/unit/proxy/reasoning-input-sanitizer.test.ts tests/unit/routes/responses-optional-instructions.test.ts tests/unit/routes/responses-compact.test.ts`
- [x] `npm run build`

## E2E
- [ ] Real OpenAI upstream E2E was not run; this PR is validated by unit/build coverage only and should not be treated as a confirmed live-service fix until 3 consecutive real-service calls pass.