### PR TITLE
fix: add reasoning replay cache

### DIFF
--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -101,10 +101,10 @@ export interface CodexReasoningTextPart {
 
 export interface CodexReasoningItem {
   type: "reasoning";
-  id?: string;
+  id: string;
   status?: CodexReasoningStatus;
   encrypted_content?: string;
-  summary?: CodexReasoningSummaryPart[];
+  summary: CodexReasoningSummaryPart[];
   content?: CodexReasoningTextPart[];
 }
 

--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -87,13 +87,43 @@ export type CodexContentPart =
   | { type: "input_text"; text: string }
   | { type: "input_image"; image_url: string };
 
+export type CodexReasoningStatus = "in_progress" | "completed" | "incomplete";
+
+export interface CodexReasoningSummaryPart {
+  type: "summary_text";
+  text: string;
+}
+
+export interface CodexReasoningTextPart {
+  type: "reasoning_text";
+  text: string;
+}
+
+export interface CodexReasoningItem {
+  type: "reasoning";
+  id?: string;
+  status?: CodexReasoningStatus;
+  encrypted_content?: string;
+  summary?: CodexReasoningSummaryPart[];
+  content?: CodexReasoningTextPart[];
+}
+
+export interface CodexCompactionItem {
+  type: "compaction";
+  id?: string;
+  encrypted_content: string;
+  created_by?: string;
+}
+
 export type CodexInputItem =
   | { role: "user"; content: string | CodexContentPart[] }
   | { role: "assistant"; content: string }
   | { role: "system"; content: string }
   | { role: "developer"; content: string }
   | { type: "function_call"; id?: string; call_id: string; name: string; arguments: string }
-  | { type: "function_call_output"; call_id: string; output: string };
+  | { type: "function_call_output"; call_id: string; output: string }
+  | CodexReasoningItem
+  | CodexCompactionItem;
 
 /** Parsed SSE event from the Codex Responses stream */
 export interface CodexSSEEvent {

--- a/src/proxy/codex-types.ts
+++ b/src/proxy/codex-types.ts
@@ -112,7 +112,6 @@ export interface CodexCompactionItem {
   type: "compaction";
   id?: string;
   encrypted_content: string;
-  created_by?: string;
 }
 
 export type CodexInputItem =

--- a/src/proxy/reasoning-input-sanitizer.ts
+++ b/src/proxy/reasoning-input-sanitizer.ts
@@ -23,13 +23,12 @@ function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
 
 function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+  return value.flatMap((part): CodexReasoningSummaryPart[] => {
     if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
       return [];
     }
     return [{ type: "summary_text", text: part.text }];
   });
-  return parts.length > 0 ? parts : undefined;
 }
 
 function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
@@ -43,15 +42,15 @@ function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
   return parts.length > 0 ? parts : undefined;
 }
 
-function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem {
-  const sanitized: CodexReasoningItem = { type: "reasoning" };
+function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem | null {
   const id = nonEmptyString(item.id);
-  if (id) sanitized.id = id;
+  const summary = sanitizeSummary(item.summary);
+  if (!id || summary === undefined) return null;
+
+  const sanitized: CodexReasoningItem = { type: "reasoning", id, summary };
   if (isReasoningStatus(item.status)) sanitized.status = item.status;
   const encryptedContent = nonEmptyString(item.encrypted_content);
   if (encryptedContent) sanitized.encrypted_content = encryptedContent;
-  const summary = sanitizeSummary(item.summary);
-  if (summary) sanitized.summary = summary;
   const content = sanitizeContent(item.content);
   if (content) sanitized.content = content;
   return sanitized;
@@ -63,15 +62,16 @@ function sanitizeCompactionItem(item: Record<string, unknown>): CodexCompactionI
   const sanitized: CodexCompactionItem = { type: "compaction", encrypted_content: encryptedContent };
   const id = nonEmptyString(item.id);
   if (id) sanitized.id = id;
-  const createdBy = nonEmptyString(item.created_by);
-  if (createdBy) sanitized.created_by = createdBy;
   return sanitized;
 }
 
 export function sanitizeCodexInputItems(input: unknown[]): CodexInputItem[] {
   return input.flatMap((item): CodexInputItem[] => {
     if (!isRecord(item)) return [item as CodexInputItem];
-    if (item.type === "reasoning") return [sanitizeReasoningItem(item)];
+    if (item.type === "reasoning") {
+      const sanitized = sanitizeReasoningItem(item);
+      return sanitized ? [sanitized] : [];
+    }
     if (item.type === "compaction") {
       const sanitized = sanitizeCompactionItem(item);
       return sanitized ? [sanitized] : [];

--- a/src/proxy/reasoning-input-sanitizer.ts
+++ b/src/proxy/reasoning-input-sanitizer.ts
@@ -1,0 +1,81 @@
+import type {
+  CodexCompactionItem,
+  CodexInputItem,
+  CodexReasoningItem,
+  CodexReasoningStatus,
+  CodexReasoningSummaryPart,
+  CodexReasoningTextPart,
+} from "./codex-types.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? value : undefined;
+}
+
+function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
+  return value === "in_progress" || value === "completed" || value === "incomplete";
+}
+
+function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+    if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "summary_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningTextPart[] => {
+    if (!isRecord(part) || part.type !== "reasoning_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "reasoning_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeReasoningItem(item: Record<string, unknown>): CodexReasoningItem {
+  const sanitized: CodexReasoningItem = { type: "reasoning" };
+  const id = nonEmptyString(item.id);
+  if (id) sanitized.id = id;
+  if (isReasoningStatus(item.status)) sanitized.status = item.status;
+  const encryptedContent = nonEmptyString(item.encrypted_content);
+  if (encryptedContent) sanitized.encrypted_content = encryptedContent;
+  const summary = sanitizeSummary(item.summary);
+  if (summary) sanitized.summary = summary;
+  const content = sanitizeContent(item.content);
+  if (content) sanitized.content = content;
+  return sanitized;
+}
+
+function sanitizeCompactionItem(item: Record<string, unknown>): CodexCompactionItem | null {
+  const encryptedContent = nonEmptyString(item.encrypted_content);
+  if (!encryptedContent) return null;
+  const sanitized: CodexCompactionItem = { type: "compaction", encrypted_content: encryptedContent };
+  const id = nonEmptyString(item.id);
+  if (id) sanitized.id = id;
+  const createdBy = nonEmptyString(item.created_by);
+  if (createdBy) sanitized.created_by = createdBy;
+  return sanitized;
+}
+
+export function sanitizeCodexInputItems(input: unknown[]): CodexInputItem[] {
+  return input.flatMap((item): CodexInputItem[] => {
+    if (!isRecord(item)) return [item as CodexInputItem];
+    if (item.type === "reasoning") return [sanitizeReasoningItem(item)];
+    if (item.type === "compaction") {
+      const sanitized = sanitizeCompactionItem(item);
+      return sanitized ? [sanitized] : [];
+    }
+    return [item as CodexInputItem];
+  });
+}

--- a/src/proxy/reasoning-replay-cache.ts
+++ b/src/proxy/reasoning-replay-cache.ts
@@ -27,17 +27,24 @@ export interface ReasoningReplayRecord extends ReasoningReplayLookup {
 export interface ReasoningReplayCacheOptions {
   ttlMs?: number;
   maxEntries?: number;
+  maxEntryBytes?: number;
+  maxTotalBytes?: number;
   nowMs?: () => number;
 }
 
 interface ReasoningReplayCacheEntry extends ReasoningReplayLookup {
   items: ReasoningReplayItem[];
+  byteSize: number;
   createdAt: number;
   sequence: number;
 }
 
-const DEFAULT_TTL_MS = 4 * 60 * 60 * 1000;
+export const REASONING_REPLAY_CACHE_TTL_MS = 55 * 60 * 1000;
+const DEFAULT_TTL_MS = REASONING_REPLAY_CACHE_TTL_MS;
 const DEFAULT_MAX_ENTRIES = 512;
+const DEFAULT_MAX_ENTRY_BYTES = 256 * 1024;
+const DEFAULT_MAX_TOTAL_BYTES = 4 * 1024 * 1024;
+const textEncoder = new TextEncoder();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -54,13 +61,12 @@ function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
 
 function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+  return value.flatMap((part): CodexReasoningSummaryPart[] => {
     if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
       return [];
     }
     return [{ type: "summary_text", text: part.text }];
   });
-  return parts.length > 0 ? parts : undefined;
 }
 
 function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
@@ -76,18 +82,18 @@ function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
 
 function sanitizeReasoningReplayItem(value: unknown): CodexReasoningItem | null {
   if (!isRecord(value) || value.type !== "reasoning") return null;
+  const id = nonEmptyString(value.id);
+  const summary = sanitizeSummary(value.summary);
   const encryptedContent = nonEmptyString(value.encrypted_content);
-  if (!encryptedContent) return null;
+  if (!id || summary === undefined || !encryptedContent) return null;
 
   const item: CodexReasoningItem = {
     type: "reasoning",
+    id,
+    summary,
     encrypted_content: encryptedContent,
   };
-  const id = nonEmptyString(value.id);
-  if (id) item.id = id;
   if (isReasoningStatus(value.status)) item.status = value.status;
-  const summary = sanitizeSummary(value.summary);
-  if (summary) item.summary = summary;
   const content = sanitizeContent(value.content);
   if (content) item.content = content;
   return item;
@@ -146,10 +152,10 @@ function cloneReplayItem(item: ReasoningReplayItem): ReasoningReplayItem {
   }
   return {
     type: "reasoning",
-    ...(item.id ? { id: item.id } : {}),
+    id: item.id,
     ...(item.status ? { status: item.status } : {}),
     ...(item.encrypted_content ? { encrypted_content: item.encrypted_content } : {}),
-    ...(item.summary ? { summary: item.summary.map((part) => ({ ...part })) } : {}),
+    summary: item.summary.map((part) => ({ ...part })),
     ...(item.content ? { content: item.content.map((part) => ({ ...part })) } : {}),
   };
 }
@@ -163,16 +169,25 @@ function matchesIdentity(
     entry.variantHash === identity.variantHash;
 }
 
+function estimateReplayItemsBytes(items: readonly ReasoningReplayItem[]): number {
+  return textEncoder.encode(JSON.stringify(items)).byteLength;
+}
+
 export class ReasoningReplayCache {
   private entries = new Map<string, ReasoningReplayCacheEntry>();
   private readonly ttlMs: number;
   private readonly maxEntries: number;
+  private readonly maxEntryBytes: number;
+  private readonly maxTotalBytes: number;
   private readonly nowMs: () => number;
   private nextSequence = 0;
+  private totalBytes = 0;
 
   constructor(options: ReasoningReplayCacheOptions = {}) {
     this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
-    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.maxEntries = Math.max(0, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+    this.maxEntryBytes = Math.max(0, options.maxEntryBytes ?? DEFAULT_MAX_ENTRY_BYTES);
+    this.maxTotalBytes = Math.max(0, options.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES);
     this.nowMs = options.nowMs ?? Date.now;
   }
 
@@ -180,20 +195,29 @@ export class ReasoningReplayCache {
     this.cleanupExpired();
     const items = sanitizeReasoningReplayItems(record.items);
     if (items.length === 0) {
-      this.entries.delete(record.responseId);
+      this.deleteEntry(record.responseId);
       return 0;
     }
+    const clonedItems = items.map(cloneReplayItem);
+    const byteSize = estimateReplayItemsBytes(clonedItems);
+    if (byteSize > this.maxEntryBytes) {
+      this.deleteEntry(record.responseId);
+      return 0;
+    }
+    this.deleteEntry(record.responseId);
     this.entries.set(record.responseId, {
       responseId: record.responseId,
       entryId: record.entryId,
       conversationId: record.conversationId,
       variantHash: record.variantHash,
-      items: items.map(cloneReplayItem),
+      items: clonedItems,
+      byteSize,
       createdAt: this.nowMs(),
       sequence: this.nextSequence++,
     });
+    this.totalBytes += byteSize;
     this.evictOverflow();
-    return items.length;
+    return this.entries.has(record.responseId) ? items.length : 0;
   }
 
   lookup(lookup: ReasoningReplayLookup): ReasoningReplayItem[] {
@@ -207,18 +231,19 @@ export class ReasoningReplayCache {
     let evicted = 0;
     for (const [responseId, entry] of this.entries) {
       if (!matchesIdentity(entry, identity)) continue;
-      this.entries.delete(responseId);
+      this.deleteEntry(responseId);
       evicted++;
     }
     return evicted;
   }
 
   evictByResponseId(responseId: string): boolean {
-    return this.entries.delete(responseId);
+    return this.deleteEntry(responseId);
   }
 
   clear(): void {
     this.entries.clear();
+    this.totalBytes = 0;
   }
 
   get size(): number {
@@ -230,13 +255,13 @@ export class ReasoningReplayCache {
     const now = this.nowMs();
     for (const [responseId, entry] of this.entries) {
       if (now - entry.createdAt > this.ttlMs) {
-        this.entries.delete(responseId);
+        this.deleteEntry(responseId);
       }
     }
   }
 
   private evictOverflow(): void {
-    while (this.entries.size > this.maxEntries) {
+    while (this.entries.size > this.maxEntries || this.totalBytes > this.maxTotalBytes) {
       let oldestResponseId: string | null = null;
       let oldestCreatedAt = Number.POSITIVE_INFINITY;
       let oldestSequence = Number.POSITIVE_INFINITY;
@@ -251,8 +276,16 @@ export class ReasoningReplayCache {
         }
       }
       if (!oldestResponseId) return;
-      this.entries.delete(oldestResponseId);
+      this.deleteEntry(oldestResponseId);
     }
+  }
+
+  private deleteEntry(responseId: string): boolean {
+    const entry = this.entries.get(responseId);
+    if (!entry) return false;
+    this.entries.delete(responseId);
+    this.totalBytes = Math.max(0, this.totalBytes - entry.byteSize);
+    return true;
   }
 }
 

--- a/src/proxy/reasoning-replay-cache.ts
+++ b/src/proxy/reasoning-replay-cache.ts
@@ -1,0 +1,296 @@
+import type {
+  CodexInputItem,
+  CodexReasoningItem,
+  CodexReasoningStatus,
+  CodexReasoningSummaryPart,
+  CodexReasoningTextPart,
+} from "./codex-types.js";
+
+export type ReasoningReplayItem =
+  | CodexReasoningItem
+  | Extract<CodexInputItem, { type: "function_call" }>;
+
+export interface ReasoningReplayIdentity {
+  entryId: string;
+  conversationId: string;
+  variantHash: string;
+}
+
+export interface ReasoningReplayLookup extends ReasoningReplayIdentity {
+  responseId: string;
+}
+
+export interface ReasoningReplayRecord extends ReasoningReplayLookup {
+  items: readonly unknown[];
+}
+
+export interface ReasoningReplayCacheOptions {
+  ttlMs?: number;
+  maxEntries?: number;
+  nowMs?: () => number;
+}
+
+interface ReasoningReplayCacheEntry extends ReasoningReplayLookup {
+  items: ReasoningReplayItem[];
+  createdAt: number;
+  sequence: number;
+}
+
+const DEFAULT_TTL_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 512;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return value.trim().length > 0 ? value : null;
+}
+
+function isReasoningStatus(value: unknown): value is CodexReasoningStatus {
+  return value === "in_progress" || value === "completed" || value === "incomplete";
+}
+
+function sanitizeSummary(value: unknown): CodexReasoningSummaryPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningSummaryPart[] => {
+    if (!isRecord(part) || part.type !== "summary_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "summary_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeContent(value: unknown): CodexReasoningTextPart[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.flatMap((part): CodexReasoningTextPart[] => {
+    if (!isRecord(part) || part.type !== "reasoning_text" || typeof part.text !== "string") {
+      return [];
+    }
+    return [{ type: "reasoning_text", text: part.text }];
+  });
+  return parts.length > 0 ? parts : undefined;
+}
+
+function sanitizeReasoningReplayItem(value: unknown): CodexReasoningItem | null {
+  if (!isRecord(value) || value.type !== "reasoning") return null;
+  const encryptedContent = nonEmptyString(value.encrypted_content);
+  if (!encryptedContent) return null;
+
+  const item: CodexReasoningItem = {
+    type: "reasoning",
+    encrypted_content: encryptedContent,
+  };
+  const id = nonEmptyString(value.id);
+  if (id) item.id = id;
+  if (isReasoningStatus(value.status)) item.status = value.status;
+  const summary = sanitizeSummary(value.summary);
+  if (summary) item.summary = summary;
+  const content = sanitizeContent(value.content);
+  if (content) item.content = content;
+  return item;
+}
+
+function sanitizeFunctionCallReplayItem(
+  value: unknown,
+): Extract<CodexInputItem, { type: "function_call" }> | null {
+  if (!isRecord(value) || value.type !== "function_call") return null;
+  const callId = nonEmptyString(value.call_id);
+  const name = nonEmptyString(value.name);
+  const args = typeof value.arguments === "string" ? value.arguments : null;
+  if (!callId || !name || args === null) return null;
+
+  const item: Extract<CodexInputItem, { type: "function_call" }> = {
+    type: "function_call",
+    call_id: callId,
+    name,
+    arguments: args,
+  };
+  const id = nonEmptyString(value.id);
+  if (id) item.id = id;
+  return item;
+}
+
+function replayItemKey(item: ReasoningReplayItem): string {
+  if (item.type === "function_call") return `function_call:${item.call_id}`;
+  return `reasoning:${item.id ?? item.encrypted_content ?? ""}`;
+}
+
+export function sanitizeReasoningReplayItems(items: readonly unknown[]): ReasoningReplayItem[] {
+  const seen = new Set<string>();
+  const sanitized: ReasoningReplayItem[] = [];
+  for (const item of items) {
+    const replayItem =
+      sanitizeReasoningReplayItem(item) ??
+      sanitizeFunctionCallReplayItem(item);
+    if (!replayItem) continue;
+    const key = replayItemKey(replayItem);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sanitized.push(replayItem);
+  }
+  return sanitized;
+}
+
+function cloneReplayItem(item: ReasoningReplayItem): ReasoningReplayItem {
+  if (item.type === "function_call") {
+    return {
+      type: "function_call",
+      ...(item.id ? { id: item.id } : {}),
+      call_id: item.call_id,
+      name: item.name,
+      arguments: item.arguments,
+    };
+  }
+  return {
+    type: "reasoning",
+    ...(item.id ? { id: item.id } : {}),
+    ...(item.status ? { status: item.status } : {}),
+    ...(item.encrypted_content ? { encrypted_content: item.encrypted_content } : {}),
+    ...(item.summary ? { summary: item.summary.map((part) => ({ ...part })) } : {}),
+    ...(item.content ? { content: item.content.map((part) => ({ ...part })) } : {}),
+  };
+}
+
+function matchesIdentity(
+  entry: ReasoningReplayIdentity,
+  identity: ReasoningReplayIdentity,
+): boolean {
+  return entry.entryId === identity.entryId &&
+    entry.conversationId === identity.conversationId &&
+    entry.variantHash === identity.variantHash;
+}
+
+export class ReasoningReplayCache {
+  private entries = new Map<string, ReasoningReplayCacheEntry>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+  private readonly nowMs: () => number;
+  private nextSequence = 0;
+
+  constructor(options: ReasoningReplayCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.nowMs = options.nowMs ?? Date.now;
+  }
+
+  record(record: ReasoningReplayRecord): number {
+    this.cleanupExpired();
+    const items = sanitizeReasoningReplayItems(record.items);
+    if (items.length === 0) {
+      this.entries.delete(record.responseId);
+      return 0;
+    }
+    this.entries.set(record.responseId, {
+      responseId: record.responseId,
+      entryId: record.entryId,
+      conversationId: record.conversationId,
+      variantHash: record.variantHash,
+      items: items.map(cloneReplayItem),
+      createdAt: this.nowMs(),
+      sequence: this.nextSequence++,
+    });
+    this.evictOverflow();
+    return items.length;
+  }
+
+  lookup(lookup: ReasoningReplayLookup): ReasoningReplayItem[] {
+    this.cleanupExpired();
+    const entry = this.entries.get(lookup.responseId);
+    if (!entry || !matchesIdentity(entry, lookup)) return [];
+    return entry.items.map(cloneReplayItem);
+  }
+
+  evictByIdentity(identity: ReasoningReplayIdentity): number {
+    let evicted = 0;
+    for (const [responseId, entry] of this.entries) {
+      if (!matchesIdentity(entry, identity)) continue;
+      this.entries.delete(responseId);
+      evicted++;
+    }
+    return evicted;
+  }
+
+  evictByResponseId(responseId: string): boolean {
+    return this.entries.delete(responseId);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    this.cleanupExpired();
+    return this.entries.size;
+  }
+
+  private cleanupExpired(): void {
+    const now = this.nowMs();
+    for (const [responseId, entry] of this.entries) {
+      if (now - entry.createdAt > this.ttlMs) {
+        this.entries.delete(responseId);
+      }
+    }
+  }
+
+  private evictOverflow(): void {
+    while (this.entries.size > this.maxEntries) {
+      let oldestResponseId: string | null = null;
+      let oldestCreatedAt = Number.POSITIVE_INFINITY;
+      let oldestSequence = Number.POSITIVE_INFINITY;
+      for (const [responseId, entry] of this.entries) {
+        if (
+          entry.createdAt < oldestCreatedAt ||
+          (entry.createdAt === oldestCreatedAt && entry.sequence < oldestSequence)
+        ) {
+          oldestResponseId = responseId;
+          oldestCreatedAt = entry.createdAt;
+          oldestSequence = entry.sequence;
+        }
+      }
+      if (!oldestResponseId) return;
+      this.entries.delete(oldestResponseId);
+    }
+  }
+}
+
+function stringContainsInvalidEncryptedContent(value: string): boolean {
+  const lower = value.toLowerCase();
+  return lower.includes("invalid_encrypted_content") ||
+    (lower.includes("invalid") && lower.includes("encrypted") && lower.includes("content"));
+}
+
+export function containsInvalidEncryptedContentSignal(value: unknown): boolean {
+  if (value instanceof Error) {
+    return stringContainsInvalidEncryptedContent(value.message) ||
+      stringContainsInvalidEncryptedContent(value.name);
+  }
+
+  const visit = (node: unknown, depth: number): boolean => {
+    if (depth > 5) return false;
+    if (typeof node === "string") return stringContainsInvalidEncryptedContent(node);
+    if (Array.isArray(node)) return node.some((item) => visit(item, depth + 1));
+    if (!isRecord(node)) return false;
+    for (const [key, child] of Object.entries(node)) {
+      if (stringContainsInvalidEncryptedContent(key) || visit(child, depth + 1)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  return visit(value, 0);
+}
+
+let singleton: ReasoningReplayCache | null = null;
+
+export function getReasoningReplayCache(): ReasoningReplayCache {
+  if (!singleton) singleton = new ReasoningReplayCache();
+  return singleton;
+}
+
+export function resetReasoningReplayCacheForTests(): void {
+  singleton = new ReasoningReplayCache();
+}

--- a/src/routes/responses-compact.ts
+++ b/src/routes/responses-compact.ts
@@ -8,7 +8,8 @@ import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import { CodexApi, CodexApiError } from "../proxy/codex-api.js";
-import type { CodexCompactRequest, CodexInputItem } from "../proxy/codex-api.js";
+import type { CodexCompactRequest } from "../proxy/codex-api.js";
+import { sanitizeCodexInputItems } from "../proxy/reasoning-input-sanitizer.js";
 import type { UsageInfo } from "../translation/codex-event-extractor.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
 import { parseModelName, resolveModelId } from "../models/model-store.js";
@@ -60,7 +61,7 @@ export async function handleCompact(
 
   const compactRequest: CodexCompactRequest = {
     model: modelId,
-    input: Array.isArray(body.input) ? (body.input as CodexInputItem[]) : [],
+    input: Array.isArray(body.input) ? sanitizeCodexInputItems(body.input) : [],
     instructions: typeof body.instructions === "string" ? body.instructions : "",
   };
   if (Array.isArray(body.tools) && body.tools.length > 0) {

--- a/src/routes/responses-passthrough.ts
+++ b/src/routes/responses-passthrough.ts
@@ -22,6 +22,7 @@ import {
   containsInvalidEncryptedContentSignal,
   sanitizeReasoningReplayItems,
 } from "../proxy/reasoning-replay-cache.js";
+import type { ReasoningReplayItem } from "../proxy/reasoning-replay-cache.js";
 
 // ── Shared helpers ────────────────────────────────────────────────
 
@@ -155,6 +156,13 @@ export function extractImageGenUsage(response: Record<string, unknown>): { image
   return { image_input_tokens, image_output_tokens };
 }
 
+function appendReplayArtifacts(
+  target: ReasoningReplayItem[],
+  candidates: readonly unknown[],
+): void {
+  target.push(...sanitizeReasoningReplayItems(candidates));
+}
+
 // ── Stream passthrough ────────────────────────────────────────────
 
 export async function* streamPassthrough(
@@ -172,7 +180,7 @@ export async function* streamPassthrough(
   let sawTerminal = false;
   let responseId: string | null = null;
   const streamFunctionCallIds = new Set<string>();
-  const streamReplayCandidates: unknown[] = [];
+  const streamReplayItems: ReasoningReplayItem[] = [];
 
   const stream = api.parseStream(response);
   let upstreamDone = false;
@@ -271,7 +279,7 @@ export async function* streamPassthrough(
           if (typeof callId === "string" && callId) streamFunctionCallIds.add(callId);
         }
         if (isRecord(data) && isRecord(data.item)) {
-          streamReplayCandidates.push(data.item);
+          appendReplayArtifacts(streamReplayItems, [data.item]);
         }
       }
 
@@ -290,9 +298,9 @@ export async function* streamPassthrough(
           }
           if (raw.event === "response.completed") {
             if (Array.isArray(resp.output)) {
-              streamReplayCandidates.push(...resp.output);
+              appendReplayArtifacts(streamReplayItems, resp.output);
             }
-            const replayItems = sanitizeReasoningReplayItems(streamReplayCandidates);
+            const replayItems = sanitizeReasoningReplayItems(streamReplayItems);
             if (replayItems.length > 0) {
               onResponseMetadata?.({ reasoningReplayItems: replayItems });
             }
@@ -348,7 +356,7 @@ export async function collectPassthrough(
   let responseId: string | null = null;
   const outputItems: unknown[] = [];
   const collectFunctionCallIds = new Set<string>();
-  const collectReplayCandidates: unknown[] = [];
+  const collectReplayItems: ReasoningReplayItem[] = [];
   let textDeltas = "";
 
   try {
@@ -367,7 +375,7 @@ export async function collectPassthrough(
 
       if (raw.event === "response.output_item.done" && isRecord(data.item)) {
         outputItems.push(data.item);
-        collectReplayCandidates.push(data.item);
+        appendReplayArtifacts(collectReplayItems, [data.item]);
         if (data.item.type === "function_call" && typeof data.item.call_id === "string" && data.item.call_id) {
           collectFunctionCallIds.add(data.item.call_id as string);
         }
@@ -375,9 +383,9 @@ export async function collectPassthrough(
 
       if (raw.event === "response.completed" && resp) {
         if (Array.isArray(resp.output)) {
-          collectReplayCandidates.push(...resp.output);
+          appendReplayArtifacts(collectReplayItems, resp.output);
         }
-        const replayItems = sanitizeReasoningReplayItems(collectReplayCandidates);
+        const replayItems = sanitizeReasoningReplayItems(collectReplayItems);
         if (replayItems.length > 0) {
           onResponseMetadata?.({ reasoningReplayItems: replayItems });
         }

--- a/src/routes/responses-passthrough.ts
+++ b/src/routes/responses-passthrough.ts
@@ -12,8 +12,16 @@ import { EmptyResponseError } from "../translation/codex-event-extractor.js";
 import { reconvertTupleValues } from "../translation/tuple-schema.js";
 import { extractCodexError } from "../types/codex-events.js";
 import { recordStreamCloseEvent } from "../logs/stream-close-event.js";
-import type { FormatAdapter, StreamTranslatorContext } from "./shared/proxy-handler-types.js";
+import type {
+  FormatAdapter,
+  ResponseMetadata,
+  StreamTranslatorContext,
+} from "./shared/proxy-handler-types.js";
 import { isRecord } from "../translation/shared-utils.js";
+import {
+  containsInvalidEncryptedContentSignal,
+  sanitizeReasoningReplayItems,
+} from "../proxy/reasoning-replay-cache.js";
 
 // ── Shared helpers ────────────────────────────────────────────────
 
@@ -158,12 +166,13 @@ export async function* streamPassthrough(
   tupleSchema?: Record<string, unknown> | null,
   streamContext?: StreamTranslatorContext,
   onResponseCompleted?: (id?: string) => void,
-  onResponseMetadata?: (metadata: { functionCallIds?: string[] }) => void,
+  onResponseMetadata?: (metadata: ResponseMetadata) => void,
 ): AsyncGenerator<string> {
   let tupleTextBuffer = tupleSchema ? "" : null;
   let sawTerminal = false;
   let responseId: string | null = null;
   const streamFunctionCallIds = new Set<string>();
+  const streamReplayCandidates: unknown[] = [];
 
   const stream = api.parseStream(response);
   let upstreamDone = false;
@@ -203,6 +212,12 @@ export async function* streamPassthrough(
       const raw = next.value;
       responseId = extractResponseIdFromEventData(raw.data) ?? responseId;
       if (isTerminalResponsesEvent(raw.event)) sawTerminal = true;
+      if (
+        (raw.event === "error" || raw.event === "response.failed") &&
+        containsInvalidEncryptedContentSignal(raw.data)
+      ) {
+        onResponseMetadata?.({ invalidReasoningReplay: true });
+      }
 
       if (tupleTextBuffer !== null && raw.event === "response.output_text.delta") {
         const data = raw.data;
@@ -255,6 +270,9 @@ export async function* streamPassthrough(
           const callId = data.item.call_id;
           if (typeof callId === "string" && callId) streamFunctionCallIds.add(callId);
         }
+        if (isRecord(data) && isRecord(data.item)) {
+          streamReplayCandidates.push(data.item);
+        }
       }
 
       if (
@@ -271,6 +289,13 @@ export async function* streamPassthrough(
             onUsage({ ...extractResponseUsage(resp.usage), ...(imgUsage ?? {}) });
           }
           if (raw.event === "response.completed") {
+            if (Array.isArray(resp.output)) {
+              streamReplayCandidates.push(...resp.output);
+            }
+            const replayItems = sanitizeReasoningReplayItems(streamReplayCandidates);
+            if (replayItems.length > 0) {
+              onResponseMetadata?.({ reasoningReplayItems: replayItems });
+            }
             onResponseCompleted?.(typeof resp.id === "string" ? resp.id : undefined);
             if (streamFunctionCallIds.size > 0) {
               onResponseMetadata?.({ functionCallIds: [...streamFunctionCallIds] });
@@ -312,7 +337,7 @@ export async function collectPassthrough(
   response: Response,
   _model: string,
   tupleSchema?: Record<string, unknown> | null,
-  onResponseMetadata?: (metadata: { functionCallIds?: string[] }) => void,
+  onResponseMetadata?: (metadata: ResponseMetadata) => void,
 ): Promise<{
   response: unknown;
   usage: { input_tokens: number; output_tokens: number; cached_tokens?: number; image_input_tokens?: number; image_output_tokens?: number };
@@ -323,6 +348,7 @@ export async function collectPassthrough(
   let responseId: string | null = null;
   const outputItems: unknown[] = [];
   const collectFunctionCallIds = new Set<string>();
+  const collectReplayCandidates: unknown[] = [];
   let textDeltas = "";
 
   try {
@@ -341,12 +367,20 @@ export async function collectPassthrough(
 
       if (raw.event === "response.output_item.done" && isRecord(data.item)) {
         outputItems.push(data.item);
+        collectReplayCandidates.push(data.item);
         if (data.item.type === "function_call" && typeof data.item.call_id === "string" && data.item.call_id) {
           collectFunctionCallIds.add(data.item.call_id as string);
         }
       }
 
       if (raw.event === "response.completed" && resp) {
+        if (Array.isArray(resp.output)) {
+          collectReplayCandidates.push(...resp.output);
+        }
+        const replayItems = sanitizeReasoningReplayItems(collectReplayCandidates);
+        if (replayItems.length > 0) {
+          onResponseMetadata?.({ reasoningReplayItems: replayItems });
+        }
         if (collectFunctionCallIds.size > 0) {
           onResponseMetadata?.({ functionCallIds: [...collectFunctionCallIds] });
         }
@@ -374,6 +408,9 @@ export async function collectPassthrough(
       }
 
       if (raw.event === "error" || raw.event === "response.failed") {
+        if (containsInvalidEncryptedContentSignal(data)) {
+          onResponseMetadata?.({ invalidReasoningReplay: true });
+        }
         const err = extractCodexError(data);
         throw new Error(
           `Codex API error: ${err.code}: ${err.message}`,

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -10,7 +10,8 @@ import { Hono, type Context } from "hono";
 import type { AccountPool } from "../auth/account-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
-import type { CodexResponsesRequest, CodexInputItem } from "../proxy/codex-api.js";
+import type { CodexResponsesRequest } from "../proxy/codex-api.js";
+import { sanitizeCodexInputItems } from "../proxy/reasoning-input-sanitizer.js";
 import { enqueueLogEntry } from "../logs/entry.js";
 import { summarizeRequestForLog } from "../logs/request-summary.js";
 import { getRealClientIp } from "../utils/get-real-client-ip.js";
@@ -121,7 +122,7 @@ export function createResponsesRoutes(
     const codexRequest: CodexResponsesRequest = {
       model: modelId,
       instructions: typeof body.instructions === "string" ? body.instructions : "",
-      input: Array.isArray(body.input) ? (body.input as CodexInputItem[]) : [],
+      input: Array.isArray(body.input) ? sanitizeCodexInputItems(body.input) : [],
       stream: true,
       store: false,
     };

--- a/src/routes/shared/non-streaming-handler.ts
+++ b/src/routes/shared/non-streaming-handler.ts
@@ -19,6 +19,10 @@ import {
   releaseNonStreamingSuccessAccount,
   collectNonStreamingResponse,
 } from "./non-streaming-helpers.js";
+import {
+  containsInvalidEncryptedContentSignal,
+  getReasoningReplayCache,
+} from "../../proxy/reasoning-replay-cache.js";
 
 
 const MAX_EMPTY_RETRIES = 2;
@@ -72,6 +76,14 @@ export async function handleNonStreaming(options: HandleNonStreamingOptions): Pr
   let currentEntryId = initialEntryId;
   let currentApi = initialApi;
   let currentRawResponse = initialResponse;
+  const evictReasoningReplayIdentity = (): void => {
+    if (!conversationId || !variantHash) return;
+    getReasoningReplayCache().evictByIdentity({
+      entryId: currentEntryId,
+      conversationId,
+      variantHash,
+    });
+  };
 
   for (let attempt = 1; ; attempt++) {
     try {
@@ -81,8 +93,11 @@ export async function handleNonStreaming(options: HandleNonStreamingOptions): Pr
         rawResponse: currentRawResponse,
         req,
         usageHint: getUsageHint?.(),
+        onResponseMetadata: (metadata) => {
+          if (metadata.invalidReasoningReplay) evictReasoningReplayIdentity();
+        },
       });
-      const { result, responseFunctionCallIds } = collected;
+      const { result, responseFunctionCallIds, reasoningReplayItems } = collected;
       recordNonStreamingSuccessAffinity({
         affinityMap,
         responseId: result.responseId,
@@ -94,6 +109,15 @@ export async function handleNonStreaming(options: HandleNonStreamingOptions): Pr
         responseFunctionCallIds,
         variantHash,
       });
+      if (result.responseId && conversationId && variantHash && reasoningReplayItems.length > 0) {
+        getReasoningReplayCache().record({
+          responseId: result.responseId,
+          entryId: currentEntryId,
+          conversationId,
+          variantHash,
+          items: reasoningReplayItems,
+        });
+      }
       if (result.usage) {
         logNonStreamingUsage({ tag: fmt.tag, entryId: currentEntryId, requestId, usage: result.usage });
       }
@@ -106,6 +130,9 @@ export async function handleNonStreaming(options: HandleNonStreamingOptions): Pr
       });
       return c.json(result.response);
     } catch (collectErr) {
+      if (conversationId && variantHash && containsInvalidEncryptedContentSignal(collectErr)) {
+        evictReasoningReplayIdentity();
+      }
       // Upstream FIN'd mid-reasoning (typically gpt-5.5 xhigh > 120 s cap).
       // Cross-account retry would re-hit the same cap and burn the pool, so
       // we fail fast with 504. The proxy can't recover this — the client

--- a/src/routes/shared/non-streaming-helpers.ts
+++ b/src/routes/shared/non-streaming-helpers.ts
@@ -7,7 +7,13 @@ import { CodexApiError } from "../../proxy/codex-api.js";
 import type { CookieJar } from "../../proxy/cookie-jar.js";
 import type { ProxyPool } from "../../proxy/proxy-pool.js";
 import type { UpstreamPrematureCloseError, UsageInfo, EmptyResponseError } from "../../translation/codex-event-extractor.js";
-import type { FormatAdapter, FormatCollectTranslatorResult, ProxyRequest, UsageHint } from "./proxy-handler-types.js";
+import type {
+  FormatAdapter,
+  FormatCollectTranslatorResult,
+  ProxyRequest,
+  ResponseMetadata,
+  UsageHint,
+} from "./proxy-handler-types.js";
 import { releaseAccount, acquireAccount } from "./account-acquisition.js";
 import { toErrorStatus } from "./proxy-error-handler.js";
 import { annotateImageGenOutcome, buildCodexApi, stripCodexErrorPrefix } from "./proxy-handler-utils.js";
@@ -16,6 +22,7 @@ import { withRetry } from "../../utils/retry.js";
 import { recordProxyEgressLog } from "./proxy-egress-log.js";
 import { recordStreamCloseEvent } from "../../logs/stream-close-event.js";
 import { logProxyUsage } from "./proxy-usage-log.js";
+import type { ReasoningReplayItem } from "../../proxy/reasoning-replay-cache.js";
 
 // ── 1. non-streaming-affinity ─────────────────────────────────────
 export interface RecordNonStreamingSuccessAffinityOptions {
@@ -127,11 +134,14 @@ export interface CollectNonStreamingResponseOptions {
   rawResponse: Response;
   req: ProxyRequest;
   usageHint?: UsageHint;
+  onResponseMetadata?: (metadata: ResponseMetadata) => void;
 }
 
 export interface CollectNonStreamingResponseResult {
   result: FormatCollectTranslatorResult;
   responseFunctionCallIds: Set<string>;
+  reasoningReplayItems: ReasoningReplayItem[];
+  invalidReasoningReplay: boolean;
 }
 
 export async function collectNonStreamingResponse(
@@ -143,6 +153,7 @@ export async function collectNonStreamingResponse(
     rawResponse,
     req,
     usageHint,
+    onResponseMetadata,
   } = options;
   const metadataCollector = createResponseMetadataCollector();
   const result = await fmt.collectTranslator({
@@ -151,12 +162,17 @@ export async function collectNonStreamingResponse(
     model: req.model,
     tupleSchema: req.tupleSchema,
     usageHint,
-    onResponseMetadata: metadataCollector.onResponseMetadata,
+    onResponseMetadata: (metadata) => {
+      metadataCollector.onResponseMetadata(metadata);
+      onResponseMetadata?.(metadata);
+    },
   });
 
   return {
     result,
     responseFunctionCallIds: metadataCollector.responseFunctionCallIds,
+    reasoningReplayItems: metadataCollector.reasoningReplayItems,
+    invalidReasoningReplay: metadataCollector.invalidReasoningReplay,
   };
 }
 

--- a/src/routes/shared/proxy-handler-types.ts
+++ b/src/routes/shared/proxy-handler-types.ts
@@ -7,6 +7,7 @@ import type { ProxyPool } from "../../proxy/proxy-pool.js";
 import type { UpstreamAdapter } from "../../proxy/upstream-adapter.js";
 import type { UsageInfo } from "../../translation/codex-event-extractor.js";
 import type { StreamCloseContextBase } from "../../logs/stream-close-event.js";
+import type { ReasoningReplayItem } from "../../proxy/reasoning-replay-cache.js";
 
 export interface StreamTranslatorContext extends StreamCloseContextBase {
   /** Request abort signal so format-specific translators can distinguish a
@@ -37,6 +38,8 @@ export interface UsageHint {
 
 export interface ResponseMetadata {
   functionCallIds?: string[];
+  reasoningReplayItems?: ReasoningReplayItem[];
+  invalidReasoningReplay?: boolean;
 }
 
 export interface FormatStreamTranslatorOptions {

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -58,6 +58,10 @@ import { buildProxySessionContext } from "./proxy-session-context.js";
 import { staggerIfNeeded } from "./proxy-stagger.js";
 import { sendProxyUpstreamAttempt } from "./proxy-upstream-attempt.js";
 import { buildWsPoolContext } from "./proxy-ws-context.js";
+import {
+  containsInvalidEncryptedContentSignal,
+  getReasoningReplayCache,
+} from "../../proxy/reasoning-replay-cache.js";
 
 export async function handleProxyRequest(options: HandleProxyRequestOptions): Promise<Response> {
   const { c, accountPool, cookieJar, req, fmt, proxyPool } = options;
@@ -157,6 +161,15 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
   const triedEntryIds: string[] = [entryId];
   let modelRetried = false;
   let stripAndRetryDone = false;
+  const reasoningReplayCache = getReasoningReplayCache();
+  const reasoningReplayItems = sessionContext.implicitPrevRespId
+    ? reasoningReplayCache.lookup({
+        responseId: sessionContext.implicitPrevRespId,
+        entryId,
+        conversationId: sessionContext.chainConversationId,
+        variantHash: sessionContext.variantHash,
+      })
+    : [];
 
   const implicitResume = createImplicitResumeLifecycle({
     request: req,
@@ -165,6 +178,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
     tag: fmt.tag,
     implicitPrevRespId: sessionContext.implicitPrevRespId,
     continuationInputStart: sessionContext.continuationInputStart,
+    reasoningReplayItems,
     resumeEvaluationInput: sessionContext.resumeEvaluationInput,
     acquiredEntryId: entryId,
   });
@@ -299,6 +313,13 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
         variantHash: sessionContext.variantHash,
       });
     } catch (err) {
+      if (containsInvalidEncryptedContentSignal(err)) {
+        reasoningReplayCache.evictByIdentity({
+          entryId,
+          conversationId: sessionContext.chainConversationId,
+          variantHash: sessionContext.variantHash,
+        });
+      }
       const retryAction = classifyRetryAction(
         err,
         { stripAndRetryDone, modelRetried, implicitResumeActive: implicitResume.isActive(), previousResponseId: req.codexRequest.previous_response_id },

--- a/src/routes/shared/proxy-implicit-resume-lifecycle.ts
+++ b/src/routes/shared/proxy-implicit-resume-lifecycle.ts
@@ -23,6 +23,7 @@ export interface CreateImplicitResumeLifecycleOptions {
   tag: string;
   implicitPrevRespId: string | null;
   continuationInputStart: number;
+  reasoningReplayItems?: ProxyRequest["codexRequest"]["input"];
   resumeEvaluationInput: ImplicitResumeEvaluationInput;
   acquiredEntryId: string;
   warn?: ImplicitResumeWarn;
@@ -50,6 +51,7 @@ export function createImplicitResumeLifecycle(
     tag,
     implicitPrevRespId,
     continuationInputStart,
+    reasoningReplayItems,
     resumeEvaluationInput,
     acquiredEntryId,
     warn = console.warn,
@@ -78,6 +80,7 @@ export function createImplicitResumeLifecycle(
         implicitPrevRespId,
         continuationInputStart,
         affinityMap,
+        reasoningReplayItems,
       });
       active = true;
     },

--- a/src/routes/shared/proxy-implicit-resume-request.ts
+++ b/src/routes/shared/proxy-implicit-resume-request.ts
@@ -18,6 +18,7 @@ export interface ApplyImplicitResumeRequestOptions {
   implicitPrevRespId: string;
   continuationInputStart: number;
   affinityMap: ImplicitResumeAffinityLookup;
+  reasoningReplayItems?: ProxyRequest["codexRequest"]["input"];
 }
 
 export interface RestoreImplicitResumeRequestStateOptions {
@@ -40,11 +41,20 @@ export function captureImplicitResumeRequestState(
 export function applyImplicitResumeRequest(
   options: ApplyImplicitResumeRequestOptions,
 ): UsageHint {
-  const { request, implicitPrevRespId, continuationInputStart, affinityMap } = options;
+  const {
+    request,
+    implicitPrevRespId,
+    continuationInputStart,
+    affinityMap,
+    reasoningReplayItems = [],
+  } = options;
 
   request.codexRequest.previous_response_id = implicitPrevRespId;
   request.codexRequest.useWebSocket = true;
-  request.codexRequest.input = request.codexRequest.input.slice(continuationInputStart);
+  request.codexRequest.input = [
+    ...reasoningReplayItems,
+    ...request.codexRequest.input.slice(continuationInputStart),
+  ];
   const implicitTurnState = affinityMap.lookupTurnState(implicitPrevRespId);
   if (implicitTurnState) request.codexRequest.turnState = implicitTurnState;
 

--- a/src/routes/shared/proxy-ws-context.ts
+++ b/src/routes/shared/proxy-ws-context.ts
@@ -33,7 +33,10 @@ export function buildWsPoolContext(
   const entryId = options.entryId;
   return {
     pool: (deps.getWsPool ?? defaultDeps.getWsPool)(),
-    poolKey: `${entryId}:${options.conversationId}:${options.variantHash}`,
+    // Physical WS affinity must follow the upstream response chain. Explicit
+    // previous_response_id continuations can legitimately change instructions
+    // (and therefore variantHash), but upstream still requires the same WS.
+    poolKey: `${entryId}:${options.conversationId}`,
     entryId,
     onDecision: (decision) => {
       const ridShort = options.requestId.slice(0, 8);

--- a/src/routes/shared/response-metadata-collector.ts
+++ b/src/routes/shared/response-metadata-collector.ts
@@ -1,18 +1,29 @@
 import type { ResponseMetadata } from "./proxy-handler-types.js";
+import type { ReasoningReplayItem } from "../../proxy/reasoning-replay-cache.js";
 
 export interface ResponseMetadataCollector {
   responseFunctionCallIds: Set<string>;
+  reasoningReplayItems: ReasoningReplayItem[];
+  invalidReasoningReplay: boolean;
   onResponseMetadata: (metadata: ResponseMetadata) => void;
 }
 
 export function createResponseMetadataCollector(): ResponseMetadataCollector {
   const responseFunctionCallIds = new Set<string>();
-  return {
+  const reasoningReplayItems: ReasoningReplayItem[] = [];
+  const collector: ResponseMetadataCollector = {
     responseFunctionCallIds,
+    reasoningReplayItems,
+    invalidReasoningReplay: false,
     onResponseMetadata: (metadata) => {
       for (const callId of metadata.functionCallIds ?? []) {
         responseFunctionCallIds.add(callId);
       }
+      reasoningReplayItems.push(...(metadata.reasoningReplayItems ?? []));
+      if (metadata.invalidReasoningReplay) {
+        collector.invalidReasoningReplay = true;
+      }
     },
   };
+  return collector;
 }

--- a/src/routes/shared/streaming-handler.ts
+++ b/src/routes/shared/streaming-handler.ts
@@ -11,6 +11,7 @@ import { annotateImageGenOutcome } from "./proxy-handler-utils.js";
 import { streamResponse } from "./response-processor.js";
 import { createResponseMetadataCollector } from "./response-metadata-collector.js";
 import { logProxyUsage } from "./proxy-usage-log.js";
+import { getReasoningReplayCache } from "../../proxy/reasoning-replay-cache.js";
 
 export interface HandleStreamingOptions {
   c: Context;
@@ -62,6 +63,7 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
   let capturedResponseId: string | null = null;
   let responseCompleted = false;
   const metadataCollector = createResponseMetadataCollector();
+  const reasoningReplayCache = getReasoningReplayCache();
 
   return stream(c, async (s) => {
     s.onAbort(() => {
@@ -90,6 +92,22 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
         Array.from(metadataCollector.responseFunctionCallIds),
         variantHash,
       );
+      if (!metadataCollector.invalidReasoningReplay && metadataCollector.reasoningReplayItems.length > 0) {
+        reasoningReplayCache.record({
+          responseId: capturedResponseId,
+          entryId: capturedEntryId,
+          conversationId,
+          variantHash,
+          items: metadataCollector.reasoningReplayItems,
+        });
+      }
+    };
+    const evictReasoningReplayIdentity = (): void => {
+      reasoningReplayCache.evictByIdentity({
+        entryId: capturedEntryId,
+        conversationId,
+        variantHash,
+      });
     };
     try {
       await streamResponse({
@@ -115,6 +133,9 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
         usageHint,
         onResponseMetadata: (metadata) => {
           metadataCollector.onResponseMetadata(metadata);
+          if (metadataCollector.invalidReasoningReplay) {
+            evictReasoningReplayIdentity();
+          }
           recordStreamAffinity();
         },
         diagnostics: {

--- a/tests/unit/proxy/reasoning-input-sanitizer.test.ts
+++ b/tests/unit/proxy/reasoning-input-sanitizer.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCodexInputItems } from "@src/proxy/reasoning-input-sanitizer.js";
+
+describe("sanitizeCodexInputItems", () => {
+  it("preserves valid reasoning items and removes unsupported signature fields", () => {
+    const input = [{
+      type: "reasoning",
+      id: "rs_1",
+      status: "completed",
+      encrypted_content: "enc_valid",
+      summary: [{ type: "summary_text", text: "brief" }],
+      content: [{ type: "reasoning_text", text: "hidden" }],
+      signature: "anthropic-style-signature",
+      extra: "drop-me",
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      id: "rs_1",
+      status: "completed",
+      encrypted_content: "enc_valid",
+      summary: [{ type: "summary_text", text: "brief" }],
+      content: [{ type: "reasoning_text", text: "hidden" }],
+    }]);
+  });
+
+  it("drops invalid encrypted_content values instead of forwarding them", () => {
+    const input = [
+      { type: "reasoning", id: "rs_empty", encrypted_content: "" },
+      { type: "reasoning", id: "rs_number", encrypted_content: 123 },
+      { type: "reasoning", id: "rs_spaces", encrypted_content: "   " },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([
+      { type: "reasoning", id: "rs_empty" },
+      { type: "reasoning", id: "rs_number" },
+      { type: "reasoning", id: "rs_spaces" },
+    ]);
+  });
+
+  it("filters malformed reasoning summary and content parts", () => {
+    const input = [{
+      type: "reasoning",
+      summary: [
+        { type: "summary_text", text: "keep" },
+        { type: "summary_text", text: 42 },
+        { type: "text", text: "drop" },
+      ],
+      content: [
+        { type: "reasoning_text", text: "keep reasoning" },
+        { type: "reasoning_text" },
+        { type: "output_text", text: "drop" },
+      ],
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      summary: [{ type: "summary_text", text: "keep" }],
+      content: [{ type: "reasoning_text", text: "keep reasoning" }],
+    }]);
+  });
+
+  it("drops compaction items with invalid encrypted_content", () => {
+    const input = [
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+      { type: "compaction", encrypted_content: "" },
+      { type: "compaction", encrypted_content: 7 },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+    ]);
+  });
+
+  it("keeps non-reasoning input items unchanged in mixed arrays", () => {
+    const user = { role: "user", content: "Hello" };
+    const callOutput = { type: "function_call_output", call_id: "call_1", output: "ok" };
+
+    expect(sanitizeCodexInputItems([
+      user,
+      { type: "reasoning", encrypted_content: "" },
+      callOutput,
+    ])).toEqual([
+      user,
+      { type: "reasoning" },
+      callOutput,
+    ]);
+  });
+});

--- a/tests/unit/proxy/reasoning-input-sanitizer.test.ts
+++ b/tests/unit/proxy/reasoning-input-sanitizer.test.ts
@@ -24,23 +24,40 @@ describe("sanitizeCodexInputItems", () => {
     }]);
   });
 
+  it("preserves reasoning items with an empty summary array", () => {
+    const input = [{
+      type: "reasoning",
+      id: "rs_empty_summary",
+      summary: [],
+      encrypted_content: "enc_valid",
+    }];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([{
+      type: "reasoning",
+      id: "rs_empty_summary",
+      summary: [],
+      encrypted_content: "enc_valid",
+    }]);
+  });
+
   it("drops invalid encrypted_content values instead of forwarding them", () => {
     const input = [
-      { type: "reasoning", id: "rs_empty", encrypted_content: "" },
-      { type: "reasoning", id: "rs_number", encrypted_content: 123 },
-      { type: "reasoning", id: "rs_spaces", encrypted_content: "   " },
+      { type: "reasoning", id: "rs_empty", summary: [], encrypted_content: "" },
+      { type: "reasoning", id: "rs_number", summary: [], encrypted_content: 123 },
+      { type: "reasoning", id: "rs_spaces", summary: [], encrypted_content: "   " },
     ];
 
     expect(sanitizeCodexInputItems(input)).toEqual([
-      { type: "reasoning", id: "rs_empty" },
-      { type: "reasoning", id: "rs_number" },
-      { type: "reasoning", id: "rs_spaces" },
+      { type: "reasoning", id: "rs_empty", summary: [] },
+      { type: "reasoning", id: "rs_number", summary: [] },
+      { type: "reasoning", id: "rs_spaces", summary: [] },
     ]);
   });
 
   it("filters malformed reasoning summary and content parts", () => {
     const input = [{
       type: "reasoning",
+      id: "rs_filtered",
       summary: [
         { type: "summary_text", text: "keep" },
         { type: "summary_text", text: 42 },
@@ -55,9 +72,20 @@ describe("sanitizeCodexInputItems", () => {
 
     expect(sanitizeCodexInputItems(input)).toEqual([{
       type: "reasoning",
+      id: "rs_filtered",
       summary: [{ type: "summary_text", text: "keep" }],
       content: [{ type: "reasoning_text", text: "keep reasoning" }],
     }]);
+  });
+
+  it("drops malformed reasoning items that are missing required identity fields", () => {
+    const input = [
+      { type: "reasoning", summary: [], encrypted_content: "enc_missing_id" },
+      { type: "reasoning", id: "rs_missing_summary", encrypted_content: "enc_missing_summary" },
+      { type: "reasoning", id: "", summary: [], encrypted_content: "enc_empty_id" },
+    ];
+
+    expect(sanitizeCodexInputItems(input)).toEqual([]);
   });
 
   it("drops compaction items with invalid encrypted_content", () => {
@@ -68,7 +96,7 @@ describe("sanitizeCodexInputItems", () => {
     ];
 
     expect(sanitizeCodexInputItems(input)).toEqual([
-      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact", created_by: "codex" },
+      { type: "compaction", id: "cmp_1", encrypted_content: "enc_compact" },
     ]);
   });
 
@@ -82,7 +110,6 @@ describe("sanitizeCodexInputItems", () => {
       callOutput,
     ])).toEqual([
       user,
-      { type: "reasoning" },
       callOutput,
     ]);
   });

--- a/tests/unit/proxy/reasoning-replay-cache.test.ts
+++ b/tests/unit/proxy/reasoning-replay-cache.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  ReasoningReplayCache,
+  containsInvalidEncryptedContentSignal,
+} from "@src/proxy/reasoning-replay-cache.js";
+
+describe("ReasoningReplayCache", () => {
+  it("captures only protocol-valid replay artifacts and isolates by account", () => {
+    let now = 1_000;
+    const cache = new ReasoningReplayCache({
+      ttlMs: 10_000,
+      maxEntries: 10,
+      nowMs: () => now,
+    });
+
+    cache.record({
+      responseId: "resp_1",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [
+        {
+          type: "reasoning",
+          id: "rs_1",
+          status: "completed",
+          encrypted_content: "encrypted",
+          signature: "unsupported",
+          content: [
+            { type: "reasoning_text", text: "kept" },
+            { type: "reasoning_text", text: 123 },
+          ],
+        },
+        { type: "reasoning", encrypted_content: "" },
+        {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "read_file",
+          arguments: "{}",
+          extra: "unsupported",
+        },
+        { type: "function_call", call_id: "call_bad", name: "missing arguments" },
+      ],
+    });
+
+    expect(cache.lookup({
+      responseId: "resp_1",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        status: "completed",
+        encrypted_content: "encrypted",
+        content: [{ type: "reasoning_text", text: "kept" }],
+      },
+      {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_1",
+        name: "read_file",
+        arguments: "{}",
+      },
+    ]);
+    expect(cache.lookup({
+      responseId: "resp_1",
+      entryId: "entry_b",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+
+    now += 10_001;
+    expect(cache.lookup({
+      responseId: "resp_1",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+  });
+
+  it("evicts oldest entries by size and affected entries by identity", () => {
+    const cache = new ReasoningReplayCache({
+      ttlMs: 10_000,
+      maxEntries: 1,
+      nowMs: () => 1_000,
+    });
+
+    cache.record({
+      responseId: "resp_old",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{ type: "reasoning", encrypted_content: "old" }],
+    });
+    cache.record({
+      responseId: "resp_new",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{ type: "reasoning", encrypted_content: "new" }],
+    });
+
+    expect(cache.lookup({
+      responseId: "resp_old",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+    expect(cache.lookup({
+      responseId: "resp_new",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toHaveLength(1);
+
+    expect(cache.evictByIdentity({
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toBe(1);
+    expect(cache.lookup({
+      responseId: "resp_new",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+  });
+});
+
+describe("containsInvalidEncryptedContentSignal", () => {
+  it("detects structured invalid encrypted reasoning content errors", () => {
+    expect(containsInvalidEncryptedContentSignal({
+      error: {
+        code: "invalid_encrypted_content",
+        message: "The reasoning encrypted_content is no longer valid.",
+      },
+    })).toBe(true);
+    expect(containsInvalidEncryptedContentSignal(
+      new Error("Codex API error: invalid encrypted content"),
+    )).toBe(true);
+    expect(containsInvalidEncryptedContentSignal({
+      error: { code: "rate_limit_exceeded" },
+    })).toBe(false);
+  });
+});

--- a/tests/unit/proxy/reasoning-replay-cache.test.ts
+++ b/tests/unit/proxy/reasoning-replay-cache.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, it } from "vitest";
 import {
   ReasoningReplayCache,
+  REASONING_REPLAY_CACHE_TTL_MS,
   containsInvalidEncryptedContentSignal,
 } from "@src/proxy/reasoning-replay-cache.js";
+import { IMPLICIT_RESUME_MAX_AGE_MS } from "@src/routes/shared/proxy-session-helpers.js";
 
 describe("ReasoningReplayCache", () => {
+  it("keeps the default TTL aligned with the implicit resume window", () => {
+    let now = 1_000;
+    const cache = new ReasoningReplayCache({ nowMs: () => now });
+
+    expect(REASONING_REPLAY_CACHE_TTL_MS).toBe(IMPLICIT_RESUME_MAX_AGE_MS);
+    expect(cache.record({
+      responseId: "resp_implicit",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{ type: "reasoning", id: "rs_implicit", summary: [], encrypted_content: "encrypted" }],
+    })).toBe(1);
+
+    now += IMPLICIT_RESUME_MAX_AGE_MS + 1;
+    expect(cache.lookup({
+      responseId: "resp_implicit",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+  });
+
   it("captures only protocol-valid replay artifacts and isolates by account", () => {
     let now = 1_000;
     const cache = new ReasoningReplayCache({
@@ -23,6 +47,7 @@ describe("ReasoningReplayCache", () => {
           type: "reasoning",
           id: "rs_1",
           status: "completed",
+          summary: [],
           encrypted_content: "encrypted",
           signature: "unsupported",
           content: [
@@ -31,6 +56,8 @@ describe("ReasoningReplayCache", () => {
           ],
         },
         { type: "reasoning", encrypted_content: "" },
+        { type: "reasoning", id: "rs_missing_summary", encrypted_content: "missing_summary" },
+        { type: "reasoning", summary: [], encrypted_content: "missing_id" },
         {
           type: "function_call",
           id: "fc_1",
@@ -53,6 +80,7 @@ describe("ReasoningReplayCache", () => {
         type: "reasoning",
         id: "rs_1",
         status: "completed",
+        summary: [],
         encrypted_content: "encrypted",
         content: [{ type: "reasoning_text", text: "kept" }],
       },
@@ -92,14 +120,14 @@ describe("ReasoningReplayCache", () => {
       entryId: "entry_a",
       conversationId: "conversation",
       variantHash: "variant",
-      items: [{ type: "reasoning", encrypted_content: "old" }],
+      items: [{ type: "reasoning", id: "rs_old", summary: [], encrypted_content: "old" }],
     });
     cache.record({
       responseId: "resp_new",
       entryId: "entry_a",
       conversationId: "conversation",
       variantHash: "variant",
-      items: [{ type: "reasoning", encrypted_content: "new" }],
+      items: [{ type: "reasoning", id: "rs_new", summary: [], encrypted_content: "new" }],
     });
 
     expect(cache.lookup({
@@ -126,6 +154,60 @@ describe("ReasoningReplayCache", () => {
       conversationId: "conversation",
       variantHash: "variant",
     })).toEqual([]);
+  });
+
+  it("drops oversized entries and evicts oldest entries by total byte budget", () => {
+    const tooLarge = new ReasoningReplayCache({
+      maxEntryBytes: 200,
+      nowMs: () => 1_000,
+    });
+
+    expect(tooLarge.record({
+      responseId: "resp_huge",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{
+        type: "reasoning",
+        id: "rs_huge",
+        summary: [],
+        encrypted_content: "x".repeat(1_000),
+      }],
+    })).toBe(0);
+    expect(tooLarge.size).toBe(0);
+
+    const budgeted = new ReasoningReplayCache({
+      maxTotalBytes: 700,
+      nowMs: () => 1_000,
+    });
+
+    budgeted.record({
+      responseId: "resp_old",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{ type: "reasoning", id: "rs_old", summary: [], encrypted_content: "o".repeat(300) }],
+    });
+    budgeted.record({
+      responseId: "resp_new",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+      items: [{ type: "reasoning", id: "rs_new", summary: [], encrypted_content: "n".repeat(300) }],
+    });
+
+    expect(budgeted.lookup({
+      responseId: "resp_old",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toEqual([]);
+    expect(budgeted.lookup({
+      responseId: "resp_new",
+      entryId: "entry_a",
+      conversationId: "conversation",
+      variantHash: "variant",
+    })).toHaveLength(1);
   });
 });
 

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -251,6 +251,38 @@ describe("POST /v1/responses/compact", () => {
     expect(format.strict).toBe(true);
   });
 
+  it("sanitizes reasoning input items before compact forwarding", async () => {
+    await app.request("/v1/responses/compact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "codex",
+        input: [
+          {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "",
+            signature: "unsupported",
+            content: [{ type: "reasoning_text", text: "kept" }],
+          },
+          { type: "compaction", encrypted_content: 123 },
+          { role: "user", content: "Hello" },
+        ],
+        instructions: "",
+      }),
+    });
+
+    const req = capturedCompactRequest as Record<string, unknown>;
+    expect(req.input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        content: [{ type: "reasoning_text", text: "kept" }],
+      },
+      { role: "user", content: "Hello" },
+    ]);
+  });
+
   it("defaults instructions to empty string when omitted", async () => {
     await app.request("/v1/responses/compact", {
       method: "POST",

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -261,6 +261,7 @@ describe("POST /v1/responses/compact", () => {
           {
             type: "reasoning",
             id: "rs_1",
+            summary: [],
             encrypted_content: "",
             signature: "unsupported",
             content: [{ type: "reasoning_text", text: "kept" }],
@@ -277,6 +278,7 @@ describe("POST /v1/responses/compact", () => {
       {
         type: "reasoning",
         id: "rs_1",
+        summary: [],
         content: [{ type: "reasoning_text", text: "kept" }],
       },
       { role: "user", content: "Hello" },

--- a/tests/unit/routes/responses-optional-instructions.test.ts
+++ b/tests/unit/routes/responses-optional-instructions.test.ts
@@ -268,6 +268,38 @@ describe("/v1/responses — optional instructions", () => {
     expect(req.version).toBe("26.318.11754");
   });
 
+  it("sanitizes reasoning input items before proxy forwarding", async () => {
+    await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "codex",
+        input: [
+          {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "",
+            signature: "unsupported",
+            summary: [{ type: "summary_text", text: "kept" }],
+          },
+          { type: "compaction", encrypted_content: 123 },
+          { role: "user", content: "Hello" },
+        ],
+        stream: true,
+      }),
+    });
+
+    const req = capturedCodexRequest as Record<string, unknown>;
+    expect(req.input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        summary: [{ type: "summary_text", text: "kept" }],
+      },
+      { role: "user", content: "Hello" },
+    ]);
+  });
+
   it("still rejects non-object body", async () => {
     const res = await app.request("/v1/responses", {
       method: "POST",

--- a/tests/unit/routes/responses-passthrough-metadata.test.ts
+++ b/tests/unit/routes/responses-passthrough-metadata.test.ts
@@ -171,7 +171,7 @@ describe("Responses passthrough metadata", () => {
     }
 
     expect(chunks.join("")).toContain("response.output_item.done");
-    expect(metadata).toEqual([{ functionCallIds: ["call_issue_571"] }]);
+    expect(metadata).toContainEqual({ functionCallIds: ["call_issue_571"] });
   });
 
   it("collects function_call call_id metadata through the Responses format adapter", async () => {
@@ -186,6 +186,91 @@ describe("Responses passthrough metadata", () => {
     });
 
     expect(result.responseId).toBe("resp_issue_571");
-    expect(metadata).toEqual([{ functionCallIds: ["call_issue_571"] }]);
+    expect(metadata).toContainEqual({ functionCallIds: ["call_issue_571"] });
+  });
+
+  it("streams sanitized reasoning replay artifacts through metadata", async () => {
+    const format = await captureResponsesFormat();
+    const metadata: ResponseMetadata[] = [];
+
+    const events: CodexSSEEvent[] = [
+      {
+        event: "response.completed",
+        data: {
+          type: "response.completed",
+          response: {
+            id: "resp_reasoning",
+            output: [
+              {
+                type: "reasoning",
+                id: "rs_1",
+                encrypted_content: "encrypted",
+                signature: "unsupported",
+                content: [{ type: "reasoning_text", text: "kept" }],
+              },
+              functionCallItem,
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          },
+        },
+      },
+    ];
+
+    const chunks: string[] = [];
+    for await (const chunk of format.streamTranslator({
+      api: createMockAdapter(events),
+      response: new Response(),
+      model: "test-upstream-model",
+      onUsage: () => {},
+      onResponseId: () => {},
+      onResponseMetadata: (value) => metadata.push(value),
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toContain("response.completed");
+    expect(metadata.flatMap((item) => item.reasoningReplayItems ?? [])).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_1",
+        encrypted_content: "encrypted",
+        content: [{ type: "reasoning_text", text: "kept" }],
+      },
+      functionCallItem,
+    ]);
+  });
+
+  it("marks invalid encrypted reasoning content errors for cache eviction", async () => {
+    const format = await captureResponsesFormat();
+    const metadata: ResponseMetadata[] = [];
+
+    const chunks: string[] = [];
+    for await (const chunk of format.streamTranslator({
+      api: createMockAdapter([
+        {
+          event: "response.failed",
+          data: {
+            type: "response.failed",
+            response: {
+              id: "resp_failed",
+              error: {
+                code: "invalid_encrypted_content",
+                message: "Invalid encrypted content.",
+              },
+            },
+          },
+        },
+      ]),
+      response: new Response(),
+      model: "test-upstream-model",
+      onUsage: () => {},
+      onResponseId: () => {},
+      onResponseMetadata: (value) => metadata.push(value),
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).toContain("response.failed");
+    expect(metadata).toContainEqual({ invalidReasoningReplay: true });
   });
 });

--- a/tests/unit/routes/responses-passthrough-metadata.test.ts
+++ b/tests/unit/routes/responses-passthrough-metadata.test.ts
@@ -204,6 +204,7 @@ describe("Responses passthrough metadata", () => {
               {
                 type: "reasoning",
                 id: "rs_1",
+                summary: [],
                 encrypted_content: "encrypted",
                 signature: "unsupported",
                 content: [{ type: "reasoning_text", text: "kept" }],
@@ -233,6 +234,7 @@ describe("Responses passthrough metadata", () => {
       {
         type: "reasoning",
         id: "rs_1",
+        summary: [],
         encrypted_content: "encrypted",
         content: [{ type: "reasoning_text", text: "kept" }],
       },

--- a/tests/unit/routes/shared/non-streaming-collect-response.test.ts
+++ b/tests/unit/routes/shared/non-streaming-collect-response.test.ts
@@ -74,4 +74,28 @@ describe("collectNonStreamingResponse", () => {
       req: makeRequest(),
     })).rejects.toBe(err);
   });
+
+  it("forwards response metadata to the caller as it is collected", async () => {
+    const onResponseMetadata = vi.fn();
+    const fmt = createMockFormatAdapter({
+      collectTranslator: vi.fn(async (options: FormatCollectTranslatorOptions) => {
+        options.onResponseMetadata?.({ invalidReasoningReplay: true });
+        return {
+          response: { id: "resp_1" },
+          usage: { input_tokens: 1, output_tokens: 2 },
+          responseId: "resp_1",
+        };
+      }),
+    });
+
+    await collectNonStreamingResponse({
+      fmt,
+      api: {} as unknown as CodexApi,
+      rawResponse: new Response("ok"),
+      req: makeRequest(),
+      onResponseMetadata,
+    });
+
+    expect(onResponseMetadata).toHaveBeenCalledWith({ invalidReasoningReplay: true });
+  });
 });

--- a/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
+++ b/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
@@ -77,6 +77,34 @@ describe("implicit resume request state helpers", () => {
     expect(affinityMap.lookupInputTokens).toHaveBeenCalledWith("resp_implicit");
   });
 
+  it("prepends account-scoped reasoning replay items before the continuation slice", () => {
+    const request = makeProxyRequest();
+
+    const usageHint = applyImplicitResumeRequest({
+      request,
+      implicitPrevRespId: "resp_implicit",
+      continuationInputStart: 2,
+      affinityMap: makeAffinityLookup({
+        turnState: "turn-implicit",
+        inputTokens: 123,
+      }),
+      reasoningReplayItems: [
+        { type: "reasoning", encrypted_content: "encrypted" },
+        { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+      ],
+    });
+
+    expect(request.codexRequest.previous_response_id).toBe("resp_implicit");
+    expect(request.codexRequest.useWebSocket).toBe(true);
+    expect(request.codexRequest.turnState).toBe("turn-implicit");
+    expect(request.codexRequest.input).toEqual([
+      { type: "reasoning", encrypted_content: "encrypted" },
+      { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+      { role: "user", content: "continue" },
+    ]);
+    expect(usageHint).toEqual({ reusedInputTokensUpperBound: 123 });
+  });
+
   it("does not overwrite an existing turn state when the affinity map has none", () => {
     const request = makeProxyRequest();
 
@@ -99,6 +127,7 @@ describe("implicit resume request state helpers", () => {
       implicitPrevRespId: "resp_implicit",
       continuationInputStart: 2,
       affinityMap: makeAffinityLookup({ turnState: "turn-implicit", inputTokens: 123 }),
+      reasoningReplayItems: [{ type: "reasoning", encrypted_content: "encrypted" }],
     });
     request.codexRequest.instructions = "mutated-system";
 

--- a/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
+++ b/tests/unit/routes/shared/proxy-implicit-resume-request.test.ts
@@ -89,7 +89,7 @@ describe("implicit resume request state helpers", () => {
         inputTokens: 123,
       }),
       reasoningReplayItems: [
-        { type: "reasoning", encrypted_content: "encrypted" },
+        { type: "reasoning", id: "rs_replay", summary: [], encrypted_content: "encrypted" },
         { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
       ],
     });
@@ -98,7 +98,7 @@ describe("implicit resume request state helpers", () => {
     expect(request.codexRequest.useWebSocket).toBe(true);
     expect(request.codexRequest.turnState).toBe("turn-implicit");
     expect(request.codexRequest.input).toEqual([
-      { type: "reasoning", encrypted_content: "encrypted" },
+      { type: "reasoning", id: "rs_replay", summary: [], encrypted_content: "encrypted" },
       { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
       { role: "user", content: "continue" },
     ]);
@@ -127,7 +127,7 @@ describe("implicit resume request state helpers", () => {
       implicitPrevRespId: "resp_implicit",
       continuationInputStart: 2,
       affinityMap: makeAffinityLookup({ turnState: "turn-implicit", inputTokens: 123 }),
-      reasoningReplayItems: [{ type: "reasoning", encrypted_content: "encrypted" }],
+      reasoningReplayItems: [{ type: "reasoning", id: "rs_replay", summary: [], encrypted_content: "encrypted" }],
     });
     request.codexRequest.instructions = "mutated-system";
 

--- a/tests/unit/routes/shared/proxy-ws-context.test.ts
+++ b/tests/unit/routes/shared/proxy-ws-context.test.ts
@@ -62,7 +62,7 @@ describe("buildWsPoolContext", () => {
     }
   });
 
-  it("builds a pool context keyed by entry id, chain conversation id, and variant hash", () => {
+  it("builds a pool context keyed by entry id and chain conversation id", () => {
     const pool = createPool();
     const deps = createDeps(pool);
 
@@ -71,8 +71,24 @@ describe("buildWsPoolContext", () => {
     expect(context).toBeDefined();
     expect(context?.pool).toBe(pool);
     expect(context?.entryId).toBe("entry-A");
-    expect(context?.poolKey).toBe("entry-A:conv-1:vh-123");
+    expect(context?.poolKey).toBe("entry-A:conv-1");
     expect(deps.getPoolCalls).toBe(1);
+  });
+
+  it("keeps the same physical WebSocket across explicit previous-response variant changes", () => {
+    const deps = createDeps();
+
+    const first = buildWsPoolContext(
+      { ...baseOptions(), variantHash: "main-turn" },
+      deps.deps,
+    );
+    const continuation = buildWsPoolContext(
+      { ...baseOptions(), variantHash: "changed-instructions" },
+      deps.deps,
+    );
+
+    expect(first?.poolKey).toBe("entry-A:conv-1");
+    expect(continuation?.poolKey).toBe(first?.poolKey);
   });
 
   it("logs pool decisions with the route tag and shortened request id", () => {

--- a/tests/unit/routes/shared/response-metadata-collector.test.ts
+++ b/tests/unit/routes/shared/response-metadata-collector.test.ts
@@ -7,8 +7,20 @@ describe("createResponseMetadataCollector", () => {
 
     collector.onResponseMetadata({ functionCallIds: ["call-a", "call-b"] });
     collector.onResponseMetadata({ functionCallIds: ["call-a", "call-c"] });
+    collector.onResponseMetadata({
+      reasoningReplayItems: [
+        { type: "reasoning", encrypted_content: "encrypted" },
+        { type: "function_call", call_id: "call-a", name: "read_file", arguments: "{}" },
+      ],
+    });
+    collector.onResponseMetadata({ invalidReasoningReplay: true });
     collector.onResponseMetadata({});
 
     expect(Array.from(collector.responseFunctionCallIds)).toEqual(["call-a", "call-b", "call-c"]);
+    expect(collector.reasoningReplayItems).toEqual([
+      { type: "reasoning", encrypted_content: "encrypted" },
+      { type: "function_call", call_id: "call-a", name: "read_file", arguments: "{}" },
+    ]);
+    expect(collector.invalidReasoningReplay).toBe(true);
   });
 });

--- a/tests/unit/routes/shared/response-metadata-collector.test.ts
+++ b/tests/unit/routes/shared/response-metadata-collector.test.ts
@@ -9,7 +9,7 @@ describe("createResponseMetadataCollector", () => {
     collector.onResponseMetadata({ functionCallIds: ["call-a", "call-c"] });
     collector.onResponseMetadata({
       reasoningReplayItems: [
-        { type: "reasoning", encrypted_content: "encrypted" },
+        { type: "reasoning", id: "rs_replay", summary: [], encrypted_content: "encrypted" },
         { type: "function_call", call_id: "call-a", name: "read_file", arguments: "{}" },
       ],
     });
@@ -18,7 +18,7 @@ describe("createResponseMetadataCollector", () => {
 
     expect(Array.from(collector.responseFunctionCallIds)).toEqual(["call-a", "call-b", "call-c"]);
     expect(collector.reasoningReplayItems).toEqual([
-      { type: "reasoning", encrypted_content: "encrypted" },
+      { type: "reasoning", id: "rs_replay", summary: [], encrypted_content: "encrypted" },
       { type: "function_call", call_id: "call-a", name: "read_file", arguments: "{}" },
     ]);
     expect(collector.invalidReasoningReplay).toBe(true);

--- a/tests/unit/routes/shared/streaming-handler.test.ts
+++ b/tests/unit/routes/shared/streaming-handler.test.ts
@@ -7,6 +7,10 @@ import { handleStreaming } from "@src/routes/shared/streaming-handler.js";
 import type { ProxyRequest } from "@src/routes/shared/proxy-handler-types.js";
 import type { FormatStreamTranslatorOptions } from "@src/routes/shared/proxy-handler-types.js";
 import { createMockFormatAdapter } from "@helpers/format-adapter.js";
+import {
+  getReasoningReplayCache,
+  resetReasoningReplayCacheForTests,
+} from "@src/proxy/reasoning-replay-cache.js";
 
 function createMockAccountPool(): { pool: AccountPool; release: ReturnType<typeof vi.fn> } {
   const release = vi.fn();
@@ -35,6 +39,7 @@ describe("handleStreaming", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetReasoningReplayCacheForTests();
     for (const affinityMap of affinityMaps) {
       affinityMap.dispose();
     }
@@ -59,7 +64,10 @@ describe("handleStreaming", () => {
           image_output_tokens: 4,
         });
         options.onResponseId("resp_stream");
-        options.onResponseMetadata?.({ functionCallIds: ["call_stream"] });
+        options.onResponseMetadata?.({
+          functionCallIds: ["call_stream"],
+          reasoningReplayItems: [{ type: "reasoning", encrypted_content: "encrypted-stream" }],
+        });
         options.onResponseCompleted?.("resp_stream");
         yield "event: response.completed\ndata: {}\n\n";
       }),
@@ -112,6 +120,12 @@ describe("handleStreaming", () => {
       undefined,
       "variant-stream",
     )).toBe("resp_stream");
+    expect(getReasoningReplayCache().lookup({
+      responseId: "resp_stream",
+      entryId: "entry-stream",
+      conversationId: "conversation-stream",
+      variantHash: "variant-stream",
+    })).toEqual([{ type: "reasoning", encrypted_content: "encrypted-stream" }]);
     expect(logSpy).toHaveBeenCalledWith(
       "[Test] Account entry-stream | rid=request- | Usage: in=10001 (cached=10 uncached=9991) out=7 reasoning=5 image=3/4 | hit=0.1%",
     );

--- a/tests/unit/routes/shared/streaming-handler.test.ts
+++ b/tests/unit/routes/shared/streaming-handler.test.ts
@@ -66,7 +66,12 @@ describe("handleStreaming", () => {
         options.onResponseId("resp_stream");
         options.onResponseMetadata?.({
           functionCallIds: ["call_stream"],
-          reasoningReplayItems: [{ type: "reasoning", encrypted_content: "encrypted-stream" }],
+          reasoningReplayItems: [{
+            type: "reasoning",
+            id: "rs_stream",
+            summary: [],
+            encrypted_content: "encrypted-stream",
+          }],
         });
         options.onResponseCompleted?.("resp_stream");
         yield "event: response.completed\ndata: {}\n\n";
@@ -125,7 +130,12 @@ describe("handleStreaming", () => {
       entryId: "entry-stream",
       conversationId: "conversation-stream",
       variantHash: "variant-stream",
-    })).toEqual([{ type: "reasoning", encrypted_content: "encrypted-stream" }]);
+    })).toEqual([{
+      type: "reasoning",
+      id: "rs_stream",
+      summary: [],
+      encrypted_content: "encrypted-stream",
+    }]);
     expect(logSpy).toHaveBeenCalledWith(
       "[Test] Account entry-stream | rid=request- | Usage: in=10001 (cached=10 uncached=9991) out=7 reasoning=5 image=3/4 | hit=0.1%",
     );


### PR DESCRIPTION
## Summary
- Refs #663.
- Depends on #667 / `fix/reasoning-input-sanitizer`; this PR is stacked on that branch to avoid duplicating sanitizer/type changes in the dev diff.
- Adds a bounded per-account reasoning replay cache keyed by response/account/conversation/variant identity.
- Captures sanitized reasoning and function-call replay artifacts from Responses stream/collect metadata, prepends matching cached artifacts during implicit resume, and evicts affected cache entries when upstream reports invalid encrypted reasoning content.

## Test plan
- [x] `./node_modules/.bin/vitest run --reporter=dot tests/unit/proxy/reasoning-input-sanitizer.test.ts tests/unit/proxy/reasoning-replay-cache.test.ts tests/unit/routes/shared/proxy-implicit-resume-request.test.ts tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts tests/unit/routes/implicit-resume-from-derived-key.test.ts tests/unit/routes/responses-passthrough-metadata.test.ts tests/unit/routes/responses-optional-instructions.test.ts tests/unit/routes/responses-compact.test.ts tests/unit/routes/shared/response-metadata-collector.test.ts tests/unit/routes/shared/streaming-handler.test.ts tests/unit/routes/shared/non-streaming-collect-response.test.ts tests/unit/routes/shared/non-streaming-affinity.test.ts tests/unit/routes/shared/non-streaming-handler-boundary.test.ts tests/unit/routes/shared/streaming-handler-boundary.test.ts`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `rg -n "as any|: any|<any>" <changed files>`
- [x] `git diff --check`
- [x] `npm run build`

## E2E
- [ ] Real OpenAI upstream E2E was not run; this PR is validated by unit/type/build coverage only and should not be treated as a confirmed live-service fix until 3 consecutive real-service calls pass.