### PR TITLE
fix: retry WebSocket overload before streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Fixed
 
+- 修复上游 WebSocket 首帧 `server_is_overloaded` 被当作普通 SSE 错误透传、最终表现为 `stream disconnected before completion` 的问题：现在在 HTTP 响应提交前映射为 503，进入账号切换/有限重试；已产生输出后不重放请求，且 `response.completed` 后的异常关闭不再误报未完成流。（`src/proxy/error-classification.ts`、`src/proxy/ws-pool.ts`、`src/proxy/ws-transport.ts`、`src/routes/shared/proxy-error-handler.ts`、`src/translation/codex-api-error-from-event.ts`）
+
 - 修复 Dashboard Errors tab 的“全部标记已读”和“删除”操作被 Settings Bearer-token middleware 拦截成 401 的问题；`/admin/error-logs*` 统一交给 dashboard session auth，避免 cookie 登录会话被误判失效并跳回登录页。（`src/routes/admin/settings.ts`、`tests/integration/error-logs-dashboard-auth.test.ts`）
 - 修复 release notes 生成脚本在 LLM endpoint 不可达时可能被 60s 默认请求超时拖慢测试的问题；新增 `RELEASE_NOTES_REQUEST_TIMEOUT_MS` 仅用于覆盖该脚本请求超时，生产默认仍为 60s。（`.github/scripts/summarize-release-notes.mjs`、`tests/unit/ci/summarize-release-notes.test.ts`）
 - 修复并强化 WebSocket 消息流的生命周期管理：通过缓冲早期元数据帧（如 `response.created`），延迟解析 HTTP 响应，从而解决由于内部限流事件导致的提前解析和挂起问题，并在重构中排除了首字时间（TTFT）超过 20s 会引发超时的隐患。（#678，感谢 [@zyycn](https://github.com/zyycn)）

--- a/src/proxy/error-classification.ts
+++ b/src/proxy/error-classification.ts
@@ -52,6 +52,18 @@ export function isQuotaExhaustedError(err: unknown): boolean {
   return err.status === 402;
 }
 
+/** Check if a 503 is the upstream capacity error that is safe to retry. */
+export function isServerOverloadedError(err: unknown): boolean {
+  if (!isCodexLike(err) || err.status !== 503) return false;
+  try {
+    const parsed = JSON.parse(err.body) as Record<string, unknown>;
+    const error = parsed.error as Record<string, unknown> | undefined;
+    return error?.code === "server_is_overloaded";
+  } catch {
+    return false;
+  }
+}
+
 /** Check if a 403 body is a Cloudflare challenge rather than an account ban. */
 export function isCfChallengeError(err: unknown): boolean {
   if (!isCodexLike(err)) return false;

--- a/src/proxy/ws-pool.ts
+++ b/src/proxy/ws-pool.ts
@@ -123,6 +123,7 @@ const ROTATABLE_ERROR_CODES: Readonly<Record<string, number>> = {
   banned: 403,
   previous_response_not_found: 400,
   websocket_connection_limit_reached: 503,
+  server_is_overloaded: 503,
 };
 
 function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number; code: string } | null {

--- a/src/proxy/ws-transport.ts
+++ b/src/proxy/ws-transport.ts
@@ -63,6 +63,8 @@ const ROTATABLE_ERROR_CODES: Readonly<Record<string, number>> = {
   // 400 — stale previous_response_id (account doesn't recognise it; let
   // proxy-handler strip the ID and retry on the same account)
   previous_response_not_found: 400,
+  // 503 — transient upstream capacity error
+  server_is_overloaded: 503,
 };
 
 function classifyWsErrorEvent(msg: Record<string, unknown>): { status: number } | null {

--- a/src/routes/shared/proxy-error-handler.ts
+++ b/src/routes/shared/proxy-error-handler.ts
@@ -12,6 +12,7 @@ import {
   isCfChallengeError,
   isCfPathBlockError,
   isQuotaExhaustedError,
+  isServerOverloadedError,
   isTokenInvalidError,
   isModelNotSupportedError,
 } from "../../proxy/error-classification.js";
@@ -107,6 +108,20 @@ export function handleCodexApiError(
       `[${tag}] Account ${entryId} (${email}) | 402 quota exhausted, trying different account...`,
     );
     return { action: "retry", status: 402, message: err.message };
+  }
+
+  // 503 server capacity — transient upstream condition. Retry on another
+  // account when available, but do not mutate account health or quota state.
+  if (isServerOverloadedError(err)) {
+    console.warn(
+      `[${tag}] Account ${entryId} (${email}) | 503 server overloaded, trying different account...`,
+    );
+    return {
+      action: "retry",
+      releaseBeforeRetry: true,
+      status: 503,
+      message: err.message,
+    };
   }
 
   // 4. Cloudflare challenge (403 HTML/challenge response) — cooldown, not ban.

--- a/src/translation/codex-api-error-from-event.ts
+++ b/src/translation/codex-api-error-from-event.ts
@@ -18,6 +18,7 @@ export function codexApiErrorFromEvent(
 
 function statusForCode(code: string): number {
   const lower = code.toLowerCase();
+  if (lower === "server_is_overloaded") return 503;
   if (lower.includes("invalid_request") || lower.includes("not_found")) return 400;
   if (lower.includes("rate_limit") || lower.includes("usage_limit")) return 429;
   if (lower.includes("unauthorized") || lower.includes("invalid_api_key")) return 401;

--- a/tests/unit/proxy/error-classification.test.ts
+++ b/tests/unit/proxy/error-classification.test.ts
@@ -6,6 +6,7 @@ import {
   isCfChallengeError,
   isCfPathBlockError,
   isQuotaExhaustedError,
+  isServerOverloadedError,
   isTokenInvalidError,
   isModelNotSupportedError,
   isUnansweredFunctionCallError,
@@ -59,6 +60,18 @@ describe("isQuotaExhaustedError", () => {
   it("returns false for non-CodexApiError", () => {
     expect(isQuotaExhaustedError(new Error("402"))).toBe(false);
     expect(isQuotaExhaustedError(null)).toBe(false);
+  });
+});
+
+describe("isServerOverloadedError", () => {
+  it("accepts only a structured server_is_overloaded 503", () => {
+    expect(isServerOverloadedError(new CodexApiError(503, JSON.stringify({
+      error: { code: "server_is_overloaded" },
+    })))).toBe(true);
+    expect(isServerOverloadedError(new CodexApiError(503, "database unavailable"))).toBe(false);
+    expect(isServerOverloadedError(new CodexApiError(502, JSON.stringify({
+      error: { code: "server_is_overloaded" },
+    })))).toBe(false);
   });
 });
 

--- a/tests/unit/proxy/ws-pool.test.ts
+++ b/tests/unit/proxy/ws-pool.test.ts
@@ -236,6 +236,77 @@ describe("PersistentWs", () => {
     expect((err as CodexApiError).status).toBe(429);
   });
 
+  it("classifies server_is_overloaded as a transient 503 without evicting the pooled WS", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushMessage({
+      type: "error",
+      error: { code: "server_is_overloaded", message: "The server is overloaded" },
+    });
+    const err = await promise.then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(CodexApiError);
+    expect((err as CodexApiError).status).toBe(503);
+    expect(persistent.isAlive()).toBe(true);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("does not retry server_is_overloaded after partial output has been committed", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: true,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created", response: { id: "resp_1" } });
+    ws.pushMessage({ type: "response.output_text.delta", delta: "partial" });
+    const response = await promise;
+    ws.pushMessage({
+      type: "error",
+      error: { code: "server_is_overloaded", message: "The server is overloaded" },
+    });
+
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("event: response.output_text.delta");
+    expect(text).toContain("partial");
+    expect(text).toContain("event: error");
+    expect(text).toContain("server_is_overloaded");
+    expect(persistent.isAlive()).toBe(true);
+    expect(onDead).not.toHaveBeenCalled();
+  });
+
+  it("accepts an abnormal close after response.completed as a completed stream", async () => {
+    const { ws, persistent, onDead } = newPersistentWs();
+    persistent.tryAcquire();
+    const promise = persistent.send({
+      request: { type: "response.create", model: "m", instructions: "", input: [] },
+      signal: undefined,
+      onRateLimits: undefined,
+      reused: false,
+    });
+    await nextTick();
+    ws.pushMessage({ type: "response.created", response: { id: "resp_1" } });
+    ws.pushMessage({ type: "response.output_text.delta", delta: "done" });
+    const response = await promise;
+    ws.pushMessage({ type: "response.completed", response: { id: "resp_1" } });
+    ws.pushClose(1006, "tcp rst after terminal frame");
+
+    const text = await response.text();
+    expect(text).toContain("event: response.completed");
+    expect(text).toContain("resp_1");
+    expect(onDead).toHaveBeenCalledOnce();
+  });
+
   it("websocket_connection_limit_reached early error evicts the WS", async () => {
     const { ws, persistent, onDead } = newPersistentWs();
     persistent.tryAcquire();

--- a/tests/unit/proxy/ws-transport-early-error.test.ts
+++ b/tests/unit/proxy/ws-transport-early-error.test.ts
@@ -169,6 +169,25 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     }
   });
 
+  it("rejects with CodexApiError(503) when first frame is server_is_overloaded", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    promise.catch(() => { /* asserted below */ });
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "server_is_overloaded", message: "The server is overloaded" },
+    }));
+
+    await expect(promise).rejects.toBeInstanceOf(CodexApiError);
+    try {
+      await promise;
+    } catch (err) {
+      expect((err as CodexApiError).status).toBe(503);
+      expect((err as CodexApiError).body).toContain("server_is_overloaded");
+    }
+  });
+
   it("resolves normally when first frame is an error with an unmapped code", async () => {
     // Genuine model errors (e.g. invalid request, model_not_supported_in_plan)
     // must NOT trigger rotation — they keep the SSE pass-through behavior so
@@ -271,6 +290,42 @@ describe("createWebSocketResponse — early-stream error rejection", () => {
     expect(text).toContain("event: response.output_text.delta");
     expect(text).toContain("event: error");
     expect(text).toContain("usage_limit_reached");
+  });
+
+  it("does not retry server_is_overloaded after partial output has been committed", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "partial" }));
+    const response = await promise;
+
+    ws.emit("message", JSON.stringify({
+      type: "error",
+      error: { code: "server_is_overloaded", message: "The server is overloaded" },
+    }));
+
+    expect(response.status).toBe(200);
+    const text = await readAll(response);
+    expect(text).toContain("event: response.output_text.delta");
+    expect(text).toContain("partial");
+    expect(text).toContain("event: error");
+    expect(text).toContain("server_is_overloaded");
+  });
+
+  it("accepts an abnormal close after response.completed as a completed stream", async () => {
+    const promise = createWebSocketResponse("wss://test/ws", {}, BASE_REQUEST);
+    const ws = await waitForOpen();
+
+    ws.emit("message", JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+    ws.emit("message", JSON.stringify({ type: "response.output_text.delta", delta: "done" }));
+    const response = await promise;
+    ws.emit("message", JSON.stringify({ type: "response.completed", response: { id: "resp_1" } }));
+    ws.emit("close", 1006, Buffer.from("tcp rst after terminal frame"));
+
+    const text = await readAll(response);
+    expect(text).toContain("event: response.completed");
+    expect(text).toContain("resp_1");
   });
 
   it("rejects when the WebSocket closes before any data frame", async () => {

--- a/tests/unit/routes/shared/proxy-error-handler.test.ts
+++ b/tests/unit/routes/shared/proxy-error-handler.test.ts
@@ -140,6 +140,32 @@ describe("handleCodexApiError", () => {
     });
   });
 
+  describe("503 server overloaded", () => {
+    it("retries on another account without mutating account health or quota", () => {
+      const err = new CodexApiError(503, JSON.stringify({
+        error: { code: "server_is_overloaded", message: "The server is overloaded" },
+      }));
+
+      const result = handleCodexApiError(err, pool as never, entryId, model, tag, false);
+
+      expect(result.action).toBe("retry");
+      expect(result.status).toBe(503);
+      expect(result.releaseBeforeRetry).toBe(true);
+      expect(pool.markStatus).not.toHaveBeenCalled();
+      expect(pool.applyRateLimit429).not.toHaveBeenCalled();
+    });
+
+    it("does not retry an unrelated generic 503", () => {
+      const result = handleCodexApiError(
+        new CodexApiError(503, "database unavailable"),
+        pool as never, entryId, model, tag, false,
+      );
+
+      expect(result.action).toBe("respond");
+      expect(result.status).toBe(503);
+    });
+  });
+
   // ── 403 ban ──
 
   describe("403 ban", () => {

--- a/tests/unit/routes/shared/proxy-error-retry-transition.test.ts
+++ b/tests/unit/routes/shared/proxy-error-retry-transition.test.ts
@@ -188,4 +188,66 @@ describe("applyProxyErrorRetryTransition", () => {
     expect(restoreImplicitResumeRequest).toHaveBeenCalledOnce();
     expect(accountPool.acquire).not.toHaveBeenCalled();
   });
+
+  it("releases an overloaded account and excludes every tried account from retry", () => {
+    const accountPool = mockPool({ acquiredAccount: acquired({ entryId: "entry-3" }) });
+    const restoreImplicitResumeRequest = vi.fn();
+
+    const result = applyProxyErrorRetryTransition({
+      accountPool,
+      entryId: "entry-2",
+      model: "gpt-5.4",
+      triedEntryIds: ["entry-1", "entry-2"],
+      tag: "Test",
+      decision: retryDecision({
+        status: 503,
+        message: "The server is overloaded",
+        releaseBeforeRetry: true,
+      }),
+      released: new Set<string>(),
+      restoreImplicitResumeRequest,
+      modelRetried: false,
+    });
+
+    expect(result.action).toBe("retry");
+    expect(accountPool.release).toHaveBeenCalledWith("entry-2", undefined);
+    expect(accountPool.acquire).toHaveBeenCalledWith({
+      model: "gpt-5.4",
+      excludeIds: ["entry-1", "entry-2"],
+      preferredEntryId: undefined,
+    });
+  });
+
+  it("returns one finite 503 response when overload has no fallback account", () => {
+    const accountPool = mockPool({
+      available: false,
+      summary: summary({ rate_limited: 0, active: 0 }),
+    });
+    const restoreImplicitResumeRequest = vi.fn();
+
+    const result = applyProxyErrorRetryTransition({
+      accountPool,
+      entryId: "entry-1",
+      model: "gpt-5.4",
+      triedEntryIds: ["entry-1"],
+      tag: "Test",
+      decision: retryDecision({
+        status: 503,
+        message: "The server is overloaded",
+        releaseBeforeRetry: true,
+      }),
+      released: new Set<string>(),
+      restoreImplicitResumeRequest,
+      modelRetried: false,
+    });
+
+    expect(result).toEqual({
+      action: "respond",
+      status: 503,
+      message: "No accounts available. The server is overloaded",
+      modelRetried: false,
+    });
+    expect(accountPool.release).toHaveBeenCalledWith("entry-1", undefined);
+    expect(accountPool.acquire).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/translation/codex-api-error-from-event.test.ts
+++ b/tests/unit/translation/codex-api-error-from-event.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { codexApiErrorFromEvent } from "@src/translation/codex-api-error-from-event.js";
+
+describe("codexApiErrorFromEvent", () => {
+  it("maps server_is_overloaded to HTTP 503", () => {
+    const err = codexApiErrorFromEvent({
+      code: "server_is_overloaded",
+      message: "The server is overloaded",
+    });
+
+    expect(err.status).toBe(503);
+    expect(err.body).toContain("server_is_overloaded");
+  });
+});


### PR DESCRIPTION
## Summary
- classify Codex `server_is_overloaded` events as HTTP 503 before committing a streaming response
- release the current account and retry a bounded attempt on another account without mutating account health, quota, or rate-limit state
- preserve streaming safety by avoiding replay after partial output and ignoring abnormal close after `response.completed`

## Root cause
The upstream WebSocket could emit `error.code=server_is_overloaded` as its first frame and then close. The old path forwarded that event inside an HTTP 200 SSE stream, so the client never received `response.completed` and reported `stream disconnected before completion`.

## Test plan
- [x] Focused Vitest suite: 6 files, 121 tests passed
- [x] Full Vitest suite after frontend build: 260 files passed; 2575 tests passed, 1 skipped
- [x] `npm run build`: Vite build and TypeScript compilation passed
- [x] Real upstream WebSocket baseline: 3 consecutive streams received created, delta, and completed events
- [ ] Real overload failover E2E: not completed because `server_is_overloaded` cannot be triggered deterministically; no claim of full live failover validation