### PR TITLE
fix: hide ChatGPT-only auto model

### DIFF
--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -119,6 +119,12 @@ interface NormalizedModelWithMeta extends CodexModelInfo {
 
 const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
 const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+/** ChatGPT UI selectors that are not valid Codex model IDs. */
+const CHATGPT_ONLY_MODEL_IDS = new Set(["auto"]);
+
+function isAdmittedBackendModel(model: Pick<CodexModelInfo, "id">): boolean {
+  return !CHATGPT_ONLY_MODEL_IDS.has(model.id);
+}
 
 export function stripKnownModelSuffixes(input: string): {
   modelName: string;
@@ -194,14 +200,16 @@ export class ModelStore {
         const planSnapshots = cached.planSnapshots ?? null;
         if (planSnapshots) {
           for (const [planType, models] of Object.entries(planSnapshots)) {
-            const backendModels = models.map((m) => ({ ...m, source: "backend" as const }));
+            const backendModels = models
+              .filter(isAdmittedBackendModel)
+              .map((m) => ({ ...m, source: "backend" as const }));
             this.planModelSnapshots.set(planType, backendModels);
             this.planModelMap.set(planType, new Set(backendModels.map((m) => m.id)));
           }
           this.rebuildCatalogFromPlanSnapshots();
           console.log(`[ModelStore] Loaded ${this.catalog.length} cached backend models from data/models-cache.yaml`);
         } else {
-          const cachedModels = cached.models ?? [];
+          const cachedModels = (cached.models ?? []).filter(isAdmittedBackendModel);
           this.catalog = cachedModels.map((m) => ({ ...m, source: "backend" as const }));
           if (this.catalog.length > 0) {
             this.planModelSnapshots.set("cache", this.catalog.map((m) => ({ ...m })));
@@ -229,7 +237,9 @@ export class ModelStore {
   }
 
   applyBackendModelsForPlan(planType: string, backendModels: BackendModelEntry[]): void {
-    const models = backendModels.map((raw) => stripNormalizeMetadata(normalizeBackendModel(raw)));
+    const models = backendModels
+      .map((raw) => stripNormalizeMetadata(normalizeBackendModel(raw)))
+      .filter(isAdmittedBackendModel);
     const admittedIds = new Set(models.map((model) => model.id));
 
     this.planModelSnapshots.delete(planType);

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -174,6 +174,16 @@ describe("ModelStore", () => {
         if (filePath.endsWith("models-cache.yaml")) {
           return `
 models:
+  - id: auto
+    displayName: auto
+    description: ChatGPT selector
+    isDefault: false
+    supportedReasoningEfforts:
+      - { reasoningEffort: medium, description: "Medium" }
+    defaultReasoningEffort: medium
+    inputModalities: [text]
+    supportsPersonality: false
+    upgrade: null
   - id: cached-only
     displayName: Cached Only
     description: Cached snapshot model
@@ -194,6 +204,7 @@ aliases:
       loadStaticModels("/tmp/test-config");
 
       expect(getModelCatalog().map((m) => m.id)).toEqual(["cached-only"]);
+      expect(getModelInfo("auto")).toBeUndefined();
       expect(getModelAliases()).toEqual({});
       expect(getModelInfo("cached-only")!.source).toBe("backend");
     });
@@ -206,6 +217,16 @@ aliases:
           return `
 planSnapshots:
   plus:
+    - id: auto
+      displayName: auto
+      description: ChatGPT selector
+      isDefault: false
+      supportedReasoningEfforts:
+        - { reasoningEffort: medium, description: "Medium" }
+      defaultReasoningEffort: medium
+      inputModalities: [text]
+      supportsPersonality: false
+      upgrade: null
     - id: cached-plus
       displayName: Cached Plus
       description: Cached plus model
@@ -234,6 +255,7 @@ aliases: {}
       });
 
       loadStaticModels("/tmp/test-config");
+      expect(getModelInfo("auto")).toBeUndefined();
       applyBackendModelsForPlan("plus", [{ slug: "fresh-plus", display_name: "Fresh Plus" }]);
 
       expect(getModelInfo("fresh-plus")).toBeDefined();
@@ -539,15 +561,18 @@ aliases: {}
       expect(info).toBeDefined();
     });
 
-    it("admits all backend models without client-side filtering", () => {
+    it("filters the ChatGPT-only auto selector from backend models", () => {
       loadStaticModels("/tmp/test-config");
       applyBackendModels([{
-        slug: "research",
-        display_name: "Research Model",
+        slug: "auto",
+        display_name: "auto",
+      }, {
+        slug: "gpt-5.4",
+        display_name: "GPT-5.4",
       }]);
-      // All backend models are trusted — no client-side filtering
-      const info = getModelInfo("research");
-      expect(info).toBeDefined();
+
+      expect(getModelInfo("auto")).toBeUndefined();
+      expect(getModelInfo("gpt-5.4")).toBeDefined();
     });
 
     it("uses normalized default efforts when backend has none", () => {


### PR DESCRIPTION
## Summary

- hide the ChatGPT-only `auto` selector from `/v1/models`
- filter live backend catalogs and both cached model formats
- preserve normal Codex models such as `gpt-5.4`

Fixes #695.

## Test plan

- [x] `npx vitest run tests/unit/models/model-store.test.ts tests/unit/routes/plan-routing-integration.test.ts` (65 passed)
- [x] `npm run build`
- [x] `git diff --check`
- [ ] `npm test` (259 files passed; 2 unrelated existing failures: Codex App Server reconnect test received 404, and error-log performance test exceeded its 100ms threshold at 110ms)