### PR TITLE
fix: preserve Cursor ApplyPatch payloads

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -28,7 +28,10 @@ import type { UpstreamRouter } from "../proxy/upstream-router.js";
 import { summarizeRequestForLog } from "../logs/request-summary.js";
 import { apiKeyAuth } from "../middleware/api-key-auth.js";
 
-function makeOpenAIFormat(wantReasoning: boolean): FormatAdapter {
+function makeOpenAIFormat(
+  wantReasoning: boolean,
+  customToolCallsAsFunctions = false,
+): FormatAdapter {
   return {
     tag: "Chat",
     noAccountStatus: 503,
@@ -58,10 +61,24 @@ function makeOpenAIFormat(wantReasoning: boolean): FormatAdapter {
       },
     }),
     streamTranslator: ({ api, response, model, onUsage, onResponseId, onResponseCompleted, tupleSchema }) =>
-      streamCodexToOpenAI(api, response, model, onUsage, onResponseId, wantReasoning, tupleSchema, onResponseCompleted),
+      streamCodexToOpenAI(
+        api,
+        response,
+        model,
+        onUsage,
+        onResponseId,
+        wantReasoning,
+        tupleSchema,
+        onResponseCompleted,
+        customToolCallsAsFunctions,
+      ),
     collectTranslator: ({ api, response, model, tupleSchema }) =>
-      collectCodexResponse(api, response, model, wantReasoning, tupleSchema),
+      collectCodexResponse(api, response, model, wantReasoning, tupleSchema, customToolCallsAsFunctions),
   };
+}
+
+function isCursorClient(c: Context): boolean {
+  return /^cursor\//i.test(c.req.header("user-agent") ?? "");
 }
 
 function formatModelNotFound(model: string) {
@@ -113,7 +130,7 @@ export function createChatRoutes(
       && codexRequest.tools.some((t): t is Record<string, unknown> => isRecord(t) && t.type === "image_generation");
     // Check after translation so suffix-parsed and config-default effort are included.
     const wantReasoning = !!codexRequest.reasoning?.effort;
-    const fmt = makeOpenAIFormat(wantReasoning);
+    const fmt = makeOpenAIFormat(wantReasoning, isCursorClient(c));
     const displayModel = buildDisplayModelName(parseModelName(req.model));
     const proxyReq: ProxyRequest = {
       codexRequest,

--- a/src/translation/codex-event-extractor.ts
+++ b/src/translation/codex-event-extractor.ts
@@ -43,6 +43,23 @@ export interface FunctionCallDone {
   arguments: string;
 }
 
+export interface CustomToolCallStart {
+  callId: string;
+  name: string;
+  outputIndex: number;
+}
+
+export interface CustomToolCallDelta {
+  callId: string;
+  delta: string;
+}
+
+export interface CustomToolCallDone {
+  callId: string;
+  name: string;
+  input: string;
+}
+
 export class EmptyResponseError extends Error {
   constructor(
     public readonly responseId: string | null,
@@ -89,6 +106,9 @@ export interface ExtractedEvent {
   functionCallStart?: FunctionCallStart;
   functionCallDelta?: FunctionCallDelta;
   functionCallDone?: FunctionCallDone;
+  customToolCallStart?: CustomToolCallStart;
+  customToolCallDelta?: CustomToolCallDelta;
+  customToolCallDone?: CustomToolCallDone;
   imageGenerationDone?: {
     id: string;
     result: string;
@@ -106,6 +126,7 @@ export async function* iterateCodexEvents(
 ): AsyncGenerator<ExtractedEvent> {
   // Map item_id → { call_id, name } for resolving delta/done events
   const itemIdToCallInfo = new Map<string, { callId: string; name: string }>();
+  const completedCustomToolCallIds = new Set<string>();
 
   for await (const raw of api.parseStream(rawResponse)) {
     const typed = parseCodexEvent(raw);
@@ -131,6 +152,17 @@ export async function* iterateCodexEvents(
         break;
 
       case "response.output_item.added":
+        if (typed.item.type === "custom_tool_call" && typed.item.call_id && typed.item.name) {
+          itemIdToCallInfo.set(typed.item.id, {
+            callId: typed.item.call_id,
+            name: typed.item.name,
+          });
+          extracted.customToolCallStart = {
+            callId: typed.item.call_id,
+            name: typed.item.name,
+            outputIndex: typed.outputIndex,
+          };
+        }
         if (typed.item.type === "function_call" && typed.item.call_id && typed.item.name) {
           // Register item_id → call_id mapping
           itemIdToCallInfo.set(typed.item.id, {
@@ -166,12 +198,47 @@ export async function* iterateCodexEvents(
         break;
       }
 
+      case "response.custom_tool_call_input.delta": {
+        const deltaInfo = itemIdToCallInfo.get(typed.itemId);
+        extracted.customToolCallDelta = {
+          callId: deltaInfo?.callId ?? typed.itemId,
+          delta: typed.delta,
+        };
+        break;
+      }
+
+      case "response.custom_tool_call_input.done": {
+        const doneInfo = itemIdToCallInfo.get(typed.itemId);
+        if (!doneInfo) break;
+        completedCustomToolCallIds.add(doneInfo.callId);
+        extracted.customToolCallDone = {
+          callId: doneInfo.callId,
+          name: doneInfo.name,
+          input: typed.input,
+        };
+        break;
+      }
+
       case "response.output_item.done":
         if (typed.item.type === "image_generation_call") {
           extracted.imageGenerationDone = {
             id: typed.item.id || "",
             result: typed.item.result || "",
             revised_prompt: typed.item.revised_prompt,
+          };
+        }
+        if (
+          typed.item.type === "custom_tool_call" &&
+          typed.item.call_id &&
+          typed.item.name &&
+          typeof typed.item.input === "string" &&
+          !completedCustomToolCallIds.has(typed.item.call_id)
+        ) {
+          completedCustomToolCallIds.add(typed.item.call_id);
+          extracted.customToolCallDone = {
+            callId: typed.item.call_id,
+            name: typed.item.name,
+            input: typed.item.input,
           };
         }
         break;

--- a/src/translation/codex-to-openai.ts
+++ b/src/translation/codex-to-openai.ts
@@ -47,6 +47,7 @@ export async function* streamCodexToOpenAI(
   wantReasoning?: boolean,
   tupleSchema?: Record<string, unknown> | null,
   onResponseCompleted?: (id?: string) => void,
+  customToolCallsAsFunctions = false,
 ): AsyncGenerator<string> {
   const chunkId = `chatcmpl-${randomUUID().replace(/-/g, "").slice(0, 24)}`;
   const created = Math.floor(Date.now() / 1000);
@@ -59,6 +60,8 @@ export async function* streamCodexToOpenAI(
   let nextToolCallIndex = 0;
   // Track which call_ids have received argument deltas
   const callIdsWithDeltas = new Set<string>();
+  const customToolCallIndexMap = new Map<string, number>();
+  const customCallIdsWithDeltas = new Set<string>();
 
   // Send initial role chunk
   yield formatSSE({
@@ -166,6 +169,49 @@ export async function* streamCodexToOpenAI(
       continue;
     }
 
+    if (evt.customToolCallStart) {
+      hasToolCalls = true;
+      hasContent = true;
+      const idx = nextToolCallIndex++;
+      customToolCallIndexMap.set(evt.customToolCallStart.callId, idx);
+      const toolCall: ChatCompletionChunkToolCall = customToolCallsAsFunctions
+        ? {
+          index: idx,
+          id: evt.customToolCallStart.callId,
+          type: "function",
+          // Cursor's Chat Completions adapter dereferences function.name for
+          // every call, including its grammar-backed ApplyPatch tool. Keep
+          // the patch body raw in function.arguments; do not JSON-encode it.
+          function: {
+            name: evt.customToolCallStart.name,
+            arguments: "",
+          },
+        }
+        : {
+          index: idx,
+          id: evt.customToolCallStart.callId,
+          type: "custom",
+          custom: {
+            name: evt.customToolCallStart.name,
+            input: "",
+          },
+        };
+      yield formatSSE({
+        id: chunkId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [toolCall] },
+            finish_reason: null,
+          },
+        ],
+      });
+      continue;
+    }
+
     if (evt.functionCallDelta) {
       callIdsWithDeltas.add(evt.functionCallDelta.callId);
       const idx = toolCallIndexMap.get(evt.functionCallDelta.callId) ?? 0;
@@ -192,6 +238,40 @@ export async function* streamCodexToOpenAI(
     }
 
     // functionCallDone — emit full arguments if no deltas were streamed
+    if (evt.customToolCallDelta) {
+      const idx = customToolCallIndexMap.get(evt.customToolCallDelta.callId);
+      if (idx !== undefined) {
+        customCallIdsWithDeltas.add(evt.customToolCallDelta.callId);
+        const toolCall: ChatCompletionChunkToolCall = customToolCallsAsFunctions
+          ? {
+            index: idx,
+            function: {
+              arguments: evt.customToolCallDelta.delta,
+            },
+          }
+          : {
+            index: idx,
+            custom: {
+              input: evt.customToolCallDelta.delta,
+            },
+          };
+        yield formatSSE({
+          id: chunkId,
+          object: "chat.completion.chunk",
+          created,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: { tool_calls: [toolCall] },
+              finish_reason: null,
+            },
+          ],
+        });
+      }
+      continue;
+    }
+
     if (evt.functionCallDone) {
       if (!callIdsWithDeltas.has(evt.functionCallDone.callId)) {
         const idx = toolCallIndexMap.get(evt.functionCallDone.callId) ?? 0;
@@ -201,6 +281,65 @@ export async function* streamCodexToOpenAI(
             arguments: evt.functionCallDone.arguments,
           },
         };
+        yield formatSSE({
+          id: chunkId,
+          object: "chat.completion.chunk",
+          created,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: { tool_calls: [toolCall] },
+              finish_reason: null,
+            },
+          ],
+        });
+      }
+      continue;
+    }
+
+    if (evt.customToolCallDone) {
+      hasToolCalls = true;
+      hasContent = true;
+      if (!customCallIdsWithDeltas.has(evt.customToolCallDone.callId)) {
+        const existingIndex = customToolCallIndexMap.get(evt.customToolCallDone.callId);
+        const idx = existingIndex ?? nextToolCallIndex++;
+        if (existingIndex === undefined) {
+          customToolCallIndexMap.set(evt.customToolCallDone.callId, idx);
+        }
+        const toolCall: ChatCompletionChunkToolCall = existingIndex === undefined
+          ? customToolCallsAsFunctions
+            ? {
+              index: idx,
+              id: evt.customToolCallDone.callId,
+              type: "function",
+              function: {
+                name: evt.customToolCallDone.name,
+                arguments: evt.customToolCallDone.input,
+              },
+            }
+            : {
+              index: idx,
+              id: evt.customToolCallDone.callId,
+              type: "custom",
+              custom: {
+                name: evt.customToolCallDone.name,
+                input: evt.customToolCallDone.input,
+              },
+            }
+          : customToolCallsAsFunctions
+            ? {
+              index: idx,
+              function: {
+                arguments: evt.customToolCallDone.input,
+              },
+            }
+            : {
+              index: idx,
+              custom: {
+                input: evt.customToolCallDone.input,
+              },
+            };
         yield formatSSE({
           id: chunkId,
           object: "chat.completion.chunk",
@@ -364,6 +503,7 @@ export async function collectCodexResponse(
   model: string,
   wantReasoning?: boolean,
   tupleSchema?: Record<string, unknown> | null,
+  customToolCallsAsFunctions = false,
 ): Promise<{ response: ChatCompletionResponse; usage: UsageInfo; responseId: string | null }> {
   const id = `chatcmpl-${randomUUID().replace(/-/g, "").slice(0, 24)}`;
   const created = Math.floor(Date.now() / 1000);
@@ -413,6 +553,25 @@ export async function collectCodexResponse(
           arguments: evt.functionCallDone.arguments,
         },
       });
+    }
+    if (evt.customToolCallDone) {
+      toolCalls.push(customToolCallsAsFunctions
+        ? {
+          id: evt.customToolCallDone.callId,
+          type: "function",
+          function: {
+            name: evt.customToolCallDone.name,
+            arguments: evt.customToolCallDone.input,
+          },
+        }
+        : {
+          id: evt.customToolCallDone.callId,
+          type: "custom",
+          custom: {
+            name: evt.customToolCallDone.name,
+            input: evt.customToolCallDone.input,
+          },
+        });
     }
     if (evt.imageGenerationDone) {
       toolCalls.push({

--- a/src/translation/openai-to-codex.ts
+++ b/src/translation/openai-to-codex.ts
@@ -69,6 +69,19 @@ function extractContent(
   return parts.length > 0 ? parts : "";
 }
 
+/**
+ * Cursor serializes grammar-backed custom calls in the normal Chat
+ * `function` envelope on subsequent turns. The tool definition identifies
+ * which raw `function.arguments` values are actually custom tool input.
+ */
+function getCustomToolNames(tools: ChatCompletionRequest["tools"]): Set<string> {
+  const names = new Set<string>();
+  for (const tool of tools ?? []) {
+    if (tool.type === "custom") names.add(tool.name);
+  }
+  return names;
+}
+
 
 /**
  * Convert a ChatCompletionRequest to a CodexResponsesRequest.
@@ -102,6 +115,8 @@ export function translateToCodexRequest(
   // Build input items from non-system messages
   // Handles new format (tool/tool_calls) and legacy format (function/function_call)
   const input: CodexInputItem[] = [];
+  const customToolNames = getCustomToolNames(req.tools);
+  const toolCallKinds = new Map<string, "function" | "custom">();
   for (const msg of req.messages) {
     if (msg.role === "system" || msg.role === "developer") continue;
 
@@ -114,12 +129,28 @@ export function translateToCodexRequest(
       // Then push tool calls as native function_call items
       if (msg.tool_calls?.length) {
         for (const tc of msg.tool_calls) {
-          input.push({
-            type: "function_call",
-            call_id: tc.id,
-            name: tc.function.name,
-            arguments: tc.function.arguments,
-          });
+          const isNativeCustomCall = tc.type === "custom";
+          const name = isNativeCustomCall ? tc.custom.name : tc.function.name;
+          const inputValue = isNativeCustomCall ? tc.custom.input : tc.function.arguments;
+          const toolCallKind = isNativeCustomCall || customToolNames.has(name)
+            ? "custom"
+            : "function";
+          toolCallKinds.set(tc.id, toolCallKind);
+          if (toolCallKind === "custom") {
+            input.push({
+              type: "custom_tool_call",
+              call_id: tc.id,
+              name,
+              input: inputValue,
+            });
+          } else {
+            input.push({
+              type: "function_call",
+              call_id: tc.id,
+              name,
+              arguments: inputValue,
+            });
+          }
         }
       }
       if (msg.function_call) {
@@ -132,11 +163,20 @@ export function translateToCodexRequest(
       }
     } else if (msg.role === "tool") {
       // Native tool result
-      input.push({
-        type: "function_call_output",
-        call_id: msg.tool_call_id ?? "unknown",
-        output: extractText(msg.content),
-      });
+      const callId = msg.tool_call_id ?? "unknown";
+      if (msg.tool_call_type === "custom" || toolCallKinds.get(callId) === "custom") {
+        input.push({
+          type: "custom_tool_call_output",
+          call_id: callId,
+          output: extractText(msg.content),
+        });
+      } else {
+        input.push({
+          type: "function_call_output",
+          call_id: callId,
+          output: extractText(msg.content),
+        });
+      }
     } else if (msg.role === "function") {
       // Legacy function result → native format
       input.push({

--- a/src/translation/tool-format.ts
+++ b/src/translation/tool-format.ts
@@ -32,6 +32,13 @@ export interface CodexToolDefinition {
   strict?: boolean;
 }
 
+export interface CodexCustomToolDefinition {
+  type: "custom";
+  name: string;
+  description?: string;
+  format?: Record<string, unknown>;
+}
+
 export interface CodexHostedWebSearchTool {
   type: "web_search";
   search_context_size?: "low" | "medium" | "high";
@@ -43,7 +50,11 @@ export interface CodexImageGenerationTool {
   [key: string]: unknown;
 }
 
-export type CodexTool = CodexToolDefinition | CodexHostedWebSearchTool | CodexImageGenerationTool;
+export type CodexTool =
+  | CodexToolDefinition
+  | CodexCustomToolDefinition
+  | CodexHostedWebSearchTool
+  | CodexImageGenerationTool;
 
 export interface AnthropicToolConversionOptions {
   mapClaudeCodeWebSearch?: boolean;
@@ -134,6 +145,17 @@ export function openAIToolsToCodex(
       continue;
     }
 
+    if (t.type === "custom") {
+      const def: CodexCustomToolDefinition = {
+        type: "custom",
+        name: t.name,
+      };
+      if (t.description) def.description = t.description;
+      if (t.format) def.format = t.format;
+      defs.push(def);
+      continue;
+    }
+
     if (t.type !== "function") continue;
     const def: CodexToolDefinition = {
       type: "function",
@@ -149,7 +171,7 @@ export function openAIToolsToCodex(
 
 export function openAIToolChoiceToCodex(
   choice: ChatCompletionRequest["tool_choice"],
-): string | { type: "function"; name: string } | { type: "web_search" } | undefined {
+): string | { type: "function"; name: string } | { type: "custom"; name: string } | { type: "web_search" } | undefined {
   if (!choice) return undefined;
   if (typeof choice === "string") {
     // "none" | "auto" | "required" → pass through
@@ -159,6 +181,9 @@ export function openAIToolChoiceToCodex(
     return { type: "web_search" };
   }
   // { type: "function", function: { name } } → { type: "function", name }
+  if (choice.type === "custom") {
+    return { type: "custom", name: choice.name };
+  }
   const fn = isRecord(choice.function) ? choice.function : null;
   const name = typeof fn?.name === "string" ? fn.name : "";
   return { type: "function", name };

--- a/src/types/codex-events.ts
+++ b/src/types/codex-events.ts
@@ -117,6 +117,20 @@ export interface CodexFunctionCallArgsDoneEvent {
   name: string;
 }
 
+export interface CodexCustomToolCallInputDeltaEvent {
+  type: "response.custom_tool_call_input.delta";
+  delta: string;
+  outputIndex: number;
+  itemId: string;
+}
+
+export interface CodexCustomToolCallInputDoneEvent {
+  type: "response.custom_tool_call_input.done";
+  input: string;
+  outputIndex: number;
+  itemId: string;
+}
+
 export interface CodexOutputItemDoneEvent {
   type: "response.output_item.done";
   outputIndex: number;
@@ -126,6 +140,7 @@ export interface CodexOutputItemDoneEvent {
     call_id?: string;
     name?: string;
     arguments?: string;
+    input?: string;
     content?: unknown[];
     actions?: unknown[];
     result?: string;
@@ -197,6 +212,8 @@ export type TypedCodexEvent =
   | CodexQueuedEvent
   | CodexFunctionCallArgsDeltaEvent
   | CodexFunctionCallArgsDoneEvent
+  | CodexCustomToolCallInputDeltaEvent
+  | CodexCustomToolCallInputDoneEvent
   | CodexErrorEvent
   | CodexResponseFailedEvent
   | CodexUnknownEvent;
@@ -462,6 +479,42 @@ export function parseCodexEvent(evt: CodexSSEEvent): TypedCodexEvent {
       }
       return { type: "unknown", raw: data };
     }
+    case "response.custom_tool_call_input.delta": {
+      const itemId = isRecord(data)
+        ? (typeof data.item_id === "string" ? data.item_id : typeof data.call_id === "string" ? data.call_id : "")
+        : "";
+      if (
+        isRecord(data) &&
+        typeof data.delta === "string" &&
+        itemId
+      ) {
+        return {
+          type: "response.custom_tool_call_input.delta",
+          delta: data.delta,
+          outputIndex: typeof data.output_index === "number" ? data.output_index : 0,
+          itemId,
+        };
+      }
+      return { type: "unknown", raw: data };
+    }
+    case "response.custom_tool_call_input.done": {
+      const itemId = isRecord(data)
+        ? (typeof data.item_id === "string" ? data.item_id : typeof data.call_id === "string" ? data.call_id : "")
+        : "";
+      if (
+        isRecord(data) &&
+        typeof data.input === "string" &&
+        itemId
+      ) {
+        return {
+          type: "response.custom_tool_call_input.done",
+          input: data.input,
+          outputIndex: typeof data.output_index === "number" ? data.output_index : 0,
+          itemId,
+        };
+      }
+      return { type: "unknown", raw: data };
+    }
     case "error": {
       return {
         type: "error",
@@ -490,6 +543,7 @@ export function parseCodexEvent(evt: CodexSSEEvent): TypedCodexEvent {
             ...(typeof data.item.call_id === "string" ? { call_id: data.item.call_id } : {}),
             ...(typeof data.item.name === "string" ? { name: data.item.name } : {}),
             ...(typeof data.item.arguments === "string" ? { arguments: data.item.arguments } : {}),
+            ...(typeof data.item.input === "string" ? { input: data.item.input } : {}),
             ...(Array.isArray(data.item.content) ? { content: data.item.content } : {}),
             ...(Array.isArray(data.item.actions) ? { actions: data.item.actions } : {}),
             ...(typeof data.item.result === "string" ? { result: data.item.result } : {}),

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -84,6 +84,21 @@ function responsesContentToText(content: unknown): string {
     .join("\n");
 }
 
+function normalizeToolCall(toolCall: unknown): unknown {
+  if (!isRecord(toolCall) || toolCall.type !== "custom" || isRecord(toolCall.custom)) {
+    return toolCall;
+  }
+
+  const name = optionalString(toolCall.name);
+  const input = optionalString(toolCall.input);
+  if (!name || input === undefined) return toolCall;
+
+  return {
+    ...toolCall,
+    custom: { name, input },
+  };
+}
+
 function normalizeResponsesInputItem(item: unknown): unknown[] {
   if (typeof item === "string") {
     return [{ role: "user", content: item }];
@@ -119,6 +134,32 @@ function normalizeResponsesInputItem(item: unknown): unknown[] {
     }];
   }
 
+  if (item.type === "custom_tool_call") {
+    const name = optionalString(item.name);
+    const input = optionalString(item.input);
+    if (!name || input === undefined) return [];
+    const callId = optionalString(item.call_id) ?? optionalString(item.id) ?? `ctc_${name}`;
+    return [{
+      role: "assistant",
+      content: null,
+      tool_calls: [{
+        id: callId,
+        type: "custom",
+        custom: { name, input },
+      }],
+    }];
+  }
+
+  if (item.type === "custom_tool_call_output") {
+    const callId = optionalString(item.call_id) ?? optionalString(item.id) ?? "unknown";
+    return [{
+      role: "tool",
+      content: responsesContentToText(item.output ?? item.content),
+      tool_call_id: callId,
+      tool_call_type: "custom",
+    }];
+  }
+
   if (item.type === "message" || isChatRole(item.role)) {
     const role = isChatRole(item.role) ? item.role : "user";
     const message: Record<string, unknown> = {
@@ -127,7 +168,9 @@ function normalizeResponsesInputItem(item: unknown): unknown[] {
     };
     if (typeof item.name === "string") message.name = item.name;
     if (typeof item.tool_call_id === "string") message.tool_call_id = item.tool_call_id;
-    if (Array.isArray(item.tool_calls)) message.tool_calls = item.tool_calls;
+    if (Array.isArray(item.tool_calls)) {
+      message.tool_calls = item.tool_calls.map(normalizeToolCall);
+    }
     if (isRecord(item.function_call)) message.function_call = item.function_call;
     return [message];
   }
@@ -156,8 +199,21 @@ function normalizeFlatTool(tool: unknown): unknown {
   if (!isRecord(tool)) return tool;
 
   const type = tool.type;
+  if (type === "custom") {
+    const nestedCustom = optionalRecord(tool.custom);
+    const name = optionalString(tool.name) ?? optionalString(nestedCustom?.name);
+    if (!name) return tool;
+
+    const normalized: Record<string, unknown> = { type: "custom", name };
+    const description = optionalString(tool.description) ?? optionalString(nestedCustom?.description);
+    const format = optionalRecord(tool.format) ?? optionalRecord(nestedCustom?.format);
+    if (description !== undefined) normalized.description = description;
+    if (format !== undefined) normalized.format = format;
+    return normalized;
+  }
+
   const existingFunction = optionalRecord(tool.function);
-  if (type !== "function" && type !== "custom") return tool;
+  if (type !== "function") return tool;
   if (existingFunction) return tool;
 
   const name = optionalString(tool.name);
@@ -179,7 +235,12 @@ function normalizeFlatTool(tool: unknown): unknown {
 
 function normalizeToolChoice(choice: unknown): unknown {
   if (!isRecord(choice)) return choice;
-  if ((choice.type === "function" || choice.type === "custom") && !isRecord(choice.function)) {
+  if (choice.type === "custom") {
+    const nestedCustom = optionalRecord(choice.custom);
+    const name = optionalString(choice.name) ?? optionalString(nestedCustom?.name);
+    if (name) return { type: "custom", name };
+  }
+  if (choice.type === "function" && !isRecord(choice.function)) {
     const name = optionalString(choice.name);
     if (name) return { type: "function", function: { name } };
   }
@@ -200,6 +261,16 @@ function normalizeChatCompletionRequestInput(value: unknown): unknown {
     if (messages.length > 0) {
       normalized.messages = messages;
     }
+  }
+
+  if (Array.isArray(normalized.messages)) {
+    normalized.messages = normalized.messages.map((message) => {
+      if (!isRecord(message) || !Array.isArray(message.tool_calls)) return message;
+      return {
+        ...message,
+        tool_calls: message.tool_calls.map(normalizeToolCall),
+      };
+    });
   }
 
   const reasoning = optionalRecord(value.reasoning);
@@ -228,15 +299,27 @@ export const ChatMessageSchema = z.object({
   content: z.union([z.string(), z.array(ContentPartSchema)]).nullable().optional(),
   name: z.string().optional(),
   // New format: tool_calls (array, on assistant messages)
-  tool_calls: z.array(z.object({
-    id: z.string(),
-    type: z.literal("function"),
-    function: z.object({
-      name: z.string(),
-      arguments: z.string(),
+  tool_calls: z.array(z.union([
+    z.object({
+      id: z.string(),
+      type: z.literal("function"),
+      function: z.object({
+        name: z.string(),
+        arguments: z.string(),
+      }),
     }),
-  })).optional(),
+    z.object({
+      id: z.string(),
+      type: z.literal("custom"),
+      custom: z.object({
+        name: z.string(),
+        input: z.string(),
+      }),
+    }),
+  ])).optional(),
   tool_call_id: z.string().optional(),
+  /** Internal marker retained when a Responses-style custom tool output is normalized. */
+  tool_call_type: z.enum(["function", "custom"]).optional(),
   // Legacy format: function_call (single object, on assistant messages)
   function_call: z.object({
     name: z.string(),
@@ -274,6 +357,12 @@ const ChatCompletionRequestObjectSchema = z.object({
       }),
     }),
     z.object({
+      type: z.literal("custom"),
+      name: z.string(),
+      description: z.string().optional(),
+      format: z.record(z.unknown()).optional(),
+    }),
+    z.object({
       type: z.enum(["web_search", "web_search_preview"]),
       search_context_size: z.enum(["low", "medium", "high"]).optional(),
       user_location: z.record(z.unknown()).optional(),
@@ -285,6 +374,7 @@ const ChatCompletionRequestObjectSchema = z.object({
   tool_choice: z.union([
     z.enum(["none", "auto", "required"]),
     z.object({ type: z.literal("function"), function: z.object({ name: z.string() }) }),
+    z.object({ type: z.literal("custom"), name: z.string() }),
     z.object({ type: z.enum(["web_search", "web_search_preview"]) }).passthrough(),
   ]).optional(),
   parallel_tool_calls: z.boolean().optional(),
@@ -320,14 +410,23 @@ export type ChatCompletionRequest = z.infer<typeof ChatCompletionRequestSchema>;
 
 // --- Response (non-streaming) ---
 
-export interface ChatCompletionToolCall {
-  id: string;
-  type: "function";
-  function: {
-    name: string;
-    arguments: string;
+export type ChatCompletionToolCall =
+  | {
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }
+  | {
+    id: string;
+    type: "custom";
+    custom: {
+      name: string;
+      input: string;
+    };
   };
-}
 
 export interface ChatCompletionChoice {
   index: number;
@@ -366,10 +465,14 @@ export interface ChatCompletionResponse {
 export interface ChatCompletionChunkToolCall {
   index: number;
   id?: string;
-  type?: "function";
+  type?: "function" | "custom";
   function?: {
     name?: string;
     arguments?: string;
+  };
+  custom?: {
+    name?: string;
+    input?: string;
   };
 }
 

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -26,6 +26,7 @@ import {
   buildToolCallStreamChunks,
   buildReasoningStreamChunks,
   buildImageGenStreamChunks,
+  sseChunk,
 } from "@helpers/sse.js";
 import { createValidJwt } from "@helpers/jwt.js";
 
@@ -260,6 +261,11 @@ describe("E2E: POST /v1/chat/completions", () => {
           type: "custom",
           name: "apply_patch",
           description: "Apply a patch",
+          format: {
+            type: "grammar",
+            syntax: "lark",
+            definition: "start: begin_patch hunk end_patch",
+          },
         },
       ],
       reasoning: { effort: "high" },
@@ -270,7 +276,7 @@ describe("E2E: POST /v1/chat/completions", () => {
     const sentBody = JSON.parse(getLastTransportBody()!) as {
       instructions?: string;
       input?: Array<{ role?: string; content?: unknown }>;
-      tools?: Array<{ type?: string; name?: string; parameters?: unknown }>;
+      tools?: Array<{ type?: string; name?: string; parameters?: unknown; format?: unknown }>;
       reasoning?: { effort?: string };
     };
     expect(sentBody.instructions).toContain("Preserve the existing style.");
@@ -283,13 +289,97 @@ describe("E2E: POST /v1/chat/completions", () => {
         parameters: { type: "object", properties: { path: { type: "string" } } },
       },
       {
-        type: "function",
+        type: "custom",
         name: "apply_patch",
-        strict: false,
         description: "Apply a patch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
+        },
       },
     ]);
     expect(sentBody.reasoning?.effort).toBe("high");
+  });
+
+  it("Cursor-style custom calls stream the raw patch input", async () => {
+    const rawPatch = "*** Begin Patch\n*** Update File: temp-agent-edit-test.txt\n*** End Patch";
+    setTransportPost(async () =>
+      makeTransportResponse(
+        sseChunk("response.created", { response: { id: "resp_custom_patch" } }) +
+        sseChunk("response.in_progress", { response: { id: "resp_custom_patch" } }) +
+        sseChunk("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "custom_tool_call",
+            id: "item_patch",
+            call_id: "call_patch",
+            name: "ApplyPatch",
+          },
+        }) +
+        sseChunk("response.custom_tool_call_input.delta", {
+          output_index: 0,
+          item_id: "item_patch",
+          delta: rawPatch,
+        }) +
+        sseChunk("response.custom_tool_call_input.done", {
+          output_index: 0,
+          item_id: "item_patch",
+          input: rawPatch,
+        }) +
+        sseChunk("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "custom_tool_call",
+            id: "item_patch",
+            call_id: "call_patch",
+            name: "ApplyPatch",
+            input: rawPatch,
+          },
+        }) +
+        sseChunk("response.completed", {
+          response: {
+            id: "resp_custom_patch",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+        }),
+      ),
+    );
+
+    const res = await chatRequest({
+      model: "gpt-5.4",
+      input: [{ role: "user", content: [{ type: "input_text", text: "Apply the patch." }] }],
+      tools: [{
+        type: "custom",
+        name: "ApplyPatch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
+        },
+      }],
+      stream: true,
+    });
+
+    expect(res.status).toBe(200);
+    const chunks = parseOpenAISSE(await res.text());
+    const toolCalls = chunks.flatMap((chunk) => {
+      const choices = chunk.choices as Array<{
+        delta?: { tool_calls?: Array<Record<string, unknown>> };
+      }> | undefined;
+      return choices?.[0]?.delta?.tool_calls ?? [];
+    });
+
+    expect(toolCalls).toContainEqual({
+      index: 0,
+      id: "call_patch",
+      type: "custom",
+      custom: { name: "ApplyPatch", input: "" },
+    });
+    const streamedInput = toolCalls
+      .map((toolCall) => (toolCall.custom as { input?: string } | undefined)?.input ?? "")
+      .join("");
+    expect(streamedInput).toBe(rawPatch);
   });
 
   // ── Error format ──────────────────────────────────────────────

--- a/tests/unit/translation/codex-to-openai.test.ts
+++ b/tests/unit/translation/codex-to-openai.test.ts
@@ -50,10 +50,24 @@ import type { CodexApi } from "@src/proxy/codex-api.js";
 const fakeCodexApi = {} as CodexApi;
 const fakeResponse = new Response(null);
 
-async function collectStreamOutput(events: ExtractedEvent[], wantReasoning = false): Promise<string[]> {
+async function collectStreamOutput(
+  events: ExtractedEvent[],
+  wantReasoning = false,
+  customToolCallsAsFunctions = false,
+): Promise<string[]> {
   mockEvents = events;
   const chunks: string[] = [];
-  for await (const chunk of streamCodexToOpenAI(fakeCodexApi, fakeResponse, "gpt-5.4", undefined, undefined, wantReasoning)) {
+  for await (const chunk of streamCodexToOpenAI(
+    fakeCodexApi,
+    fakeResponse,
+    "gpt-5.4",
+    undefined,
+    undefined,
+    wantReasoning,
+    undefined,
+    undefined,
+    customToolCallsAsFunctions,
+  )) {
     chunks.push(chunk);
   }
   return chunks;
@@ -196,6 +210,147 @@ describe("collectCodexResponse", () => {
       .rejects.toThrow("empty response");
 
     expect(dumpSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("custom tool call translation", () => {
+  const patch = "*** Begin Patch\n*** Update File: temp-agent-edit-test.txt\n*** End Patch";
+
+  function customToolStream(): ExtractedEvent[] {
+    return [
+      createCreated("resp_custom"),
+      createInProgress("resp_custom"),
+      {
+        typed: {
+          type: "response.output_item.added",
+          outputIndex: 0,
+          item: {
+            type: "custom_tool_call",
+            id: "item_patch",
+            call_id: "call_patch",
+            name: "ApplyPatch",
+          },
+        },
+        customToolCallStart: {
+          callId: "call_patch",
+          name: "ApplyPatch",
+          outputIndex: 0,
+        },
+      },
+      {
+        typed: {
+          type: "response.custom_tool_call_input.delta",
+          delta: patch,
+          outputIndex: 0,
+          itemId: "item_patch",
+        },
+        customToolCallDelta: {
+          callId: "call_patch",
+          delta: patch,
+        },
+      },
+      {
+        typed: {
+          type: "response.custom_tool_call_input.done",
+          input: patch,
+          outputIndex: 0,
+          itemId: "item_patch",
+        },
+        customToolCallDone: {
+          callId: "call_patch",
+          name: "ApplyPatch",
+          input: patch,
+        },
+      },
+      createCompleted("resp_custom", { input_tokens: 10, output_tokens: 5 }),
+    ];
+  }
+
+  it("streams raw custom input instead of function arguments", async () => {
+    const chunks = await collectStreamOutput(customToolStream());
+    const toolCalls = chunks
+      .filter((chunk) => chunk.startsWith("data: {"))
+      .flatMap((chunk) => {
+        const parsed = JSON.parse(chunk.replace("data: ", "")) as {
+          choices?: Array<{ delta?: { tool_calls?: Array<Record<string, unknown>> } }>;
+        };
+        return parsed.choices?.[0]?.delta?.tool_calls ?? [];
+      });
+
+    expect(toolCalls).toContainEqual({
+      index: 0,
+      id: "call_patch",
+      type: "custom",
+      custom: { name: "ApplyPatch", input: "" },
+    });
+    const streamedInput = toolCalls
+      .map((toolCall) => (toolCall.custom as { input?: string } | undefined)?.input ?? "")
+      .join("");
+    expect(streamedInput).toBe(patch);
+  });
+
+  it("collects custom calls with the exact raw input", async () => {
+    mockEvents = customToolStream();
+    const { response } = await collectCodexResponse(
+      fakeCodexApi, fakeResponse, "gpt-5.4",
+    );
+
+    expect(response.choices[0].message.tool_calls).toEqual([
+      {
+        id: "call_patch",
+        type: "custom",
+        custom: {
+          name: "ApplyPatch",
+          input: patch,
+        },
+      },
+    ]);
+  });
+
+  it("uses Cursor's function envelope without JSON-encoding raw custom input", async () => {
+    const chunks = await collectStreamOutput(customToolStream(), false, true);
+    const toolCalls = chunks
+      .filter((chunk) => chunk.startsWith("data: {"))
+      .flatMap((chunk) => {
+        const parsed = JSON.parse(chunk.replace("data: ", "")) as {
+          choices?: Array<{ delta?: { tool_calls?: Array<Record<string, unknown>> } }>;
+        };
+        return parsed.choices?.[0]?.delta?.tool_calls ?? [];
+      });
+
+    expect(toolCalls).toContainEqual({
+      index: 0,
+      id: "call_patch",
+      type: "function",
+      function: { name: "ApplyPatch", arguments: "" },
+    });
+    const streamedInput = toolCalls
+      .map((toolCall) => (toolCall.function as { arguments?: string } | undefined)?.arguments ?? "")
+      .join("");
+    expect(streamedInput).toBe(patch);
+  });
+
+  it("collects Cursor-compatible custom calls as raw function arguments", async () => {
+    mockEvents = customToolStream();
+    const { response } = await collectCodexResponse(
+      fakeCodexApi,
+      fakeResponse,
+      "gpt-5.4",
+      false,
+      undefined,
+      true,
+    );
+
+    expect(response.choices[0].message.tool_calls).toEqual([
+      {
+        id: "call_patch",
+        type: "function",
+        function: {
+          name: "ApplyPatch",
+          arguments: patch,
+        },
+      },
+    ]);
   });
 });
 

--- a/tests/unit/translation/openai-to-codex.test.ts
+++ b/tests/unit/translation/openai-to-codex.test.ts
@@ -136,6 +136,77 @@ describe("translateToCodexRequest", () => {
     expect(fcOutput).toBeDefined();
   });
 
+  it("preserves custom tool input and output types", () => {
+    const patch = "*** Begin Patch\n*** Update File: temp-agent-edit-test.txt\n*** End Patch";
+    const result = translateToCodexRequest(makeRequest({
+      messages: [
+        { role: "user", content: "Apply the patch." },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{
+            id: "call_patch",
+            type: "custom" as const,
+            custom: { name: "ApplyPatch", input: patch },
+          }],
+        },
+        { role: "tool", content: "Done", tool_call_id: "call_patch" },
+      ],
+    }));
+
+    expect(result.input).toContainEqual({
+      type: "custom_tool_call",
+      call_id: "call_patch",
+      name: "ApplyPatch",
+      input: patch,
+    });
+    expect(result.input).toContainEqual({
+      type: "custom_tool_call_output",
+      call_id: "call_patch",
+      output: "Done",
+    });
+  });
+
+  it("recognizes Cursor's function-envelope history for a custom tool", () => {
+    const patch = "*** Begin Patch\n*** Update File: temp-agent-edit-test.txt\n*** End Patch";
+    const result = translateToCodexRequest(makeRequest({
+      tools: [{
+        type: "custom",
+        name: "ApplyPatch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch",
+        },
+      }],
+      messages: [
+        { role: "user", content: "Apply the patch." },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{
+            id: "call_patch",
+            type: "function" as const,
+            function: { name: "ApplyPatch", arguments: patch },
+          }],
+        },
+        { role: "tool", content: "Done", tool_call_id: "call_patch" },
+      ],
+    }));
+
+    expect(result.input).toContainEqual({
+      type: "custom_tool_call",
+      call_id: "call_patch",
+      name: "ApplyPatch",
+      input: patch,
+    });
+    expect(result.input).toContainEqual({
+      type: "custom_tool_call_output",
+      call_id: "call_patch",
+      output: "Done",
+    });
+  });
+
   it("resolves model alias via parseModelName", () => {
     const result = translateToCodexRequest(makeRequest({ model: "codex" }));
     expect(result.model).toBe("gpt-5.4");

--- a/tests/unit/translation/tool-format.test.ts
+++ b/tests/unit/translation/tool-format.test.ts
@@ -117,6 +117,34 @@ describe("openAIToolsToCodex", () => {
       { type: "image_generation", size: "1024x1024", quality: "high" },
     ]);
   });
+
+  it("preserves custom grammar tools without converting them to functions", () => {
+    const result = openAIToolsToCodex([
+      {
+        type: "custom",
+        name: "ApplyPatch",
+        description: "Apply a repository patch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
+        },
+      },
+    ] satisfies NonNullable<ChatCompletionRequest["tools"]>);
+
+    expect(result).toEqual([
+      {
+        type: "custom",
+        name: "ApplyPatch",
+        description: "Apply a repository patch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
+        },
+      },
+    ]);
+  });
 });
 
 // ── openAIToolChoiceToCodex ─────────────────────────────────────
@@ -138,6 +166,13 @@ describe("openAIToolChoiceToCodex", () => {
       function: { name: "my_func" },
     });
     expect(result).toEqual({ type: "function", name: "my_func" });
+  });
+
+  it("preserves custom tool choices", () => {
+    expect(openAIToolChoiceToCodex({ type: "custom", name: "ApplyPatch" })).toEqual({
+      type: "custom",
+      name: "ApplyPatch",
+    });
   });
 });
 

--- a/tests/unit/types/openai-schemas.test.ts
+++ b/tests/unit/types/openai-schemas.test.ts
@@ -84,7 +84,7 @@ describe("ChatCompletionRequestSchema", () => {
     }
   });
 
-  it("normalizes named custom tools as function-compatible tools", () => {
+  it("preserves Cursor custom tools and their grammar format", () => {
     const result = ChatCompletionRequestSchema.safeParse({
       model: "gpt-5.4",
       messages: [{ role: "user", content: "Apply a patch" }],
@@ -92,18 +92,69 @@ describe("ChatCompletionRequestSchema", () => {
         type: "custom",
         name: "apply_patch",
         description: "Apply a repository patch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
+        },
       }],
     });
 
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.tools?.[0]).toEqual({
-        type: "function",
-        function: {
-          name: "apply_patch",
-          description: "Apply a repository patch",
+        type: "custom",
+        name: "apply_patch",
+        description: "Apply a repository patch",
+        format: {
+          type: "grammar",
+          syntax: "lark",
+          definition: "start: begin_patch hunk end_patch",
         },
       });
+    }
+  });
+
+  it("normalizes custom tool calls and outputs from Responses-style input", () => {
+    const result = ChatCompletionRequestSchema.safeParse({
+      model: "gpt-5.4",
+      input: [
+        {
+          type: "custom_tool_call",
+          call_id: "call_patch",
+          name: "ApplyPatch",
+          input: "*** Begin Patch\n*** End Patch",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_patch",
+          output: "Done",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.messages).toEqual([
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{
+            id: "call_patch",
+            type: "custom",
+            custom: {
+              name: "ApplyPatch",
+              input: "*** Begin Patch\n*** End Patch",
+            },
+          }],
+        },
+        {
+          role: "tool",
+          content: "Done",
+          tool_call_id: "call_patch",
+          tool_call_type: "custom",
+        },
+      ]);
     }
   });
 


### PR DESCRIPTION
## Summary

This draft PR fixes Cursor's ApplyPatch/custom grammar tool routing through the OpenAI-compatible bridge.

- Preserves Responses-style `custom` tool definitions, including `format: { type: "grammar", ... }`.
- Preserves native `custom_tool_call` and `custom_tool_call_output` events while translating requests and responses.
- Emits Cursor-compatible `type: "function"` tool-call envelopes only for Cursor clients, with the raw patch text in `function.arguments`.
- Rehydrates Cursor's function-envelope history back into native custom calls on the next request.
- Adds schema, translation, streaming, and end-to-end regression coverage.

Related issue: #707

## Root cause

Cursor sends ApplyPatch as a grammar-backed custom tool. Its input is deliberately raw patch text, not a JSON object. The bridge previously treated this tool as a normal function, which lost the custom grammar metadata and caused the patch payload to arrive as an empty object.

A native custom-tool response alone exposed a second compatibility problem in Cursor 3.14.27: Cursor's agent adapter assumes every returned tool call has `tool_call.function.name`. When the bridge returned the Responses custom-call shape directly, Cursor crashed before dispatching the local tool with:

```
Cannot read properties of undefined (reading 'name')
```

That combination produced the observed retry loop and `Missing *** Add/Update File header.`: the editor parser was receiving an empty payload, not a malformed patch.

## Fix details

1. The request schema and Responses event extractor now retain custom grammar definitions and custom call/output events instead of coercing them into schema-less functions.
2. The response translator keeps native custom semantics for normal clients.
3. For requests identified as Cursor (`User-Agent: Cursor/...`), custom calls are presented in the function envelope that Cursor's adapter expects: `{ type: "function", function: { name, arguments: rawInput } }`.
4. The raw input is assigned directly to `function.arguments`; it is not JSON-stringified into an object and is never replaced with `{}`.
5. On subsequent Cursor turns, function-envelope calls whose names match custom tool definitions are converted back to native `custom_tool_call` items, and their results become `custom_tool_call_output` items.

This keeps the upstream Responses API representation correct while satisfying Cursor's current tool-call adapter.

## Validation

- `tsc --noEmit`
- Focused unit suites: 4 files, 114 tests passed.
- `tests/e2e/chat.test.ts`: 16 tests passed.
- Rebuilt proxy smoke test with an authenticated Cursor-shaped request returned HTTP 200 with:
  - `toolEnvelopeType: "function"`
  - `toolName: "ApplyPatch"`
  - raw arguments containing `*** Begin Patch`
  - no native custom envelope in the Cursor-facing response
- `git diff --check` passed.

## Scope

This PR contains only the proxy translation/schema changes and regression tests required for Cursor custom tools. It does not change product source files, authority documents, Git configuration, or runtime artifacts.
