### PR TITLE
fix(ci): ignore stale release failures in promotion gate

### DIFF
--- a/.github/scripts/check-promote-ci.sh
+++ b/.github/scripts/check-promote-ci.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHA="${1:?commit SHA is required}"
+REPO="${2:?repository is required}"
+
+# A commit can have many historical check-runs: release retries, beta builds,
+# and scheduled jobs may all reuse the same SHA. Promotion must be gated by
+# the current quality workflow only; an old release failure must not poison a
+# commit after a later release retry succeeded.
+if ! RUNS_JSON=$(gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"); then
+  printf '%s\n' "api-error"
+  exit 0
+fi
+
+QUALITY_PATH=".github/workflows/ci-quality.yml"
+LATEST_CONCLUSION=$(jq -r --arg path "$QUALITY_PATH" --arg sha "$SHA" '
+  [.workflow_runs[]
+   | select(.path == $path and .head_sha == $sha)
+   | {conclusion, status, created_at}
+  ]
+  | sort_by(.created_at)
+  | if length == 0 then "missing-checks" else .[-1] | if .status != "completed" then "not-green" else (.conclusion // "") end end
+' <<< "$RUNS_JSON")
+
+case "$LATEST_CONCLUSION" in
+  success) printf '%s\n' "green" ;;
+  missing-checks) printf '%s\n' "missing-checks" ;;
+  *) printf '%s\n' "not-green" ;;
+esac

--- a/.github/scripts/check-promote-ci.sh
+++ b/.github/scripts/check-promote-ci.sh
@@ -8,14 +8,15 @@ REPO="${2:?repository is required}"
 # and scheduled jobs may all reuse the same SHA. Promotion must be gated by
 # the current quality workflow only; an old release failure must not poison a
 # commit after a later release retry succeeded.
-if ! RUNS_JSON=$(gh api "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"); then
+if ! RUNS_JSON=$(gh api --paginate --slurp "repos/${REPO}/actions/runs?head_sha=${SHA}&per_page=100"); then
   printf '%s\n' "api-error"
   exit 0
 fi
 
 QUALITY_PATH=".github/workflows/ci-quality.yml"
 LATEST_CONCLUSION=$(jq -r --arg path "$QUALITY_PATH" --arg sha "$SHA" '
-  [.workflow_runs[]
+  [ (if type == "array" then .[] else . end)
+   | .workflow_runs[]?
    | select(.path == $path and .head_sha == $sha)
    | {conclusion, status, created_at}
   ]

--- a/.github/workflows/promote-dev-to-master.yml
+++ b/.github/workflows/promote-dev-to-master.yml
@@ -102,28 +102,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATES: ${{ steps.soak.outputs.candidates }}
         run: |
-          # Exclude this workflow's own checks (promote-dev) and bump workflows from the gate.
-          # (?i) makes the regex case-insensitive so we catch "promote"/"Promote", "bump-beta"/etc.
+          # Gate on the latest CI - Quality gate run for this SHA. Do not scan
+          # commit check-runs: release retries and historical failures may
+          # share the same SHA and would permanently poison promotion.
           PICKED=""
           while read -r SHA; do
             [ -z "$SHA" ] && continue
-            # `|| STATUS=api-error`: a transient gh/API failure must skip the
-            # candidate (like missing-checks), not abort the job — an abort
-            # here would fire the ff-failure issue/webhook with a wrong cause.
-            STATUS=$(gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs" \
-              --jq '
-                [.check_runs[]
-                 | select(.name | test("(?i)promote|bump") | not)
-                ] as $relevant
-                | if ($relevant | length) == 0
-                  then "missing-checks"
-                  else
-                    if all($relevant[]; .conclusion == "success" or .conclusion == "skipped")
-                    then "green"
-                    else "not-green"
-                    end
-                  end
-              ') || STATUS="api-error"
+            STATUS=$(bash .github/scripts/check-promote-ci.sh "$SHA" "${{ github.repository }}")
             echo "$SHA → $STATUS"
             if [ "$STATUS" = "green" ]; then
               PICKED="$SHA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### Fixed
 
-- 修复 `promote-dev-to-master` 将同一 commit 上历史 Electron release 失败记录误当作当前 CI 失败的问题：晋升门禁现在只读取该 commit 最新的 `ci-quality.yml` 结果，避免一次临时发布下载错误在成功重试后永久阻塞 `dev → master`，并补充回归测试（`.github/scripts/check-promote-ci.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/promote-ci-gate.test.ts`）
+- 修复 `promote-dev-to-master` 将同一 commit 上历史 Electron release 失败记录误当作当前 CI 失败的问题：晋升门禁现在只读取该 commit 最新的 `ci-quality.yml` 结果，并支持分页读取 workflow runs，避免一次临时发布下载错误在成功重试后永久阻塞 `dev → master`，并补充回归测试（`.github/scripts/check-promote-ci.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/promote-ci-gate.test.ts`）
 
 - 修复上游 WebSocket 首帧 `server_is_overloaded` 被当作普通 SSE 错误透传、最终表现为 `stream disconnected before completion` 的问题：现在在 HTTP 响应提交前映射为 503，进入账号切换/有限重试；已产生输出后不重放请求，且 `response.completed` 后的异常关闭不再误报未完成流。（`src/proxy/error-classification.ts`、`src/proxy/ws-pool.ts`、`src/proxy/ws-transport.ts`、`src/routes/shared/proxy-error-handler.ts`、`src/translation/codex-api-error-from-event.ts`）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 ### Fixed
 
+- 修复 `promote-dev-to-master` 将同一 commit 上历史 Electron release 失败记录误当作当前 CI 失败的问题：晋升门禁现在只读取该 commit 最新的 `ci-quality.yml` 结果，避免一次临时发布下载错误在成功重试后永久阻塞 `dev → master`，并补充回归测试（`.github/scripts/check-promote-ci.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/promote-ci-gate.test.ts`）
+
 - 修复 Dashboard Errors tab 的“全部标记已读”和“删除”操作被 Settings Bearer-token middleware 拦截成 401 的问题；`/admin/error-logs*` 统一交给 dashboard session auth，避免 cookie 登录会话被误判失效并跳回登录页。（`src/routes/admin/settings.ts`、`tests/integration/error-logs-dashboard-auth.test.ts`）
 - 修复 release notes 生成脚本在 LLM endpoint 不可达时可能被 60s 默认请求超时拖慢测试的问题；新增 `RELEASE_NOTES_REQUEST_TIMEOUT_MS` 仅用于覆盖该脚本请求超时，生产默认仍为 60s。（`.github/scripts/summarize-release-notes.mjs`、`tests/unit/ci/summarize-release-notes.test.ts`）
 - 修复并强化 WebSocket 消息流的生命周期管理：通过缓冲早期元数据帧（如 `response.created`），延迟解析 HTTP 响应，从而解决由于内部限流事件导致的提前解析和挂起问题，并在重构中排除了首字时间（TTFT）超过 20s 会引发超时的隐患。（#678，感谢 [@zyycn](https://github.com/zyycn)）

--- a/tests/unit/ci/promote-ci-gate.test.ts
+++ b/tests/unit/ci/promote-ci-gate.test.ts
@@ -24,6 +24,22 @@ function runWithWorkflowRuns(workflowRuns: unknown[]): string {
   }).trim();
 }
 
+function runWithWorkflowRunPages(pages: unknown[]): string {
+  const binDir = mkdtempSync(join(tmpdir(), "codex-proxy-promote-ci-pages-"));
+  const fixture = join(binDir, "workflow-runs-pages.json");
+  writeFileSync(fixture, JSON.stringify(pages));
+  const gh = join(binDir, "gh");
+  writeFileSync(
+    gh,
+    `#!/bin/sh\ncat ${JSON.stringify(fixture)}\n`,
+  );
+  chmodSync(gh, 0o755);
+  return execFileSync("bash", [SCRIPT, SHA, "icebear0828/codex-proxy"], {
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+  }).trim();
+}
+
 describe("promote CI gate", () => {
   it("ignores an old failed release run when the quality gate succeeded", () => {
     expect(runWithWorkflowRuns([
@@ -73,5 +89,24 @@ describe("promote CI gate", () => {
         created_at: "2026-08-15T17:56:53Z",
       },
     ])).toBe("missing-checks");
+  });
+
+  it("finds a quality-gate run returned on a later API page", () => {
+    expect(runWithWorkflowRunPages([
+      { workflow_runs: Array.from({ length: 100 }, (_, index) => ({
+        path: ".github/workflows/release.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "failure",
+        created_at: `2026-08-15T10:${String(index).padStart(2, "0")}:00Z`,
+      })) },
+      { workflow_runs: [{
+        path: ".github/workflows/ci-quality.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-08-15T17:56:53Z",
+      }] },
+    ])).toBe("green");
   });
 });

--- a/tests/unit/ci/promote-ci-gate.test.ts
+++ b/tests/unit/ci/promote-ci-gate.test.ts
@@ -1,0 +1,77 @@
+import { execFileSync } from "child_process";
+import { chmodSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(__dirname, "..", "..", "..");
+const SCRIPT = resolve(ROOT, ".github", "scripts", "check-promote-ci.sh");
+const SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function runWithWorkflowRuns(workflowRuns: unknown[]): string {
+  const binDir = mkdtempSync(join(tmpdir(), "codex-proxy-promote-ci-") );
+  const fixture = join(binDir, "workflow-runs.json");
+  writeFileSync(fixture, JSON.stringify({ workflow_runs: workflowRuns }));
+  const gh = join(binDir, "gh");
+  writeFileSync(
+    gh,
+    `#!/bin/sh\ncat ${JSON.stringify(fixture)}\n`,
+  );
+  chmodSync(gh, 0o755);
+  return execFileSync("bash", [SCRIPT, SHA, "icebear0828/codex-proxy"], {
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+  }).trim();
+}
+
+describe("promote CI gate", () => {
+  it("ignores an old failed release run when the quality gate succeeded", () => {
+    expect(runWithWorkflowRuns([
+      {
+        path: ".github/workflows/release.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "failure",
+        created_at: "2026-08-12T17:02:44Z",
+      },
+      {
+        path: ".github/workflows/ci-quality.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-08-15T17:56:53Z",
+      },
+    ])).toBe("green");
+  });
+
+  it("uses the newest quality-gate run for the candidate", () => {
+    expect(runWithWorkflowRuns([
+      {
+        path: ".github/workflows/ci-quality.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-08-14T17:56:53Z",
+      },
+      {
+        path: ".github/workflows/ci-quality.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "failure",
+        created_at: "2026-08-15T17:56:53Z",
+      },
+    ])).toBe("not-green");
+  });
+
+  it("reports missing quality checks instead of treating unrelated runs as green", () => {
+    expect(runWithWorkflowRuns([
+      {
+        path: ".github/workflows/release.yml",
+        head_sha: SHA,
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-08-15T17:56:53Z",
+      },
+    ])).toBe("missing-checks");
+  });
+});


### PR DESCRIPTION
## Summary
- gate dev → master promotion on the latest ci-quality workflow run for each candidate SHA
- ignore historical Electron release failures that are unrelated to the current quality gate
- add regression coverage for stale release failures, latest quality failures, and missing checks

## Verification
- `npx vitest run tests/unit/ci/promote-ci-gate.test.ts tests/unit/ci/select-promote-candidate.test.ts tests/unit/ci/electron-smoke-script.test.ts`
- `npm run typecheck:scripts`
- `npm run build`
- `git diff --check`
- live helper check for blocked SHA `35726b85`: `green`