### PR TITLE
feat(models): default to GPT-5.6 sol/terra/luna

### DIFF
--- a/.github/guides/claude-code-setup.md
+++ b/.github/guides/claude-code-setup.md
@@ -36,7 +36,7 @@ cat ~/.claude/settings.json
 - **`ANTHROPIC_BASE_URL`** — Codex Proxy 地址（默认 `http://localhost:8080`）
 - **`ANTHROPIC_API_KEY`** — 从 Dashboard 获取的 proxy API key
 
-> **Tip:** Dashboard 的 **Anthropic SDK Setup** 卡片可一键复制所有环境变量（含 Opus / Sonnet / Haiku 层级模型配置）。推荐模型：Opus → `gpt-5.4`，Sonnet → `gpt-5.3-codex`，Haiku → `gpt-5.4-mini`。
+> **Tip:** Dashboard 的 **Anthropic SDK Setup** 卡片可一键复制所有环境变量（含 Opus / Sonnet / Haiku 层级模型配置）。推荐模型：Opus → `gpt-5.6-sol`，Sonnet → `gpt-5.6-terra`，Haiku → `gpt-5.6-luna`。
 
 如果需要手动创建，在 `~/.claude/settings.json` 中填入：
 
@@ -45,9 +45,9 @@ cat ~/.claude/settings.json
   "env": {
     "ANTHROPIC_BASE_URL": "http://localhost:8080",
     "ANTHROPIC_API_KEY": "your-proxy-api-key",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.4",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.3-codex",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5.4-mini"
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.6-sol",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.6-terra",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5.6-luna"
   }
 }
 ```

--- a/API.md
+++ b/API.md
@@ -149,7 +149,7 @@ message content. `data:` URLs and HTTPS URLs both work.
 
 ```jsonc
 {
-  "model": "gpt-5.5",
+  "model": "gpt-5.6-sol",
   "stream": true,
   "input": [{
     "role": "user",
@@ -238,12 +238,12 @@ Model catalog entries can include token metadata:
 
 Static catalog values are defined in `config/models.yaml`; dynamic entries from
 `/backend-api/codex/models` win when the same model ID is returned by upstream.
-On 2026-05-08, real Codex backend metadata returned `context_window=272000`,
-`max_context_window=272000`, `truncation_policy.limit=10000` for `gpt-5.5`, and
-`context_window=272000`, `max_context_window=1000000`,
-`truncation_policy.limit=10000` for `gpt-5.4`. Treat these as runtime Codex
-limits, not as proof that request-level context or max-token switches are
-supported.
+The static GPT-5.6 family (`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` /
+`gpt-5.6`) uses a 1,050,000 context window and 128,000 max output tokens.
+Earlier runtime samples still document `context_window=272000` for `gpt-5.5` /
+`gpt-5.4`, with `max_context_window=1000000` on `gpt-5.4`. Treat these as
+runtime Codex limits, not as proof that request-level context or max-token
+switches are supported.
 
 ---
 

--- a/API_CN.md
+++ b/API_CN.md
@@ -145,7 +145,7 @@ token 混到一起。
 
 ```jsonc
 {
-  "model": "gpt-5.5",
+  "model": "gpt-5.6-sol",
   "stream": true,
   "input": [{
     "role": "user",
@@ -188,11 +188,11 @@ OpenAI Chat 兼容路径会接受 `tools: [{"type":"image_generation"}]`，但�
 | `truncationPolicyLimit` | 上游提供的截断策略限制（如果返回） |
 
 静态值定义在 `config/models.yaml`；同一模型 ID 如果从
-`/backend-api/codex/models` 拉到动态条目，则以上游动态值为准。实测
-2026-05-08 的 Codex 后端对 `gpt-5.5` 回传 `context_window=272000`、
-`max_context_window=272000`、`truncation_policy.limit=10000`，对 `gpt-5.4`
-回传 `context_window=272000`、`max_context_window=1000000`、
-`truncation_policy.limit=10000`。这些是 Codex 运行时限制，不代表请求级
+`/backend-api/codex/models` 拉到动态条目，则以上游动态值为准。静态 GPT-5.6
+家族（`gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.6`）使用
+1,050,000 上下文与 128,000 最大输出。更早的运行时样本仍记录 `gpt-5.5` /
+`gpt-5.4` 的 `context_window=272000`，以及 `gpt-5.4` 的
+`max_context_window=1000000`。这些是 Codex 运行时限制，不代表请求级
 context 或 max-token 开关可用。
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 
 - Dashboard 日志页面完善深色模式适配，补齐筛选控件、统计卡片、详情抽屉和 JSON 代码块的深色状态；复制 JSON 成功后改为绿色反馈（`web/src/pages/LogsPage.tsx`）。
+- 默认模型与 Claude/Anthropic 推荐档位切换到 GPT-5.6 家族：`config/default.yaml` 默认模型改为 `gpt-5.6-sol`；Dashboard Anthropic Setup 预设与 Claude Code 指南改为 Opus → `gpt-5.6-sol` / Sonnet → `gpt-5.6-terra` / Haiku → `gpt-5.6-luna`；README / API 文档模型表与客户端示例同步更新（`config/default.yaml`、`web/src/components/AnthropicSetup.tsx`、`.github/guides/claude-code-setup.md`、`README.md`、`README_EN.md`、`API.md`、`API_CN.md`）
 - 账号持久化从 `accounts.json` 主存储迁移到 `accounts.sqlite`，启动时自动从旧 JSON 迁移并继续保留 `accounts.json` 镜像用于降级/回滚；批量导入改为持久化批处理，避免每个账号同步重写整份 JSON 导致大批量导入卡死。（#657）
 - 重构：消除类型守卫 `isRecord` 的多处重复声明（收拢翻译层与路由层到 `shared-utils.ts`）
 - 重构：合并推理预算映射表 `REASONING_EFFORT_BUDGET`（提取为 `shared-utils.ts` 的公共常量）

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ npm run dev                        # 开发模式（热重载）
 curl http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-api-key" \
-  -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+  -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
 ```
 
 看到 AI 回复的文字流即部署成功。如果返回 401，请检查 API Key 是否正确。
@@ -214,8 +214,11 @@ curl http://localhost:8080/v1/chat/completions \
 
 | 模型 ID | 推理等级 | 当前上下文 | 最大上下文 | 最大输出 | 输出 | 说明 |
 |---------|---------|------------|------------|----------|------|------|
-| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | 文本 | 复杂编码、研究和真实工作流旗舰模型 |
-| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | 文本 | 日常编码强模型（默认） |
+| `gpt-5.6-sol` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 旗舰：复杂推理与编码（默认；`gpt-5.6` 为其别名） |
+| `gpt-5.6-terra` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 智能与成本平衡 |
+| `gpt-5.6-luna` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 高性价比 / 高吞吐 |
+| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | 文本 | 复杂编码、研究和真实工作流 |
+| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | 文本 | 日常编码强模型 |
 | `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | — | 128,000 | 文本 | 5.4 轻量版 |
 | `gpt-5.3-codex` | low / medium / high / xhigh | 400,000 | — | 128,000 | 文本 | 5.3 编程优化模型 |
 | `gpt-5.2` | low / medium / high / xhigh | 400,000 | — | 128,000 | 文本 | 专业工作 + 长时间代理 |
@@ -225,7 +228,7 @@ curl http://localhost:8080/v1/chat/completions \
 | `gpt-oss-20b` | low / medium / high | 131,072 | — | — | 文本 | 开源 20B 模型 |
 | `gpt-image-2` | — | — | — | — | 图像 | 图像生成工具后端（通过 `image_generation` 调用） |
 
-> **后缀**：任意 chat 模型名后追加 `-fast` 启用 Fast 模式，`-high`/`-low` 切换推理等级。例如：`gpt-5.4-fast`、`gpt-5.4-high-fast`。图像模型（`gpt-image-2`）不支持后缀。
+> **后缀**：任意 chat 模型名后追加 `-fast` 启用 Fast 模式，`-high`/`-low` 切换推理等级。例如：`gpt-5.6-sol-fast`、`gpt-5.6-sol-high-fast`。图像模型（`gpt-image-2`）不支持后缀。
 >
 > **Plan Routing**：不同 plan（free/plus/team/business）的账号自动路由到各自支持的模型，模型可用性以登录账号对应的 Codex 后端返回为准，不要按旧的 Plus-only 表理解。模型列表由后端动态获取，自动同步；只要模型出现在 Dashboard / `/v1/models/catalog` 中，就可以作为请求里的 `model` 使用。
 >
@@ -244,7 +247,7 @@ curl -N http://localhost:8080/v1/responses \
   -H "Authorization: Bearer $PROXY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.5",
+    "model": "gpt-5.6-sol",
     "stream": true,
     "input": [{"role":"user","content":"Draw a red circle on white background."}],
     "tools": [{"type":"image_generation","size":"3840x2160"}]
@@ -263,20 +266,20 @@ curl -N http://localhost:8080/v1/responses \
 
 ## 🔗 客户端接入
 
-> 所有客户端的 API Key 均从控制面板 (`http://localhost:8080`) 获取。模型名填具体 ID（默认 `gpt-5.4`）或任意 [可用模型](#-可用模型) ID。
+> 所有客户端的 API Key 均从控制面板 (`http://localhost:8080`) 获取。模型名填具体 ID（默认 `gpt-5.6-sol`）或任意 [可用模型](#-可用模型) ID。
 
 ### Claude Code (CLI)
 
 ```bash
 export ANTHROPIC_BASE_URL=http://localhost:8080
 export ANTHROPIC_API_KEY=your-api-key
-# 切换模型: export ANTHROPIC_MODEL=gpt-5.4 / gpt-5.4-fast / gpt-5.4-mini ...
+# 切换模型: export ANTHROPIC_MODEL=gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna / gpt-5.6-sol-fast ...
 claude
 ```
 
 > 控制面板的 **Anthropic SDK Setup** 卡片可一键复制环境变量（含 Opus / Sonnet / Haiku 层级模型配置）。
 >
-> 推荐模型：Opus → `gpt-5.5`，Sonnet → `gpt-5.4`，Haiku → `gpt-5.3-codex`。
+> 推荐模型：Opus → `gpt-5.6-sol`，Sonnet → `gpt-5.6-terra`，Haiku → `gpt-5.6-luna`。
 >
 > ⚠️ 配置不生效？请参考 **[Claude Code 配置避坑指南](.github/guides/claude-code-setup.md)**（AUTH_TOKEN 劫持、API Key 黑名单等常见问题）。
 
@@ -294,7 +297,7 @@ wire_api = "responses"
 Authorization = "Bearer your-api-key"
 
 [profiles.default]
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_provider = "proxy_codex"
 ```
 
@@ -329,9 +332,9 @@ model_provider = "proxy_codex"
 ```yaml
 model:
   aliases:
-    claude-opus-4-7: gpt-5.5
-    claude-sonnet-4-6: gpt-5.4
-    claude-haiku-4-5: gpt-5.3-codex
+    claude-opus-4-7: gpt-5.6-sol
+    claude-sonnet-4-6: gpt-5.6-terra
+    claude-haiku-4-5: gpt-5.6-luna
     my-openai: openai:gpt-4o
     my-deepseek: deepseek-chat
 ```
@@ -359,7 +362,7 @@ wire_api = "responses"
 Authorization = "Bearer your-api-key"
 
 [profiles.default]
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_provider = "proxy_codex"
 ```
 
@@ -388,7 +391,7 @@ model_provider = "proxy_codex"
 2. 选择 OpenAI API
 3. 设置 **Base URL**: `http://localhost:8080/v1`
 4. 设置 **API Key**: 你的 API Key
-5. 添加模型名 `gpt-5.4`（或其他模型 ID）
+5. 添加模型名 `gpt-5.6-sol`（或其他模型 ID）
 
 ### Windsurf
 
@@ -396,7 +399,7 @@ model_provider = "proxy_codex"
 2. 选择 **OpenAI Compatible**
 3. **API Base URL**: `http://localhost:8080/v1`
 4. **API Key**: 你的 API Key
-5. **Model**: `gpt-5.4`
+5. **Model**: `gpt-5.6-sol`
 
 ### Cline (VSCode 扩展)
 
@@ -404,7 +407,7 @@ model_provider = "proxy_codex"
 2. **API Provider**: 选择 OpenAI Compatible
 3. **Base URL**: `http://localhost:8080/v1`
 4. **API Key**: 你的 API Key
-5. **Model ID**: `gpt-5.4`
+5. **Model ID**: `gpt-5.6-sol`
 
 ### Continue (VSCode 扩展)
 
@@ -414,7 +417,7 @@ model_provider = "proxy_codex"
   "models": [{
     "title": "Codex",
     "provider": "openai",
-    "model": "gpt-5.4",
+    "model": "gpt-5.6-sol",
     "apiBase": "http://localhost:8080/v1",
     "apiKey": "your-api-key"
   }]
@@ -426,14 +429,14 @@ model_provider = "proxy_codex"
 ```bash
 aider --openai-api-base http://localhost:8080/v1 \
       --openai-api-key your-api-key \
-      --model openai/gpt-5.4
+      --model openai/gpt-5.6-sol
 ```
 
 或设置环境变量：
 ```bash
 export OPENAI_API_BASE=http://localhost:8080/v1
 export OPENAI_API_KEY=your-api-key
-aider --model openai/gpt-5.4
+aider --model openai/gpt-5.6-sol
 ```
 
 ### Cherry Studio
@@ -442,7 +445,7 @@ aider --model openai/gpt-5.4
 2. **类型**: OpenAI
 3. **API 地址**: `http://localhost:8080/v1`
 4. **API Key**: 你的 API Key
-5. 添加模型 `gpt-5.4`
+5. 添加模型 `gpt-5.6-sol`
 
 ### Pi Coding Agent (pi)
 
@@ -540,14 +543,14 @@ pi --provider codex-proxy --model gpt-5.4
 |--------|-----|
 | Base URL | `http://localhost:11434` |
 | API Key | 不需要，Bridge 内部会使用 Codex Proxy 的密钥访问主服务 |
-| Model | `gpt-5.4`（或其他模型 ID） |
+| Model | `gpt-5.6-sol`（或其他模型 ID） |
 
 ```bash
 curl http://localhost:11434/api/tags
 
 curl http://localhost:11434/api/chat \
   -H "Content-Type: application/json" \
-  -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+  -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
 ```
 
 > Ollama API 本身没有鉴权。默认仅监听 `127.0.0.1`，不建议暴露到公网或未信任的局域网。
@@ -560,7 +563,7 @@ curl http://localhost:11434/api/chat \
 |--------|-----|
 | Base URL | `http://localhost:8080/v1` |
 | API Key | 控制面板获取 |
-| Model | `gpt-5.4`（或其他模型 ID） |
+| Model | `gpt-5.6-sol`（或其他模型 ID） |
 
 <details>
 <summary>SDK 代码示例（Python / Node.js）</summary>
@@ -570,7 +573,7 @@ curl http://localhost:11434/api/chat \
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="your-api-key")
 for chunk in client.chat.completions.create(
-    model="gpt-5.4", messages=[{"role": "user", "content": "Hello!"}], stream=True
+    model="gpt-5.6-sol", messages=[{"role": "user", "content": "Hello!"}], stream=True
 ):
     print(chunk.choices[0].delta.content or "", end="")
 ```
@@ -580,7 +583,7 @@ for chunk in client.chat.completions.create(
 import OpenAI from "openai";
 const client = new OpenAI({ baseURL: "http://localhost:8080/v1", apiKey: "your-api-key" });
 const stream = await client.chat.completions.create({
-  model: "gpt-5.4", messages: [{ role: "user", content: "Hello!" }], stream: true,
+  model: "gpt-5.6-sol", messages: [{ role: "user", content: "Hello!" }], stream: true,
 });
 for await (const chunk of stream) {
   process.stdout.write(chunk.choices[0]?.delta?.content || "");
@@ -651,8 +654,8 @@ client:
 ```yaml
 model:
   aliases:
-    claude-opus-4-7: gpt-5.5
-    sonnet-local: gpt-5.4
+    claude-opus-4-7: gpt-5.6-sol
+    sonnet-local: gpt-5.6-terra
     openai-fast: openai:gpt-4o
     deepseek-local: deepseek-chat
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -103,7 +103,7 @@ After logging in, open the dashboard at `http://localhost:8080` and find your AP
 curl http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-api-key" \
-  -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+  -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
 ```
 
 If you see streaming AI text, the setup is working. If you get 401, double-check the API Key.
@@ -189,8 +189,11 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 
 | Model ID | Reasoning | Current context | Max context | Max output | Output | Description |
 |----------|-----------|-----------------|-------------|------------|--------|-------------|
-| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | text | Frontier model for complex coding, research, and real-world work |
-| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | text | Strong model for everyday coding (default) |
+| `gpt-5.6-sol` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 flagship for complex reasoning & coding (default; `gpt-5.6` is an alias) |
+| `gpt-5.6-terra` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 balanced intelligence and cost |
+| `gpt-5.6-luna` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 cost-efficient / high-throughput |
+| `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | text | Complex coding, research, and real-world work |
+| `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | text | Strong model for everyday coding |
 | `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | — | 128,000 | text | GPT-5.4 lightweight model |
 | `gpt-5.3-codex` | low / medium / high / xhigh | 400,000 | — | 128,000 | text | GPT-5.3 coding-optimized model |
 | `gpt-5.2` | low / medium / high / xhigh | 400,000 | — | 128,000 | text | Professional work & long-running agents |
@@ -200,7 +203,7 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 | `gpt-oss-20b` | low / medium / high | 131,072 | — | — | text | Open-source 20B model |
 | `gpt-image-2` | — | — | — | — | image | Image-generation tool backend, invoked via `image_generation` |
 
-> **Suffixes**: Append `-fast` to any chat model for Fast mode, `-high`/`-low` for reasoning effort. E.g. `gpt-5.4-fast`, `gpt-5.4-high-fast`. The image model (`gpt-image-2`) does not take suffixes.
+> **Suffixes**: Append `-fast` to any chat model for Fast mode, `-high`/`-low` for reasoning effort. E.g. `gpt-5.6-sol-fast`, `gpt-5.6-sol-high-fast`. The image model (`gpt-image-2`) does not take suffixes.
 >
 > **Plan Routing**: Accounts on different plans auto-route to the models returned for that account by the Codex backend. Do not treat old Plus-only notes as fixed model access rules. Models are dynamically fetched and auto-synced; if a model appears in the Dashboard or `/v1/models/catalog`, it can be used as the request `model`.
 >
@@ -219,7 +222,7 @@ curl -N http://localhost:8080/v1/responses \
   -H "Authorization: Bearer $PROXY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-5.5",
+    "model": "gpt-5.6-sol",
     "stream": true,
     "input": [{"role":"user","content":"Draw a red circle on white background."}],
     "tools": [{"type":"image_generation","size":"3840x2160"}]
@@ -238,20 +241,20 @@ In the stream, the `image_generation_call` item's `result` field is a base64-enc
 
 ## 🔗 Client Setup
 
-> Get your API Key from the dashboard (`http://localhost:8080`). Use a concrete model ID (default `gpt-5.4`) or any [model ID](#-available-models) as the model name.
+> Get your API Key from the dashboard (`http://localhost:8080`). Use a concrete model ID (default `gpt-5.6-sol`) or any [model ID](#-available-models) as the model name.
 
 ### Claude Code (CLI)
 
 ```bash
 export ANTHROPIC_BASE_URL=http://localhost:8080
 export ANTHROPIC_API_KEY=your-api-key
-# Switch model: export ANTHROPIC_MODEL=gpt-5.4 / gpt-5.4-fast / gpt-5.4-mini ...
+# Switch model: export ANTHROPIC_MODEL=gpt-5.6-sol / gpt-5.6-terra / gpt-5.6-luna / gpt-5.6-sol-fast ...
 claude
 ```
 
 > Copy env vars from the **Anthropic SDK Setup** card in the dashboard (includes Opus / Sonnet / Haiku tier model config).
 >
-> Recommended models: Opus → `gpt-5.5`, Sonnet → `gpt-5.4`, Haiku → `gpt-5.3-codex`.
+> Recommended models: Opus → `gpt-5.6-sol`, Sonnet → `gpt-5.6-terra`, Haiku → `gpt-5.6-luna`.
 
 ### Codex CLI
 
@@ -267,7 +270,7 @@ wire_api = "responses"
 Authorization = "Bearer your-api-key"
 
 [profiles.default]
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_provider = "proxy_codex"
 ```
 
@@ -303,9 +306,9 @@ Built-in Claude-shaped model names map to Codex models. Put custom mappings in `
 ```yaml
 model:
   aliases:
-    claude-opus-4-7: gpt-5.5
-    claude-sonnet-4-6: gpt-5.4
-    claude-haiku-4-5: gpt-5.3-codex
+    claude-opus-4-7: gpt-5.6-sol
+    claude-sonnet-4-6: gpt-5.6-terra
+    claude-haiku-4-5: gpt-5.6-luna
     my-openai: openai:gpt-4o
     my-deepseek: deepseek-chat
 ```
@@ -333,7 +336,7 @@ wire_api = "responses"
 Authorization = "Bearer your-api-key"
 
 [profiles.default]
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_provider = "proxy_codex"
 ```
 
@@ -353,14 +356,14 @@ Open Claude extension settings → **API Configuration**:
 1. Settings → Models → OpenAI API
 2. **Base URL**: `http://localhost:8080/v1`
 3. **API Key**: your API key
-4. Add model `gpt-5.4`
+4. Add model `gpt-5.6-sol`
 
 ### Windsurf
 
 1. Settings → AI Provider → **OpenAI Compatible**
 2. **API Base URL**: `http://localhost:8080/v1`
 3. **API Key**: your API key
-4. **Model**: `gpt-5.4`
+4. **Model**: `gpt-5.6-sol`
 
 ### Cline (VSCode Extension)
 
@@ -368,7 +371,7 @@ Open Claude extension settings → **API Configuration**:
 2. **API Provider**: OpenAI Compatible
 3. **Base URL**: `http://localhost:8080/v1`
 4. **API Key**: your API key
-5. **Model ID**: `gpt-5.4`
+5. **Model ID**: `gpt-5.6-sol`
 
 ### Continue (VSCode Extension)
 
@@ -378,7 +381,7 @@ Open Claude extension settings → **API Configuration**:
   "models": [{
     "title": "Codex",
     "provider": "openai",
-    "model": "gpt-5.4",
+    "model": "gpt-5.6-sol",
     "apiBase": "http://localhost:8080/v1",
     "apiKey": "your-api-key"
   }]
@@ -390,7 +393,7 @@ Open Claude extension settings → **API Configuration**:
 ```bash
 aider --openai-api-base http://localhost:8080/v1 \
       --openai-api-key your-api-key \
-      --model openai/gpt-5.4
+      --model openai/gpt-5.6-sol
 ```
 
 ### Cherry Studio
@@ -399,7 +402,7 @@ aider --openai-api-base http://localhost:8080/v1 \
 2. **Type**: OpenAI
 3. **API URL**: `http://localhost:8080/v1`
 4. **API Key**: your API key
-5. Add model `gpt-5.4`
+5. Add model `gpt-5.6-sol`
 
 ### Pi Coding Agent (pi)
 
@@ -497,14 +500,14 @@ Enable it in Dashboard → Settings → **Ollama Bridge**, then use the default 
 |---------|-------|
 | Base URL | `http://localhost:11434` |
 | API Key | Not required; the bridge uses the Codex Proxy key internally |
-| Model | `gpt-5.4` (or any model ID) |
+| Model | `gpt-5.6-sol` (or any model ID) |
 
 ```bash
 curl http://localhost:11434/api/tags
 
 curl http://localhost:11434/api/chat \
   -H "Content-Type: application/json" \
-  -d '{"model":"gpt-5.4","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+  -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
 ```
 
 > The Ollama API has no authentication. The bridge listens on `127.0.0.1` by default; do not expose it to the public internet or untrusted LANs.
@@ -515,7 +518,7 @@ curl http://localhost:11434/api/chat \
 |---------|-------|
 | Base URL | `http://localhost:8080/v1` |
 | API Key | from dashboard |
-| Model | `gpt-5.4` (or any model ID) |
+| Model | `gpt-5.6-sol` (or any model ID) |
 
 <details>
 <summary>SDK examples (Python / Node.js)</summary>
@@ -525,7 +528,7 @@ curl http://localhost:11434/api/chat \
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="your-api-key")
 for chunk in client.chat.completions.create(
-    model="gpt-5.4", messages=[{"role": "user", "content": "Hello!"}], stream=True
+    model="gpt-5.6-sol", messages=[{"role": "user", "content": "Hello!"}], stream=True
 ):
     print(chunk.choices[0].delta.content or "", end="")
 ```
@@ -535,7 +538,7 @@ for chunk in client.chat.completions.create(
 import OpenAI from "openai";
 const client = new OpenAI({ baseURL: "http://localhost:8080/v1", apiKey: "your-api-key" });
 const stream = await client.chat.completions.create({
-  model: "gpt-5.4", messages: [{ role: "user", content: "Hello!" }], stream: true,
+  model: "gpt-5.6-sol", messages: [{ role: "user", content: "Hello!" }], stream: true,
 });
 for await (const chunk of stream) {
   process.stdout.write(chunk.choices[0]?.delta?.content || "");
@@ -603,8 +606,8 @@ You can also manage aliases in Dashboard → Settings → **Model Aliases**. Sav
 ```yaml
 model:
   aliases:
-    claude-opus-4-7: gpt-5.5
-    sonnet-local: gpt-5.4
+    claude-opus-4-7: gpt-5.6-sol
+    sonnet-local: gpt-5.6-terra
     openai-fast: openai:gpt-4o
     deepseek-local: deepseek-chat
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -11,7 +11,7 @@ client:
   chromium_version: "146"
 
 model:
-  default: gpt-5.4
+  default: gpt-5.6-sol
   # Codex host model for POST /v1/images/generations. The client-facing
   # gpt-image-2 identifier only means "generate an image" — it is never
   # sent upstream as the chat model itself.

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -36,7 +36,7 @@ client:
   arch: "arm64"
   chromium_version: "136"
 model:
-  default: "gpt-5.4"
+  default: "gpt-5.6-sol"
   default_reasoning_effort: null
   default_service_tier: null
   suppress_desktop_directives: true
@@ -92,7 +92,7 @@ describe("config", () => {
     const config = loadConfig("/tmp/test-config");
     expect(config.api.base_url).toBe("https://chatgpt.com/backend-api");
     expect(config.server.port).toBe(8080);
-    expect(config.model.default).toBe("gpt-5.4");
+    expect(config.model.default).toBe("gpt-5.6-sol");
     expect(config.usage_stats.snapshot_interval_minutes).toBe(5);
     expect(config.usage_stats.history_retention_days).toBeNull();
   });

--- a/tests/unit/ollama/bridge.test.ts
+++ b/tests/unit/ollama/bridge.test.ts
@@ -140,9 +140,13 @@ describe("Ollama bridge routes", () => {
     expect(body.models[0].digest).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it.each(["gpt-5.5", "gpt-5.4-mini"])(
-    "returns 400k context metadata for %s and can suppress vision capability",
-    async (model) => {
+  it.each([
+    ["gpt-5.6-sol", "gpt-5.6", 1050000],
+    ["gpt-5.5", "gpt-5.5", 400000],
+    ["gpt-5.4-mini", "gpt-5.4", 400000],
+  ])(
+    "returns context metadata for %s and can suppress vision capability",
+    async (model, architecture, contextLength) => {
       fetchMock.mockResolvedValueOnce(json({
         id: model,
         displayName: model,
@@ -165,15 +169,15 @@ describe("Ollama bridge routes", () => {
       );
       const body = await res.json() as Record<string, unknown>;
       expect(body.capabilities).toEqual(["completion", "tools", "thinking"]);
-      expect(body.parameters).toBe("num_ctx 400000\nreasoning medium");
-      const architecture = model.startsWith("gpt-5.4") ? "gpt-5.4" : model;
+      expect(body.parameters).toBe(`num_ctx ${contextLength}\nreasoning medium`);
       expect(body.model_info).toMatchObject({
-        [`${architecture}.context_length`]: 400000,
-        context_length: 400000,
+        [`${architecture}.context_length`]: contextLength,
+        context_length: contextLength,
         upstream_id: model,
         input_modalities: ["text", "image"],
       });
-    });
+    },
+  );
 
   it("converts non-streaming Ollama chat requests and responses", async () => {
     fetchMock.mockResolvedValueOnce(json({

--- a/tests/unit/web/anthropic-setup.test.ts
+++ b/tests/unit/web/anthropic-setup.test.ts
@@ -7,14 +7,15 @@ import {
 describe("AnthropicSetup defaults", () => {
   it("maps current Claude families to the desired Codex defaults", () => {
     expect(DEFAULT_ANTHROPIC_MODELS).toEqual({
-      opus: "gpt-5.5",
-      sonnet: "gpt-5.4",
-      haiku: "gpt-5.4-mini",
+      opus: "gpt-5.6-sol",
+      sonnet: "gpt-5.6-terra",
+      haiku: "gpt-5.6-luna",
     });
 
-    expect(ANTHROPIC_MODEL_PRESETS.slice(0, 2)).toEqual([
-      { label: "gpt-5.5 (Opus 4.7)", value: "gpt-5.5" },
-      { label: "gpt-5.4 (Sonnet 4.6)", value: "gpt-5.4" },
+    expect(ANTHROPIC_MODEL_PRESETS.slice(0, 3)).toEqual([
+      { label: "gpt-5.6-sol (Opus)", value: "gpt-5.6-sol" },
+      { label: "gpt-5.6-terra (Sonnet)", value: "gpt-5.6-terra" },
+      { label: "gpt-5.6-luna (Haiku)", value: "gpt-5.6-luna" },
     ]);
   });
 });

--- a/web/src/components/AnthropicSetup.tsx
+++ b/web/src/components/AnthropicSetup.tsx
@@ -10,15 +10,15 @@ interface AnthropicSetupProps {
 }
 
 export const DEFAULT_ANTHROPIC_MODELS = {
-  opus: "gpt-5.5",
-  sonnet: "gpt-5.4",
-  haiku: "gpt-5.4-mini",
+  opus: "gpt-5.6-sol",
+  sonnet: "gpt-5.6-terra",
+  haiku: "gpt-5.6-luna",
 };
 
 export const ANTHROPIC_MODEL_PRESETS: Array<{ label: string; value: string }> = [
-  { label: "gpt-5.5 (Opus 4.7)", value: DEFAULT_ANTHROPIC_MODELS.opus },
-  { label: "gpt-5.4 (Sonnet 4.6)", value: DEFAULT_ANTHROPIC_MODELS.sonnet },
-  { label: "gpt-5.4-mini (Haiku)", value: "gpt-5.4-mini" },
+  { label: "gpt-5.6-sol (Opus)", value: DEFAULT_ANTHROPIC_MODELS.opus },
+  { label: "gpt-5.6-terra (Sonnet)", value: DEFAULT_ANTHROPIC_MODELS.sonnet },
+  { label: "gpt-5.6-luna (Haiku)", value: DEFAULT_ANTHROPIC_MODELS.haiku },
 ];
 
 export function AnthropicSetup({ apiKey, selectedModel, reasoningEffort, serviceTier }: AnthropicSetupProps) {


### PR DESCRIPTION
## Summary

### 中文
将默认模型与 Claude/Anthropic 推荐档位统一切换到 GPT-5.6 家族（`sol` / `terra` / `luna`），并同步 README、API 文档与 Dashboard Anthropic Setup 预设，避免文档与实际默认值继续停留在 GPT-5.4/5.5。

### English
Promote the GPT-5.6 family as the default/recommended models across config, Dashboard Anthropic setup, and docs so local examples match the post-GA catalog.

## Changes

- `config/default.yaml`：默认模型 `gpt-5.4` → `gpt-5.6-sol`
- Dashboard Anthropic Setup：Opus/Sonnet/Haiku 预设改为 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`（`web/src/components/AnthropicSetup.tsx`）
- Claude Code 指南同步推荐档位（`.github/guides/claude-code-setup.md`）
- README / README_EN / API.md / API_CN：模型表、客户端示例、别名映射与图像生成示例同步到 GPT-5.6
- 单测覆盖默认值与 Ollama context metadata（`tests/unit/config.test.ts`、`tests/unit/web/anthropic-setup.test.ts`、`tests/unit/ollama/bridge.test.ts`）
- CHANGELOG `[Unreleased]` 增加对应 Changed 条目

## Test Plan

- [x] `npx vitest run tests/unit/web/anthropic-setup.test.ts tests/unit/config.test.ts tests/unit/ollama/bridge.test.ts tests/unit/config-schema.test.ts`（35/35 passed）
- [x] `npx tsc --noEmit`
- [ ] Full `npm test` / web build not required for this docs+defaults change set
- [ ] `npm run test:real` N/A（不改上游协议路径）

## Notes

- `origin/dev` 已包含 GPT-5.6 的 schema default 与 Ollama context overrides；本 PR 补齐 `config/default.yaml`、Dashboard 推荐预设与文档面。
- 未改 `config/models.yaml`：`origin/dev` 已刻意清空静态 catalog，改为运行时动态拉取。
- 旧分支 `fix/anthropic-mcp-gateway-debug` 上的历史提交未带入本 PR。