### PR TITLE
fix(models): sync catalog isDefault with config.model.default and fix status loading

### DIFF
--- a/shared/hooks/use-status.test.ts
+++ b/shared/hooks/use-status.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  getFamilyId,
+  isTierVariant,
+  isSelectableChatModel,
+  selectDefaultModel,
+  type CatalogModel,
+} from "./use-status.js";
+
+describe("use-status helpers", () => {
+  describe("getFamilyId", () => {
+    it("extracts family from bare model names", () => {
+      expect(getFamilyId("gpt-5.4")).toBe("gpt-5.4");
+      expect(getFamilyId("gpt-5")).toBe("gpt-5");
+    });
+
+    it("identifies spark as a distinct family", () => {
+      expect(getFamilyId("gpt-5.3-codex-spark")).toBe("gpt-5.3-codex-spark");
+    });
+
+    it("identifies mini as a distinct family", () => {
+      expect(getFamilyId("gpt-5.3-codex-mini")).toBe("gpt-5.3-codex-mini");
+      expect(getFamilyId("gpt-5-codex-mini")).toBe("gpt-5-codex-mini");
+    });
+
+    it("strips tier suffixes (high, mid, low, max) to base family", () => {
+      expect(getFamilyId("gpt-5.3-codex-high")).toBe("gpt-5.3-codex");
+      expect(getFamilyId("gpt-5.3-codex-mid")).toBe("gpt-5.3-codex");
+      expect(getFamilyId("gpt-5.3-codex-low")).toBe("gpt-5.3-codex");
+      expect(getFamilyId("gpt-5.3-codex-max")).toBe("gpt-5.3-codex");
+      expect(getFamilyId("gpt-5-codex-high")).toBe("gpt-5-codex");
+    });
+  });
+
+  describe("isTierVariant", () => {
+    it("returns true for tier variant IDs", () => {
+      expect(isTierVariant("gpt-5.3-codex-high")).toBe(true);
+      expect(isTierVariant("gpt-5.3-codex-mid")).toBe(true);
+      expect(isTierVariant("gpt-5.3-codex-low")).toBe(true);
+      expect(isTierVariant("gpt-5.3-codex-max")).toBe(true);
+    });
+
+    it("returns false for base models or spark/mini", () => {
+      expect(isTierVariant("gpt-5.4")).toBe(false);
+      expect(isTierVariant("gpt-5.3-codex")).toBe(false);
+      expect(isTierVariant("gpt-5.3-codex-spark")).toBe(false);
+      expect(isTierVariant("gpt-5.3-codex-mini")).toBe(false);
+    });
+  });
+
+  describe("isSelectableChatModel", () => {
+    it("returns true for models with text output and supported reasoning efforts", () => {
+      const model: CatalogModel = {
+        id: "gpt-5.4",
+        displayName: "GPT-5.4",
+        isDefault: false,
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium effort" }],
+        defaultReasoningEffort: "medium",
+        outputModalities: ["text"],
+      };
+      expect(isSelectableChatModel(model)).toBe(true);
+    });
+
+    it("returns false for non-text output models", () => {
+      const model: CatalogModel = {
+        id: "image-gen-1",
+        displayName: "Image Gen",
+        isDefault: false,
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium effort" }],
+        defaultReasoningEffort: "medium",
+        outputModalities: ["image"],
+      };
+      expect(isSelectableChatModel(model)).toBe(false);
+    });
+
+    it("returns false for models without reasoning efforts", () => {
+      const model: CatalogModel = {
+        id: "gpt-5.4",
+        displayName: "GPT-5.4",
+        isDefault: false,
+        supportedReasoningEfforts: [],
+        defaultReasoningEffort: "",
+        outputModalities: ["text"],
+      };
+      expect(isSelectableChatModel(model)).toBe(false);
+    });
+  });
+
+  describe("selectDefaultModel", () => {
+    const catalog: CatalogModel[] = [
+      {
+        id: "gpt-5.3-codex",
+        displayName: "GPT-5.3 Codex",
+        isDefault: false,
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        defaultReasoningEffort: "medium",
+        outputModalities: ["text"],
+      },
+      {
+        id: "gpt-5.4",
+        displayName: "GPT-5.4",
+        isDefault: true,
+        supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
+        defaultReasoningEffort: "high",
+        outputModalities: ["text"],
+      },
+    ];
+
+    it("selects the model marked as isDefault", () => {
+      expect(selectDefaultModel(catalog, ["gpt-5.3-codex", "gpt-5.4"])).toBe("gpt-5.4");
+    });
+
+    it("falls back to the first selectable model when none is marked isDefault", () => {
+      const noDefaultCatalog = catalog.map((m) => ({ ...m, isDefault: false }));
+      expect(selectDefaultModel(noDefaultCatalog, ["gpt-5.3-codex", "gpt-5.4"])).toBe("gpt-5.3-codex");
+    });
+
+    it("ignores unselectable models marked as isDefault and falls back", () => {
+      const unselectableDefaultCatalog: CatalogModel[] = [
+        {
+          id: "image-only",
+          displayName: "Image Only",
+          isDefault: true,
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: "",
+          outputModalities: ["image"],
+        },
+        {
+          id: "gpt-5.4",
+          displayName: "GPT-5.4",
+          isDefault: false,
+          supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
+          defaultReasoningEffort: "high",
+          outputModalities: ["text"],
+        },
+      ];
+      expect(selectDefaultModel(unselectableDefaultCatalog, ["image-only", "gpt-5.4"])).toBe("gpt-5.4");
+    });
+
+    it("falls back to ids array when catalog is empty", () => {
+      expect(selectDefaultModel([], ["gpt-5.4"])).toBe("gpt-5.4");
+    });
+
+    it("returns empty string when both catalog and ids are empty", () => {
+      expect(selectDefaultModel([], [])).toBe("");
+    });
+  });
+});

--- a/shared/hooks/use-status.ts
+++ b/shared/hooks/use-status.ts
@@ -93,11 +93,14 @@ export function useStatus(accountCount: number) {
 
     async function loadStatus() {
       try {
-        const resp = await fetch("/auth/status");
-        const data = await resp.json();
-        if (!data.authenticated) return;
         setBaseUrl(`${window.location.origin}/v1`);
-        setApiKey(data.proxy_api_key || "any-string");
+        const resp = await fetch("/auth/status");
+        if (resp.ok) {
+          const data = await resp.json();
+          setApiKey(data.proxy_api_key || "any-string");
+        } else {
+          setApiKey("any-string");
+        }
         await fetchModels(true);
 
         // Refresh model list every 60s to pick up dynamic backend changes

--- a/shared/hooks/use-status.ts
+++ b/shared/hooks/use-status.ts
@@ -22,7 +22,7 @@ export interface ModelFamily {
  * gpt-5.3-codex-spark → gpt-5.3-codex-spark (spark is a distinct family)
  * gpt-5.4 → gpt-5.4
  */
-function getFamilyId(id: string): string {
+export function getFamilyId(id: string): string {
   // Bare model: gpt-5.4
   if (/^gpt-\d+(?:\.\d+)?$/.test(id)) return id;
   // Spark family: gpt-X.Y-codex-spark
@@ -39,16 +39,16 @@ function getFamilyId(id: string): string {
 }
 
 /** Check if a model ID is a tier variant (not the base family model). */
-function isTierVariant(id: string): boolean {
+export function isTierVariant(id: string): boolean {
   return /^gpt-\d+(?:\.\d+)?-codex-(?:high|mid|low|max)$/.test(id);
 }
 
-function isSelectableChatModel(model: CatalogModel): boolean {
+export function isSelectableChatModel(model: CatalogModel): boolean {
   if (model.outputModalities && !model.outputModalities.includes("text")) return false;
   return model.supportedReasoningEfforts.length > 0;
 }
 
-function selectDefaultModel(catalog: CatalogModel[], ids: string[]): string {
+export function selectDefaultModel(catalog: CatalogModel[], ids: string[]): string {
   const selectable = catalog.filter(isSelectableChatModel);
   return selectable.find((m) => m.isDefault)?.id ?? selectable[0]?.id ?? ids[0] ?? "";
 }

--- a/src/routes/models.ts
+++ b/src/routes/models.ts
@@ -110,6 +110,8 @@ export function createModelRoutes(apiKeyPool?: ApiKeyPool, clientKeyPool?: Clien
   // Must be before :modelId to avoid being matched as a model ID
   app.get("/v1/models/catalog", (c) => {
     let catalog = getModelCatalog();
+    const config = getConfig();
+    const configDefault = config.model?.default;
     const allowed = getClientKeyAllowedModels(c);
     if (allowed) {
       catalog = catalog.filter((m) => allowed.includes(m.id));
@@ -120,6 +122,7 @@ export function createModelRoutes(apiKeyPool?: ApiKeyPool, clientKeyPool?: Clien
     return c.json(
       catalog.map((m) => ({
         ...m,
+        isDefault: configDefault ? m.id === configDefault : m.isDefault,
         outputModalities: m.outputModalities ?? ["text"],
       })),
     );

--- a/src/routes/models.ts
+++ b/src/routes/models.ts
@@ -8,6 +8,7 @@ import {
   getModelCatalog,
   getModelInfo,
   getModelStoreDebug,
+  resolveModelId,
   type CodexModelInfo,
 } from "../models/model-store.js";
 import { triggerImmediateRefresh } from "../models/model-fetcher.js";
@@ -111,7 +112,8 @@ export function createModelRoutes(apiKeyPool?: ApiKeyPool, clientKeyPool?: Clien
   app.get("/v1/models/catalog", (c) => {
     let catalog = getModelCatalog();
     const config = getConfig();
-    const configDefault = config.model?.default;
+    const rawDefault = config.model?.default?.trim();
+    const configDefault = rawDefault ? resolveModelId(rawDefault) : undefined;
     const allowed = getClientKeyAllowedModels(c);
     if (allowed) {
       catalog = catalog.filter((m) => allowed.includes(m.id));

--- a/tests/unit/routes/models-catalog.test.ts
+++ b/tests/unit/routes/models-catalog.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for GET /v1/models/catalog route.
+ * Verifies that model.isDefault dynamically tracks config.model.default (including aliases)
+ * and honors client key allowed_models restrictions.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createModelRoutes } from "@src/routes/models.js";
+import { resetModelStoreForTesting, loadStaticModels } from "@src/models/model-store.js";
+import type { ClientKeyPool } from "@src/auth/client-key-pool.js";
+
+const mockConfig = {
+  model: {
+    default: "gpt-5.4",
+    aliases: {
+      codex: "gpt-5.3-codex",
+    },
+    custom_models: [],
+  },
+  server: {
+    proxy_api_key: null as string | null,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getConfigDir: vi.fn(() => "/tmp/test-models-catalog-config"),
+  getDataDir: vi.fn(() => "/tmp/test-models-catalog-data"),
+}));
+
+const FIXTURE_YAML = `
+models:
+  - id: gpt-5.3-codex
+    displayName: GPT-5.3 Codex
+    description: Coding specialist
+    isDefault: true
+    supportedReasoningEfforts:
+      - reasoningEffort: medium
+        description: Standard
+    defaultReasoningEffort: medium
+    inputModalities: ["text"]
+    supportsPersonality: false
+    upgrade: null
+  - id: gpt-5.4
+    displayName: GPT-5.4
+    description: Flagship
+    isDefault: false
+    supportedReasoningEfforts:
+      - reasoningEffort: high
+        description: Deep
+    defaultReasoningEffort: high
+    inputModalities: ["text"]
+    supportsPersonality: false
+    upgrade: null
+aliases:
+  codex: gpt-5.3-codex
+`;
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn((path: string) => {
+      if (typeof path === "string" && path.includes("models.yaml")) {
+        return FIXTURE_YAML;
+      }
+      return "";
+    }),
+    existsSync: vi.fn(() => false),
+    writeFile: vi.fn((_p: string, _d: string, _e: string, cb: (err: Error | null) => void) => cb(null)),
+    mkdirSync: vi.fn(),
+  };
+});
+
+describe("GET /v1/models/catalog", () => {
+  beforeEach(() => {
+    mockConfig.model.default = "gpt-5.4";
+    mockConfig.model.aliases = { codex: "gpt-5.3-codex" };
+    mockConfig.server.proxy_api_key = null;
+    resetModelStoreForTesting();
+    loadStaticModels();
+  });
+
+  it("marks the model matching config.model.default as isDefault: true and others as false", async () => {
+    mockConfig.model.default = "gpt-5.4";
+    const app = createModelRoutes();
+    const res = await app.request("/v1/models/catalog");
+
+    expect(res.status).toBe(200);
+    const catalog = (await res.json()) as Array<{ id: string; isDefault: boolean; outputModalities: string[] }>;
+
+    const gpt54 = catalog.find((m) => m.id === "gpt-5.4");
+    const gpt53 = catalog.find((m) => m.id === "gpt-5.3-codex");
+
+    expect(gpt54?.isDefault).toBe(true);
+    expect(gpt53?.isDefault).toBe(false);
+    expect(gpt54?.outputModalities).toEqual(["text"]);
+  });
+
+  it("resolves alias when config.model.default is an alias", async () => {
+    mockConfig.model.default = "codex";
+    const app = createModelRoutes();
+    const res = await app.request("/v1/models/catalog");
+
+    expect(res.status).toBe(200);
+    const catalog = (await res.json()) as Array<{ id: string; isDefault: boolean }>;
+
+    const gpt53 = catalog.find((m) => m.id === "gpt-5.3-codex");
+    const gpt54 = catalog.find((m) => m.id === "gpt-5.4");
+
+    expect(gpt53?.isDefault).toBe(true);
+    expect(gpt54?.isDefault).toBe(false);
+  });
+
+  it("preserves catalog isDefault if config.model.default is empty or undefined", async () => {
+    mockConfig.model.default = "";
+    const app = createModelRoutes();
+    const res = await app.request("/v1/models/catalog");
+
+    expect(res.status).toBe(200);
+    const catalog = (await res.json()) as Array<{ id: string; isDefault: boolean }>;
+
+    const gpt53 = catalog.find((m) => m.id === "gpt-5.3-codex");
+    const gpt54 = catalog.find((m) => m.id === "gpt-5.4");
+
+    expect(gpt53?.isDefault).toBe(true);
+    expect(gpt54?.isDefault).toBe(false);
+  });
+
+  it("filters catalog based on client key allowed_models", async () => {
+    const mockClientKeyPool = {
+      getByKey: vi.fn((key: string) => {
+        if (key === "test-client-key") {
+          return { allowed_models: ["gpt-5.4"] };
+        }
+        return null;
+      }),
+    } as unknown as ClientKeyPool;
+
+    const app = createModelRoutes(undefined, mockClientKeyPool);
+    const res = await app.request("/v1/models/catalog", {
+      headers: {
+        Authorization: "Bearer test-client-key",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const catalog = (await res.json()) as Array<{ id: string }>;
+    expect(catalog.length).toBe(1);
+    expect(catalog[0].id).toBe("gpt-5.4");
+  });
+});


### PR DESCRIPTION
## Summary
- **Sync Catalog isDefault**: Map `/v1/models/catalog` `isDefault` property dynamically to `config.model.default` when configured, ensuring client model selectors and default models match server configuration.
- **Fix Web Status Loading**: Remove early `if (!data.authenticated) return;` exit in `useStatus` hook so `baseUrl`, `apiKey`, and models catalog are always initialized even when accounts in pool are unauthenticated or empty, preventing code snippets from being stuck on `Loading...`.