### PR TITLE
fix: align api key status switch

### DIFF
--- a/web/src/components/ApiKeyManager.tsx
+++ b/web/src/components/ApiKeyManager.tsx
@@ -438,7 +438,7 @@ function KeyRow({ entry, onDelete, onToggle }: {
           isActive ? "bg-primary" : "bg-slate-300 dark:bg-slate-600"
         }`}
       >
-        <span class={`absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white shadow transition-transform ${
+        <span class={`absolute left-0 top-0.5 w-3.5 h-3.5 rounded-full bg-white shadow transition-transform ${
           isActive ? "translate-x-[16px]" : "translate-x-0.5"
         }`} />
       </button>


### PR DESCRIPTION
## Summary

Fixes the API Keys status switch knob alignment by anchoring the knob to the left edge before applying the existing translate offset.

## Changes

- Adds `left-0` to the API key status switch knob.
- Keeps the existing switch dimensions and translate values unchanged.

## Verification

- `npm --prefix web run build`

Fixes #684 