### PR TITLE
fix: isolate upstream session identity

### DIFF
--- a/src/proxy/codex-api.ts
+++ b/src/proxy/codex-api.ts
@@ -10,6 +10,7 @@
  */
 
 import { getConfig } from "../config.js";
+import { createHash } from "crypto";
 import { getTransport, type TlsTransport } from "../tls/transport.js";
 import {
   buildHeaders,
@@ -108,18 +109,33 @@ export class CodexApi {
     conversationId: string | null;
     windowId: string | null;
   } {
-    const conversationId =
+    const clientConversationId =
       typeof request.prompt_cache_key === "string" && request.prompt_cache_key.trim()
         ? request.prompt_cache_key.trim()
         : null;
+    const conversationId = clientConversationId
+      ? this.buildAccountScopedIdentity("conversation", clientConversationId)
+      : null;
+    const clientWindowId = this.firstRequestString(request, X_CODEX_WINDOW_ID_HEADER);
     return {
       conversationId,
-      windowId:
-        (typeof request.codexWindowId === "string" && request.codexWindowId.trim()
-          ? request.codexWindowId.trim()
-          : null) ??
-        (conversationId ? `${conversationId}:0` : null),
+      windowId: clientWindowId
+        ? this.buildAccountScopedIdentity("window", clientWindowId)
+        : conversationId ? `${conversationId}:0` : null,
     };
+  }
+
+  private buildAccountScopedIdentity(kind: "conversation" | "window", clientValue: string): string {
+    const accountScope = this.entryId ?? this.accountId ?? "anonymous";
+    const digest = createHash("sha256")
+      .update(kind)
+      .update("\0")
+      .update(accountScope)
+      .update("\0")
+      .update(clientValue)
+      .digest("hex")
+      .slice(0, 32);
+    return `${kind === "conversation" ? "cp" : "cw"}_${digest}`;
   }
 
   private firstRequestString(request: CodexResponsesRequest, key: string): string | null {
@@ -337,7 +353,7 @@ export class CodexApi {
     if (request.text) wsRequest.text = request.text;
     const serviceTier = normalizeServiceTierForUpstream(request.service_tier);
     if (serviceTier) wsRequest.service_tier = serviceTier;
-    if (request.prompt_cache_key) wsRequest.prompt_cache_key = request.prompt_cache_key;
+    if (identity.conversationId) wsRequest.prompt_cache_key = identity.conversationId;
     if (request.include?.length) wsRequest.include = request.include;
     wsRequest.client_metadata = this.buildCodexClientMetadata(request, installationId, identity.windowId);
 
@@ -392,6 +408,7 @@ export class CodexApi {
     const bodyWithMetadata = {
       ...bodyFields,
       ...(upstreamServiceTier ? { service_tier: upstreamServiceTier } : {}),
+      ...(identity.conversationId ? { prompt_cache_key: identity.conversationId } : {}),
       client_metadata: this.buildCodexClientMetadata(request, installationId, identity.windowId),
     };
     const body = JSON.stringify(bodyWithMetadata);

--- a/tests/e2e/messages.test.ts
+++ b/tests/e2e/messages.test.ts
@@ -232,7 +232,7 @@ describe("E2E: POST /v1/messages", () => {
     expect(typeof usage.output_tokens).toBe("number");
   });
 
-  it("uses Claude Code session id as prompt_cache_key", async () => {
+  it("maps Claude Code session id to an account-scoped upstream prompt_cache_key", async () => {
     const res = await ctx.app.request("/v1/messages", {
       method: "POST",
       headers: {
@@ -250,8 +250,15 @@ describe("E2E: POST /v1/messages", () => {
       throw new Error("Expected upstream transport body to be captured");
     }
 
-    const upstreamRequest = JSON.parse(transportBody) as { prompt_cache_key?: unknown };
-    expect(upstreamRequest.prompt_cache_key).toBe("claude-code-session-123");
+    const upstreamRequest = JSON.parse(transportBody) as {
+      prompt_cache_key?: unknown;
+      client_metadata?: Record<string, unknown>;
+    };
+    expect(upstreamRequest.prompt_cache_key).toMatch(/^cp_[0-9a-f]{32}$/);
+    expect(upstreamRequest.prompt_cache_key).not.toBe("claude-code-session-123");
+    expect(upstreamRequest.client_metadata?.["x-codex-window-id"]).toBe(
+      `${upstreamRequest.prompt_cache_key}:0`,
+    );
   });
 
   // ── Anthropic error format ─────────────────────────────────────

--- a/tests/unit/proxy/codex-api-headers.test.ts
+++ b/tests/unit/proxy/codex-api-headers.test.ts
@@ -85,9 +85,9 @@ describe("codex-api headers", () => {
   });
 
   // Lazy import to let mocks register first
-  async function createApi() {
+  async function createApi(entryId = "e1", accountId = "acct-1") {
     const { CodexApi } = await import("@src/proxy/codex-api.js");
-    return new CodexApi("test-token", "acct-1", null, "e1", null, "https://test.example", transport);
+    return new CodexApi("test-token", accountId, null, entryId, null, "https://test.example", transport);
   }
 
   describe("HTTP SSE path", () => {
@@ -169,15 +169,42 @@ describe("codex-api headers", () => {
       expect(body.client_metadata["x-openai-subagent"]).toBe("review");
     });
 
-    it("uses prompt_cache_key as Codex conversation identity", async () => {
+    it("derives a stable account-scoped upstream identity from prompt_cache_key", async () => {
       const api = await createApi();
       await api.createResponse(makeRequest({ prompt_cache_key: "thread-123" }));
 
-      expect(transport.lastHeaders!["x-client-request-id"]).toBe("thread-123");
-      expect(transport.lastHeaders!["session_id"]).toBe("thread-123");
-      expect(transport.lastHeaders!["x-codex-window-id"]).toBe("thread-123:0");
+      const firstIdentity = transport.lastHeaders!["x-client-request-id"];
+      expect(firstIdentity).toMatch(/^cp_[0-9a-f]{32}$/);
+      expect(firstIdentity).not.toBe("thread-123");
+      expect(transport.lastHeaders!["session_id"]).toBe(firstIdentity);
+      expect(transport.lastHeaders!["x-codex-window-id"]).toBe(`${firstIdentity}:0`);
+      const firstBody = JSON.parse(transport.lastBody!) as {
+        prompt_cache_key: string;
+        client_metadata: Record<string, string>;
+      };
+      expect(firstBody.prompt_cache_key).toBe(firstIdentity);
+      expect(firstBody.client_metadata["x-codex-window-id"]).toBe(`${firstIdentity}:0`);
+
+      await api.createResponse(makeRequest({ prompt_cache_key: "thread-123" }));
+      expect(transport.lastHeaders!["x-client-request-id"]).toBe(firstIdentity);
+
+      const otherAccountApi = await createApi("e2", "acct-2");
+      await otherAccountApi.createResponse(makeRequest({ prompt_cache_key: "thread-123" }));
+      expect(transport.lastHeaders!["x-client-request-id"]).toMatch(/^cp_[0-9a-f]{32}$/);
+      expect(transport.lastHeaders!["x-client-request-id"]).not.toBe(firstIdentity);
+    });
+
+    it("maps explicit Codex window ids before upstream forwarding", async () => {
+      const api = await createApi();
+      await api.createResponse(makeRequest({
+        prompt_cache_key: "thread-123",
+        codexWindowId: "thread-123:1",
+      }));
+
+      expect(transport.lastHeaders!["x-codex-window-id"]).toMatch(/^cw_[0-9a-f]{32}$/);
+      expect(transport.lastHeaders!["x-codex-window-id"]).not.toBe("thread-123:1");
       const body = JSON.parse(transport.lastBody!) as { client_metadata: Record<string, string> };
-      expect(body.client_metadata["x-codex-window-id"]).toBe("thread-123:0");
+      expect(body.client_metadata["x-codex-window-id"]).toBe(transport.lastHeaders!["x-codex-window-id"]);
     });
 
     it("forwards Codex review context headers and metadata", async () => {
@@ -195,12 +222,13 @@ describe("codex-api headers", () => {
       expect(transport.lastHeaders!["x-codex-beta-features"]).toBe("feature-a");
       expect(transport.lastHeaders!["x-responsesapi-include-timing-metrics"]).toBe("true");
       expect(transport.lastHeaders!["Version"]).toBe("26.318.11754");
-      expect(transport.lastHeaders!["x-codex-window-id"]).toBe("thread-123:1");
+      expect(transport.lastHeaders!["x-codex-window-id"]).toMatch(/^cw_[0-9a-f]{32}$/);
+      expect(transport.lastHeaders!["x-codex-window-id"]).not.toBe("thread-123:1");
       expect(transport.lastHeaders!["x-codex-parent-thread-id"]).toBe("parent-123");
       const body = JSON.parse(transport.lastBody!) as { client_metadata: Record<string, string> };
       expect(body.client_metadata).toMatchObject({
         "x-codex-turn-metadata": "{\"thread_source\":\"subagent\"}",
-        "x-codex-window-id": "thread-123:1",
+        "x-codex-window-id": transport.lastHeaders!["x-codex-window-id"],
         "x-codex-parent-thread-id": "parent-123",
       });
     });
@@ -288,7 +316,7 @@ describe("codex-api headers", () => {
       expect(wsRequest.service_tier).toBe("priority");
     });
 
-    it("uses prompt_cache_key as WebSocket conversation identity", async () => {
+    it("derives a stable account-scoped WebSocket identity from prompt_cache_key", async () => {
       mockCreateWebSocketResponse.mockResolvedValue(
         new Response("data: {}\n\n", {
           headers: { "content-type": "text/event-stream" },
@@ -304,13 +332,62 @@ describe("codex-api headers", () => {
       );
 
       const headers = mockCreateWebSocketResponse.mock.calls[0][1] as Record<string, string>;
-      expect(headers["x-client-request-id"]).toBe("thread-456");
-      expect(headers["session_id"]).toBe("thread-456");
-      expect(headers["x-codex-window-id"]).toBe("thread-456:0");
+      const firstIdentity = headers["x-client-request-id"];
+      expect(firstIdentity).toMatch(/^cp_[0-9a-f]{32}$/);
+      expect(firstIdentity).not.toBe("thread-456");
+      expect(headers["session_id"]).toBe(firstIdentity);
+      expect(headers["x-codex-window-id"]).toBe(`${firstIdentity}:0`);
+      const wsRequest = mockCreateWebSocketResponse.mock.calls[0][2] as {
+        prompt_cache_key?: string;
+        client_metadata?: Record<string, string>;
+      };
+      expect(wsRequest.prompt_cache_key).toBe(firstIdentity);
+      expect(wsRequest.client_metadata?.["x-codex-window-id"]).toBe(`${firstIdentity}:0`);
+
+      await api.createResponse(
+        makeRequest({
+          useWebSocket: true,
+          prompt_cache_key: "thread-456",
+        }),
+      );
+      const secondHeaders = mockCreateWebSocketResponse.mock.calls[1][1] as Record<string, string>;
+      expect(secondHeaders["x-client-request-id"]).toBe(firstIdentity);
+
+      const otherAccountApi = await createApi("e2", "acct-2");
+      await otherAccountApi.createResponse(
+        makeRequest({
+          useWebSocket: true,
+          prompt_cache_key: "thread-456",
+        }),
+      );
+      const otherHeaders = mockCreateWebSocketResponse.mock.calls[2][1] as Record<string, string>;
+      expect(otherHeaders["x-client-request-id"]).toMatch(/^cp_[0-9a-f]{32}$/);
+      expect(otherHeaders["x-client-request-id"]).not.toBe(firstIdentity);
+    });
+
+    it("maps explicit Codex window ids on WebSocket requests", async () => {
+      mockCreateWebSocketResponse.mockResolvedValue(
+        new Response("data: {}\n\n", {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      );
+
+      const api = await createApi();
+      await api.createResponse(
+        makeRequest({
+          useWebSocket: true,
+          prompt_cache_key: "thread-456",
+          codexWindowId: "thread-456:1",
+        }),
+      );
+
+      const headers = mockCreateWebSocketResponse.mock.calls[0][1] as Record<string, string>;
+      expect(headers["x-codex-window-id"]).toMatch(/^cw_[0-9a-f]{32}$/);
+      expect(headers["x-codex-window-id"]).not.toBe("thread-456:1");
       const wsRequest = mockCreateWebSocketResponse.mock.calls[0][2] as {
         client_metadata?: Record<string, string>;
       };
-      expect(wsRequest.client_metadata?.["x-codex-window-id"]).toBe("thread-456:0");
+      expect(wsRequest.client_metadata?.["x-codex-window-id"]).toBe(headers["x-codex-window-id"]);
     });
 
     it("forwards Codex review context on WebSocket requests", async () => {
@@ -338,14 +415,15 @@ describe("codex-api headers", () => {
       expect(headers["x-codex-beta-features"]).toBe("feature-a");
       expect(headers["x-responsesapi-include-timing-metrics"]).toBe("true");
       expect(headers["Version"]).toBe("26.318.11754");
-      expect(headers["x-codex-window-id"]).toBe("thread-456:1");
+      expect(headers["x-codex-window-id"]).toMatch(/^cw_[0-9a-f]{32}$/);
+      expect(headers["x-codex-window-id"]).not.toBe("thread-456:1");
       expect(headers["x-codex-parent-thread-id"]).toBe("parent-456");
       const wsRequest = mockCreateWebSocketResponse.mock.calls[0][2] as {
         client_metadata?: Record<string, string>;
       };
       expect(wsRequest.client_metadata).toMatchObject({
         "x-codex-turn-metadata": "{\"thread_source\":\"subagent\"}",
-        "x-codex-window-id": "thread-456:1",
+        "x-codex-window-id": headers["x-codex-window-id"],
         "x-codex-parent-thread-id": "parent-456",
       });
     });


### PR DESCRIPTION
## Summary
- Derive deterministic account-scoped upstream conversation identities from client `prompt_cache_key` before forwarding to Codex.
- Apply the derived identity to `prompt_cache_key`, `x-client-request-id`, `session_id`, and implicit `x-codex-window-id` on HTTP and WebSocket paths.
- Preserve local client conversation/session affinity semantics; this slice does not implement streamed response ID restoration.

Refs #661

## Test plan
- `./node_modules/.bin/vitest run --reporter=dot tests/unit/proxy/codex-api-headers.test.ts tests/unit/proxy/codex-api.test.ts tests/unit/routes/shared/proxy-request-preparation.test.ts tests/unit/routes/shared/proxy-session-context.test.ts tests/unit/routes/implicit-resume-from-derived-key.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `! rg -n "as any|: any|<any>" src/proxy/codex-api.ts tests/unit/proxy/codex-api-headers.test.ts`
- `git diff --check`
- `npm run build`

No real OpenAI E2E was run for this upstream-facing change.