### PR TITLE
fix(ws): ignore internal metadata before response

### DIFF
--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -149,6 +149,10 @@ function isEarlyMetadataWsEvent(type: string): boolean {
   return type === "response.created" || type === "response.in_progress";
 }
 
+function isInternalWsEvent(type: string): boolean {
+  return type === "codex.rate_limits" || type === "codex.response.metadata";
+}
+
 // ── PersistentWs ───────────────────────────────────────────────────
 
 export interface PersistentWsHooks {
@@ -419,11 +423,11 @@ export class PersistentWs {
       /* fall through to raw passthrough */
     }
 
-    // Internal rate-limit frames bypass the stream and don't flip the
-    // early-decision flag; they're observed via the per-session callback.
-    if (msg && type === "codex.rate_limits") {
-      const rl = parseRateLimitsEvent(msg);
-      if (rl) sess.onRateLimits?.(rl);
+    if (msg && isInternalWsEvent(type)) {
+      if (type === "codex.rate_limits") {
+        const rl = parseRateLimitsEvent(msg);
+        if (rl) sess.onRateLimits?.(rl);
+      }
       return;
     }
 

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -88,6 +88,10 @@ function isEarlyMetadataWsEvent(type: string): boolean {
   return type === "response.created" || type === "response.in_progress";
 }
 
+function isInternalWsEvent(type: string): boolean {
+  return type === "codex.rate_limits" || type === "codex.response.metadata";
+}
+
 const WS_CONNECTING = 0;
 const WS_CLOSING = 2;
 const WS_CLOSED = 3;
@@ -250,8 +254,9 @@ export async function createWebSocketResponse(
   poolCtx?: WsPoolContext,
 ): Promise<Response> {
   if (poolCtx) {
+    let acquired: Awaited<ReturnType<WsConnectionPool["acquire"]>>;
     try {
-      const acquired = await poolCtx.pool.acquire(
+      acquired = await poolCtx.pool.acquire(
         poolCtx.entryId,
         poolCtx.poolKey,
         (deps) =>
@@ -264,25 +269,6 @@ export async function createWebSocketResponse(
             hooks: deps.hooks,
           }),
       );
-      if ("ws" in acquired) {
-        poolCtx.onDecision?.({
-          kind: acquired.reused ? "reuse" : "new",
-          wsId: acquired.ws.id,
-        });
-        try {
-          return await acquired.ws.send({ request, signal, onRateLimits, reused: acquired.reused });
-        } catch (err) {
-          if (err instanceof WsReusedConnectionError) {
-            // Stale-reuse: open a fresh one-shot WS for this single request.
-            // The pool's onDead hook has already evicted the dead entry.
-            poolCtx.onDecision?.({ kind: "retry-after-stale-reuse", wsId: acquired.ws.id });
-            return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
-          }
-          throw err;
-        }
-      }
-      // Bypass (busy / cap / dead / no_key / disabled) → fall through to one-shot.
-      poolCtx.onDecision?.({ kind: "bypass", reason: acquired.bypass });
     } catch (err) {
       // Pool itself failed (e.g. factory could not connect). Don't punish the
       // caller — fall back to the legacy one-shot path. The error is still
@@ -290,7 +276,29 @@ export async function createWebSocketResponse(
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[ws-pool] acquire failed, using one-shot fallback: ${msg}`);
       poolCtx.onDecision?.({ kind: "bypass", reason: "factory_error" });
+      return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
     }
+
+    if ("ws" in acquired) {
+      poolCtx.onDecision?.({
+        kind: acquired.reused ? "reuse" : "new",
+        wsId: acquired.ws.id,
+      });
+      try {
+        return await acquired.ws.send({ request, signal, onRateLimits, reused: acquired.reused });
+      } catch (err) {
+        if (err instanceof WsReusedConnectionError) {
+          // Stale-reuse: open a fresh one-shot WS for this single request.
+          // The pool's onDead hook has already evicted the dead entry.
+          poolCtx.onDecision?.({ kind: "retry-after-stale-reuse", wsId: acquired.ws.id });
+          return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
+        }
+        throw err;
+      }
+    }
+
+    // Bypass (busy / cap / dead / no_key / disabled) → fall through to one-shot.
+    poolCtx.onDecision?.({ kind: "bypass", reason: acquired.bypass });
   }
 
   return openOneShotWs(wsUrl, headers, request, signal, proxyUrl, onRateLimits);
@@ -452,9 +460,11 @@ async function openOneShotWs(
         // Non-JSON message — handled below as raw data.
       }
 
-      if (msg && type === "codex.rate_limits") {
-        const rl = parseRateLimitsEvent(msg);
-        if (rl) onRateLimits?.(rl);
+      if (msg && isInternalWsEvent(type)) {
+        if (type === "codex.rate_limits") {
+          const rl = parseRateLimitsEvent(msg);
+          if (rl) onRateLimits?.(rl);
+        }
         return;
       }
 

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -220,6 +220,22 @@ describe("PersistentWs", () => {
     expect(text).not.toContain("codex.rate_limits");
   });
 
+  it("response metadata stays internal and preserves early error classification", async () => {
+    const { ws, persistent } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "codex.response.metadata", response_id: "resp_internal" });
+    ws.pushMessage({ type: "error", error: { code: "usage_limit_reached", message: "limit" } });
+
+    await expect(promise).rejects.toMatchObject({ status: 429 });
+  });
+
   it("classified early error rejects with CodexApiError without resolving stream", async () => {
     const { ws, persistent } = newPersistentWs();
     persistent.tryAcquire();

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -249,6 +249,23 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     expect(onRateLimits).toHaveBeenCalledTimes(1);
   });
 
+  it("treats codex.response.metadata as internal before an early error", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "codex.response.metadata",
+      response_id: "resp_internal",
+    }));
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "usage_limit_reached", message: "Limit reached" },
+    }));
+
+    await expect(promise).rejects.toMatchObject({ status: 429 });
+  });
+
   it("passes through error events that arrive after a real frame", async () => {
     // Once a real frame has been streamed, switching accounts is no longer
     // safe — the client has already started receiving bytes. Errors arriving

--- a/tests/unit/proxy/ws-transport.test.ts
+++ b/tests/unit/proxy/ws-transport.test.ts
@@ -57,7 +57,12 @@ vi.mock("@src/tls/proxy.js", () => ({
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { createWebSocketResponse, type WsCreateRequest } from "@src/proxy/ws-transport.js";
+import {
+  createWebSocketResponse,
+  type WsCreateRequest,
+  type WsPoolContext,
+} from "@src/proxy/ws-transport.js";
+import { CodexApiError } from "@src/proxy/codex-types.js";
 
 interface MockWs extends EventEmitter {
   url: string;
@@ -255,6 +260,37 @@ describe("createWebSocketResponse", () => {
     await expect(
       createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST, controller.signal),
     ).rejects.toThrow("aborted");
+  });
+
+  it("does not retry a pooled request error as a factory failure", async () => {
+    const requestError = new CodexApiError(429, "rate limited");
+    const onDecision = vi.fn();
+    const poolCtx = {
+      entryId: "entry-A",
+      poolKey: "entry-A:conv-1",
+      onDecision,
+      pool: {
+        acquire: vi.fn().mockResolvedValue({
+          ws: { id: "ws-1", send: vi.fn().mockRejectedValue(requestError) },
+          reused: false,
+        }),
+      },
+    } as unknown as WsPoolContext;
+
+    await expect(
+      createWebSocketResponse(
+        "wss://test/ws",
+        {},
+        BASE_REQUEST,
+        undefined,
+        undefined,
+        undefined,
+        poolCtx,
+      ),
+    ).rejects.toBe(requestError);
+    expect(wsInstances).toHaveLength(0);
+    expect(onDecision).toHaveBeenCalledTimes(1);
+    expect(onDecision).toHaveBeenCalledWith({ kind: "new", wsId: "ws-1" });
   });
 
   it("rejects before returning a Response when WS closes after only metadata", async () => {


### PR DESCRIPTION
fix #689 