### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ Codex Proxy 主要由个人维护，但一路上收到了很多社区帮助。�
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=icebear0828/codex-proxy&type=Date)](https://star-history.com/#icebear0828/codex-proxy&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=icebear0828/codex-proxy&type=Date)](https://star-history.dera.page/#icebear0828/codex-proxy&Date)
 
 ## 📄 许可协议
 


### PR DESCRIPTION
The star history chart in the README was broken. This switches it to a working data source so the chart renders correctly again.