### PR TITLE
fix(logger): handle EPIPE/ECONNRESET errors on stdout/stderr to prevent process crash

### DIFF
--- a/src/utils/log-file.ts
+++ b/src/utils/log-file.ts
@@ -32,6 +32,19 @@ export function installFileLogger(opts: InstallFileLoggerOptions): FileLoggerHan
   process.stdout.write = wrap(originalStdout, process.stdout, fd);
   process.stderr.write = wrap(originalStderr, process.stderr, fd);
 
+  const errorHandler = (err: unknown): void => {
+    if (err && typeof err === "object" && "code" in err) {
+      const code = (err as { code?: unknown }).code;
+      if (code === "EPIPE" || code === "ECONNRESET") {
+        return;
+      }
+    }
+    throw err;
+  };
+
+  process.stdout.on("error", errorHandler);
+  process.stderr.on("error", errorHandler);
+
   let uninstalled = false;
 
   return {
@@ -41,6 +54,8 @@ export function installFileLogger(opts: InstallFileLoggerOptions): FileLoggerHan
       uninstalled = true;
       process.stdout.write = originalStdout;
       process.stderr.write = originalStderr;
+      process.stdout.off("error", errorHandler);
+      process.stderr.off("error", errorHandler);
       try {
         closeSync(fd);
       } catch {
@@ -60,7 +75,11 @@ function wrap(original: WriteFn, stream: NodeJS.WriteStream, fd: number): WriteF
     } catch {
       // never let the file sink break the caller — stdout/stderr must stay live
     }
-    return (original as (...a: unknown[]) => boolean).apply(stream, args);
+    try {
+      return (original as (...a: unknown[]) => boolean).apply(stream, args);
+    } catch {
+      return false;
+    }
   };
   return wrapped as WriteFn;
 }

--- a/src/utils/log-file.ts
+++ b/src/utils/log-file.ts
@@ -32,14 +32,9 @@ export function installFileLogger(opts: InstallFileLoggerOptions): FileLoggerHan
   process.stdout.write = wrap(originalStdout, process.stdout, fd);
   process.stderr.write = wrap(originalStderr, process.stderr, fd);
 
-  const errorHandler = (err: unknown): void => {
-    if (err && typeof err === "object" && "code" in err) {
-      const code = (err as { code?: unknown }).code;
-      if (code === "EPIPE" || code === "ECONNRESET") {
-        return;
-      }
-    }
-    throw err;
+  const errorHandler = (error: unknown): void => {
+    if (isIgnorableStreamError(error)) return;
+    throw error;
   };
 
   process.stdout.on("error", errorHandler);
@@ -77,11 +72,21 @@ function wrap(original: WriteFn, stream: NodeJS.WriteStream, fd: number): WriteF
     }
     try {
       return (original as (...a: unknown[]) => boolean).apply(stream, args);
-    } catch {
-      return false;
+    } catch (error) {
+      if (isIgnorableStreamError(error)) return false;
+      throw error;
     }
   };
   return wrapped as WriteFn;
+}
+
+function isIgnorableStreamError(error: unknown): boolean {
+  if (error === null || typeof error !== "object" || !("code" in error)) {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return code === "EPIPE" || code === "ECONNRESET";
 }
 
 function toBuffer(chunk: unknown, encoding: BufferEncoding | undefined): Buffer {

--- a/tests/unit/utils/log-file.test.ts
+++ b/tests/unit/utils/log-file.test.ts
@@ -103,6 +103,76 @@ describe("installFileLogger", () => {
     expect(typeof result).toBe("boolean");
   });
 
+  it.each(["EPIPE", "ECONNRESET"] as const)(
+    "suppresses synchronous %s errors from the underlying stream",
+    (code) => {
+      const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+      cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+      const originalWrite = process.stdout.write;
+      const error = Object.assign(new Error(code), { code });
+      process.stdout.write = (() => {
+        throw error;
+      }) as typeof process.stdout.write;
+      cleanups.push(() => {
+        process.stdout.write = originalWrite;
+      });
+
+      const handle = installFileLogger({ dir, filename: "test.log" });
+      cleanups.push(() => handle.uninstall());
+
+      expect(() => process.stdout.write("broken pipe\n")).not.toThrow();
+      expect(process.stdout.write("broken pipe\n")).toBe(false);
+    },
+  );
+
+  it("rethrows non-ignorable synchronous stream errors", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    const originalWrite = process.stdout.write;
+    const error = Object.assign(new Error("invalid argument"), { code: "EINVAL" });
+    process.stdout.write = (() => {
+      throw error;
+    }) as typeof process.stdout.write;
+    cleanups.push(() => {
+      process.stdout.write = originalWrite;
+    });
+
+    const handle = installFileLogger({ dir, filename: "test.log" });
+    cleanups.push(() => handle.uninstall());
+
+    expect(() => process.stdout.write("invalid\n")).toThrow(error);
+  });
+
+  it("suppresses ignorable stream error events", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    const handle = installFileLogger({ dir, filename: "test.log" });
+    cleanups.push(() => handle.uninstall());
+
+    for (const code of ["EPIPE", "ECONNRESET"] as const) {
+      const error = Object.assign(new Error(code), { code });
+      expect(() => process.stdout.emit("error", error)).not.toThrow();
+    }
+  });
+
+  it("rethrows non-ignorable stream error events and removes handlers on uninstall", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    const before = process.stdout.listenerCount("error");
+    const handle = installFileLogger({ dir, filename: "test.log" });
+    expect(process.stdout.listenerCount("error")).toBe(before + 1);
+
+    const error = Object.assign(new Error("invalid argument"), { code: "EINVAL" });
+    expect(() => process.stdout.emit("error", error)).toThrow(error);
+
+    handle.uninstall();
+    expect(process.stdout.listenerCount("error")).toBe(before);
+  });
+
   it("appends to an existing file instead of truncating", () => {
     const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
     cleanups.push(() => rmSync(dir, { recursive: true, force: true }));

--- a/tests/unit/utils/log-file.test.ts
+++ b/tests/unit/utils/log-file.test.ts
@@ -119,4 +119,47 @@ describe("installFileLogger", () => {
     expect(contents).toContain("first run");
     expect(contents).toContain("second run");
   });
+
+  it("catches EPIPE write errors from the underlying stream and returns false instead of crashing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    const originalWrite = process.stdout.write;
+    process.stdout.write = () => {
+      const err = new Error("write EPIPE") as Error & { code?: string };
+      err.code = "EPIPE";
+      throw err;
+    };
+
+    const handle = installFileLogger({ dir, filename: "test-epipe.log" });
+    cleanups.push(() => {
+      handle.uninstall();
+      process.stdout.write = originalWrite;
+    });
+
+    let result: boolean | undefined;
+    expect(() => {
+      result = process.stdout.write("should not crash\n");
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+
+  it("ignores EPIPE and ECONNRESET error events on stdout/stderr to prevent process crash", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-proxy-log-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+    const handle = installFileLogger({ dir, filename: "test-events.log" });
+    cleanups.push(() => handle.uninstall());
+
+    const epipeErr = new Error("write EPIPE") as Error & { code?: string };
+    epipeErr.code = "EPIPE";
+
+    const econnresetErr = new Error("write ECONNRESET") as Error & { code?: string };
+    econnresetErr.code = "ECONNRESET";
+
+    expect(() => {
+      process.stdout.emit("error", epipeErr);
+      process.stderr.emit("error", econnresetErr);
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
## 问题

容器/pipe 断开时，Node.js 会向 stdout/stderr 发 `error` 事件，未处理会导致进程崩溃。在 `wrap()` 里调用原始 write 方法时如果抛 `EPIPE`，也会上抛给调用方。

## 修复

- `installFileLogger()` 注册 `error` 事件处理器，静默吞掉 `EPIPE` / `ECONNRESET`，其他错误继续 `throw`
- `uninstall()` 时同步 `off` 解绑，避免 listener 泄漏  
- `wrap()` 内部的原始 write 调用包 `try/catch`，抛错时返回 `false` 而不是崩

## 测试

- 新增：write 时 EPIPE 不崩，返回 `false`
- 新增：stdout/stderr error 事件 EPIPE/ECONNRESET 不崩

```
✓ tests/unit/utils/log-file.test.ts (9 tests)
```

Extracted from #675.