### PR TITLE
fix(web): use clipboardCopy fallback and prevent false logout on provider 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,7 @@
 - 重构：抽象路由层的 JSON 拦截与 API Key 校验（提取统一的 API Key 提取器 `extractProxyApiKey`；由全局 `errorHandler` 统一拦截 SyntaxError 带来的 JSON 解析失败并返回 400）
 - 更新 `README_EN.md` 中过时的模型推荐说明以匹配最新的模型别名映射（`README_EN.md`）
 
-### Fixed
-
-- 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级，解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 排除 `/auth/api-keys/models` 与 `/auth/dashboard-login` 等非会话过期 401 响应，避免添加第三方 Key 时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
+- 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级（含 `readOnly` 与字号保护适配移动端），解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入并暴露 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 精确基于该响应头判定会话过期，彻底杜绝添加第三方 Key 或非会话 401 响应时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`shared/utils/clipboard.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
 - 修复分发 Key（Client Access Keys）页面创建与编辑弹窗背景透明问题：修正非标准 Tailwind 类名（`bg-surface-light`、`bg-surface-dark`、`border-border-light` 等），采用标准 `bg-white dark:bg-card-dark` 与 `border-slate-200 dark:border-border-dark` 确保弹窗遮罩及背景不透明显示。（`web/src/pages/ClientKeysPage.tsx`）
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级，解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 排除 `/auth/api-keys/models` 与 `/auth/dashboard-login` 等非会话过期 401 响应，避免添加第三方 Key 时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
 - 修复分发 Key（Client Access Keys）页面创建与编辑弹窗背景透明问题：修正非标准 Tailwind 类名（`bg-surface-light`、`bg-surface-dark`、`border-border-light` 等），采用标准 `bg-white dark:bg-card-dark` 与 `border-slate-200 dark:border-border-dark` 确保弹窗遮罩及背景不透明显示。（`web/src/pages/ClientKeysPage.tsx`）
 
 ### Added

--- a/shared/hooks/use-dashboard-auth.test.ts
+++ b/shared/hooks/use-dashboard-auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isNonDashboardSessionEndpoint } from "./use-dashboard-auth.js";
+
+describe("isNonDashboardSessionEndpoint", () => {
+  it("recognizes proxy routes and third-party validation routes as non-dashboard session endpoints", () => {
+    expect(isNonDashboardSessionEndpoint("/auth/api-keys/models")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("http://localhost:8080/auth/api-keys/models")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("/auth/dashboard-login")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("/auth/dashboard-status")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("/v1/chat/completions")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("/v1beta/models")).toBe(true);
+    expect(isNonDashboardSessionEndpoint("/responses")).toBe(true);
+  });
+
+  it("does not classify dashboard protected endpoints as non-dashboard session endpoints", () => {
+    expect(isNonDashboardSessionEndpoint("/auth/accounts")).toBe(false);
+    expect(isNonDashboardSessionEndpoint("/auth/status")).toBe(false);
+    expect(isNonDashboardSessionEndpoint("/admin/rotation-settings")).toBe(false);
+    expect(isNonDashboardSessionEndpoint("/admin/client-keys")).toBe(false);
+  });
+});
+
+describe("installFetchInterceptor", () => {
+  it("dispatches auth-expired when x-dashboard-auth: required is present on 401", async () => {
+    const { installFetchInterceptor, AUTH_EXPIRED_EVENT } = await import("./use-dashboard-auth.js");
+    const eventHandler = vi.fn();
+    const mockOriginalFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "x-dashboard-auth": "required" },
+    }));
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        fetch: mockOriginalFetch,
+        dispatchEvent: eventHandler,
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    installFetchInterceptor();
+    await window.fetch("/auth/accounts");
+
+    expect(eventHandler).toHaveBeenCalled();
+    const event = eventHandler.mock.calls[0][0] as Event;
+    expect(event.type).toBe(AUTH_EXPIRED_EVENT);
+  });
+
+  it("does not dispatch auth-expired when /auth/api-keys/models returns 401 without dashboard-auth header", async () => {
+    const { installFetchInterceptor } = await import("./use-dashboard-auth.js");
+    const eventHandler = vi.fn();
+    const mockOriginalFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: "Failed to fetch models: unauthorized" }), {
+      status: 401,
+    }));
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        fetch: mockOriginalFetch,
+        dispatchEvent: eventHandler,
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    installFetchInterceptor();
+    await window.fetch("/auth/api-keys/models");
+
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+});

--- a/shared/hooks/use-dashboard-auth.test.ts
+++ b/shared/hooks/use-dashboard-auth.test.ts
@@ -1,22 +1,33 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isNonDashboardSessionEndpoint } from "./use-dashboard-auth.js";
+import { isDashboardAuthExpiredResponse } from "./use-dashboard-auth.js";
 
-describe("isNonDashboardSessionEndpoint", () => {
-  it("recognizes proxy routes and third-party validation routes as non-dashboard session endpoints", () => {
-    expect(isNonDashboardSessionEndpoint("/auth/api-keys/models")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("http://localhost:8080/auth/api-keys/models")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("/auth/dashboard-login")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("/auth/dashboard-status")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("/v1/chat/completions")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("/v1beta/models")).toBe(true);
-    expect(isNonDashboardSessionEndpoint("/responses")).toBe(true);
+describe("isDashboardAuthExpiredResponse", () => {
+  it("identifies 401 with x-dashboard-auth: required as expired", () => {
+    const expiredResp = new Response(JSON.stringify({ error: "Dashboard login required" }), {
+      status: 401,
+      headers: { "x-dashboard-auth": "required" },
+    });
+    expect(isDashboardAuthExpiredResponse(expiredResp)).toBe(true);
   });
 
-  it("does not classify dashboard protected endpoints as non-dashboard session endpoints", () => {
-    expect(isNonDashboardSessionEndpoint("/auth/accounts")).toBe(false);
-    expect(isNonDashboardSessionEndpoint("/auth/status")).toBe(false);
-    expect(isNonDashboardSessionEndpoint("/admin/rotation-settings")).toBe(false);
-    expect(isNonDashboardSessionEndpoint("/admin/client-keys")).toBe(false);
+  it("does not classify 401 without x-dashboard-auth header as expired", () => {
+    const provider401 = new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+    });
+    expect(isDashboardAuthExpiredResponse(provider401)).toBe(false);
+  });
+
+  it("does not classify non-401 responses as expired", () => {
+    const okResp = new Response("{}", {
+      status: 200,
+      headers: { "x-dashboard-auth": "required" },
+    });
+    expect(isDashboardAuthExpiredResponse(okResp)).toBe(false);
+
+    const forbiddenResp = new Response("{}", {
+      status: 403,
+    });
+    expect(isDashboardAuthExpiredResponse(forbiddenResp)).toBe(false);
   });
 });
 

--- a/shared/hooks/use-dashboard-auth.ts
+++ b/shared/hooks/use-dashboard-auth.ts
@@ -5,18 +5,9 @@ export type DashboardAuthStatus = "loading" | "login" | "authenticated";
 /** Custom event fired when any fetch receives a 401 from dashboard endpoints. */
 export const AUTH_EXPIRED_EVENT = "codex:auth-expired";
 
-/** Paths or route patterns that are not dashboard-gate session expirations. */
-export function isNonDashboardSessionEndpoint(url: string): boolean {
-  return (
-    url.includes("/v1/") ||
-    url.includes("/v1beta/") ||
-    url.includes("/gemini/") ||
-    url.includes("/responses") ||
-    url.includes("/official-agent/") ||
-    url.includes("/auth/dashboard-login") ||
-    url.includes("/auth/dashboard-status") ||
-    url.includes("/auth/api-keys/models")
-  );
+/** Check whether a response indicates an expired dashboard session. */
+export function isDashboardAuthExpiredResponse(resp: Response): boolean {
+  return resp.status === 401 && resp.headers.get("x-dashboard-auth") === "required";
 }
 
 /**
@@ -31,14 +22,8 @@ export function installFetchInterceptor(): void {
   const originalFetch = window.fetch.bind(window);
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const resp = await originalFetch(input, init);
-    if (resp.status === 401) {
-      const isDashboardAuthRequired = resp.headers.get("x-dashboard-auth") === "required";
-      const url = typeof input === "string" ? input : input instanceof URL ? input.pathname : (input as Request).url;
-      const isNonDashboard = isNonDashboardSessionEndpoint(url);
-
-      if (isDashboardAuthRequired || !isNonDashboard) {
-        window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
-      }
+    if (isDashboardAuthExpiredResponse(resp)) {
+      window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
     }
     return resp;
   };

--- a/shared/hooks/use-dashboard-auth.ts
+++ b/shared/hooks/use-dashboard-auth.ts
@@ -3,14 +3,28 @@ import { useState, useEffect, useCallback } from "preact/hooks";
 export type DashboardAuthStatus = "loading" | "login" | "authenticated";
 
 /** Custom event fired when any fetch receives a 401 from dashboard endpoints. */
-const AUTH_EXPIRED_EVENT = "codex:auth-expired";
+export const AUTH_EXPIRED_EVENT = "codex:auth-expired";
+
+/** Paths or route patterns that are not dashboard-gate session expirations. */
+export function isNonDashboardSessionEndpoint(url: string): boolean {
+  return (
+    url.includes("/v1/") ||
+    url.includes("/v1beta/") ||
+    url.includes("/gemini/") ||
+    url.includes("/responses") ||
+    url.includes("/official-agent/") ||
+    url.includes("/auth/dashboard-login") ||
+    url.includes("/auth/dashboard-status") ||
+    url.includes("/auth/api-keys/models")
+  );
+}
 
 /**
  * Install a one-time global fetch wrapper that detects 401 responses
  * from dashboard-protected endpoints and dispatches an auth-expired event.
  */
 let interceptorInstalled = false;
-function installFetchInterceptor(): void {
+export function installFetchInterceptor(): void {
   if (interceptorInstalled) return;
   interceptorInstalled = true;
 
@@ -18,10 +32,11 @@ function installFetchInterceptor(): void {
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const resp = await originalFetch(input, init);
     if (resp.status === 401) {
-      // Only fire for dashboard endpoints, not for proxy API routes
+      const isDashboardAuthRequired = resp.headers.get("x-dashboard-auth") === "required";
       const url = typeof input === "string" ? input : input instanceof URL ? input.pathname : (input as Request).url;
-      const isProxyApi = url.includes("/v1/") || url.includes("/v1beta/");
-      if (!isProxyApi) {
+      const isNonDashboard = isNonDashboardSessionEndpoint(url);
+
+      if (isDashboardAuthRequired || !isNonDashboard) {
         window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
       }
     }

--- a/shared/utils/__tests__/clipboard.test.ts
+++ b/shared/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { clipboardCopy } from "../clipboard.js";
+
+describe("clipboardCopy", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("safely handles undefined navigator.clipboard in non-secure contexts without throwing", async () => {
+    Object.defineProperty(globalThis, "window", {
+      value: { isSecureContext: false, prompt: vi.fn() },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "document", {
+      value: {
+        createElement: vi.fn(() => ({
+          style: {},
+          value: "",
+          focus: vi.fn(),
+          select: vi.fn(),
+          setSelectionRange: vi.fn(),
+        })),
+        body: {
+          appendChild: vi.fn(),
+          removeChild: vi.fn(),
+        },
+        execCommand: vi.fn(() => true),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(clipboardCopy("secret-token")).resolves.toBe(true);
+  });
+
+  it("uses navigator.clipboard.writeText when secure context and available", async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, "window", {
+      value: { isSecureContext: true },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText: writeTextMock } },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = await clipboardCopy("secret-token");
+    expect(result).toBe(true);
+    expect(writeTextMock).toHaveBeenCalledWith("secret-token");
+  });
+});

--- a/shared/utils/__tests__/clipboard.test.ts
+++ b/shared/utils/__tests__/clipboard.test.ts
@@ -22,6 +22,8 @@ describe("clipboardCopy", () => {
         createElement: vi.fn(() => ({
           style: {},
           value: "",
+          readOnly: false,
+          setAttribute: vi.fn(),
           focus: vi.fn(),
           select: vi.fn(),
           setSelectionRange: vi.fn(),

--- a/shared/utils/clipboard.ts
+++ b/shared/utils/clipboard.ts
@@ -1,7 +1,8 @@
 function fallbackCopy(text: string): boolean {
   const ta = document.createElement("textarea");
   ta.value = text;
-  ta.style.cssText = "position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;opacity:0";
+  ta.readOnly = true;
+  ta.style.cssText = "position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;opacity:0;font-size:16px";
   document.body.appendChild(ta);
   ta.focus();
   ta.select();

--- a/src/middleware/dashboard-auth.ts
+++ b/src/middleware/dashboard-auth.ts
@@ -68,5 +68,6 @@ export async function dashboardAuth(c: Context, next: Next): Promise<Response | 
 
   // Not authenticated — reject
   c.status(401);
+  c.header("X-Dashboard-Auth", "required");
   return c.json({ error: "Dashboard login required" });
 }

--- a/src/middleware/dashboard-auth.ts
+++ b/src/middleware/dashboard-auth.ts
@@ -69,5 +69,6 @@ export async function dashboardAuth(c: Context, next: Next): Promise<Response | 
   // Not authenticated — reject
   c.status(401);
   c.header("X-Dashboard-Auth", "required");
+  c.header("Access-Control-Expose-Headers", "X-Dashboard-Auth");
   return c.json({ error: "Dashboard login required" });
 }

--- a/tests/unit/middleware/dashboard-auth.test.ts
+++ b/tests/unit/middleware/dashboard-auth.test.ts
@@ -119,6 +119,7 @@ describe("dashboard-auth middleware", () => {
     const res = await app.request("/auth/accounts");
     expect(res.status).toBe(401);
     expect(res.headers.get("x-dashboard-auth")).toBe("required");
+    expect(res.headers.get("access-control-expose-headers")).toBe("X-Dashboard-Auth");
     const body = await res.json();
     expect(body.error).toBeTruthy();
   });

--- a/tests/unit/middleware/dashboard-auth.test.ts
+++ b/tests/unit/middleware/dashboard-auth.test.ts
@@ -114,24 +114,27 @@ describe("dashboard-auth middleware", () => {
     }
   });
 
-  it("returns 401 for /auth/accounts without session", async () => {
+  it("returns 401 for /auth/accounts without session and sets X-Dashboard-Auth header", async () => {
     const app = createApp();
     const res = await app.request("/auth/accounts");
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-dashboard-auth")).toBe("required");
     const body = await res.json();
     expect(body.error).toBeTruthy();
   });
 
-  it("returns 401 for /admin/* without session", async () => {
+  it("returns 401 for /admin/* without session and sets X-Dashboard-Auth header", async () => {
     const app = createApp();
     const res = await app.request("/admin/rotation-settings");
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-dashboard-auth")).toBe("required");
   });
 
-  it("returns 401 for /auth/status without session", async () => {
+  it("returns 401 for /auth/status without session and sets X-Dashboard-Auth header", async () => {
     const app = createApp();
     const res = await app.request("/auth/status");
     expect(res.status).toBe(401);
+    expect(res.headers.get("x-dashboard-auth")).toBe("required");
   });
 
   it("passes through with valid session cookie", async () => {

--- a/tests/unit/web/client-keys-page.test.ts
+++ b/tests/unit/web/client-keys-page.test.ts
@@ -17,6 +17,24 @@ describe("ClientKeysPage Web Component", () => {
     expect(source).toContain("createdSecretKey");
     expect(source).toContain("totalCostUsd");
     expect(source).toContain("totalRequests");
+    expect(source).toContain("clipboardCopy");
+    expect(source).not.toContain("navigator.clipboard.writeText");
+  });
+
+  it("ensures LogsPage and UpdateModal use clipboardCopy instead of raw navigator.clipboard", () => {
+    const logsSource = readFileSync(
+      resolve(__dirname, "../../../web/src/pages/LogsPage.tsx"),
+      "utf-8",
+    );
+    expect(logsSource).toContain("clipboardCopy");
+    expect(logsSource).not.toContain("navigator.clipboard.writeText");
+
+    const updateModalSource = readFileSync(
+      resolve(__dirname, "../../../web/src/components/UpdateModal.tsx"),
+      "utf-8",
+    );
+    expect(updateModalSource).toContain("clipboardCopy");
+    expect(updateModalSource).not.toContain("navigator.clipboard.writeText");
   });
 
   it("is registered in App.tsx navigation and main switch", () => {

--- a/web/src/components/UpdateModal.tsx
+++ b/web/src/components/UpdateModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "preact/hooks";
 import { useI18n } from "../../../shared/i18n/context";
+import { clipboardCopy } from "../../../shared/utils/clipboard";
 import type { UpdateStep } from "../../../shared/hooks/use-update-status";
 import type { TranslationKey } from "../../../shared/i18n/translations";
 
@@ -189,7 +190,7 @@ export function UpdateModal({
             ) : mode === "docker" ? (
               <div class="flex flex-col items-end gap-1.5">
                 <button
-                  onClick={() => { navigator.clipboard.writeText("docker compose pull && docker compose up -d"); }}
+                  onClick={() => { void clipboardCopy("docker compose pull && docker compose up -d"); }}
                   class="px-4 py-2 text-xs font-semibold bg-primary-action text-white rounded-lg hover:bg-primary-action-hover transition-colors"
                 >
                   {t("copy")} docker compose pull && docker compose up -d

--- a/web/src/pages/ClientKeysPage.tsx
+++ b/web/src/pages/ClientKeysPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "preact/hooks";
 import type { FunctionalComponent, JSX } from "preact";
 import { useClientKeys } from "../../../shared/hooks/use-client-keys";
 import { useT } from "../../../shared/i18n/context";
+import { clipboardCopy } from "../../../shared/utils/clipboard";
 import type {
   ClientKeyPublicSummary,
   CreateClientKeyInput,
@@ -238,9 +239,9 @@ export const ClientKeysPage: FunctionalComponent<ClientKeysPageProps> = ({
     }
   };
 
-  const handleCopySecret = () => {
+  const handleCopySecret = async () => {
     if (createdSecretKey) {
-      navigator.clipboard.writeText(createdSecretKey);
+      await clipboardCopy(createdSecretKey);
       setCopiedKey(true);
       setTimeout(() => setCopiedKey(false), 2000);
     }

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -3,6 +3,7 @@ import { useT } from "../../../shared/i18n/context";
 import { useLogs, type LogRecord } from "../../../shared/hooks/use-logs";
 import { useSettings } from "../../../shared/hooks/use-settings";
 import { useGeneralSettings } from "../../../shared/hooks/use-general-settings";
+import { clipboardCopy } from "../../../shared/utils/clipboard";
 import { CopyButton } from "../components/CopyButton";
 
 function formatDuration(ms?: number | null): string {
@@ -40,7 +41,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
   const copyDetailsJson = useCallback(async () => {
     if (!logs.selected) return;
     try {
-      await navigator.clipboard.writeText(JSON.stringify(logs.selected, null, 2));
+      await clipboardCopy(JSON.stringify(logs.selected, null, 2));
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading 'writeText')` in `ClientKeysPage`, `LogsPage`, and `UpdateModal` when running in non-secure HTTP / LAN environments by migrating to `clipboardCopy`.
- Fix dashboard false-logout when adding/probing API keys: set `X-Dashboard-Auth: required` header in `dashboardAuth` middleware and ignore non-dashboard 401s (e.g. upstream provider key probe failures on `/auth/api-keys/models`) in `use-dashboard-auth`.

## Tests
- `npm run build` passed.
- `npm test` passed (294 test files, 2872 tests).