### PR TITLE
feat(server): support explicit cors_allow_null_origin for local desktop webviews (#700)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,6 +32,7 @@ server:
   port: 8080
   proxy_api_key: null
   trust_proxy: false
+  cors_allow_null_origin: false
 logs:
   enabled: false
   capacity: 2000

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -203,6 +203,13 @@ export function applyEnvOverrides(
       .map((h: string) => h.trim())
       .filter((h: string) => h.length > 0);
   }
+  const corsAllowNullOriginEnv = process.env.CORS_ALLOW_NULL_ORIGIN?.trim().toLowerCase();
+  const localHasServerCorsAllowNullOrigin = localServerCors !== undefined && "cors_allow_null_origin" in localServerCors;
+  if (corsAllowNullOriginEnv !== undefined && !localHasServerCorsAllowNullOrigin) {
+    if (!raw.server) raw.server = {};
+    (raw.server as Record<string, unknown>).cors_allow_null_origin =
+      corsAllowNullOriginEnv === "true" || corsAllowNullOriginEnv === "1";
+  }
   const serverHostEnv = process.env.CODEX_PROXY_HOST?.trim();
   const localServerHost = localOverrides?.server as Record<string, unknown> | undefined;
   const localHasServerHost = localServerHost !== undefined && "host" in localServerHost;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -120,6 +120,7 @@ export const ConfigSchema = z.object({
     }, {
       message: "Invalid hostname format. Use bare hostnames like 'example.com' or '192.168.1.1'",
     })).default([]),
+    cors_allow_null_origin: z.boolean().default(false),
   }),
   logs: z.object({
     enabled: z.boolean().default(false),

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -45,6 +45,9 @@ function isCorsEnabledPath(path: string): boolean {
 
 export function getAllowedOrigin(origin: string | undefined): string | null {
   if (!origin) return null;
+  if (origin === "null") {
+    return getConfig().server.cors_allow_null_origin ? "null" : null;
+  }
   try {
     const url = new URL(origin);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;

--- a/src/ollama/bridge.ts
+++ b/src/ollama/bridge.ts
@@ -8,6 +8,7 @@ export interface OllamaBridgeOptions {
   proxyApiKey: string | null;
   version: string;
   disableVision: boolean;
+  corsAllowNullOrigin?: boolean;
 }
 
 interface ModelInfo {
@@ -91,9 +92,12 @@ function getString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function getAllowedCorsOrigin(request?: Request): string | null {
+function getAllowedCorsOrigin(request?: Request, corsAllowNullOrigin = false): string | null {
   const origin = request?.headers.get("Origin");
   if (!origin) return null;
+  if (origin === "null") {
+    return corsAllowNullOrigin ? "null" : null;
+  }
   try {
     const url = new URL(origin);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
@@ -103,9 +107,9 @@ function getAllowedCorsOrigin(request?: Request): string | null {
   }
 }
 
-function responseHeaders(init: HeadersInit, request?: Request): Headers {
+function responseHeaders(init: HeadersInit, request?: Request, corsAllowNullOrigin = false): Headers {
   const headers = new Headers(init);
-  const origin = getAllowedCorsOrigin(request);
+  const origin = getAllowedCorsOrigin(request, corsAllowNullOrigin);
   if (origin) {
     headers.set("Access-Control-Allow-Origin", origin);
     headers.set("Vary", "Origin");
@@ -153,30 +157,30 @@ function synthesizeCapabilities(info: ModelInfo, disableVision: boolean): string
   return [...capabilities];
 }
 
-function jsonResponse(status: number, body: unknown, request?: Request): Response {
+function jsonResponse(status: number, body: unknown, request?: Request, corsAllowNullOrigin = false): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: responseHeaders({
       "Content-Type": "application/json",
-    }, request),
+    }, request, corsAllowNullOrigin),
   });
 }
 
-function textResponse(status: number, body: string, request?: Request): Response {
+function textResponse(status: number, body: string, request?: Request, corsAllowNullOrigin = false): Response {
   return new Response(body, {
     status,
     headers: responseHeaders({
       "Content-Type": "text/plain; charset=utf-8",
-    }, request),
+    }, request, corsAllowNullOrigin),
   });
 }
 
-function errorResponse(status: number, message: string, request?: Request): Response {
-  return jsonResponse(status, { error: message }, request);
+function errorResponse(status: number, message: string, request?: Request, corsAllowNullOrigin = false): Response {
+  return jsonResponse(status, { error: message }, request, corsAllowNullOrigin);
 }
 
-function corsNoContent(request: Request): Response {
-  const headers = responseHeaders({}, request);
+function corsNoContent(request: Request, corsAllowNullOrigin = false): Response {
+  const headers = responseHeaders({}, request, corsAllowNullOrigin);
   if (request.headers.has("Origin") && !headers.has("Access-Control-Allow-Origin")) {
     return new Response(null, { status: 403 });
   }
@@ -485,9 +489,10 @@ async function streamOllamaChat(
   upstreamResponse: Response,
   body: Record<string, unknown>,
   request: Request,
+  corsAllowNullOrigin = false,
 ): Promise<Response> {
   if (!upstreamResponse.body) {
-    return errorResponse(502, "Upstream response body is empty", request);
+    return errorResponse(502, "Upstream response body is empty", request, corsAllowNullOrigin);
   }
 
   const model = getString(body.model) ?? "unknown";
@@ -603,7 +608,7 @@ async function streamOllamaChat(
       "Content-Type": "application/x-ndjson; charset=utf-8",
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
-    }, request),
+    }, request, corsAllowNullOrigin),
   });
 }
 
@@ -611,9 +616,10 @@ async function handleChat(
   body: Record<string, unknown>,
   upstreamFetch: ReturnType<typeof makeUpstreamFetch>,
   request: Request,
+  corsAllowNullOrigin = false,
 ): Promise<Response> {
   if (typeof body.model !== "string" || !Array.isArray(body.messages)) {
-    return errorResponse(400, "Missing required fields: model, messages", request);
+    return errorResponse(400, "Missing required fields: model, messages", request, corsAllowNullOrigin);
   }
 
   const openAIRequest = buildOpenAIRequest(body);
@@ -624,7 +630,7 @@ async function handleChat(
 
   if (!upstreamResponse.ok || !upstreamResponse.body) {
     const text = await upstreamResponse.text();
-    return errorResponse(upstreamResponse.status || 502, text || "Upstream request failed", request);
+    return errorResponse(upstreamResponse.status || 502, text || "Upstream request failed", request, corsAllowNullOrigin);
   }
 
   if (body.stream === false) {
@@ -653,14 +659,14 @@ async function handleChat(
       prompt_eval_duration: 0,
       eval_count: typeof usage.completion_tokens === "number" ? usage.completion_tokens : 0,
       eval_duration: 0,
-    }, request);
+    }, request, corsAllowNullOrigin);
   }
 
-  return streamOllamaChat(upstreamResponse, body, request);
+  return streamOllamaChat(upstreamResponse, body, request, corsAllowNullOrigin);
 }
 
-async function copyUpstreamResponse(upstreamResponse: Response, request: Request): Promise<Response> {
-  const headers = responseHeaders({}, request);
+async function copyUpstreamResponse(upstreamResponse: Response, request: Request, corsAllowNullOrigin = false): Promise<Response> {
+  const headers = responseHeaders({}, request, corsAllowNullOrigin);
   const contentType = upstreamResponse.headers.get("content-type");
   if (contentType) headers.set("Content-Type", contentType);
   const cacheControl = upstreamResponse.headers.get("cache-control");
@@ -685,6 +691,7 @@ async function proxyOpenAIRequest(
   request: Request,
   pathname: string,
   upstreamFetch: ReturnType<typeof makeUpstreamFetch>,
+  corsAllowNullOrigin = false,
 ): Promise<Response> {
   const rawBody = request.method === "GET" || request.method === "HEAD"
     ? undefined
@@ -699,52 +706,53 @@ async function proxyOpenAIRequest(
     headers,
     body: rawBody && rawBody.length > 0 ? rawBody : undefined,
   });
-  return copyUpstreamResponse(upstreamResponse, request);
+  return copyUpstreamResponse(upstreamResponse, request, corsAllowNullOrigin);
 }
 
 export function createOllamaBridgeApp(options: OllamaBridgeOptions): Hono {
   const app = new Hono();
   const upstreamFetch = makeUpstreamFetch(options);
   const startedAt = new Date().toISOString();
+  const corsAllowNullOrigin = options.corsAllowNullOrigin ?? false;
 
-  app.options("*", (c) => corsNoContent(c.req.raw));
+  app.options("*", (c) => corsNoContent(c.req.raw, corsAllowNullOrigin));
 
-  app.get("/api/version", (c) => jsonResponse(200, { version: options.version }, c.req.raw));
+  app.get("/api/version", (c) => jsonResponse(200, { version: options.version }, c.req.raw, corsAllowNullOrigin));
 
   app.all("/v1/*", async (c) => {
     const search = new URL(c.req.raw.url).search;
     const upstreamPath = c.req.path.replace(/^\/v1/, "");
-    return proxyOpenAIRequest(c.req.raw, `${upstreamPath}${search}`, upstreamFetch);
+    return proxyOpenAIRequest(c.req.raw, `${upstreamPath}${search}`, upstreamFetch, corsAllowNullOrigin);
   });
 
   app.get("/api/tags", async (c) => {
     const catalog = await getCatalog(upstreamFetch);
-    return jsonResponse(200, { models: catalog.map((info) => toOllamaTag(info, startedAt)) }, c.req.raw);
+    return jsonResponse(200, { models: catalog.map((info) => toOllamaTag(info, startedAt)) }, c.req.raw, corsAllowNullOrigin);
   });
 
   app.post("/api/show", async (c) => {
     const body = await readJsonBody(c.req.raw);
     const model = getString(body.model)?.trim();
-    if (!model) return errorResponse(400, "Missing model", c.req.raw);
+    if (!model) return errorResponse(400, "Missing model", c.req.raw, corsAllowNullOrigin);
     const info = await getModelInfo(upstreamFetch, model);
-    return jsonResponse(200, toShowResponse(model, info, startedAt, options.disableVision), c.req.raw);
+    return jsonResponse(200, toShowResponse(model, info, startedAt, options.disableVision), c.req.raw, corsAllowNullOrigin);
   });
 
   app.post("/api/chat", async (c) => {
     const body = await readJsonBody(c.req.raw);
-    return handleChat(body, upstreamFetch, c.req.raw);
+    return handleChat(body, upstreamFetch, c.req.raw, corsAllowNullOrigin);
   });
 
-  app.get("/", (c) => textResponse(200, "codex-proxy ollama bridge", c.req.raw));
+  app.get("/", (c) => textResponse(200, "codex-proxy ollama bridge", c.req.raw, corsAllowNullOrigin));
 
-  app.notFound((c) => errorResponse(404, `Unsupported path: ${c.req.path}`, c.req.raw));
+  app.notFound((c) => errorResponse(404, `Unsupported path: ${c.req.path}`, c.req.raw, corsAllowNullOrigin));
 
   app.onError((error, c) => {
     if (error instanceof OllamaBridgeError) {
-      return errorResponse(error.status, error.message, c.req.raw);
+      return errorResponse(error.status, error.message, c.req.raw, corsAllowNullOrigin);
     }
     const message = error instanceof Error ? error.message : String(error);
-    return errorResponse(500, message, c.req.raw);
+    return errorResponse(500, message, c.req.raw, corsAllowNullOrigin);
   });
 
   return app;

--- a/src/ollama/server.ts
+++ b/src/ollama/server.ts
@@ -119,6 +119,7 @@ export async function startOllamaBridge(
     proxyApiKey: config.server.proxy_api_key,
     version: config.ollama.version,
     disableVision: config.ollama.disable_vision,
+    corsAllowNullOrigin: config.server.cors_allow_null_origin,
   });
 
   try {

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -329,6 +329,7 @@ describe("applyEnvOverrides", () => {
     savedEnv.OLLAMA_BRIDGE_PORT = process.env.OLLAMA_BRIDGE_PORT;
     savedEnv.OLLAMA_BRIDGE_VERSION = process.env.OLLAMA_BRIDGE_VERSION;
     savedEnv.OLLAMA_BRIDGE_DISABLE_VISION = process.env.OLLAMA_BRIDGE_DISABLE_VISION;
+    savedEnv.CORS_ALLOW_NULL_ORIGIN = process.env.CORS_ALLOW_NULL_ORIGIN;
     // Clear
     delete process.env.CODEX_JWT_TOKEN;
     delete process.env.CODEX_PLATFORM;
@@ -342,6 +343,7 @@ describe("applyEnvOverrides", () => {
     delete process.env.OLLAMA_BRIDGE_PORT;
     delete process.env.OLLAMA_BRIDGE_VERSION;
     delete process.env.OLLAMA_BRIDGE_DISABLE_VISION;
+    delete process.env.CORS_ALLOW_NULL_ORIGIN;
   });
 
   afterEach(() => {
@@ -456,4 +458,29 @@ describe("applyEnvOverrides", () => {
       disable_vision: false,
     });
   });
+
+  it("applies CORS_ALLOW_NULL_ORIGIN when not overridden by local.yaml", () => {
+    process.env.CORS_ALLOW_NULL_ORIGIN = "true";
+    const raw = { auth: {}, server: {} } as Record<string, unknown>;
+    applyEnvOverrides(raw, null);
+    expect((raw.server as Record<string, unknown>).cors_allow_null_origin).toBe(true);
+
+    process.env.CORS_ALLOW_NULL_ORIGIN = "1";
+    const raw2 = { auth: {}, server: {} } as Record<string, unknown>;
+    applyEnvOverrides(raw2, null);
+    expect((raw2.server as Record<string, unknown>).cors_allow_null_origin).toBe(true);
+
+    process.env.CORS_ALLOW_NULL_ORIGIN = "false";
+    const raw3 = { auth: {}, server: { cors_allow_null_origin: true } } as Record<string, unknown>;
+    applyEnvOverrides(raw3, null);
+    expect((raw3.server as Record<string, unknown>).cors_allow_null_origin).toBe(false);
+  });
+
+  it("does not override explicit local.yaml cors_allow_null_origin with env", () => {
+    process.env.CORS_ALLOW_NULL_ORIGIN = "true";
+    const raw = { auth: {}, server: { cors_allow_null_origin: false } } as Record<string, unknown>;
+    applyEnvOverrides(raw, { server: { cors_allow_null_origin: false } });
+    expect((raw.server as Record<string, unknown>).cors_allow_null_origin).toBe(false);
+  });
 });
+

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -32,6 +32,7 @@ describe("ConfigSchema", () => {
     expect(result.server.port).toBe(8080);
     expect(result.server.host).toBe("127.0.0.1");
     expect(result.server.proxy_api_key).toBeNull();
+    expect(result.server.cors_allow_null_origin).toBe(false);
     expect(result.auth.rotation_strategy).toBe("least_used");
     expect(result.auth.refresh_concurrency).toBe(2);
     expect(result.auth.max_concurrent_per_account).toBe(3);
@@ -97,7 +98,7 @@ describe("ConfigSchema", () => {
         ],
       },
       auth: { rotation_strategy: "round_robin", max_concurrent_per_account: null },
-      server: { port: 3000, proxy_api_key: "sk-test" },
+      server: { port: 3000, proxy_api_key: "sk-test", cors_allow_null_origin: true },
       session: { ttl_minutes: 120 },
       tls: { force_http11: true, health_check_url: "https://my-health.org" },
       providers: {
@@ -151,6 +152,7 @@ describe("ConfigSchema", () => {
     expect(result.auth.max_concurrent_per_account).toBeNull();
     expect(result.server.port).toBe(3000);
     expect(result.server.proxy_api_key).toBe("sk-test");
+    expect(result.server.cors_allow_null_origin).toBe(true);
     expect(result.tls.force_http11).toBe(true);
     expect(result.tls.health_check_url).toBe("https://my-health.org");
     expect(result.providers?.anthropic?.base_url).toBe("https://my-anthropic.com/v1");

--- a/tests/unit/middleware/cors.test.ts
+++ b/tests/unit/middleware/cors.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { cors } from "@src/middleware/cors.js";
 
 const mocks = vi.hoisted(() => ({
-  getConfig: vi.fn(() => ({ server: { cors: [] as string[] } })),
+  getConfig: vi.fn(() => ({ server: { cors: [] as string[], cors_allow_null_origin: false } })),
 }));
 
 vi.mock("@src/config.js", () => ({
@@ -19,7 +19,7 @@ function createApp(): Hono {
 
 describe("cors middleware", () => {
   beforeEach(() => {
-    mocks.getConfig.mockClear();
+    mocks.getConfig.mockReturnValue({ server: { cors: [], cors_allow_null_origin: false } });
   });
   it("allows loopback origins on API compatibility routes", async () => {
     const app = createApp();
@@ -131,7 +131,7 @@ describe("cors middleware", () => {
     });
 
     it("rejects non-allowlisted non-loopback origins", async () => {
-      mocks.getConfig.mockReturnValue({ server: { cors: ["allowed.com"] } });
+      mocks.getConfig.mockReturnValue({ server: { cors: ["allowed.com"], cors_allow_null_origin: false } });
 
       const app = createApp();
 
@@ -145,6 +145,76 @@ describe("cors middleware", () => {
 
       expect(res.status).toBe(403);
       expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+  });
+
+  describe("cors_allow_null_origin", () => {
+    it("rejects Origin: null by default (when false)", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: [], cors_allow_null_origin: false } });
+
+      const app = createApp();
+
+      const preflight = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "null",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(preflight.status).toBe(403);
+      expect(preflight.headers.get("Access-Control-Allow-Origin")).toBeNull();
+
+      const req = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Origin: "null",
+        },
+      });
+      expect(req.status).toBe(200);
+      expect(req.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("allows Origin: null on API preflight and actual requests when enabled", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: [], cors_allow_null_origin: true } });
+
+      const app = createApp();
+
+      const preflight = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "null",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(preflight.status).toBe(204);
+      expect(preflight.headers.get("Access-Control-Allow-Origin")).toBe("null");
+      expect(preflight.headers.get("Vary")).toBe("Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
+
+      const req = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Origin: "null",
+        },
+      });
+      expect(req.status).toBe(200);
+      expect(req.headers.get("Access-Control-Allow-Origin")).toBe("null");
+      expect(req.headers.get("Vary")).toBe("Origin");
+    });
+
+    it("does not allow non-loopback origins even when cors_allow_null_origin is true", async () => {
+      mocks.getConfig.mockReturnValue({ server: { cors: [], cors_allow_null_origin: true } });
+
+      const app = createApp();
+
+      const preflight = await app.request("/v1/chat/completions", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://evil.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      });
+      expect(preflight.status).toBe(403);
+      expect(preflight.headers.get("Access-Control-Allow-Origin")).toBeNull();
     });
   });
 });

--- a/tests/unit/ollama/bridge.test.ts
+++ b/tests/unit/ollama/bridge.test.ts
@@ -11,12 +11,13 @@ function json(body: unknown, status = 200, headers: HeadersInit = {}): Response 
   });
 }
 
-function createApp(disableVision = false) {
+function createApp(disableVision = false, corsAllowNullOrigin = false) {
   return createOllamaBridgeApp({
     upstreamBaseUrl: "http://upstream.test",
     proxyApiKey: "proxy-secret",
     version: "0.18.3-test",
     disableVision,
+    corsAllowNullOrigin,
   });
 }
 
@@ -72,6 +73,40 @@ describe("Ollama bridge routes", () => {
     });
     expect(externalPreflight.status).toBe(403);
     expect(externalPreflight.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("handles Origin: null according to corsAllowNullOrigin option", async () => {
+    const defaultApp = createApp(false, false);
+
+    const defaultPreflight = await defaultApp.request("/api/chat", {
+      method: "OPTIONS",
+      headers: { Origin: "null" },
+    });
+    expect(defaultPreflight.status).toBe(403);
+    expect(defaultPreflight.headers.get("access-control-allow-origin")).toBeNull();
+
+    const defaultRes = await defaultApp.request("/api/version", {
+      headers: { Origin: "null" },
+    });
+    expect(defaultRes.status).toBe(200);
+    expect(defaultRes.headers.get("access-control-allow-origin")).toBeNull();
+
+    const allowedApp = createApp(false, true);
+
+    const allowedPreflight = await allowedApp.request("/api/chat", {
+      method: "OPTIONS",
+      headers: { Origin: "null" },
+    });
+    expect(allowedPreflight.status).toBe(204);
+    expect(allowedPreflight.headers.get("access-control-allow-origin")).toBe("null");
+    expect(allowedPreflight.headers.get("vary")).toBe("Origin");
+
+    const allowedRes = await allowedApp.request("/api/version", {
+      headers: { Origin: "null" },
+    });
+    expect(allowedRes.status).toBe(200);
+    expect(allowedRes.headers.get("access-control-allow-origin")).toBe("null");
+    expect(allowedRes.headers.get("vary")).toBe("Origin");
   });
 
   it("maps the model catalog to Ollama tags", async () => {


### PR DESCRIPTION
## Summary

Addresses #700. Supports explicit opt-in allowlisting of `Origin: null` requests to accommodate local desktop WebViews / `file://` contexts (such as ONLYOFFICE Desktop AI Agent plugin) when calling OpenAI-compatible, Anthropic, or Ollama bridge endpoints.

## Changes

1. **Config & Schema**:
   - Added `server.cors_allow_null_origin` boolean (default `false`) in `src/config-schema.ts` and `config/default.yaml`.
   - Supported `CORS_ALLOW_NULL_ORIGIN` environment variable parsing in `src/config-loader.ts`.
2. **CORS Middleware**:
   - Updated `getAllowedOrigin` in `src/middleware/cors.ts` to inspect `origin === "null"` and return `"null"` when `cors_allow_null_origin` is enabled.
3. **Ollama Bridge**:
   - Added `corsAllowNullOrigin?: boolean` to `OllamaBridgeOptions` in `src/ollama/bridge.ts`.
   - Wired `config.server.cors_allow_null_origin` through `src/ollama/server.ts`.
   - Handled `Origin: null` in preflight and normal responses according to this option.
4. **Testing**:
   - Unit tests covering default rejection and enabled acceptance for `Origin: null` across API routes, Ollama bridge routes, config schemas, and environment variable loaders.

Closes #700