### PR TITLE
fix(ws): harden WebSocket stream lifecycle

### DIFF
--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -73,6 +73,7 @@ interface InFlightSession {
   onRateLimits: ((rl: ParsedRateLimit) => void) | undefined;
   earlyDecisionMade: boolean;
   sawTerminalEvent: boolean;
+  earlyMetadataChunks: Uint8Array[];
   /** Resolves the outer send() Promise with the SSE Response.
    *  Closes over the freshly-built ReadableStream so callers don't need to
    *  pass it back in. */
@@ -142,6 +143,10 @@ function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number; c
 
 function isTerminalWsEvent(type: string): boolean {
   return type === "response.completed" || type === "response.failed" || type === "error";
+}
+
+function isEarlyMetadataWsEvent(type: string): boolean {
+  return type === "response.created" || type === "response.in_progress";
 }
 
 // ── PersistentWs ───────────────────────────────────────────────────
@@ -309,6 +314,7 @@ export class PersistentWs {
             onRateLimits: opts.onRateLimits,
             earlyDecisionMade: false,
             sawTerminalEvent: false,
+            earlyMetadataChunks: [],
             resolveResponse: () => resolve(this.buildResponse(stream)),
             reject: wrappedReject,
             abortListener: null,
@@ -385,6 +391,20 @@ export class PersistentWs {
     return new Response(stream, { status: 200, headers: responseHeaders });
   }
 
+  private enqueueSessionChunk(sess: InFlightSession, chunk: Uint8Array): void {
+    if (sess.streamClosed) return;
+    sess.controller.enqueue(chunk);
+  }
+
+  private resolveSessionResponse(sess: InFlightSession): void {
+    if (sess.earlyDecisionMade) return;
+    sess.earlyDecisionMade = true;
+    sess.resolveResponse();
+    for (const chunk of sess.earlyMetadataChunks.splice(0)) {
+      this.enqueueSessionChunk(sess, chunk);
+    }
+  }
+
   private handleMessage(data: Buffer | string): void {
     const sess = this.currentSession;
     if (!sess || sess.streamClosed) return;
@@ -399,8 +419,15 @@ export class PersistentWs {
       /* fall through to raw passthrough */
     }
 
+    // Internal rate-limit frames bypass the stream and don't flip the
+    // early-decision flag; they're observed via the per-session callback.
+    if (msg && type === "codex.rate_limits") {
+      const rl = parseRateLimitsEvent(msg);
+      if (rl) sess.onRateLimits?.(rl);
+      return;
+    }
+
     if (!sess.earlyDecisionMade) {
-      sess.earlyDecisionMade = true;
       if (msg) {
         const classified = classifyWsErrorEvent(msg);
         if (classified) {
@@ -414,29 +441,25 @@ export class PersistentWs {
           }
           return;
         }
+        if (isEarlyMetadataWsEvent(type)) {
+          sess.earlyMetadataChunks.push(this.encoder.encode(`event: ${type}\ndata: ${raw}\n\n`));
+          return;
+        }
       }
-      sess.resolveResponse();
+      this.resolveSessionResponse(sess);
       // Fall through to enqueue this first frame.
-    }
-
-    // Internal rate-limit frames bypass the stream and don't flip the
-    // early-decision flag; they're observed via the per-session callback.
-    if (msg && type === "codex.rate_limits" && sess.onRateLimits) {
-      const rl = parseRateLimitsEvent(msg);
-      if (rl) sess.onRateLimits(rl);
-      return;
     }
 
     if (msg) {
       const sse = `event: ${type}\ndata: ${raw}\n\n`;
-      sess.controller.enqueue(this.encoder.encode(sse));
+      this.enqueueSessionChunk(sess, this.encoder.encode(sse));
 
       if (isTerminalWsEvent(type)) {
         sess.sawTerminalEvent = true;
         queueMicrotask(() => this.releaseAfterTerminalFrame());
       }
     } else {
-      sess.controller.enqueue(this.encoder.encode(`data: ${raw}\n\n`));
+      this.enqueueSessionChunk(sess, this.encoder.encode(`data: ${raw}\n\n`));
     }
   }
 
@@ -479,7 +502,7 @@ export class PersistentWs {
     if (sess && !sess.earlyDecisionMade) {
       sess.earlyDecisionMade = true;
       sess.reject(new Error(
-        `WebSocket closed before any data: code=${code}` +
+        `WebSocket closed before terminal event: code=${code}` +
           (reasonStr ? ` reason=${reasonStr}` : ""),
       ));
     } else if (sess && !sess.streamClosed) {

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -84,6 +84,15 @@ function isTerminalWsEvent(type: string): boolean {
   return type === "response.completed" || type === "response.failed" || type === "error";
 }
 
+function isEarlyMetadataWsEvent(type: string): boolean {
+  return type === "response.created" || type === "response.in_progress";
+}
+
+const WS_CONNECTING = 0;
+const WS_CLOSING = 2;
+const WS_CLOSED = 3;
+const WS_CLOSED_BEFORE_OPEN_MESSAGE = "WebSocket was closed before the connection was established";
+
 /** Cached ws module — loaded once on first use. */
 let _WS: typeof import("ws").default | undefined;
 
@@ -299,12 +308,20 @@ async function openOneShotWs(
   const wsOpts = await buildWsConstructorOpts(WS, headers, proxyUrl);
 
   return new Promise<Response>((resolve, reject) => {
-    const ws = new WS(wsUrl, wsOpts);
     const encoder = new TextEncoder();
+    if (signal?.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+
+    const ws = new WS(wsUrl, wsOpts);
     let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
     let streamClosed = false;
     let earlyDecisionMade = false;
     let sawTerminalEvent = false;
+    let abortRequested = false;
+    let expectedCloseBeforeOpen = false;
+    const earlyMetadataChunks: Uint8Array[] = [];
     let pingTimer: ReturnType<typeof setInterval> | undefined;
 
     // Open timeout: if the WS handshake never completes, reject after 20s.
@@ -312,7 +329,7 @@ async function openOneShotWs(
       if (!earlyDecisionMade) {
         earlyDecisionMade = true;
         cleanupTimers();
-        try { ws.close(1000, "open timeout"); } catch { /* already closing */ }
+        closeWs(1000, "open timeout", true);
         reject(new Error("WebSocket open timeout (20s)"));
       }
     }, 20_000);
@@ -325,8 +342,21 @@ async function openOneShotWs(
       }
     }
 
+    function cleanupAbortListener() {
+      signal?.removeEventListener("abort", onAbort);
+    }
+
+    function closeWs(code?: number, reason?: string, expectCloseBeforeOpen = false) {
+      if (expectCloseBeforeOpen && ws.readyState === WS_CONNECTING) {
+        expectedCloseBeforeOpen = true;
+      }
+      if (ws.readyState === WS_CLOSING || ws.readyState === WS_CLOSED) return;
+      try { ws.close(code, reason); } catch { /* already closing */ }
+    }
+
     function closeStream() {
       cleanupTimers();
+      cleanupAbortListener();
       if (!streamClosed && controller) {
         streamClosed = true;
         try { controller.close(); } catch { /* already closed */ }
@@ -335,16 +365,34 @@ async function openOneShotWs(
 
     function errorStream(err: Error) {
       cleanupTimers();
+      cleanupAbortListener();
       if (!streamClosed && controller) {
         streamClosed = true;
         try { controller.error(err); } catch { /* already closed */ }
       }
     }
 
+    function enqueueChunk(chunk: Uint8Array) {
+      if (!streamClosed && controller) {
+        controller.enqueue(chunk);
+      }
+    }
+
+    function resolveResponse() {
+      if (earlyDecisionMade) return;
+      earlyDecisionMade = true;
+      resolve(buildResponse());
+      for (const chunk of earlyMetadataChunks.splice(0)) {
+        enqueueChunk(chunk);
+      }
+    }
+
     // Abort signal handling
     const onAbort = () => {
+      abortRequested = true;
       cleanupTimers();
-      try { ws.close(1000, "aborted"); } catch { /* already closing */ }
+      cleanupAbortListener();
+      closeWs(1000, "aborted", true);
       if (!earlyDecisionMade) {
         earlyDecisionMade = true;
         reject(new Error("aborted"));
@@ -354,10 +402,6 @@ async function openOneShotWs(
     };
 
     if (signal) {
-      if (signal.aborted) {
-        onAbort();
-        return;
-      }
       signal.addEventListener("abort", onAbort, { once: true });
     }
 
@@ -415,40 +459,49 @@ async function openOneShotWs(
       }
 
       if (!earlyDecisionMade) {
-        earlyDecisionMade = true;
         if (msg) {
           const classified = classifyWsErrorEvent(msg);
           if (classified) {
             cleanupTimers();
+            earlyDecisionMade = true;
             reject(new CodexApiError(classified.status, JSON.stringify(msg)));
-            try { ws.close(1000, "early upstream error"); } catch { /* already closing */ }
+            closeWs(1000, "early upstream error", true);
+            return;
+          }
+          if (isEarlyMetadataWsEvent(type)) {
+            earlyMetadataChunks.push(encoder.encode(`event: ${type}\ndata: ${raw}\n\n`));
             return;
           }
         }
-        resolve(buildResponse());
+        resolveResponse();
       }
 
       if (msg) {
         const sse = `event: ${type}\ndata: ${raw}\n\n`;
-        controller!.enqueue(encoder.encode(sse));
+        enqueueChunk(encoder.encode(sse));
 
         if (isTerminalWsEvent(type)) {
           sawTerminalEvent = true;
           queueMicrotask(() => {
             closeStream();
-            ws.close(1000);
+            closeWs(1000);
           });
         }
       } else {
         const sse = `data: ${raw}\n\n`;
-        controller!.enqueue(encoder.encode(sse));
+        enqueueChunk(encoder.encode(sse));
       }
     });
 
     ws.on("error", (err: Error) => {
+      if (expectedCloseBeforeOpen && err.message === WS_CLOSED_BEFORE_OPEN_MESSAGE) {
+        cleanupTimers();
+        cleanupAbortListener();
+        return;
+      }
       console.error(`[WS-Error] ❌ WebSocket error for request:`, err.message);
       cleanupTimers();
-      signal?.removeEventListener("abort", onAbort);
+      cleanupAbortListener();
       if (!earlyDecisionMade) {
         earlyDecisionMade = true;
         reject(err);
@@ -461,11 +514,14 @@ async function openOneShotWs(
       const reasonStr = reason && reason.length ? reason.toString("utf-8") : "";
       console.log(`[WS-Close] 🔴 WebSocket closed. Code: ${code}, Reason: ${reasonStr}`);
       cleanupTimers();
-      signal?.removeEventListener("abort", onAbort);
+      cleanupAbortListener();
+      if (abortRequested) {
+        return;
+      }
       if (!earlyDecisionMade) {
         earlyDecisionMade = true;
         reject(new Error(
-          `WebSocket closed before any data: code=${code}` +
+          `WebSocket closed before terminal event: code=${code}` +
             (reasonStr ? ` reason=${reasonStr}` : ""),
         ));
         return;

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -469,6 +469,7 @@ async function openOneShotWs(
             return;
           }
           if (isEarlyMetadataWsEvent(type)) {
+            clearTimeout(openTimer);
             earlyMetadataChunks.push(encoder.encode(`event: ${type}\ndata: ${raw}\n\n`));
             return;
           }

--- a/src/routes/shared/streaming-handler.ts
+++ b/src/routes/shared/streaming-handler.ts
@@ -68,7 +68,13 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
   const reasoningReplayCache = getReasoningReplayCache();
 
   return stream(c, async (s) => {
+    let clientAborted = false;
+    let streamFailed = true;
     s.onAbort(() => {
+      if (streamCompletedWithoutError || responseCompleted) {
+        return;
+      }
+      clientAborted = true;
       console.warn(`[stream-client-abort] rid=${requestId.slice(0, 8)} tag=${fmt.tag} model=${req.model}`);
       recordStreamCloseEvent({
         kind: "client-abort",
@@ -150,9 +156,12 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
           abortSignal: abortController.signal,
         },
       });
+      streamFailed = false;
       streamCompletedWithoutError = true;
     } finally {
-      abortController.abort();
+      if (streamFailed && !clientAborted && !abortController.signal.aborted) {
+        abortController.abort();
+      }
       recordStreamAffinity();
       if (streamCompletedWithoutError) clearCfChallengeCooldown(capturedEntryId);
       if (usageInfo) {

--- a/tests/integration/ws-pool-reuse.test.ts
+++ b/tests/integration/ws-pool-reuse.test.ts
@@ -125,6 +125,42 @@ describe("ws-pool integration: persistent connection reuse", () => {
     expect(pool.size()).toBe(1);
   });
 
+  it("retries a reused WS on a metadata-only close before exposing the stream", async () => {
+    const entryId = "entry-A";
+    const poolKey = `${entryId}:conv-1`;
+
+    const r1 = await createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey },
+    );
+    await drainResponse(r1);
+    expect(server.connectionCount()).toBe(1);
+    expect(pool.size()).toBe(1);
+
+    server.script([{ type: "response.created", data: { response: { id: "resp_metadata_only" } } }]);
+    const retrying = createWebSocketResponse(
+      server.url, {}, baseRequest, undefined, null, undefined,
+      { pool, entryId, poolKey },
+    );
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    server.script([
+      { type: "response.created", data: { response: { id: "resp_retry" } } },
+      { type: "response.completed", data: { response: { id: "resp_retry" } } },
+    ]);
+    server.closeAllSockets(1000, "metadata-only close");
+
+    const r2 = await retrying;
+    const text = await drainResponse(r2);
+    expect(text).toContain("event: response.completed");
+    expect(text).toContain("resp_retry");
+    expect(text).not.toContain("resp_metadata_only");
+    expect(server.connectionCount()).toBe(2);
+    // Stale reuse falls back to a one-shot connection; the old pooled socket
+    // has been evicted and the one-shot retry is not inserted into the pool.
+    expect(pool.size()).toBe(0);
+  });
+
   it("disabled pool falls back to one-shot connections (every turn opens a new socket)", async () => {
     const disabled = new WsConnectionPool({ enabled: false }, { startGc: false });
     try {

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -117,7 +117,7 @@ describe("PersistentWs", () => {
     await expect(promise).rejects.not.toBeInstanceOf(WsReusedConnectionError);
   });
 
-  it("send resolves Response on first non-internal frame and streams subsequent events", async () => {
+  it("send resolves Response on first non-metadata frame and flushes early metadata", async () => {
     const { ws, persistent } = newPersistentWs();
     persistent.tryAcquire();
     const promise = persistent.send({
@@ -128,10 +128,10 @@ describe("PersistentWs", () => {
     });
     await nextTick();
     ws.pushMessage({ type: "response.created", id: "r1" });
+    ws.pushMessage({ type: "response.output_text.delta", delta: "hi" });
     const resp = await promise;
     expect(resp.status).toBe(200);
     expect(resp.headers.get("content-type")).toBe("text/event-stream");
-    ws.pushMessage({ type: "response.output_text.delta", delta: "hi" });
     ws.pushMessage({ type: "response.completed" });
     const text = await resp.text();
     expect(text).toContain("event: response.created");
@@ -139,7 +139,25 @@ describe("PersistentWs", () => {
     expect(text).toContain("event: response.completed");
   });
 
-  it("errors the response stream when the WS closes after first frame without terminal event", async () => {
+  it("send rejects before resolving when the WS closes after only metadata", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created", response: { id: "resp_mid" } });
+    ws.pushClose(1000, "");
+
+    await expect(promise).rejects.toBeInstanceOf(WsReusedConnectionError);
+    expect(persistent.isAlive()).toBe(false);
+    expect(onDead).toHaveBeenCalled();
+  });
+
+  it("errors the response stream when the WS closes after a visible frame without terminal event", async () => {
     const { ws, persistent, onDead } = newPersistentWs();
     persistent.tryAcquire();
     const promise = persistent.send({
@@ -150,6 +168,7 @@ describe("PersistentWs", () => {
     });
     await nextTick();
     ws.pushMessage({ type: "response.created", response: { id: "resp_mid" } });
+    ws.pushMessage({ type: "response.output_text.delta", delta: "partial" });
     const resp = await promise;
     ws.pushClose(1006, "tcp rst");
 
@@ -195,8 +214,8 @@ describe("PersistentWs", () => {
     });
     expect(onRateLimits).toHaveBeenCalledTimes(1);
     ws.pushMessage({ type: "response.created" });
-    const resp = await promise;
     ws.pushMessage({ type: "response.completed" });
+    const resp = await promise;
     const text = await resp.text();
     expect(text).not.toContain("codex.rate_limits");
   });
@@ -290,6 +309,7 @@ describe("PersistentWs", () => {
     });
     await nextTick();
     ws.pushMessage({ type: "response.created" });
+    ws.pushMessage({ type: "response.output_text.delta", delta: "partial" });
     const resp = await promise;
     persistent.closeGracefully();
     expect(onDead).not.toHaveBeenCalled(); // still busy
@@ -334,6 +354,7 @@ describe("PersistentWs", () => {
     });
     await nextTick();
     ws.pushMessage({ type: "response.created" });
+    ws.pushMessage({ type: "response.completed" });
     const resp = await promise;
     expect(resp.headers.get("x-codex-primary-used-percent")).toBe("42");
   });

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -257,6 +257,7 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     const ws = await waitForOpen();
 
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "partial" }));
     const response = await promise;
     expect(response.status).toBe(200);
 
@@ -267,6 +268,7 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
 
     const text = await readAll(response);
     expect(text).toContain("event: response.created");
+    expect(text).toContain("event: response.output_text.delta");
     expect(text).toContain("event: error");
     expect(text).toContain("usage_limit_reached");
   });
@@ -283,7 +285,7 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
       throw new Error("expected rejection");
     } catch (err) {
       expect(err).toBeInstanceOf(Error);
-      expect((err as Error).message).toContain("WebSocket closed before any data");
+      expect((err as Error).message).toContain("WebSocket closed before terminal event");
       expect((err as Error).message).toContain("code=1006");
     }
   });

--- a/tests/unit/proxy/ws-transport-premature-close.test.ts
+++ b/tests/unit/proxy/ws-transport-premature-close.test.ts
@@ -87,7 +87,7 @@ describe("ws-transport close behavior", () => {
     expect(output).not.toContain("premature_close");
   });
 
-  it("errors stream when WS closes without terminal event", async () => {
+  it("rejects before returning a Response when WS closes after only metadata", async () => {
     vi.doMock("ws", () => ({
       default: createMockWsClass([
         { type: "response.created", response: { id: "resp_1" } },
@@ -96,13 +96,11 @@ describe("ws-transport close behavior", () => {
     }));
 
     const { createWebSocketResponse } = await import("@src/proxy/ws-transport.js");
-    const response = await createWebSocketResponse(
+    await expect(createWebSocketResponse(
       "wss://example.com/ws",
       { Authorization: "Bearer test" },
       { type: "response.create", model: "test", instructions: "", input: [] },
-    );
-
-    await expect(collectSSE(response)).rejects.toThrow(
+    )).rejects.toThrow(
       "WebSocket closed before terminal event",
     );
   });

--- a/tests/unit/proxy/ws-transport.test.ts
+++ b/tests/unit/proxy/ws-transport.test.ts
@@ -99,8 +99,8 @@ async function waitForOpen(): Promise<void> {
  * promise + the MockWs so tests can drive the message sequence.
  *
  * `createWebSocketResponse` no longer resolves on `open` — it waits for the
- * first non-internal frame so it can detect early upstream errors and reject
- * with a `CodexApiError` instead of streaming the error to the client.
+ * first non-internal, non-metadata frame so it can still retry/reject if a WS
+ * dies after `response.created` but before any client-visible work.
  */
 async function startConnect(
   req: WsCreateRequest = BASE_REQUEST,
@@ -116,13 +116,14 @@ async function startConnect(
   return { promise, ws: lastWs() };
 }
 
-/** Drive a normal connect: emit `response.created` to unblock resolve. */
+/** Drive a normal connect: emit metadata plus one visible frame to unblock resolve. */
 async function connect(
   req: WsCreateRequest = BASE_REQUEST,
   headers: Record<string, string> = {},
 ): Promise<{ response: Response; ws: MockWs }> {
   const { promise, ws } = await startConnect(req, headers);
   ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_init" } }));
+  ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
   const response = await promise;
   return { response, ws };
 }
@@ -154,8 +155,8 @@ describe("createWebSocketResponse", () => {
     expect(ws.sentMessages).toHaveLength(1);
     expect(JSON.parse(ws.sentMessages[0])).toEqual(BASE_REQUEST);
 
-    // Unblock resolve and verify the Response is HTTP 200.
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "hi" }));
     const response = await promise;
     expect(response.status).toBe(200);
 
@@ -198,9 +199,9 @@ describe("createWebSocketResponse", () => {
     const { promise, ws } = await startConnect();
 
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_123" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
     const response = await promise;
 
-    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
     ws.emit("message", JSON.stringify({
       type: "response.completed",
       response: { id: "resp_123", usage: { input_tokens: 10, output_tokens: 5 } },
@@ -256,6 +257,15 @@ describe("createWebSocketResponse", () => {
     ).rejects.toThrow("aborted");
   });
 
+  it("rejects before returning a Response when WS closes after only metadata", async () => {
+    const { promise, ws } = await startConnect();
+
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_early" } }));
+    ws.emit("close", 1000, Buffer.from(""));
+
+    await expect(promise).rejects.toThrow("WebSocket closed before terminal event");
+  });
+
   it("ignores codex.rate_limits for early response resolution", async () => {
     let rateLimitCalled = false;
     const onRateLimits = () => { rateLimitCalled = true; };
@@ -273,6 +283,7 @@ describe("createWebSocketResponse", () => {
     expect(rateLimitCalled).toBe(true);
 
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "hi" }));
     const response = await promise;
     expect(response.status).toBe(200);
 
@@ -298,9 +309,10 @@ describe("createWebSocketResponse", () => {
     const { promise, ws } = await startConnect();
 
     ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "chunk0" }));
     const response = await promise;
 
-    for (let i = 0; i < 5; i++) {
+    for (let i = 1; i < 5; i++) {
       ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: `chunk${i}` }));
     }
     ws.emit("message", JSON.stringify({ type: "response.completed", response: { id: "resp_1" } }));
@@ -323,7 +335,6 @@ describe("createWebSocketResponse", () => {
 
     const { response, ws } = await connect();
 
-    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "Hello" }));
     ws.emit("message", JSON.stringify({
       type: "response.completed",
       response: { id: "resp_init", usage: { input_tokens: 10, output_tokens: 5 } },

--- a/tests/unit/routes/shared/streaming-handler.test.ts
+++ b/tests/unit/routes/shared/streaming-handler.test.ts
@@ -46,7 +46,7 @@ describe("handleStreaming", () => {
     affinityMaps.length = 0;
   });
 
-  it("records response affinity, aborts upstream, and releases with annotated usage", async () => {
+  it("records response affinity and releases with annotated usage without aborting upstream on success", async () => {
     const { pool, release } = createMockAccountPool();
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -102,7 +102,7 @@ describe("handleStreaming", () => {
 
     expect(res.headers.get("Content-Type")).toContain("text/event-stream");
     expect(text).toContain("event: response.completed");
-    expect(abortController.signal.aborted).toBe(true);
+    expect(abortController.signal.aborted).toBe(false);
     expect(release).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledWith("entry-stream", {
       input_tokens: 10_001,
@@ -155,6 +155,43 @@ describe("handleStreaming", () => {
       accountEntryId: "entry-stream",
       variantHash: "variant-stream",
     });
+  });
+
+  it("aborts upstream when stream processing fails", async () => {
+    const { pool, release } = createMockAccountPool();
+    const affinityMap = new SessionAffinityMap();
+    affinityMaps.push(affinityMap);
+    const abortController = new AbortController();
+    const fmt = createMockFormatAdapter({
+      streamTranslator: vi.fn(async function* () {
+        yield "event: response.created\ndata: {}\n\n";
+        throw new Error("upstream stream failed");
+      }),
+    });
+    const app = new Hono();
+
+    app.get("/stream", (c) => handleStreaming({
+      c,
+      accountPool: pool,
+      req: createStreamingRequest(),
+      fmt,
+      api: {} as unknown as CodexApi,
+      response: new Response(""),
+      entryId: "entry-stream",
+      abortController,
+      released: new Set<string>(),
+      requestId: "request-stream-123",
+      affinityMap,
+      conversationId: "conversation-stream",
+      variantHash: "variant-stream",
+    }));
+
+    const res = await app.request("/stream");
+    const text = await res.text();
+
+    expect(text).toContain("event: response.failed");
+    expect(text).toContain("upstream stream failed");
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("does not record response affinity before upstream completion", async () => {


### PR DESCRIPTION
## Summary
- suppress expected `ws` CONNECTING abort-handshake errors for local abort/timeout/early upstream error paths
- keep `response.created` / `response.in_progress` metadata-only frames buffered until the stream is safe to expose, preserving retry/replay on metadata-only early close
- align persistent WebSocket reuse with one-shot behavior and avoid aborting upstream after successful streaming completion

## Root cause
In local production logs, `WebSocket was closed before the connection was established` was emitted in bursts from `WebSocket.close -> onAbort -> openOneShotWs` when local abort paths closed a `ws` socket that was still CONNECTING. Separately, reused WebSocket streams could expose SSE after only early metadata, so a close before `response.completed` was surfaced to clients as `stream_disconnected` instead of staying in the retry window.

## Verification
- `npm test -- --run tests/integration/ws-pool-reuse.test.ts tests/unit/proxy/ws-transport.test.ts tests/unit/proxy/ws-transport-premature-close.test.ts tests/unit/proxy/ws-transport-early-error.test.ts tests/unit/proxy/ws-pool.test.ts tests/unit/routes/shared/streaming-handler.test.ts`
- `npm test -- --run tests/unit tests/integration`
- `npm run build`
- deployed locally behind the existing Docker service and verified `/health`, a real streaming `/v1/responses` request reaching `response.completed`, and no new runtime error-log entries in the post-deploy observation window
