### PR TITLE
feat: add GPT-5.6 (sol/terra/luna) support

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -3,8 +3,8 @@ api:
   timeout_seconds: 600
 client:
   originator: Codex Desktop
-  app_version: 26.609.30741
-  build_number: "3808"
+  app_version: 26.609.41114
+  build_number: "3888"
   platform: darwin
   arch: arm64
   chromium_version: "146"

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -79,7 +79,7 @@ export const ConfigSchema = z.object({
     chromium_version: z.string().default("136"),
   }),
   model: z.object({
-    default: z.string().default("gpt-5.4"),
+    default: z.string().default("gpt-5.6-sol"),
     default_reasoning_effort: z.string().nullable().default(null),
     default_service_tier: z.string().nullable().default(null),
     aliases: z.record(z.string(), z.string()).default({}),

--- a/src/ollama/bridge.ts
+++ b/src/ollama/bridge.ts
@@ -53,6 +53,11 @@ class OllamaBridgeError extends Error {
 }
 
 const CONTEXT_WINDOW_OVERRIDES = new Map<string, number>([
+  // GPT-5.6 family (GA 2026-07-09) — 1 M token context window
+  ["gpt-5.6-sol", 1050000],
+  ["gpt-5.6-terra", 1050000],
+  ["gpt-5.6-luna", 1050000],
+  ["gpt-5.6", 1050000],
   ["gpt-5.5", 400000],
   ["gpt-5.4", 400000],
   ["gpt-5.4-pro", 400000],
@@ -110,6 +115,7 @@ function responseHeaders(init: HeadersInit, request?: Request): Headers {
 
 function inferFamily(modelId: string): string {
   const normalized = modelId.toLowerCase();
+  if (normalized.startsWith("gpt-5.6")) return "gpt-5.6";
   if (normalized.startsWith("gpt-5.5")) return "gpt-5.5";
   if (normalized.startsWith("gpt-5.4")) return "gpt-5.4";
   if (normalized.startsWith("gpt-5.3")) return "gpt-5.3";

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -36,7 +36,7 @@ describe("ConfigSchema", () => {
     expect(result.auth.refresh_concurrency).toBe(2);
     expect(result.auth.max_concurrent_per_account).toBe(3);
     expect(result.auth.request_interval_ms).toBe(50);
-    expect(result.model.default).toBe("gpt-5.4");
+    expect(result.model.default).toBe("gpt-5.6-sol");
     expect(result.model.default_reasoning_effort).toBeNull();
     expect(result.model.aliases).toEqual({});
     expect(result.model.custom_models).toEqual([]);


### PR DESCRIPTION
## Changes

GPT-5.6 family went GA on 2026-07-09. This PR adds support for the new model series.

### What changed

- **`src/ollama/bridge.ts`**: Add `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.6` to `CONTEXT_WINDOW_OVERRIDES` (1,050,000 tokens); add `gpt-5.6` branch to `inferFamily()`
- **`src/config-schema.ts`**: Bump default model `gpt-5.4` → `gpt-5.6-sol`
- **`tests/unit/config-schema.test.ts`**: Update default model assertion
- **`config/default.yaml`**: Bump `app_version`/`build_number` (fingerprint sync)

### Notes

- `config/models.yaml` is empty by design — model list is pulled dynamically from `/backend-api/codex/models`; gpt-5.6 will appear automatically for Plus/Pro accounts
- Plan gating for gpt-5.6 not yet verified (free accounts may not see it)