### PR TITLE
docs: clarify image generation size behavior

### DIFF
--- a/API.md
+++ b/API.md
@@ -100,7 +100,8 @@ and the model falls back to returning SVG text.
 
 **Silently rewritten / hard-rejected fields**:
 
-- `model` — whatever you send, upstream forces `gpt-image-2`.
+- `model` — whatever you send, upstream forces `gpt-image-2` (echoed as `gpt-image-2-codex` in responses).
+- `size` — user-requested dimensions like `2048x2048`, `2K`, `4K` are echoed/normalized upstream to `auto` and the actual resolution is decided server-side (e.g. `1254x1254`).
 - `quality` — any value is echoed back as `auto`; the user-supplied value has no effect.
 - `n` — rejected (`unknown_parameter`); one image per call.
 - `input_image`, `mask`, `input_fidelity`, `style`, `response_format` — rejected.

--- a/API_CN.md
+++ b/API_CN.md
@@ -99,7 +99,8 @@ Google Gemini 兼容接口。
 
 **静默改写 / 明确拒绝的字段**：
 
-- `model` — 不管传啥，上游强制改回 `gpt-image-2`。
+- `model` — 不管传啥，上游强制改回 `gpt-image-2`（响应回显为 `gpt-image-2-codex`）。
+- `size` — 客户端请求的 `2048x2048`、`2K`、`4K` 等尺寸会被上游回显/归一化为 `auto`，实际输出分辨率由服务端自行决定（例如实测 `1254x1254`）。
 - `quality` — 传任何值都被 echo 为 `auto`，用户值不生效。
 - `n` — `unknown_parameter`；一次只能出一张图。
 - `input_image`、`mask`、`input_fidelity`、`style`、`response_format` — 全部拒绝。

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ curl -N http://localhost:8080/v1/responses \
   }'
 ```
 
-常用参数：`size`（1024×1024 / 1024×1536 / 1536×1024 / 2048×2048 / 2048×3072 / 3072×2048 / 3840×2160（4K UHD）/ `auto`，最长边 ≤ 3840 px，像素预算约 8 MP）、`output_format`（`png` / `jpeg` / `webp`）、`output_compression`（jpeg / webp 可调）、`background`（`auto` / `opaque`）、`moderation`（`auto` / `low`）、`partial_images`（0–3）。一次只能出 1 张图（`n` 固定为 1）；`model` 字段不管传什么都会被上游改写回 `gpt-image-2`。详见 [API.md](./API.md#image_generation-tool)。
+常用参数：`size`（可请求 1024×1024 / 1024×1536 / 1536×1024 / 2048×2048 / 2048×3072 / 3072×2048 / 3840×2160 / `auto`）、`output_format`（`png` / `jpeg` / `webp`）、`output_compression`（jpeg / webp 可调）、`background`（`auto` / `opaque`）、`moderation`（`auto` / `low`）、`partial_images`（0–3）。一次只能出 1 张图（`n` 固定为 1）；`model` 字段不管传什么都会被上游改写为图像工具的实际模型（当前响应回显为 `gpt-image-2-codex`）。详见 [API.md](./API.md#image_generation-tool)。
+
+> **`size` 不是固定像素保证。** Proxy 会保留并发送客户端填写的值，但当前上游会把 `2048x2048`、`2K`、`4K` 等请求归一化为 `size: "auto"`，再自行决定实际尺寸。2026-08-10 的真实请求中，`size: "2048x2048"` 的工具配置回显为 `auto`，最终 `image_generation_call.size` 和 PNG 像素均为 `1254x1254`。因此不能依靠该字段获得原生、精确的 2K/4K 输出；请以结果 item 的 `size` 或解码后图片像素为准。若业务必须拿到精确 `2048x2048` 文件，需要在生成后使用插值或 AI 超分辨率进行后处理。
 
 事件流里 `image_generation_call` item 的 `result` 字段即 base64 编码的图像；`revised_prompt` 是上游改写后的最终提示词。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -224,7 +224,9 @@ curl -N http://localhost:8080/v1/responses \
   }'
 ```
 
-Tunable fields: `size` (1024×1024 / 1024×1536 / 1536×1024 / 2048×2048 / 2048×3072 / 3072×2048 / 3840×2160 (4K UHD) / `auto`; longest edge ≤ 3840 px, pixel budget ≈ 8 MP), `output_format` (`png` / `jpeg` / `webp`), `output_compression` (jpeg / webp only), `background` (`auto` / `opaque`), `moderation` (`auto` / `low`), `partial_images` (0–3). Upstream forces `model = gpt-image-2` and rejects `n`, `input_image`, `mask`, `input_fidelity`, `style`, `response_format`. See [API.md](./API.md#image_generation-tool) for the full matrix.
+Tunable fields: `size` (can request 1024×1024 / 1024×1536 / 1536×1024 / 2048×2048 / 2048×3072 / 3072×2048 / 3840×2160 / `auto`), `output_format` (`png` / `jpeg` / `webp`), `output_compression` (jpeg / webp only), `background` (`auto` / `opaque`), `moderation` (`auto` / `low`), `partial_images` (0–3). Only 1 image per call (`n` is fixed to 1); the `model` field is always rewritten upstream to the image tool's actual model (currently echoed as `gpt-image-2-codex`). See [API.md](./API.md#image_generation-tool).
+
+> **`size` is not a strict pixel-dimension guarantee.** The proxy preserves and sends the client-specified value, but upstream currently normalizes requests like `2048x2048`, `2K`, and `4K` to `size: "auto"` and determines the actual output dimensions dynamically. In real requests tested on 2026-08-10, a `size: "2048x2048"` tool configuration echoed back as `auto`, and both `image_generation_call.size` and the decoded PNG pixels were `1254x1254`. Therefore, you cannot rely on this field for native, exact 2K/4K outputs; refer to the result item's `size` or the decoded image dimensions. If your workload strictly requires exact `2048x2048` files, apply post-processing such as interpolation or AI upscaling after generation.
 
 In the stream, the `image_generation_call` item's `result` field is a base64-encoded image; `revised_prompt` contains the final prompt used by the model.
 


### PR DESCRIPTION
## Summary
- clarify that image generation `size` values are requests rather than fixed pixel guarantees
- document the observed upstream normalization of `2048x2048` to `auto` and the resulting `1254x1254` output
- update the observed image model name to `gpt-image-2-codex` and recommend post-processing for exact 2K output

## Test plan
- [x] Run `git diff --check origin/dev...HEAD`
- [x] Verify the README contains `gpt-image-2-codex`, `size` normalization, and `1254x1254`
- [x] Verify the obsolete 3840 px / 8 MP guarantee is absent