### PR TITLE
fix(translation): honor Claude reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Fixed
 
+- 修复 Claude Code / Claude Desktop 的 Anthropic Messages 请求中 `output_config.effort` 被 schema 丢弃、最终总是使用默认推理等级的问题；显式 effort 现在优先于 thinking budget、模型后缀和默认配置，`ultra` / `ultracode` 会兼容映射为 Codex 支持的 `xhigh`（`src/types/anthropic.ts`、`src/translation/anthropic-to-codex.ts`、`src/routes/messages.ts`）。
 - 修复 Dashboard Errors tab 的“全部标记已读”和“删除”操作被 Settings Bearer-token middleware 拦截成 401 的问题；`/admin/error-logs*` 统一交给 dashboard session auth，避免 cookie 登录会话被误判失效并跳回登录页。（`src/routes/admin/settings.ts`、`tests/integration/error-logs-dashboard-auth.test.ts`）
 - 修复 release notes 生成脚本在 LLM endpoint 不可达时可能被 60s 默认请求超时拖慢测试的问题；新增 `RELEASE_NOTES_REQUEST_TIMEOUT_MS` 仅用于覆盖该脚本请求超时，生产默认仍为 60s。（`.github/scripts/summarize-release-notes.mjs`、`tests/unit/ci/summarize-release-notes.test.ts`）
 - 修复并强化 WebSocket 消息流的生命周期管理：通过缓冲早期元数据帧（如 `response.created`），延迟解析 HTTP 响应，从而解决由于内部限流事件导致的提前解析和挂起问题，并在重构中排除了首字时间（TTFT）超过 20s 会引发超时的隐患。（#678，感谢 [@zyycn](https://github.com/zyycn)）

--- a/src/logs/request-summary.ts
+++ b/src/logs/request-summary.ts
@@ -56,6 +56,12 @@ export function summarizeRequestForLog(route: string, body: unknown, meta: Recor
       summary.stream = typeof body.stream === "boolean" ? body.stream : undefined;
       summary.max_tokens = typeof body.max_tokens === "number" ? body.max_tokens : undefined;
       summary.thinking = isRecord(body.thinking) ? body.thinking.type : undefined;
+      summary.thinking_budget_tokens = isRecord(body.thinking) && typeof body.thinking.budget_tokens === "number"
+        ? body.thinking.budget_tokens
+        : undefined;
+      summary.output_config_effort = isRecord(body.output_config) && typeof body.output_config.effort === "string"
+        ? body.output_config.effort
+        : undefined;
       summary.tools = toCount(body.tools);
       summary.headers = isRecord(meta.headers) ? summarizeHeaders(meta.headers) : undefined;
     }

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -184,8 +184,8 @@ export function createMessagesRoutes(
     if (!allowUnauthenticated) {
       codexRequest.useWebSocket = true;
     }
-    // Check after translation so suffix-parsed and config-default effort are included.
-    const wantThinking = !!codexRequest.reasoning?.effort;
+    // Anthropic thinking blocks are returned only when the client explicitly requests them.
+    const wantThinking = req.thinking?.type === "enabled" || req.thinking?.type === "adaptive";
     const proxyReq = {
       codexRequest,
       model: buildDisplayModelName(parseModelName(req.model)),

--- a/src/translation/anthropic-to-codex.ts
+++ b/src/translation/anthropic-to-codex.ts
@@ -44,6 +44,11 @@ function mapThinkingToEffort(
   return budgetToEffort(thinking.budget_tokens);
 }
 
+function normalizeCodexEffort(effort: string | null | undefined): string | undefined {
+  if (!effort) return undefined;
+  return effort === "ultra" || effort === "ultracode" ? "xhigh" : effort;
+}
+
 /**
  * Extract text-only content from Anthropic blocks.
  */
@@ -191,7 +196,7 @@ function contentToInputItems(
  *   - system (top-level) → instructions field
  *   - messages → input array
  *   - model → resolved model ID
- *   - thinking → reasoning.effort
+ *   - output_config.effort / thinking → reasoning.effort
  */
 export function translateAnthropicToCodexRequest(
   req: AnthropicMessagesRequest,
@@ -267,12 +272,14 @@ export function translateAnthropicToCodexRequest(
     request.tool_choice = codexToolChoice;
   }
 
-  // Reasoning effort: thinking config > suffix > config default
+  // Reasoning effort: explicit output config > thinking config > suffix > config default.
   const thinkingEffort = mapThinkingToEffort(req.thinking);
-  const effort =
+  const anthropicEffort =
+    req.output_config?.effort ??
     thinkingEffort ??
     parsed.reasoningEffort ??
     cfg.default_reasoning_effort;
+  const effort = normalizeCodexEffort(anthropicEffort);
   if (effort) {
     request.reasoning = { effort, summary: "auto" };
   }

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -94,6 +94,10 @@ const AnthropicThinkingAdaptiveSchema = z.object({
   budget_tokens: z.number().int().positive().optional(),
 });
 
+const AnthropicOutputConfigSchema = z.object({
+  effort: z.string().trim().min(1).optional(),
+}).passthrough();
+
 export const AnthropicMessagesRequestSchema = z.object({
   model: z.string(),
   max_tokens: z.number().int().positive(),
@@ -118,6 +122,7 @@ export const AnthropicMessagesRequestSchema = z.object({
       AnthropicThinkingAdaptiveSchema,
     ])
     .optional(),
+  output_config: AnthropicOutputConfigSchema.optional(),
   // Tool-related fields. Custom tools are converted to Codex function tools;
   // Anthropic hosted web search is converted to Codex hosted web_search.
   tools: z.array(z.union([
@@ -155,6 +160,7 @@ export const AnthropicCountTokensRequestSchema = z.object({
   tools: AnthropicMessagesRequestSchema.shape.tools,
   tool_choice: AnthropicMessagesRequestSchema.shape.tool_choice,
   thinking: AnthropicMessagesRequestSchema.shape.thinking,
+  output_config: AnthropicMessagesRequestSchema.shape.output_config,
   betas: z.array(z.string()).optional(),
 });
 

--- a/tests/e2e/messages.test.ts
+++ b/tests/e2e/messages.test.ts
@@ -232,6 +232,41 @@ describe("E2E: POST /v1/messages", () => {
     expect(typeof usage.output_tokens).toBe("number");
   });
 
+  it.each([
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "high"],
+    ["xhigh", "xhigh"],
+    ["max", "max"],
+    ["ultra", "xhigh"],
+    ["ultracode", "xhigh"],
+  ])(
+    "maps output_config effort %s to Codex effort %s",
+    async (effort, expectedEffort) => {
+      const res = await messagesRequest(defaultBody({
+        model: "gpt-5.6-sol",
+        output_config: { effort },
+      }));
+      expect(res.status).toBe(200);
+
+      const transportBody = getLastTransportBody();
+      if (!transportBody) {
+        throw new Error("Expected upstream transport body to be captured");
+      }
+
+      const upstreamRequest = JSON.parse(transportBody) as {
+        reasoning?: { effort?: string; summary?: string };
+      };
+      expect(upstreamRequest.reasoning).toEqual({
+        effort: expectedEffort,
+        summary: "auto",
+      });
+
+      const body = await res.json() as { content?: Array<{ type?: string }> };
+      expect(body.content?.some((block) => block.type === "thinking")).toBe(false);
+    },
+  );
+
   it("maps Claude Code session id to an account-scoped upstream prompt_cache_key", async () => {
     const res = await ctx.app.request("/v1/messages", {
       method: "POST",

--- a/tests/unit/logs/request-summary-reasoning.test.ts
+++ b/tests/unit/logs/request-summary-reasoning.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => ({ logs: { capture_body: false } })),
+}));
+
+import { summarizeRequestForLog } from "@src/logs/request-summary.js";
+
+describe("request summary reasoning fields", () => {
+  it("summarizes Anthropic effort sources", () => {
+    const summary = summarizeRequestForLog("messages", {
+      model: "gpt-5.6-sol",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: "Think deeply" }],
+      thinking: { type: "adaptive", budget_tokens: 32000 },
+      output_config: { effort: "ultra" },
+    });
+
+    expect(summary).toMatchObject({
+      body_type: "anthropic.messages",
+      thinking: "adaptive",
+      thinking_budget_tokens: 32000,
+      output_config_effort: "ultra",
+    });
+  });
+});

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -403,6 +403,67 @@ describe("translateAnthropicToCodexRequest", () => {
     });
   });
 
+  describe("output_config effort", () => {
+    it.each(["low", "medium", "high", "xhigh", "max"])(
+      "forwards %s unchanged",
+      (effort) => {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({ output_config: { effort } }),
+        );
+
+        expect(result.reasoning).toEqual({ effort, summary: "auto" });
+      },
+    );
+
+    it.each(["ultra", "ultracode"])("maps %s to Codex xhigh", (effort) => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({ output_config: { effort } }),
+      );
+
+      expect(result.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    });
+
+    it("takes priority over thinking budget and model suffix", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          model: "gpt-5.4-high",
+          thinking: { type: "enabled", budget_tokens: 15000 },
+          output_config: { effort: "ultra" },
+        }),
+      );
+
+      expect(result.reasoning?.effort).toBe("xhigh");
+    });
+
+    it.each(["low", "medium", "high", "xhigh", "max"])(
+      "overrides the configured default with %s",
+      (effort) => {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({ output_config: { effort } }),
+          {
+            default_reasoning_effort: effort === "high" ? "low" : "high",
+            default_service_tier: null,
+            inject_desktop_context: false,
+            suppress_desktop_directives: false,
+          },
+        );
+
+        expect(result.reasoning?.effort).toBe(effort);
+      },
+    );
+
+    it("keeps xhigh unchanged when user content mentions ultracode", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          messages: [{ role: "user", content: "let me try ultracode mode" }],
+          output_config: { effort: "xhigh" },
+        }),
+      );
+
+      expect(result.reasoning?.effort).toBe("xhigh");
+    });
+  });
+
   // ── Thinking → reasoning effort ──────────────────────────────────────
 
   describe("thinking to reasoning effort", () => {


### PR DESCRIPTION
## Summary

修复 Claude Code 和 Claude Desktop 通过 Anthropic Messages API 选择推理等级时，`output_config.effort` 被 Zod schema 丢弃、请求最终回退到服务端默认 effort 的问题。显式 effort 现在优先于 thinking budget、模型后缀和默认配置；Codex 不支持的 `ultra` / `ultracode` 兼容输入会映射为 `xhigh`，避免上游返回 400。

## Changes

- 在 Anthropic Messages 与 count_tokens schema 中声明并保留 `output_config.effort` 及其透传字段（`src/types/anthropic.ts`）。
- 按 `output_config.effort > thinking budget > model suffix > default` 的顺序解析推理等级，并将 `ultra` / `ultracode` 映射为 Codex 支持的 `xhigh`（`src/translation/anthropic-to-codex.ts`）。
- 仅在客户端明确启用 Anthropic thinking 时返回 thinking block，避免仅设置 effort 就改变响应内容结构（`src/routes/messages.ts`）。
- 在 ingress 摘要中记录 `thinking_budget_tokens` 和 `output_config_effort`，并补充翻译层、日志和 Messages E2E 回归测试。

## Test Plan

- [x] `npm test -- --run tests/unit/translation/anthropic-to-codex.test.ts tests/e2e/messages.test.ts tests/unit/logs/request-summary-reasoning.test.ts tests/unit/types/schemas.test.ts` — 4 个文件、90 项测试通过
- [x] `npx tsc --noEmit`
- [x] `npm test` — Windows 本地环境中的 POSIX CI 脚本测试无法运行：`docker-entrypoint-arch.test.ts` 报 `spawnSync sh ENOENT`，`release-notes-script.test.ts` 和 `select-promote-candidate.test.ts` 也依赖 Bash；产品代码及本次相关测试没有失败
- [x] `npm run test:real`

## Notes

请重点检查 Anthropic `output_config.effort` 的优先级，以及 `ultra` / `ultracode → xhigh` 的兼容映射。Codex 后端当前只接受 `none`、`minimal`、`low`、`medium`、`high` 和 `xhigh`。