### PR TITLE
fix(ws): keep pooled connections alive during in-flight requests

### DIFF
--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -259,9 +259,10 @@ export class PersistentWs {
   }
 
   private sendKeepalivePing(): void {
-    // Skip when busy: the active stream's data frames already keep the LB /
-    // NAT idle timers fresh, so a ping would be redundant bandwidth.
-    if (this.dead || this.busy || this.ws.readyState !== WS_OPEN) return;
+    // Keep pinging during in-flight requests too. Reasoning-heavy responses may
+    // stay silent for 60-120s; without control frames, NAT/LB paths can drop an
+    // otherwise healthy pooled connection with close code 1006.
+    if (this.dead || this.ws.readyState !== WS_OPEN) return;
     // Liveness check: if the peer hasn't produced ANY signal (pong or message)
     // for too long, the connection is silently broken (middlebox dropped it
     // without sending FIN/RST). Evicting now beats eating a real-request cache

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -480,8 +480,11 @@ describe("PersistentWs", () => {
       expect(ws.pingCount).toBe(1);
     });
 
-    it("skips ping while a request is in-flight (active stream keeps the LB alive)", async () => {
-      const { ws, persistent } = newPersistentWs({ pingIntervalMs: 1_000 });
+    it("continues pinging while a request is in-flight", async () => {
+      const { ws, persistent } = newPersistentWs({
+        pingIntervalMs: 1_000,
+        livenessTimeoutMs: 0,
+      });
       persistent.tryAcquire();
       void persistent.send({
         request: { type: "response.create", model: "m", instructions: "", input: [] },
@@ -491,7 +494,7 @@ describe("PersistentWs", () => {
       });
       await vi.advanceTimersByTimeAsync(0); // let send() start
       vi.advanceTimersByTime(3_500);
-      expect(ws.pingCount).toBe(0); // busy → no pings while streaming
+      expect(ws.pingCount).toBe(3);
     });
   });
 


### PR DESCRIPTION
## Summary

- Keep pooled WebSocket pings active during in-flight requests.
- Prevent silent reasoning periods from hitting NAT/LB idle timeouts and closing with code 1006.
- Align pooled connections with the existing one-shot WebSocket behavior and add a regression test.

## Tests

- `npx vitest run tests/unit/proxy/ws-pool.test.ts`
- `npm run build`
