### PR TITLE
fix(auth): import accountId-less Sub2API accounts

### DIFF
--- a/src/auth/account-persistence.ts
+++ b/src/auth/account-persistence.ts
@@ -561,7 +561,9 @@ function normalizeAccountEntries(rawEntries: unknown[]): {
       needsPersist = true;
     }
 
-    // Backfill missing fields from JWT
+    // Backfill legacy fields using the stable JWT helper contract. Portable
+    // organization metadata is injected by AccountImportService and persisted
+    // in entry_json; old entries simply normalize it to null.
     if (!entry.planType || !entry.email || !entry.accountId || !entry.userId) {
       const profile = extractUserProfile(entry.token);
       const accountId = extractChatGptAccountId(entry.token);
@@ -588,6 +590,14 @@ function normalizeAccountEntries(rawEntries: unknown[]): {
     }
     if (entry.accountId === undefined) {
       entry.accountId = null;
+      needsPersist = true;
+    }
+    if (entry.organizationId === undefined) {
+      entry.organizationId = null;
+      needsPersist = true;
+    }
+    if (entry.accountIdSource === undefined) {
+      entry.accountIdSource = null;
       needsPersist = true;
     }
     // Backfill userId for entries missing it (pre-v1.0.68)
@@ -689,6 +699,8 @@ function migrateFromLegacy(): AccountEntry[] {
       refreshToken: null,
       email: data.userInfo?.email ?? null,
       accountId: accountId,
+      organizationId: null,
+      accountIdSource: accountId ? "access_token" : null,
       userId: extractUserProfile(data.token)?.chatgpt_user_id ?? null,
       label: null,
       codexFingerprintMode: "off",

--- a/src/auth/account-pool.ts
+++ b/src/auth/account-pool.ts
@@ -12,6 +12,7 @@ import { AccountRegistry } from "./account-registry.js";
 import { AccountLifecycle } from "./account-lifecycle.js";
 import type { AccountPersistence, PersistenceLoadHealth } from "./account-persistence.js";
 import type { AccountCapacitySummary } from "./account-lifecycle.js";
+import type { CodexTokenMetadata } from "./token-metadata.js";
 import type { RotationStrategyName } from "./rotation-strategy.js";
 import type {
   AccountEntry,
@@ -132,8 +133,12 @@ export class AccountPool {
 
   // ── CRUD ──────────────────────────────────────────────────────────
 
-  addAccount(token: string, refreshToken?: string | null): string {
-    return this.registry.addAccount(token, refreshToken);
+  addAccount(
+    token: string,
+    refreshToken?: string | null,
+    metadata?: Partial<CodexTokenMetadata>,
+  ): string {
+    return this.registry.addAccount(token, refreshToken, metadata);
   }
 
   async withPersistenceBatch<T>(fn: () => Promise<T>): Promise<T> {

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -14,6 +14,7 @@ import {
   extractUserProfile,
   isTokenExpired,
 } from "./jwt-utils.js";
+import type { CodexTokenMetadata } from "./token-metadata.js";
 import type { AccountPersistence } from "./account-persistence.js";
 import type {
   AccountEntry,
@@ -97,27 +98,50 @@ export class AccountRegistry {
 
   // ── CRUD ──────────────────────────────────────────────────────────
 
-  addAccount(token: string, refreshToken?: string | null): string {
-    const accountId = extractChatGptAccountId(token);
+  addAccount(
+    token: string,
+    refreshToken?: string | null,
+    metadata?: Partial<CodexTokenMetadata>,
+  ): string {
+    const tokenAccountId = extractChatGptAccountId(token);
     const profile = extractUserProfile(token);
-    const userId = profile?.chatgpt_user_id ?? null;
+    const accountId = tokenAccountId ?? metadata?.accountId ?? null;
+    const organizationId = metadata?.organizationId ?? null;
+    const userId = profile?.chatgpt_user_id ?? metadata?.userId ?? null;
+    const email = profile?.email ?? metadata?.email ?? null;
+    const planType = profile?.chatgpt_plan_type ?? metadata?.planType ?? null;
+    const accountIdSource = tokenAccountId
+      ? "access_token"
+      : metadata?.accountIdSource ?? null;
 
     for (const existing of this.accounts.values()) {
-      if (accountId) {
-        if (existing.accountId === accountId && existing.userId === userId) {
-          existing.token = token;
-          if (typeof refreshToken === "string" && refreshToken.length > 0) {
-            existing.refreshToken = refreshToken;
-          }
-          existing.email = profile?.email ?? existing.email;
-          existing.planType = profile?.chatgpt_plan_type ?? existing.planType;
-          existing.status = isTokenExpired(token) ? "expired" : "active";
-          this.persistNow();
-          return existing.id;
-        }
-      } else if (existing.token === token) {
-        return existing.id;
+      const sameAccountUser = Boolean(
+        accountId &&
+        existing.accountId === accountId &&
+        existing.userId === userId,
+      );
+      const sameOrganizationUser = Boolean(
+        organizationId &&
+        userId &&
+        (!accountId || !existing.accountId) &&
+        existing.organizationId === organizationId &&
+        existing.userId === userId,
+      );
+      if (!sameAccountUser && !sameOrganizationUser && existing.token !== token) continue;
+
+      existing.token = token;
+      if (typeof refreshToken === "string" && refreshToken.length > 0) {
+        existing.refreshToken = refreshToken;
       }
+      existing.email = email ?? existing.email;
+      existing.accountId = accountId ?? existing.accountId;
+      existing.organizationId = organizationId ?? existing.organizationId ?? null;
+      existing.accountIdSource = accountIdSource ?? existing.accountIdSource ?? null;
+      existing.userId = userId ?? existing.userId;
+      existing.planType = planType ?? existing.planType;
+      existing.status = isTokenExpired(token) ? "expired" : "active";
+      this.persistNow();
+      return existing.id;
     }
 
     const id = randomBytes(8).toString("hex");
@@ -125,12 +149,14 @@ export class AccountRegistry {
       id,
       token,
       refreshToken: refreshToken ?? null,
-      email: profile?.email ?? null,
+      email,
       accountId,
+      organizationId,
+      accountIdSource,
       userId,
       label: null,
       codexFingerprintMode: "off",
-      planType: profile?.chatgpt_plan_type ?? null,
+      planType,
       proxyApiKey: "codex-proxy-" + randomBytes(24).toString("hex"),
       status: isTokenExpired(token) ? "expired" : "active",
       usage: {
@@ -173,10 +199,12 @@ export class AccountRegistry {
       entry.refreshToken = refreshToken;
     }
     const profile = extractUserProfile(newToken);
+    const accountId = extractChatGptAccountId(newToken);
     entry.email = profile?.email ?? entry.email;
     entry.planType = profile?.chatgpt_plan_type ?? entry.planType;
-    entry.accountId = extractChatGptAccountId(newToken) ?? entry.accountId;
+    entry.accountId = accountId ?? entry.accountId;
     entry.userId = profile?.chatgpt_user_id ?? entry.userId;
+    if (accountId) entry.accountIdSource = "access_token";
     // Don't reactivate manually disabled or banned accounts
     if (entry.status !== "disabled" && entry.status !== "banned") {
       entry.status = isTokenExpired(newToken) ? "expired" : "active";
@@ -696,6 +724,8 @@ export class AccountRegistry {
       id: entry.id,
       email: entry.email,
       accountId: entry.accountId,
+      organizationId: entry.organizationId ?? null,
+      accountIdSource: entry.accountIdSource ?? null,
       userId: entry.userId,
       label: entry.label,
       codexFingerprintMode: entry.codexFingerprintMode === "session" ? "session" : "off",

--- a/src/auth/chatgpt-oauth.ts
+++ b/src/auth/chatgpt-oauth.ts
@@ -5,9 +5,11 @@ import {
 } from "./jwt-utils.js";
 
 /**
- * Validate a manually-pasted JWT token.
+ * Validate the non-negotiable JWT structure shared by all import paths.
+ * This deliberately does not require chatgpt_account_id: some legitimate
+ * OpenAI access tokens omit that claim and need identity discovery instead.
  */
-export function validateManualToken(token: string): {
+export function validateTokenStructure(token: string): {
   valid: boolean;
   error?: string;
 } {
@@ -24,9 +26,28 @@ export function validateManualToken(token: string): {
     };
   }
 
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+    return { valid: false, error: "Token missing or invalid exp claim" };
+  }
+
   if (isTokenExpired(trimmed)) {
     return { valid: false, error: "Token is expired" };
   }
+
+  return { valid: true };
+}
+
+/**
+ * Validate a manually-pasted JWT token using the legacy strict contract.
+ */
+export function validateManualToken(token: string): {
+  valid: boolean;
+  error?: string;
+} {
+  const structure = validateTokenStructure(token);
+  if (!structure.valid) return structure;
+
+  const trimmed = token.trim();
 
   const accountId = extractChatGptAccountId(trimmed);
   if (!accountId) {

--- a/src/auth/oauth-pkce.ts
+++ b/src/auth/oauth-pkce.ts
@@ -190,6 +190,8 @@ export async function refreshAccessToken(
     grant_type: "refresh_token",
     client_id: config.auth.oauth_client_id,
     refresh_token: refreshToken,
+    // Ask Auth0/OpenAI to keep returning id_token metadata. Some legitimate
+    // refreshed access tokens omit chatgpt_account_id while id_token carries it.
     scope: "openid profile email offline_access",
   });
 

--- a/src/auth/token-metadata.ts
+++ b/src/auth/token-metadata.ts
@@ -1,0 +1,115 @@
+import { decodeJwtPayload } from "./jwt-utils.js";
+
+export type AccountIdSource = "access_token" | "id_token" | "upstream_discovery" | null;
+
+export interface CodexTokenMetadata {
+  accountId: string | null;
+  organizationId: string | null;
+  userId: string | null;
+  email: string | null;
+  planType: string | null;
+  accountIdSource: AccountIdSource;
+}
+
+export interface CodexTokenMetadataHints {
+  organizationId?: string | null;
+  userId?: string | null;
+  email?: string | null;
+  planType?: string | null;
+}
+
+function recordClaim(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function nonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function organizationIdFromClaims(auth: Record<string, unknown>): string | null {
+  const direct = nonEmptyString(
+    auth.organization_id,
+    auth.chatgpt_organization_id,
+    auth.chatgpt_org_id,
+    auth.poid,
+  );
+  if (direct) return direct;
+
+  const organizations = Array.isArray(auth.organizations) ? auth.organizations : [];
+  const records = organizations.map(recordClaim);
+  const defaultOrg = records.find((org) => org.is_default === true);
+  return nonEmptyString(defaultOrg?.id, ...records.map((org) => org.id));
+}
+
+/**
+ * Extract portable Codex identity metadata from both OAuth tokens.
+ *
+ * Important trust boundary:
+ * - accountId only comes from token claims here. File-level account-id hints are
+ *   intentionally excluded because they eventually control ChatGPT-Account-Id.
+ * - organizationId is kept separate and must never be sent as accountId.
+ * - callers decide whether an unverified file-supplied id_token account ID must
+ *   be confirmed by upstream discovery before use.
+ */
+export function extractCodexTokenMetadata(
+  accessToken: string,
+  idToken?: string | null,
+  hints: CodexTokenMetadataHints = {},
+): CodexTokenMetadata {
+  const accessPayload = decodeJwtPayload(accessToken);
+  const idPayload = idToken ? decodeJwtPayload(idToken) : null;
+  const accessAuth = recordClaim(accessPayload?.["https://api.openai.com/auth"]);
+  const idAuth = recordClaim(idPayload?.["https://api.openai.com/auth"]);
+  const accessProfile = recordClaim(accessPayload?.["https://api.openai.com/profile"]);
+  const idProfile = recordClaim(idPayload?.["https://api.openai.com/profile"]);
+
+  const accessAccountId = nonEmptyString(accessAuth.chatgpt_account_id);
+  const idAccountId = nonEmptyString(idAuth.chatgpt_account_id);
+  const accountId = accessAccountId ?? idAccountId;
+
+  return {
+    accountId,
+    organizationId: nonEmptyString(
+      organizationIdFromClaims(accessAuth),
+      organizationIdFromClaims(idAuth),
+      hints.organizationId,
+    ),
+    userId: nonEmptyString(
+      accessAuth.chatgpt_user_id,
+      accessAuth.user_id,
+      accessProfile.chatgpt_user_id,
+      accessProfile.user_id,
+      idAuth.chatgpt_user_id,
+      idAuth.user_id,
+      idProfile.chatgpt_user_id,
+      idProfile.user_id,
+      hints.userId,
+    ),
+    email: nonEmptyString(
+      accessProfile.email,
+      accessPayload?.email,
+      idProfile.email,
+      idPayload?.email,
+      hints.email,
+    ),
+    planType: nonEmptyString(
+      accessAuth.chatgpt_plan_type,
+      accessProfile.chatgpt_plan_type,
+      idAuth.chatgpt_plan_type,
+      idProfile.chatgpt_plan_type,
+      hints.planType,
+    ),
+    accountIdSource: accessAccountId
+      ? "access_token"
+      : idAccountId
+        ? "id_token"
+        : null,
+  };
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -66,6 +66,10 @@ export interface AccountEntry {
   refreshToken: string | null;
   email: string | null;
   accountId: string | null;
+  /** OpenAI organization identity. Never send this as ChatGPT-Account-Id. */
+  organizationId?: string | null;
+  /** Auditable source of the workspace account ID. */
+  accountIdSource?: "access_token" | "id_token" | "upstream_discovery" | null;
   /** Per-user unique ID (chatgpt_user_id). Team members share accountId but have distinct userId. */
   userId: string | null;
   /** User-editable label for disambiguation (e.g. "Team Alpha", "Personal"). */
@@ -89,6 +93,8 @@ export interface AccountInfo {
   id: string;
   email: string | null;
   accountId: string | null;
+  organizationId?: string | null;
+  accountIdSource?: "access_token" | "id_token" | "upstream_discovery" | null;
   userId: string | null;
   label: string | null;
   codexFingerprintMode: CodexFingerprintMode;

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -18,8 +18,10 @@ import { clearWarnings, getActiveWarnings, getWarningsLastUpdated } from "../aut
 import { probeAccount, batchHealthCheck } from "../auth/health-check.js";
 import { AccountImportService } from "../services/account-import.js";
 import type { ImportEntry } from "../services/account-import.js";
+import { discoverCodexAccountIdentity } from "../services/account-identity-resolver.js";
 import { AccountQueryService } from "../services/account-query.js";
 import { AccountMutationService } from "../services/account-mutation.js";
+import { getProxyUrl as getRuntimeProxyUrl } from "../tls/proxy.js";
 import {
   buildAccountExportPayload,
   parseAccountExportFormat,
@@ -41,7 +43,15 @@ export function createAccountRoutes(pool: AccountPool, scheduler: RefreshSchedul
   const importSvc = new AccountImportService(pool, scheduler, {
     validateToken: validateManualToken,
     refreshToken: refreshAccessToken,
-    getProxyUrl: () => getConfig().tls?.proxy_url ?? null,
+    // Use the process-level resolved proxy (configured or auto-detected), not
+    // only config.tls.proxy_url. Passing null would force direct transport and
+    // bypass the Clash proxy selected during startup.
+    getProxyUrl: getRuntimeProxyUrl,
+    discoverIdentity: (token, metadata, options) =>
+      discoverCodexAccountIdentity(token, metadata, {
+        proxyUrl: options.proxyUrl,
+        accountIdHint: options.accountIdHint,
+      }),
     // Warmup disabled: sending GET /codex/usage immediately after RT exchange
     // triggers OpenAI risk detection and causes account deactivation.
     warmup: undefined,

--- a/src/services/account-identity-resolver.ts
+++ b/src/services/account-identity-resolver.ts
@@ -126,9 +126,102 @@ function identityEndpoint(baseUrl: string): string {
   return `${base}/accounts/check/v4-2023-04-27?timezone_offset_min=${timezoneOffset}`;
 }
 
+function usageEndpoint(baseUrl: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  return `${base}/wham/usage`;
+}
+
+function headersForAccount(
+  token: string,
+  accountId: string | null,
+  transport: TlsTransport,
+  supplied?: Record<string, string>,
+): Record<string, string> {
+  const headers = supplied
+    ? { ...supplied }
+    : buildHeaders(token, accountId);
+
+  // Test-supplied/base headers may contain a stale account header. Identity
+  // discovery must start without one and add only an upstream-confirmed value.
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === "chatgpt-account-id") delete headers[key];
+  }
+  if (accountId) headers["ChatGPT-Account-Id"] = accountId;
+  headers.Accept = "application/json";
+  if (!transport.isImpersonate()) headers["Accept-Encoding"] = "gzip, deflate";
+  return headers;
+}
+
+async function getJson(
+  transport: TlsTransport,
+  url: string,
+  headers: Record<string, string>,
+  proxyUrl: string | null | undefined,
+  label: string,
+): Promise<unknown> {
+  let result: Awaited<ReturnType<TlsTransport["get"]>> | null = null;
+  let lastNetworkError: unknown;
+  // These are read-only identity GETs. Retry one transport exception so a
+  // transient TLS close/reset does not turn a valid import into a hard failure.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      result = await transport.get(url, headers, 20, proxyUrl);
+      break;
+    } catch (err) {
+      lastNetworkError = err;
+    }
+  }
+  if (!result) {
+    const detail = lastNetworkError instanceof Error
+      ? lastNetworkError.message
+      : String(lastNetworkError);
+    throw new Error(`${label} request failed: ${detail}`);
+  }
+  if (result.status < 200 || result.status >= 300) {
+    // Never include the upstream body: auth endpoints may echo sensitive data.
+    throw new Error(`${label} returned HTTP ${result.status}`);
+  }
+  try {
+    return JSON.parse(result.body) as unknown;
+  } catch {
+    throw new Error(`${label} returned invalid JSON`);
+  }
+}
+
+/** Parse the account ID returned by the authenticated quota endpoint. */
+export function parseUsageIdentityResponse(
+  payload: unknown,
+  current: CodexTokenMetadata,
+  expectedAccountId?: string | null,
+): CodexTokenMetadata | null {
+  const root = toRecord(payload);
+  if (!root) return null;
+  const accountId = safeAccountId(
+    root.account_id ?? root.accountId ?? root.chatgpt_account_id ?? root.workspace_id,
+  );
+  if (!accountId) return null;
+
+  const expected = safeAccountId(expectedAccountId);
+  if (expected && accountId !== expected) return null;
+
+  return {
+    accountId,
+    organizationId: current.organizationId,
+    userId: stringValue(root.user_id) ?? stringValue(root.chatgpt_user_id) ?? current.userId,
+    email: stringValue(root.email) ?? current.email,
+    planType: stringValue(root.plan_type) ?? current.planType,
+    accountIdSource: "upstream_discovery",
+  };
+}
+
 /**
- * Resolve the real ChatGPT workspace account ID without consuming a refresh
- * token. This follows the same account-check path used by Cockpit Tools.
+ * Resolve a ChatGPT account ID without consuming a refresh token.
+ *
+ * Preferred path: /accounts/check returns the workspace list.
+ * Safe fallback: some valid access-token-only accounts receive HTTP 403 from
+ * /accounts/check but /wham/usage works without an account header. In that
+ * case, accept only the account_id returned by upstream and verify it with a
+ * second quota request carrying ChatGPT-Account-Id.
  */
 export async function discoverCodexAccountIdentity(
   token: string,
@@ -137,35 +230,65 @@ export async function discoverCodexAccountIdentity(
 ): Promise<CodexTokenMetadata> {
   const transport = options.transport ?? getTransport();
   const baseUrl = options.baseUrl ?? getConfig().api.base_url;
-  const headers = options.headers
-    ? { ...options.headers }
-    : buildHeaders(token, null);
-  headers.Accept = "application/json";
-  if (!transport.isImpersonate()) headers["Accept-Encoding"] = "gzip, deflate";
-
-  const result = await transport.get(
-    identityEndpoint(baseUrl),
-    headers,
-    20,
-    options.proxyUrl,
+  const anonymousHeaders = headersForAccount(
+    token,
+    null,
+    transport,
+    options.headers,
   );
-  if (result.status < 200 || result.status >= 300) {
-    throw new Error(`Account identity endpoint returned HTTP ${result.status}`);
-  }
-
-  let payload: unknown;
+  let accountCheckError: string;
   try {
-    payload = JSON.parse(result.body) as unknown;
-  } catch {
-    throw new Error("Account identity endpoint returned invalid JSON");
+    const payload = await getJson(
+      transport,
+      identityEndpoint(baseUrl),
+      anonymousHeaders,
+      options.proxyUrl,
+      "Account identity endpoint",
+    );
+    const resolved = parseAccountIdentityResponse(
+      payload,
+      current,
+      options.accountIdHint,
+    );
+    if (!resolved?.accountId) {
+      throw new Error("Account identity endpoint returned no matching workspace");
+    }
+    return resolved;
+  } catch (err) {
+    accountCheckError = err instanceof Error ? err.message : String(err);
   }
-  const resolved = parseAccountIdentityResponse(
-    payload,
-    current,
-    options.accountIdHint,
-  );
-  if (!resolved?.accountId) {
-    throw new Error("Account identity endpoint returned no matching workspace");
+
+  try {
+    const initialUsage = await getJson(
+      transport,
+      usageEndpoint(baseUrl),
+      anonymousHeaders,
+      options.proxyUrl,
+      "Account usage discovery endpoint",
+    );
+    const discovered = parseUsageIdentityResponse(initialUsage, current);
+    if (!discovered?.accountId) {
+      throw new Error("Account usage discovery endpoint returned no account ID");
+    }
+
+    const verifiedUsage = await getJson(
+      transport,
+      usageEndpoint(baseUrl),
+      headersForAccount(token, discovered.accountId, transport, options.headers),
+      options.proxyUrl,
+      "Account usage verification endpoint",
+    );
+    const verified = parseUsageIdentityResponse(
+      verifiedUsage,
+      discovered,
+      discovered.accountId,
+    );
+    if (!verified?.accountId) {
+      throw new Error("Account usage verification returned a different account ID");
+    }
+    return verified;
+  } catch (err) {
+    const usageError = err instanceof Error ? err.message : String(err);
+    throw new Error(`${accountCheckError}; usage fallback failed: ${usageError}`);
   }
-  return resolved;
 }

--- a/src/services/account-identity-resolver.ts
+++ b/src/services/account-identity-resolver.ts
@@ -1,0 +1,171 @@
+import { getConfig } from "../config.js";
+import { buildHeaders } from "../fingerprint/manager.js";
+import type { CodexTokenMetadata } from "../auth/token-metadata.js";
+import { getTransport, type TlsTransport } from "../tls/transport.js";
+
+type JsonRecord = Record<string, unknown>;
+
+interface IdentityCandidate {
+  accountId: string;
+  organizationId: string | null;
+  userId: string | null;
+  planType: string | null;
+  activeSubscription: boolean;
+  isDefault: boolean;
+}
+
+export interface AccountIdentityDiscoveryOptions {
+  proxyUrl?: string | null;
+  baseUrl?: string;
+  transport?: TlsTransport;
+  /** Test-only escape hatch so unit tests do not need global fingerprint state. */
+  headers?: Record<string, string>;
+  accountIdHint?: string | null;
+}
+
+function toRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function safeAccountId(value: unknown): string | null {
+  const normalized = stringValue(value);
+  if (!normalized) return null;
+  // Account IDs are currently UUIDs, but keep this tolerant enough for future
+  // opaque identifiers while rejecting header injection and oversized values.
+  return /^[A-Za-z0-9_-]{8,128}$/.test(normalized) ? normalized : null;
+}
+
+function candidateFromAccountRecord(
+  value: unknown,
+  isDefault: boolean,
+): IdentityCandidate | null {
+  const wrapper = toRecord(value);
+  const account = toRecord(wrapper?.account);
+  if (!wrapper || !account) return null;
+  const entitlement = toRecord(wrapper.entitlement);
+  const accountId = safeAccountId(account.account_id);
+  if (!accountId) return null;
+
+  return {
+    accountId,
+    organizationId: stringValue(account.organization_id),
+    userId: stringValue(account.account_owner_id) ?? stringValue(account.user_id),
+    planType: stringValue(account.plan_type) ?? stringValue(entitlement?.subscription_plan),
+    activeSubscription: entitlement?.has_active_subscription === true,
+    isDefault,
+  };
+}
+
+/** Pure parser kept separate from network I/O for deterministic regression tests. */
+export function parseAccountIdentityResponse(
+  payload: unknown,
+  current: CodexTokenMetadata,
+  accountIdHint?: string | null,
+): CodexTokenMetadata | null {
+  const root = toRecord(payload);
+  const accounts = toRecord(root?.accounts);
+  if (!root || !accounts) return null;
+
+  const byId = new Map<string, IdentityCandidate>();
+  for (const [key, value] of Object.entries(accounts)) {
+    const candidate = candidateFromAccountRecord(value, key === "default");
+    if (!candidate) continue;
+    const existing = byId.get(candidate.accountId);
+    if (!existing || candidate.isDefault) byId.set(candidate.accountId, candidate);
+  }
+  let candidates = [...byId.values()];
+  if (candidates.length === 0) return null;
+
+  if (current.userId) {
+    const ownerMatches = candidates.filter((candidate) => candidate.userId === current.userId);
+    if (ownerMatches.length > 0) candidates = ownerMatches;
+  }
+  if (current.organizationId) {
+    const orgMatches = candidates.filter(
+      (candidate) => candidate.organizationId === current.organizationId,
+    );
+    if (orgMatches.length > 0) candidates = orgMatches;
+  }
+
+  // File-level IDs are only tie-breaker hints after token-derived owner/org
+  // filters. They are never promoted directly into ChatGPT-Account-Id.
+  const normalizedHint = safeAccountId(accountIdHint);
+  if (normalizedHint) {
+    const hinted = candidates.find((candidate) => candidate.accountId === normalizedHint);
+    if (hinted) candidates = [hinted];
+  }
+
+  candidates.sort((a, b) => {
+    const aScore = (a.activeSubscription ? 2 : 0) + (a.isDefault ? 1 : 0);
+    const bScore = (b.activeSubscription ? 2 : 0) + (b.isDefault ? 1 : 0);
+    return bScore - aScore;
+  });
+  const selected = candidates[0];
+
+  return {
+    accountId: selected.accountId,
+    organizationId: selected.organizationId ?? current.organizationId,
+    userId: selected.userId ?? current.userId,
+    email: current.email,
+    planType: selected.planType ?? current.planType,
+    accountIdSource: "upstream_discovery",
+  };
+}
+
+function identityEndpoint(baseUrl: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  const timezoneOffset = new Date().getTimezoneOffset();
+  return `${base}/accounts/check/v4-2023-04-27?timezone_offset_min=${timezoneOffset}`;
+}
+
+/**
+ * Resolve the real ChatGPT workspace account ID without consuming a refresh
+ * token. This follows the same account-check path used by Cockpit Tools.
+ */
+export async function discoverCodexAccountIdentity(
+  token: string,
+  current: CodexTokenMetadata,
+  options: AccountIdentityDiscoveryOptions = {},
+): Promise<CodexTokenMetadata> {
+  const transport = options.transport ?? getTransport();
+  const baseUrl = options.baseUrl ?? getConfig().api.base_url;
+  const headers = options.headers
+    ? { ...options.headers }
+    : buildHeaders(token, null);
+  headers.Accept = "application/json";
+  if (!transport.isImpersonate()) headers["Accept-Encoding"] = "gzip, deflate";
+
+  const result = await transport.get(
+    identityEndpoint(baseUrl),
+    headers,
+    20,
+    options.proxyUrl,
+  );
+  if (result.status < 200 || result.status >= 300) {
+    throw new Error(`Account identity endpoint returned HTTP ${result.status}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.body) as unknown;
+  } catch {
+    throw new Error("Account identity endpoint returned invalid JSON");
+  }
+  const resolved = parseAccountIdentityResponse(
+    payload,
+    current,
+    options.accountIdHint,
+  );
+  if (!resolved?.accountId) {
+    throw new Error("Account identity endpoint returned no matching workspace");
+  }
+  return resolved;
+}

--- a/src/services/account-import.ts
+++ b/src/services/account-import.ts
@@ -5,12 +5,24 @@
 
 import type { AccountPool } from "../auth/account-pool.js";
 import type { AccountInfo } from "../auth/types.js";
-import { decodeJwtPayload, extractChatGptAccountId, isTokenExpired } from "../auth/jwt-utils.js";
+import { decodeJwtPayload, isTokenExpired } from "../auth/jwt-utils.js";
+import { validateTokenStructure } from "../auth/chatgpt-oauth.js";
+import {
+  extractCodexTokenMetadata,
+  type CodexTokenMetadata,
+} from "../auth/token-metadata.js";
 
 export interface ImportEntry {
   token?: string;
   refreshToken?: string | null;
+  idToken?: string | null;
   label?: string | null;
+  accountIdHint?: string | null;
+  organizationId?: string | null;
+  userIdHint?: string | null;
+  emailHint?: string | null;
+  planTypeHint?: string | null;
+  sourceFormat?: "sub2api" | "generic";
 }
 
 export interface ImportResult {
@@ -24,14 +36,27 @@ export type ImportOneResult =
   | { ok: true; entryId: string; account: AccountInfo }
   | { ok: false; error: string; kind: "validation" | "refresh_failed" };
 
+function redactImportError(value: string): string {
+  return value
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]*/g, "[REDACTED_JWT]")
+    .replace(/\b(?:oaistb_rt_|rt_)[A-Za-z0-9._-]{8,}/g, "[REDACTED_REFRESH_TOKEN]")
+    .replace(/\bBearer\s+\S+/gi, "Bearer [REDACTED]");
+}
+
 /** Injected dependencies — keeps the service testable without vi.mock. */
 export interface ImportDeps {
   validateToken(token: string): { valid: boolean; error?: string };
   refreshToken(
     rt: string,
     proxyUrl: string | null,
-  ): Promise<{ access_token: string; refresh_token?: string }>;
+  ): Promise<{ access_token: string; refresh_token?: string; id_token?: string }>;
   getProxyUrl(): string | null;
+  /** Resolve the real workspace ID for structurally valid accountId-less tokens. */
+  discoverIdentity?(
+    token: string,
+    metadata: CodexTokenMetadata,
+    options: { accountIdHint?: string | null; proxyUrl: string | null },
+  ): Promise<CodexTokenMetadata>;
   /** Optional warmup: establishes session cookies after import to avoid cold-start bans. */
   warmup?(entryId: string, token: string, accountId: string | null): Promise<void>;
   /** Optional verify: checks if the account is usable and returns usage data. Only used for single imports. */
@@ -62,17 +87,18 @@ export class AccountImportService {
       const existingIds = new Set(this.pool.getAccounts().map((a) => a.id));
 
       for (const entry of entries) {
-        const resolved = await this.resolveToken(
-          entry.token,
-          entry.refreshToken ?? null,
-        );
+        const resolved = await this.resolveToken(entry);
         if (!resolved.ok) {
           failed++;
-          errors.push(resolved.error);
+          errors.push(redactImportError(resolved.error));
           continue;
         }
 
-        const entryId = this.pool.addAccount(resolved.token, resolved.rt);
+        const entryId = this.pool.addAccount(
+          resolved.token,
+          resolved.rt,
+          resolved.metadata,
+        );
         this.scheduler.scheduleOne(entryId, resolved.token);
 
         if (entry.label) {
@@ -81,9 +107,12 @@ export class AccountImportService {
 
         // Warmup: establish session cookies to avoid cold-start detection
         if (this.deps.warmup) {
-          const accountId = extractChatGptAccountId(resolved.token);
           try {
-            await this.deps.warmup(entryId, resolved.token, accountId);
+            await this.deps.warmup(
+              entryId,
+              resolved.token,
+              resolved.metadata.accountId,
+            );
           } catch (err) {
             console.warn(`[Import] Warmup failed for ${entryId}: ${err instanceof Error ? err.message : err}`);
           }
@@ -113,9 +142,17 @@ export class AccountImportService {
       };
     }
 
-    const resolved = await this.resolveToken(token, refreshToken ?? null);
+    const resolved = await this.resolveToken({
+      token,
+      refreshToken: refreshToken ?? null,
+      sourceFormat: "generic",
+    });
     if (!resolved.ok) {
-      return { ok: false, error: resolved.error, kind: resolved.kind };
+      return {
+        ok: false,
+        error: redactImportError(resolved.error),
+        kind: resolved.kind,
+      };
     }
 
     // Single import: verify account is usable and collect quota.
@@ -124,10 +161,13 @@ export class AccountImportService {
     const wasRtExchange = !token && !!refreshToken;
     let usageData: import("../proxy/codex-api.js").CodexUsageResponse | undefined;
     if (this.deps.verifyAccount && !wasRtExchange) {
-      const accountId = extractChatGptAccountId(resolved.token);
       const proxyUrl = this.deps.getProxyUrl();
       try {
-        const check = await this.deps.verifyAccount(resolved.token, accountId, proxyUrl);
+        const check = await this.deps.verifyAccount(
+          resolved.token,
+          resolved.metadata.accountId,
+          proxyUrl,
+        );
         if (!check.ok) {
           return { ok: false, error: check.error ?? "Account verification failed", kind: "validation" };
         }
@@ -141,7 +181,11 @@ export class AccountImportService {
       }
     }
 
-    const entryId = this.pool.addAccount(resolved.token, resolved.rt);
+    const entryId = this.pool.addAccount(
+      resolved.token,
+      resolved.rt,
+      resolved.metadata,
+    );
     this.scheduler.scheduleOne(entryId, resolved.token);
 
     // Cache quota from verification (so dashboard shows data immediately)
@@ -158,51 +202,169 @@ export class AccountImportService {
     return { ok: true, entryId, account };
   }
 
-  /** Validate or exchange a token, returning the resolved access token + refresh token. */
+  /** Validate or exchange a token, returning tokens plus resolved identity metadata. */
   private async resolveToken(
-    token: string | undefined,
-    rt: string | null,
+    entry: ImportEntry,
   ): Promise<
-    | { ok: true; token: string; rt: string | null }
+    | { ok: true; token: string; rt: string | null; metadata: CodexTokenMetadata }
     | { ok: false; error: string; kind: "validation" | "refresh_failed" }
   > {
+    const token = entry.token?.trim();
+    const rt = entry.refreshToken?.trim() || null;
+    const metadataHints = {
+      organizationId: entry.organizationId,
+      userId: entry.userIdHint,
+      email: entry.emailHint,
+      planType: entry.planTypeHint,
+    };
+
     if (token) {
-      const v = this.deps.validateToken(token);
-      if (!v.valid) {
-        return { ok: false, error: v.error ?? "Invalid token", kind: "validation" };
+      let metadata = extractCodexTokenMetadata(
+        token,
+        entry.idToken,
+        metadataHints,
+      );
+      // A file-supplied id_token is decoded but not signature-verified. Treat
+      // its workspace ID only as a discovery hint; the upstream account-check
+      // response must confirm it before it can control ChatGPT-Account-Id.
+      const idTokenAccountIdHint = metadata.accountIdSource === "id_token"
+        ? metadata.accountId
+        : null;
+      if (idTokenAccountIdHint) {
+        metadata = {
+          ...metadata,
+          accountId: null,
+          accountIdSource: null,
+        };
       }
-      return { ok: true, token, rt };
+      const strict = this.deps.validateToken(token);
+      if (strict.valid) {
+        return { ok: true, token, rt, metadata };
+      }
+
+      // Do not rely on a mutable error string. A token that passes the
+      // structural contract but has no token-derived account ID is the one
+      // recoverable compatibility case; all other validation failures remain fatal.
+      const structure = validateTokenStructure(token);
+      if (!structure.valid) {
+        return {
+          ok: false,
+          error: strict.error ?? structure.error ?? "Invalid token",
+          kind: "validation",
+        };
+      }
+
+      if (metadata.accountId) {
+        return {
+          ok: false,
+          error: strict.error ?? "Invalid token",
+          kind: "validation",
+        };
+      }
+
+      if (!this.deps.discoverIdentity) {
+        return {
+          ok: false,
+          error: "Token is valid but missing chatgpt_account_id and identity discovery is unavailable",
+          kind: "validation",
+        };
+      }
+
+      try {
+        metadata = await this.deps.discoverIdentity(token, metadata, {
+          accountIdHint: entry.accountIdHint ?? idTokenAccountIdHint,
+          proxyUrl: this.deps.getProxyUrl(),
+        });
+      } catch (err) {
+        return {
+          ok: false,
+          error: `Account identity discovery failed: ${err instanceof Error ? err.message : String(err)}`,
+          kind: "validation",
+        };
+      }
+      if (!metadata.accountId) {
+        return {
+          ok: false,
+          error: "Account identity discovery returned no workspace account ID",
+          kind: "validation",
+        };
+      }
+      return { ok: true, token, rt, metadata };
+    }
+
+    if (!rt) {
+      return {
+        ok: false,
+        error: "Either token or refreshToken is required",
+        kind: "validation",
+      };
     }
 
     // Refresh-token-only path — check if this RT already belongs to an existing account
     const existing = this.pool.getAllEntries().find((a) => a.refreshToken === rt);
     if (existing) {
-      return { ok: true, token: existing.token, rt: existing.refreshToken };
+      return {
+        ok: true,
+        token: existing.token,
+        rt: existing.refreshToken,
+        metadata: {
+          accountId: existing.accountId,
+          organizationId: existing.organizationId ?? null,
+          userId: existing.userId,
+          email: existing.email,
+          planType: existing.planType,
+          accountIdSource: existing.accountIdSource ?? null,
+        },
+      };
     }
 
     // Prevent concurrent refresh of the same RT (e.g. duplicate entries in import file)
-    if (this.refreshingRTs.has(rt as string)) {
+    if (this.refreshingRTs.has(rt)) {
       return { ok: false, error: "Duplicate RT in import batch (skipped to protect token)", kind: "refresh_failed" };
     }
-    this.refreshingRTs.add(rt as string);
+    this.refreshingRTs.add(rt);
 
     try {
       const proxyUrl = this.deps.getProxyUrl();
-      const tokens = await this.deps.refreshToken(rt as string, proxyUrl);
-      const v = this.canAcceptRtExchangeToken(tokens.access_token);
-      if (!v.valid) {
+      const tokens = await this.deps.refreshToken(rt, proxyUrl);
+      const accessToken = tokens.access_token.trim();
+      const structure = validateTokenStructure(accessToken);
+      if (!structure.valid) {
         return {
           ok: false,
-          error: `Refresh token exchange succeeded but token invalid: ${v.error}`,
+          error: `Refresh token exchange succeeded but token invalid: ${structure.error}`,
           kind: "validation",
         };
       }
+      // Do not immediately probe quota/account-check after an RT exchange: the
+      // existing risk controls intentionally avoid that cold-start sequence.
+      // File-supplied id_token values are portable metadata only: they are not
+      // signature-verified and must never become an authoritative workspace ID.
+      // Decode them first for non-routing hints, then extract authoritative
+      // accountId only from the exchanged access token or the token endpoint's
+      // fresh id_token response.
+      const portableMetadata = extractCodexTokenMetadata(
+        accessToken,
+        entry.idToken,
+        metadataHints,
+      );
+      const metadata = extractCodexTokenMetadata(
+        accessToken,
+        tokens.id_token,
+        {
+          organizationId: portableMetadata.organizationId,
+          userId: portableMetadata.userId,
+          email: portableMetadata.email,
+          planType: portableMetadata.planType,
+        },
+      );
       // All OpenAI RTs are single-use — if server doesn't return a new one, the old one is consumed/dead
       const newRT = tokens.refresh_token ?? null;
       return {
         ok: true,
-        token: tokens.access_token,
+        token: accessToken,
         rt: newRT,
+        metadata,
       };
     } catch (err) {
       return {
@@ -211,26 +373,7 @@ export class AccountImportService {
         kind: "refresh_failed",
       };
     } finally {
-      this.refreshingRTs.delete(rt as string);
+      this.refreshingRTs.delete(rt);
     }
-  }
-
-  /** Validate an RT-exchanged token without requiring metadata.accountId to be non-empty. */
-  private canAcceptRtExchangeToken(token: string): { valid: boolean; error?: string } {
-    if (!token || typeof token !== "string") {
-      return { valid: false, error: "Token is empty" };
-    }
-    const trimmed = token.trim();
-    const payload = decodeJwtPayload(trimmed);
-    if (!payload) {
-      return {
-        valid: false,
-        error: "Invalid JWT format — could not decode payload",
-      };
-    }
-    if (isTokenExpired(trimmed)) {
-      return { valid: false, error: "Token is expired" };
-    }
-    return { valid: true };
   }
 }

--- a/src/services/account-transfer-formats.ts
+++ b/src/services/account-transfer-formats.ts
@@ -27,6 +27,7 @@ interface PortableCodexToken {
   access_token: string;
   refresh_token?: string;
   account_id?: string;
+  organization_id?: string;
   last_refresh?: string;
   email?: string;
   type: "codex";
@@ -126,6 +127,52 @@ function candidateFromValue(value: unknown, fallbackLabel?: string | null): Impo
     ["credentials", "refreshToken"],
     ["credentials", "refresh_token"],
   ]);
+  const idToken = firstString(record, [
+    ["idToken"],
+    ["id_token"],
+    ["tokens", "idToken"],
+    ["tokens", "id_token"],
+    ["credentials", "idToken"],
+    ["credentials", "id_token"],
+  ]);
+  const accountIdHint = firstString(record, [
+    ["accountId"],
+    ["account_id"],
+    ["chatgpt_account_id"],
+    ["workspace_id"],
+    ["credentials", "accountId"],
+    ["credentials", "account_id"],
+    ["credentials", "chatgpt_account_id"],
+    ["credentials", "workspace_id"],
+  ]);
+  const organizationId = firstString(record, [
+    ["organizationId"],
+    ["organization_id"],
+    ["poid"],
+    ["credentials", "organizationId"],
+    ["credentials", "organization_id"],
+    ["credentials", "poid"],
+  ]);
+  const userIdHint = firstString(record, [
+    ["userId"],
+    ["user_id"],
+    ["chatgpt_user_id"],
+    ["credentials", "userId"],
+    ["credentials", "user_id"],
+    ["credentials", "chatgpt_user_id"],
+  ]);
+  const emailHint = firstString(record, [
+    ["email"],
+    ["credentials", "email"],
+  ]);
+  const planTypeHint = firstString(record, [
+    ["planType"],
+    ["plan_type"],
+    ["chatgpt_plan_type"],
+    ["credentials", "planType"],
+    ["credentials", "plan_type"],
+    ["credentials", "chatgpt_plan_type"],
+  ]);
   const label = labelFromValue(record) ?? fallbackLabel ?? undefined;
 
   if (!token && !refreshToken) return null;
@@ -133,7 +180,13 @@ function candidateFromValue(value: unknown, fallbackLabel?: string | null): Impo
   return {
     ...(token ? { token: normalizeBearer(token) } : {}),
     ...(refreshToken ? { refreshToken } : {}),
+    ...(idToken ? { idToken } : {}),
     ...(label !== undefined ? { label } : {}),
+    ...(accountIdHint ? { accountIdHint } : {}),
+    ...(organizationId ? { organizationId } : {}),
+    ...(userIdHint ? { userIdHint } : {}),
+    ...(emailHint ? { emailHint } : {}),
+    ...(planTypeHint ? { planTypeHint } : {}),
   };
 }
 
@@ -162,7 +215,7 @@ function parseSub2ApiPayload(value: JsonRecord): ImportEntry[] | null {
     if (!credentials) continue;
     const label = normalizeLabel(record?.name);
     const entry = candidateFromValue(credentials, label);
-    if (entry) entries.push(entry);
+    if (entry) entries.push({ ...entry, sourceFormat: "sub2api" });
   }
   return entries;
 }
@@ -254,6 +307,7 @@ function toPortableToken(entry: AccountEntry): PortableCodexToken {
     access_token: entry.token,
     ...(entry.refreshToken ? { refresh_token: entry.refreshToken } : {}),
     ...(entry.accountId ? { account_id: entry.accountId } : {}),
+    ...(entry.organizationId ? { organization_id: entry.organizationId } : {}),
     last_refresh: entry.quotaFetchedAt ?? entry.addedAt,
     ...(entry.email ? { email: entry.email } : {}),
     type: "codex",
@@ -267,6 +321,7 @@ function toSub2ApiAccount(entry: AccountEntry): Sub2ApiAccountItem {
     ...(entry.refreshToken ? { refresh_token: entry.refreshToken } : {}),
     ...(entry.email ? { email: entry.email } : {}),
     ...(entry.accountId ? { chatgpt_account_id: entry.accountId } : {}),
+    ...(entry.organizationId ? { organization_id: entry.organizationId } : {}),
     ...(entry.userId ? { chatgpt_user_id: entry.userId } : {}),
     ...(entry.planType ? { plan_type: entry.planType } : {}),
     ...(accessTokenExpiry(entry) ? { expires_at: accessTokenExpiry(entry) } : {}),

--- a/tests/_helpers/jwt.ts
+++ b/tests/_helpers/jwt.ts
@@ -9,6 +9,9 @@ interface JwtClaims {
     chatgpt_account_id?: string;
     chatgpt_plan_type?: string;
     chatgpt_user_id?: string;
+    user_id?: string;
+    poid?: string;
+    organizations?: Array<{ id?: string; is_default?: boolean }>;
   };
   "https://api.openai.com/profile"?: {
     email?: string;

--- a/tests/unit/auth/chatgpt-oauth.test.ts
+++ b/tests/unit/auth/chatgpt-oauth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateManualToken } from "@src/auth/chatgpt-oauth.js";
+import { validateManualToken, validateTokenStructure } from "@src/auth/chatgpt-oauth.js";
 import { createValidJwt, createExpiredJwt, createJwt } from "@helpers/jwt.js";
 
 describe("validateManualToken", () => {
@@ -37,5 +37,21 @@ describe("validateManualToken", () => {
     const result = validateManualToken("not-a-jwt");
     expect(result.valid).toBe(false);
     expect(result.error).toContain("Invalid JWT");
+  });
+
+  it("structural validation accepts an unexpired token without accountId", () => {
+    const token = createJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    expect(validateTokenStructure(token)).toEqual({ valid: true });
+    expect(validateManualToken(token)).toMatchObject({
+      valid: false,
+      error: expect.stringContaining("chatgpt_account_id"),
+    });
+  });
+
+  it("structural validation rejects a token without numeric exp", () => {
+    expect(validateTokenStructure(createJwt({}))).toMatchObject({
+      valid: false,
+      error: expect.stringContaining("exp"),
+    });
   });
 });

--- a/tests/unit/auth/jwt-utils.test.ts
+++ b/tests/unit/auth/jwt-utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractUserProfile,
   isTokenExpired,
 } from "@src/auth/jwt-utils.js";
+import { extractCodexTokenMetadata } from "@src/auth/token-metadata.js";
 import { createJwt, createValidJwt, createExpiredJwt } from "@helpers/jwt.js";
 
 describe("decodeJwtPayload", () => {
@@ -53,6 +54,51 @@ describe("extractChatGptAccountId", () => {
       },
     });
     expect(extractChatGptAccountId(token)).toBeNull();
+  });
+});
+
+describe("extractCodexTokenMetadata", () => {
+  it("keeps organization identity separate for accountId-less access tokens", () => {
+    const token = createJwt({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      "https://api.openai.com/auth": {
+        poid: "org-portable-123",
+        user_id: "user-portable-123",
+      },
+      "https://api.openai.com/profile": {
+        email: "portable@example.com",
+      },
+    });
+
+    expect(extractCodexTokenMetadata(token, null, { planType: "plus" })).toEqual({
+      accountId: null,
+      organizationId: "org-portable-123",
+      userId: "user-portable-123",
+      email: "portable@example.com",
+      planType: "plus",
+      accountIdSource: null,
+    });
+  });
+
+  it("uses id_token account claims without treating organization ID as account ID", () => {
+    const accessToken = createJwt({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      "https://api.openai.com/profile": { email: "access@example.com" },
+    });
+    const idToken = createJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "workspace-from-id",
+        user_id: "user-from-id",
+        organizations: [{ id: "org-from-id", is_default: true }],
+      },
+    });
+
+    expect(extractCodexTokenMetadata(accessToken, idToken)).toMatchObject({
+      accountId: "workspace-from-id",
+      organizationId: "org-from-id",
+      userId: "user-from-id",
+      accountIdSource: "id_token",
+    });
   });
 });
 

--- a/tests/unit/routes/accounts-import-export.test.ts
+++ b/tests/unit/routes/accounts-import-export.test.ts
@@ -57,6 +57,11 @@ vi.mock("@src/auth/oauth-pkce.js", () => ({
   refreshAccessToken: vi.fn(),
 }));
 
+const mockRuntimeProxyUrl = vi.hoisted(() => vi.fn(() => "http://127.0.0.1:7897"));
+vi.mock("@src/tls/proxy.js", () => ({
+  getProxyUrl: mockRuntimeProxyUrl,
+}));
+
 import { Hono } from "hono";
 import { AccountPool } from "@src/auth/account-pool.js";
 import { createAccountRoutes } from "@src/routes/accounts.js";
@@ -402,6 +407,11 @@ describe("account import/export", () => {
     expect(res.status).toBe(200);
     const data = await res.json() as { success: boolean };
     expect(data.success).toBe(true);
+
+    expect(refreshAccessToken).toHaveBeenCalledWith(
+      "rt_test_only_import",
+      "http://127.0.0.1:7897",
+    );
 
     // getUsage must NOT be called for RT-only imports — it triggers OpenAI risk detection
     expect(getUsageSpy).not.toHaveBeenCalled();

--- a/tests/unit/services/account-identity-resolver.test.ts
+++ b/tests/unit/services/account-identity-resolver.test.ts
@@ -4,6 +4,7 @@ import type { TlsTransport } from "@src/tls/transport.js";
 import {
   discoverCodexAccountIdentity,
   parseAccountIdentityResponse,
+  parseUsageIdentityResponse,
 } from "@src/services/account-identity-resolver.js";
 
 const current: CodexTokenMetadata = {
@@ -72,6 +73,23 @@ describe("account identity resolver", () => {
     expect(result?.accountId).toBe("workspace-owned");
   });
 
+  it("parses an opaque upstream usage account ID without requiring UUID shape", () => {
+    const result = parseUsageIdentityResponse({
+      account_id: "opaque-account-id-123456789",
+      user_id: "user-from-usage",
+      email: "usage@example.com",
+      plan_type: "plus",
+    }, current);
+
+    expect(result).toEqual({
+      ...current,
+      accountId: "opaque-account-id-123456789",
+      userId: "user-from-usage",
+      email: "usage@example.com",
+      accountIdSource: "upstream_discovery",
+    });
+  });
+
   it("performs one GET and returns only parsed identity metadata", async () => {
     const get = vi.fn(async () => ({
       status: 200,
@@ -99,16 +117,119 @@ describe("account identity resolver", () => {
     expect(get.mock.calls[0][0]).toContain("/accounts/check/v4-2023-04-27");
   });
 
-  it("rejects non-success responses without including the upstream body", async () => {
+  it("falls back to two-step usage verification after account-check HTTP 403", async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce({ status: 403, body: "sensitive identity body" })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({
+          account_id: "opaque-account-id-123456789",
+          user_id: "user-portable",
+          plan_type: "plus",
+        }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({
+          account_id: "opaque-account-id-123456789",
+          user_id: "user-portable",
+          plan_type: "plus",
+        }),
+      });
     const transport = {
-      get: vi.fn(async () => ({ status: 403, body: "sensitive upstream body" })),
+      get,
       isImpersonate: () => true,
     } as unknown as TlsTransport;
 
-    await expect(discoverCodexAccountIdentity("secret-token", current, {
+    const result = await discoverCodexAccountIdentity("secret-token", current, {
+      baseUrl: "https://chatgpt.example/backend-api",
+      headers: {
+        Authorization: "Bearer [redacted]",
+        "ChatGPT-Account-Id": "untrusted-stale-id",
+      },
+      transport,
+    });
+
+    expect(result.accountId).toBe("opaque-account-id-123456789");
+    expect(result.accountIdSource).toBe("upstream_discovery");
+    expect(get).toHaveBeenCalledTimes(3);
+    expect(get.mock.calls[1][0]).toContain("/wham/usage");
+    expect(get.mock.calls[1][1]).not.toHaveProperty("ChatGPT-Account-Id");
+    expect(get.mock.calls[2][1]).toMatchObject({
+      "ChatGPT-Account-Id": "opaque-account-id-123456789",
+    });
+  });
+
+  it("retries one transient usage transport failure before verification", async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce({ status: 403, body: "identity denied" })
+      .mockRejectedValueOnce(new Error("temporary TLS close"))
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({ account_id: "opaque-account-id-123456789" }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({ account_id: "opaque-account-id-123456789" }),
+      });
+    const transport = {
+      get,
+      isImpersonate: () => true,
+    } as unknown as TlsTransport;
+
+    const result = await discoverCodexAccountIdentity("secret-token", current, {
       baseUrl: "https://chatgpt.example/backend-api",
       headers: { Authorization: "Bearer [redacted]" },
       transport,
-    })).rejects.toThrow("HTTP 403");
+    });
+
+    expect(result.accountId).toBe("opaque-account-id-123456789");
+    expect(get).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects a mismatched usage verification ID without leaking response bodies", async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce({ status: 403, body: "sensitive identity body" })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({ account_id: "opaque-account-id-123456789" }),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: JSON.stringify({ account_id: "different-account-id-987654321" }),
+      });
+    const transport = {
+      get,
+      isImpersonate: () => true,
+    } as unknown as TlsTransport;
+
+    const promise = discoverCodexAccountIdentity("secret-token", current, {
+      baseUrl: "https://chatgpt.example/backend-api",
+      headers: { Authorization: "Bearer [redacted]" },
+      transport,
+    });
+
+    await expect(promise).rejects.toThrow("different account ID");
+    await expect(promise).rejects.not.toThrow("sensitive identity body");
+  });
+
+  it("rejects non-success usage fallback without including upstream bodies", async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce({ status: 403, body: "sensitive identity body" })
+      .mockResolvedValueOnce({ status: 502, body: "sensitive usage body" });
+    const transport = {
+      get,
+      isImpersonate: () => true,
+    } as unknown as TlsTransport;
+
+    const promise = discoverCodexAccountIdentity("secret-token", current, {
+      baseUrl: "https://chatgpt.example/backend-api",
+      headers: { Authorization: "Bearer [redacted]" },
+      transport,
+    });
+
+    await expect(promise).rejects.toThrow("Account identity endpoint returned HTTP 403");
+    await expect(promise).rejects.toThrow("Account usage discovery endpoint returned HTTP 502");
+    await expect(promise).rejects.not.toThrow("sensitive");
   });
 });

--- a/tests/unit/services/account-identity-resolver.test.ts
+++ b/tests/unit/services/account-identity-resolver.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodexTokenMetadata } from "@src/auth/token-metadata.js";
+import type { TlsTransport } from "@src/tls/transport.js";
+import {
+  discoverCodexAccountIdentity,
+  parseAccountIdentityResponse,
+} from "@src/services/account-identity-resolver.js";
+
+const current: CodexTokenMetadata = {
+  accountId: null,
+  organizationId: "org-portable",
+  userId: "user-portable",
+  email: "portable@example.com",
+  planType: "plus",
+  accountIdSource: null,
+};
+
+function accountRecord(accountId: string, userId: string, active = true) {
+  return {
+    account: {
+      account_id: accountId,
+      account_owner_id: userId,
+      organization_id: null,
+      plan_type: "plus",
+    },
+    entitlement: {
+      has_active_subscription: active,
+      subscription_plan: "chatgptplusplan",
+    },
+  };
+}
+
+describe("account identity resolver", () => {
+  it("extracts the real workspace ID from the default account response", () => {
+    const record = accountRecord("workspace-12345678", "user-portable");
+    const result = parseAccountIdentityResponse({
+      accounts: {
+        "workspace-12345678": record,
+        default: record,
+      },
+      account_ordering: ["workspace-12345678"],
+    }, current);
+
+    expect(result).toEqual({
+      ...current,
+      accountId: "workspace-12345678",
+      accountIdSource: "upstream_discovery",
+    });
+  });
+
+  it("uses a matching trusted account hint without ever promoting organizationId", () => {
+    const result = parseAccountIdentityResponse({
+      accounts: {
+        default: accountRecord("workspace-default", "user-portable"),
+        "workspace-hinted": accountRecord("workspace-hinted", "user-portable"),
+      },
+    }, current, "workspace-hinted");
+
+    expect(result?.accountId).toBe("workspace-hinted");
+    expect(result?.organizationId).toBe("org-portable");
+    expect(result?.accountId).not.toBe(result?.organizationId);
+  });
+
+  it("does not let an untrusted hint override the token-derived owner", () => {
+    const result = parseAccountIdentityResponse({
+      accounts: {
+        default: accountRecord("workspace-owned", "user-portable"),
+        "workspace-other": accountRecord("workspace-other", "different-user"),
+      },
+    }, current, "workspace-other");
+
+    expect(result?.accountId).toBe("workspace-owned");
+  });
+
+  it("performs one GET and returns only parsed identity metadata", async () => {
+    const get = vi.fn(async () => ({
+      status: 200,
+      body: JSON.stringify({
+        accounts: {
+          default: accountRecord("workspace-network", "user-portable"),
+        },
+      }),
+    }));
+    const transport = {
+      get,
+      isImpersonate: () => true,
+    } as unknown as TlsTransport;
+
+    const result = await discoverCodexAccountIdentity("secret-token", current, {
+      baseUrl: "https://chatgpt.example/backend-api",
+      proxyUrl: "http://127.0.0.1:7897",
+      headers: { Authorization: "Bearer [redacted]" },
+      transport,
+    });
+
+    expect(result.accountId).toBe("workspace-network");
+    expect(result.accountIdSource).toBe("upstream_discovery");
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0][0]).toContain("/accounts/check/v4-2023-04-27");
+  });
+
+  it("rejects non-success responses without including the upstream body", async () => {
+    const transport = {
+      get: vi.fn(async () => ({ status: 403, body: "sensitive upstream body" })),
+      isImpersonate: () => true,
+    } as unknown as TlsTransport;
+
+    await expect(discoverCodexAccountIdentity("secret-token", current, {
+      baseUrl: "https://chatgpt.example/backend-api",
+      headers: { Authorization: "Bearer [redacted]" },
+      transport,
+    })).rejects.toThrow("HTTP 403");
+  });
+});

--- a/tests/unit/services/account-import.test.ts
+++ b/tests/unit/services/account-import.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createMemoryPersistence } from "@helpers/account-pool-factory.js";
-import { createValidJwt } from "@helpers/jwt.js";
+import { createJwt, createValidJwt } from "@helpers/jwt.js";
 import { setConfigForTesting, resetConfigForTesting } from "@src/config.js";
 import { createMockConfig } from "@helpers/config.js";
 import { AccountPool } from "@src/auth/account-pool.js";
@@ -86,6 +86,109 @@ describe("AccountImportService", () => {
       expect(pool.getAccounts()).toHaveLength(0);
     });
 
+    it("discovers and stores identity for a valid accountId-less Sub2API token without consuming RT", async () => {
+      const pool = makePool();
+      const refreshToken = vi.fn();
+      const discoverIdentity = vi.fn(async (_token, metadata) => ({
+        ...metadata,
+        accountId: "workspace-discovered",
+        planType: "plus",
+        accountIdSource: "upstream_discovery" as const,
+      }));
+      const token = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        "https://api.openai.com/auth": {
+          poid: "org-portable",
+          user_id: "user-portable",
+        },
+        "https://api.openai.com/profile": { email: "portable@example.com" },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        validateToken: () => ({
+          valid: false,
+          error: "Token missing chatgpt_account_id claim",
+        }),
+        refreshToken,
+        discoverIdentity,
+      }));
+
+      const result = await svc.importMany([{
+        token,
+        refreshToken: "rt_must_not_be_consumed",
+        organizationId: "org-portable",
+        userIdHint: "user-portable",
+        planTypeHint: "plus",
+        sourceFormat: "sub2api",
+      }]);
+
+      expect(result).toMatchObject({ added: 1, failed: 0 });
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(discoverIdentity).toHaveBeenCalledTimes(1);
+      expect(pool.getAllEntries()[0]).toMatchObject({
+        accountId: "workspace-discovered",
+        organizationId: "org-portable",
+        userId: "user-portable",
+        planType: "plus",
+        refreshToken: "rt_must_not_be_consumed",
+        accountIdSource: "upstream_discovery",
+      });
+    });
+
+    it("uses a file-supplied id_token account ID only as an upstream discovery hint", async () => {
+      const pool = makePool();
+      const discoverIdentity = vi.fn(async (_token, metadata, options) => ({
+        ...metadata,
+        accountId: options.accountIdHint ?? null,
+        accountIdSource: "upstream_discovery" as const,
+      }));
+      const accessToken = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        "https://api.openai.com/profile": { email: "id-fallback@example.com" },
+      });
+      const idToken = createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "workspace-from-id-token",
+          user_id: "user-from-id-token",
+        },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        validateToken: () => ({ valid: false, error: "missing account ID" }),
+        discoverIdentity,
+      }));
+
+      const result = await svc.importMany([{ token: accessToken, idToken }]);
+
+      expect(result).toMatchObject({ added: 1, failed: 0 });
+      expect(discoverIdentity).toHaveBeenCalledWith(
+        accessToken,
+        expect.objectContaining({ accountId: null, accountIdSource: null }),
+        expect.objectContaining({ accountIdHint: "workspace-from-id-token" }),
+      );
+      expect(pool.getAllEntries()[0]).toMatchObject({
+        accountId: "workspace-from-id-token",
+        accountIdSource: "upstream_discovery",
+        userId: "user-from-id-token",
+      });
+    });
+
+    it("does not silently import an accountId-less direct token when identity discovery fails", async () => {
+      const pool = makePool();
+      const token = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        "https://api.openai.com/auth": { user_id: "user-portable" },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        validateToken: () => ({ valid: false, error: "missing account ID" }),
+        discoverIdentity: async () => { throw new Error("HTTP 403"); },
+      }));
+
+      const result = await svc.importMany([{ token }]);
+
+      expect(result).toMatchObject({ added: 0, failed: 1 });
+      expect(result.errors[0]).toContain("identity discovery failed");
+      expect(pool.getAccounts()).toHaveLength(0);
+    });
+
     it("exchanges refresh token when no access token provided", async () => {
       const pool = makePool();
       const scheduler = makeScheduler();
@@ -108,6 +211,137 @@ describe("AccountImportService", () => {
       expect(result.added).toBe(1);
       expect(result.failed).toBe(0);
       expect(pool.getAccounts()).toHaveLength(1);
+    });
+
+    it("accepts a structurally valid RT-exchanged token without accountId without probing upstream", async () => {
+      const pool = makePool();
+      const discoverIdentity = vi.fn();
+      const accountless = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        "https://api.openai.com/auth": {
+          poid: "org-rt",
+          user_id: "user-rt",
+        },
+        "https://api.openai.com/profile": { email: "rt@example.com" },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        validateToken: () => ({ valid: false, error: "missing account ID" }),
+        refreshToken: async () => ({
+          access_token: accountless,
+          refresh_token: "rotated_rt",
+        }),
+        discoverIdentity,
+      }));
+
+      const result = await svc.importMany([{ refreshToken: "old_rt" }]);
+
+      expect(result).toMatchObject({ added: 1, failed: 0 });
+      expect(discoverIdentity).not.toHaveBeenCalled();
+      expect(pool.getAllEntries()[0]).toMatchObject({
+        accountId: null,
+        organizationId: "org-rt",
+        userId: "user-rt",
+        refreshToken: "rotated_rt",
+      });
+    });
+
+    it("never promotes a file-supplied id_token workspace ID after RT exchange", async () => {
+      const pool = makePool();
+      const accountless = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        "https://api.openai.com/auth": { user_id: "user-from-access" },
+      });
+      const unverifiedFileIdToken = createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "workspace-unverified-file",
+          poid: "org-from-file-id-token",
+        },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        refreshToken: async () => ({
+          access_token: accountless,
+          refresh_token: "rotated_rt",
+        }),
+      }));
+
+      const result = await svc.importMany([{
+        refreshToken: "old_rt",
+        idToken: unverifiedFileIdToken,
+      }]);
+
+      expect(result).toMatchObject({ added: 1, failed: 0 });
+      expect(pool.getAllEntries()[0]).toMatchObject({
+        accountId: null,
+        accountIdSource: null,
+        organizationId: "org-from-file-id-token",
+        userId: "user-from-access",
+      });
+    });
+
+    it("accepts a workspace ID from the token endpoint's fresh id_token", async () => {
+      const pool = makePool();
+      const accountless = createJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+      const exchangedIdToken = createJwt({
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "workspace-from-exchange",
+          user_id: "user-from-exchange",
+        },
+      });
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        refreshToken: async () => ({
+          access_token: accountless,
+          refresh_token: "rotated_rt",
+          id_token: exchangedIdToken,
+        }),
+      }));
+
+      const result = await svc.importMany([{ refreshToken: "old_rt" }]);
+
+      expect(result).toMatchObject({ added: 1, failed: 0 });
+      expect(pool.getAllEntries()[0]).toMatchObject({
+        accountId: "workspace-from-exchange",
+        accountIdSource: "id_token",
+        userId: "user-from-exchange",
+      });
+    });
+
+    it("deduplicates rotating accountId-less tokens by organizationId + userId", async () => {
+      const pool = makePool();
+      let generation = 0;
+      const svc = new AccountImportService(pool, makeScheduler(), makeDeps({
+        refreshToken: async () => ({
+          access_token: createJwt({
+            exp: Math.floor(Date.now() / 1000) + 3600 + generation++,
+            jti: `generation-${generation}`,
+            "https://api.openai.com/auth": {
+              poid: "org-stable",
+              user_id: "user-stable",
+            },
+          }),
+          refresh_token: `rotated-${generation}`,
+        }),
+      }));
+
+      const first = await svc.importMany([{ refreshToken: "rt-one" }]);
+      const second = await svc.importMany([{ refreshToken: "rt-two" }]);
+
+      expect(first.added).toBe(1);
+      expect(second.updated).toBe(1);
+      expect(second.added).toBe(0);
+      expect(pool.getAccounts()).toHaveLength(1);
+    });
+
+    it("does not merge two known workspace IDs just because organization + user match", () => {
+      const pool = makePool();
+      const tokenOne = createValidJwt({ accountId: "workspace-one", userId: "same-user" });
+      const tokenTwo = createValidJwt({ accountId: "workspace-two", userId: "same-user" });
+
+      pool.addAccount(tokenOne, null, { organizationId: "same-org" });
+      pool.addAccount(tokenTwo, null, { organizationId: "same-org" });
+
+      expect(pool.getAccounts()).toHaveLength(2);
     });
 
     it("prefers new refresh token from exchange over original", async () => {
@@ -163,6 +397,25 @@ describe("AccountImportService", () => {
 
       expect(result.failed).toBe(1);
       expect(result.errors[0]).toContain("network error");
+    });
+
+    it("redacts credentials from import errors returned to the UI", async () => {
+      const leaked = "eyJaaaaaaaaaa.bbbbbbbbbb.cccccccccc";
+      const svc = new AccountImportService(
+        makePool(),
+        makeScheduler(),
+        makeDeps({
+          refreshToken: async () => {
+            throw new Error(`upstream echoed ${leaked} oaistb_rt_secretvalue123`);
+          },
+        }),
+      );
+
+      const result = await svc.importMany([{ refreshToken: "rt_input_secret123" }]);
+
+      expect(result.errors[0]).toContain("[REDACTED_JWT]");
+      expect(result.errors[0]).toContain("[REDACTED_REFRESH_TOKEN]");
+      expect(result.errors[0]).not.toContain("secretvalue123");
     });
 
     it("sets label when provided", async () => {

--- a/tests/unit/services/account-transfer-formats.test.ts
+++ b/tests/unit/services/account-transfer-formats.test.ts
@@ -35,7 +35,11 @@ describe("account transfer formats", () => {
     ]);
 
     expect(entries).toEqual([
-      { token: "access.jwt.token", refreshToken: "rt_portable" },
+      {
+        token: "access.jwt.token",
+        refreshToken: "rt_portable",
+        emailHint: "user@example.com",
+      },
       { token: "nested.jwt.token", refreshToken: "rt_nested", label: "Nested" },
     ]);
   });
@@ -53,6 +57,11 @@ describe("account transfer formats", () => {
           credentials: {
             access_token: "sub2api.jwt.token",
             refresh_token: "rt_sub2api",
+            id_token: "sub2api.id.token",
+            organization_id: "org-sub2api",
+            chatgpt_user_id: "user-sub2api",
+            email: "sub2api@example.com",
+            plan_type: "plus",
           },
           concurrency: 0,
           priority: 0,
@@ -70,7 +79,13 @@ describe("account transfer formats", () => {
       {
         token: "sub2api.jwt.token",
         refreshToken: "rt_sub2api",
+        idToken: "sub2api.id.token",
         label: "Team Alpha",
+        organizationId: "org-sub2api",
+        userIdHint: "user-sub2api",
+        emailHint: "sub2api@example.com",
+        planTypeHint: "plus",
+        sourceFormat: "sub2api",
       },
     ]);
   });
@@ -97,7 +112,9 @@ describe("account transfer formats", () => {
       email: "alpha@example.com",
       planType: "plus",
     });
-    const entryId = pool.addAccount(token, "rt_alpha");
+    const entryId = pool.addAccount(token, "rt_alpha", {
+      organizationId: "org-alpha",
+    });
     pool.setLabel(entryId, "Alpha");
     const entries = pool.getAllEntries();
 
@@ -107,6 +124,7 @@ describe("account transfer formats", () => {
         access_token: token,
         refresh_token: "rt_alpha",
         account_id: "acct-1",
+        organization_id: "org-alpha",
         email: "alpha@example.com",
         type: "codex",
       }),
@@ -125,6 +143,7 @@ describe("account transfer formats", () => {
             access_token: token,
             refresh_token: "rt_alpha",
             chatgpt_account_id: "acct-1",
+            organization_id: "org-alpha",
           }),
         }),
       ],
@@ -135,6 +154,7 @@ describe("account transfer formats", () => {
       access_token: token,
       refresh_token: "rt_alpha",
       account_id: "acct-1",
+      organization_id: "org-alpha",
       type: "codex",
     }));
   });

--- a/web/src/components/AccountImportExport.test.tsx
+++ b/web/src/components/AccountImportExport.test.tsx
@@ -42,4 +42,29 @@ describe("AccountImportExport", () => {
       expect(onExport).toHaveBeenCalledWith(["acct-1"], "sub2api");
     });
   });
+
+  it("shows the first concrete import error instead of only the failed count", async () => {
+    const onImport = vi.fn(async () => ({
+      success: true,
+      added: 0,
+      updated: 0,
+      failed: 1,
+      errors: ["Account identity discovery failed: HTTP 403"],
+    }));
+    const { container } = render(
+      <AccountImportExport
+        onExport={vi.fn()}
+        onImport={onImport}
+        selectedIds={new Set()}
+      />,
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(["{}"], "account.json", { type: "application/json" });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Account identity discovery failed: HTTP 403/)).toBeTruthy();
+    });
+  });
 });

--- a/web/src/components/AccountImportExport.tsx
+++ b/web/src/components/AccountImportExport.tsx
@@ -40,16 +40,22 @@ export function AccountImportExport({ onExport, onImport, selectedIds }: Account
     setResult(null);
     try {
       let totalAdded = 0, totalUpdated = 0, totalFailed = 0;
+      const errors: string[] = [];
       for (const file of files) {
         const res = await onImport(file);
         totalAdded += res.added;
         totalUpdated += res.updated;
         totalFailed += res.failed;
+        errors.push(...(res.errors ?? []));
       }
-      const msg = t("accountImportResult")
+      let msg = t("accountImportResult")
         .replace("{added}", String(totalAdded))
         .replace("{updated}", String(totalUpdated))
         .replace("{failed}", String(totalFailed));
+      if (errors.length > 0) {
+        const first = errors[0].replace(/\s+/g, " ").slice(0, 180);
+        msg += ` — ${first}${errors.length > 1 ? ` (+${errors.length - 1})` : ""}`;
+      }
       setResult(msg);
     } catch {
       setResult(t("accountImportError"));


### PR DESCRIPTION
## Summary

Some valid Sub2API exports contain a structurally valid OpenAI access token but no `chatgpt_account_id` claim. The current importer rejects those accounts even though the authenticated upstream can identify the real ChatGPT workspace.

This change:

- keeps malformed and expired tokens rejected by the existing structural validation;
- prefers authenticated `/accounts/check` workspace discovery;
- falls back to `/wham/usage`, then verifies the discovered ID with a second request carrying `ChatGPT-Account-Id`;
- treats file-level account IDs and file-supplied `id_token` values only as hints, never as authoritative routing identity;
- persists the verified workspace metadata and preserves safe deduplication for rotating tokens;
- shows a redacted import failure reason in the account UI.

## Security / compatibility boundaries

- Identity discovery is only attempted for structurally valid, account-ID-less access tokens.
- Upstream response bodies are not included in errors.
- `organization_id` is stored separately and is never sent as `ChatGPT-Account-Id`.
- Refresh-token-only imports retain the existing no-immediate-quota-probe behavior.
- No dependency, lockfile, license, account-data, cookie, log, or deployment-manifest changes are included.

## Verification

- `npm run build`
- `npm test` — 260 files passed; 2,585 passed, 1 skipped
- `npm run test:web` — 7 files / 25 tests passed
- `npm run typecheck:scripts`
- privacy/secrets added-line scan and `git diff --check`
