### PR TITLE
fix: expose Codex compact metadata in models

### DIFF
--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -39,6 +39,8 @@ export interface CodexModelInfo {
   maxContextWindow?: number;
   /** Maximum configurable output token budget, when known. */
   maxOutputTokens?: number;
+  /** Token threshold where clients should compact conversation history, when known. */
+  autoCompactTokenLimit?: number;
   /** Backend truncation policy limit, when reported. */
   truncationPolicyLimit?: number;
   /** Where this model entry came from */
@@ -87,6 +89,8 @@ export interface BackendModelEntry {
   maxContextWindow?: number;
   max_output_tokens?: number;
   maxOutputTokens?: number;
+  auto_compact_token_limit?: number | null;
+  autoCompactTokenLimit?: number | null;
   truncation_policy?: {
     limit?: number;
   };
@@ -512,6 +516,11 @@ function normalizeBackendModel(raw: BackendModelEntry): NormalizedModelWithMeta 
     out.maxOutputTokens = raw.max_output_tokens;
   } else if (typeof raw.maxOutputTokens === "number") {
     out.maxOutputTokens = raw.maxOutputTokens;
+  }
+  if (typeof raw.auto_compact_token_limit === "number") {
+    out.autoCompactTokenLimit = raw.auto_compact_token_limit;
+  } else if (typeof raw.autoCompactTokenLimit === "number") {
+    out.autoCompactTokenLimit = raw.autoCompactTokenLimit;
   }
   if (typeof raw.truncation_policy?.limit === "number") {
     out.truncationPolicyLimit = raw.truncation_policy.limit;

--- a/src/routes/models.ts
+++ b/src/routes/models.ts
@@ -18,14 +18,47 @@ import type { ApiKeyPool } from "../auth/api-key-pool.js";
 
 /** Stable timestamp used for all model `created` fields (2023-11-14T22:13:20Z). */
 const MODEL_CREATED_TIMESTAMP = 1700000000;
+const DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95;
+const AUTO_COMPACT_CONTEXT_WINDOW_PERCENT = 80;
+const AUTO_COMPACT_TOKEN_LIMIT_OVERRIDES: Record<string, number> = {
+  "gpt-5.5": 50_000,
+};
+
+function resolvedContextWindow(info: CodexModelInfo): number | undefined {
+  return info.contextWindow ?? info.maxContextWindow;
+}
+
+function autoCompactTokenLimit(info: CodexModelInfo): number | undefined {
+  const override = AUTO_COMPACT_TOKEN_LIMIT_OVERRIDES[info.id];
+  if (override !== undefined) return override;
+  if (info.autoCompactTokenLimit !== undefined) return info.autoCompactTokenLimit;
+  const contextWindow = resolvedContextWindow(info);
+  if (contextWindow === undefined) return undefined;
+  return Math.floor((contextWindow * AUTO_COMPACT_CONTEXT_WINDOW_PERCENT) / 100);
+}
 
 function toOpenAIModel(info: CodexModelInfo): OpenAIModel {
-  return {
+  const model: OpenAIModel = {
     id: info.id,
     object: "model",
     created: MODEL_CREATED_TIMESTAMP,
     owned_by: "openai",
   };
+
+  if (info.contextWindow !== undefined) model.context_window = info.contextWindow;
+  if (info.maxContextWindow !== undefined) model.max_context_window = info.maxContextWindow;
+  if (info.maxOutputTokens !== undefined) model.max_output_tokens = info.maxOutputTokens;
+  if (info.truncationPolicyLimit !== undefined) {
+    model.truncation_policy = { mode: "tokens", limit: info.truncationPolicyLimit };
+  }
+
+  const compactLimit = autoCompactTokenLimit(info);
+  if (compactLimit !== undefined) {
+    model.auto_compact_token_limit = compactLimit;
+    model.effective_context_window_percent = DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT;
+  }
+
+  return model;
 }
 
 function toRuntimeOpenAIModel(id: string): OpenAIModel {
@@ -48,7 +81,9 @@ export function createModelRoutes(apiKeyPool?: ApiKeyPool): Hono {
       modelsById.set(model.id, toOpenAIModel(model));
     }
     for (const modelId of apiKeyPool?.getActiveModels() ?? []) {
-      modelsById.set(modelId, toRuntimeOpenAIModel(modelId));
+      if (!modelsById.has(modelId)) {
+        modelsById.set(modelId, toRuntimeOpenAIModel(modelId));
+      }
     }
 
     const response: OpenAIModelList = { object: "list", data: [...modelsById.values()] };

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -413,6 +413,16 @@ export interface OpenAIModel {
   object: "model";
   created: number;
   owned_by: string;
+  /** Codex CLI reads these hints from /v1/models to size context and auto compact. */
+  context_window?: number;
+  max_context_window?: number;
+  max_output_tokens?: number;
+  auto_compact_token_limit?: number;
+  effective_context_window_percent?: number;
+  truncation_policy?: {
+    mode: "tokens";
+    limit: number;
+  };
 }
 
 export interface OpenAIModelList {

--- a/tests/unit/routes/plan-routing-integration.test.ts
+++ b/tests/unit/routes/plan-routing-integration.test.ts
@@ -334,6 +334,84 @@ describe("GET /v1/models with runtime API keys", () => {
     expect(body.data.some((m: { id: string }) => m.id === "gpt-5.4")).toBe(true);
   });
 
+  it("includes Codex token metadata in /v1/models for CLI auto compact", async () => {
+    applyBackendModelsForPlan("team", [
+      {
+        slug: "gpt-5.5",
+        display_name: "GPT-5.5",
+        context_window: 272_000,
+        max_context_window: 272_000,
+        max_output_tokens: 128_000,
+        truncation_policy: { limit: 10_000 },
+      },
+      {
+        slug: "gpt-5.4",
+        display_name: "GPT-5.4",
+        context_window: 200_000,
+        auto_compact_token_limit: 120_000,
+      },
+    ]);
+
+    const app = createModelRoutes();
+    const res = await app.request("/v1/models");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      data: Array<{
+        id: string;
+        context_window?: number;
+        max_context_window?: number;
+        max_output_tokens?: number;
+        auto_compact_token_limit?: number;
+        effective_context_window_percent?: number;
+        truncation_policy?: { mode?: string; limit?: number };
+      }>;
+    };
+    const model = body.data.find((m) => m.id === "gpt-5.5");
+
+    expect(model).toBeDefined();
+    expect(model?.context_window).toBe(272_000);
+    expect(model?.max_context_window).toBe(272_000);
+    expect(model?.max_output_tokens).toBe(128_000);
+    expect(model?.auto_compact_token_limit).toBe(50_000);
+    expect(model?.effective_context_window_percent).toBe(95);
+    expect(model?.truncation_policy).toEqual({ mode: "tokens", limit: 10_000 });
+
+    const backendLimitModel = body.data.find((m) => m.id === "gpt-5.4");
+    expect(backendLimitModel?.auto_compact_token_limit).toBe(120_000);
+  });
+
+  it("preserves catalog metadata when a runtime API key uses the same model id", async () => {
+    applyBackendModelsForPlan("team", [
+      {
+        slug: "gpt-5.4",
+        display_name: "GPT-5.4",
+        context_window: 200_000,
+        auto_compact_token_limit: 120_000,
+      },
+    ]);
+    const pool = new ApiKeyPool(createApiKeyMemoryPersistence());
+    pool.add({ provider: "openai", model: "gpt-5.4", apiKey: "k1" });
+
+    const app = createModelRoutes(pool);
+    const res = await app.request("/v1/models");
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as {
+      data: Array<{
+        id: string;
+        context_window?: number;
+        auto_compact_token_limit?: number;
+        effective_context_window_percent?: number;
+      }>;
+    };
+    const model = body.data.find((m) => m.id === "gpt-5.4");
+
+    expect(model?.context_window).toBe(200_000);
+    expect(model?.auto_compact_token_limit).toBe(120_000);
+    expect(model?.effective_context_window_percent).toBe(95);
+  });
+
   it("excludes disabled API key models from /v1/models", async () => {
     const pool = new ApiKeyPool(createApiKeyMemoryPersistence());
     const added = pool.add({ provider: "custom", model: "disabled-runtime-model", apiKey: "k1", baseUrl: "https://example.com/v1" });


### PR DESCRIPTION
## Summary
- include Codex token metadata in OpenAI-compatible model listings
- expose explicit auto compact token limits for CLI auto compaction
- cover the model metadata contract with a focused route test

## Test plan
- [x] git diff --check
- [x] rg -n "as any|: any|<any>" src/routes/models.ts tests/unit/routes/plan-routing-integration.test.ts src/models/model-store.ts src/types/openai.ts
- [x] npx vitest run tests/unit/routes/plan-routing-integration.test.ts -t "includes Codex token metadata"
- [x] npm run build