### PR TITLE
feat(translation): honor output_config.effort and clamp reasoning effort to model

### DIFF
--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -200,9 +200,11 @@ export function createMessagesRoutes(
       fallbackDefaultTools: ["web_search"],
     });
 
+    const requestId = c.get("requestId") ?? randomUUID().slice(0, 8);
     const codexRequest = translateAnthropicToCodexRequest(req, undefined, {
       injectHostedWebSearch: false,
       mapClaudeCodeWebSearch: !allowUnauthenticated && clientConversationId !== null,
+      requestId,
     });
     if (!allowUnauthenticated) {
       codexRequest.useWebSocket = true;
@@ -222,7 +224,6 @@ export function createMessagesRoutes(
     };
     const fmt = makeAnthropicFormat(wantThinking);
 
-    const requestId = c.get("requestId") ?? randomUUID().slice(0, 8);
     enqueueLogEntry({
       requestId,
       direction: "ingress",

--- a/src/translation/anthropic-to-codex.ts
+++ b/src/translation/anthropic-to-codex.ts
@@ -10,7 +10,7 @@ import type {
 } from "../proxy/codex-api.js";
 import { parseModelName, getModelInfo } from "../models/model-store.js";
 import { getConfig } from "../config.js";
-import { buildInstructions, budgetToEffort, isRecord } from "./shared-utils.js";
+import { buildInstructions, budgetToEffort, clampReasoningEffortToModel, isRecord, isRecognizedReasoningEffort } from "./shared-utils.js";
 import type { ModelConfigOverride } from "./shared-utils.js";
 import {
   anthropicToolsToCodex,
@@ -196,7 +196,12 @@ function contentToInputItems(
 export function translateAnthropicToCodexRequest(
   req: AnthropicMessagesRequest,
   modelConfig?: ModelConfigOverride,
-  options?: { injectHostedWebSearch?: boolean; mapClaudeCodeWebSearch?: boolean },
+  options?: {
+    injectHostedWebSearch?: boolean;
+    mapClaudeCodeWebSearch?: boolean;
+    /** Used only for effort-clamp log correlation; does not affect translation. */
+    requestId?: string;
+  },
 ): CodexResponsesRequest {
   // Extract the user-supplied system prompt (empty when none provided). The
   // synthetic default below is intentionally kept out of `userInstructions` so
@@ -292,14 +297,43 @@ export function translateAnthropicToCodexRequest(
     request.tool_choice = codexToolChoice;
   }
 
-  // Reasoning effort: thinking config > suffix > config default
+  // Reasoning effort: output_config.effort > thinking config > suffix > config default
+  //
+  // Claude Code sends the user's explicit effort selection in
+  // `output_config.effort` (adaptive thinking never carries budget_tokens), so
+  // it takes top priority. The value is validated before use: an empty or
+  // whitespace string must NOT short-circuit the fallback chain (the `??`
+  // operator only handles null/undefined), and an unknown level name must NOT
+  // be fed to clampReasoningEffortToModel to guess a direction — both are
+  // treated as "not provided" so the next source (thinking → suffix → config
+  // default) takes over. A recognized value is trimmed so e.g. `" high "`
+  // resolves to `high` instead of being treated as an unknown level.
+  const explicitEffort = (() => {
+    if (typeof req.output_config?.effort !== "string") return undefined;
+    const trimmed = req.output_config.effort.trim();
+    if (trimmed === "" || !isRecognizedReasoningEffort(trimmed)) return undefined;
+    return trimmed;
+  })();
   const thinkingEffort = mapThinkingToEffort(req.thinking);
-  const effort =
+  const requestedEffort =
+    explicitEffort ??
     thinkingEffort ??
     parsed.reasoningEffort ??
     cfg.default_reasoning_effort;
-  if (effort) {
-    request.reasoning = { effort, summary: "auto" };
+  if (requestedEffort) {
+    // Clamp to the target model's real supported levels — the Codex upstream
+    // stalls/times out (502) on unsupported efforts instead of degrading, and
+    // `supportedReasoningEfforts` model metadata was previously never
+    // consulted. Full rationale in clampReasoningEffortToModel.
+    const clampResult = clampReasoningEffortToModel(requestedEffort, modelInfo);
+    if (clampResult.clamped) {
+      console.warn(
+        `[AnthropicToCodex] rid=${options?.requestId ?? "-"} phase=effort_clamped model=${modelId} ` +
+          `requested=${requestedEffort} clamped_to=${clampResult.effort} ` +
+          `supported=${clampResult.supported.length > 0 ? clampResult.supported.join(",") : "(none declared)"}`,
+      );
+    }
+    request.reasoning = { effort: clampResult.effort, summary: "auto" };
   }
 
   // Service tier: suffix > config default

--- a/src/translation/shared-utils.ts
+++ b/src/translation/shared-utils.ts
@@ -10,6 +10,7 @@ import { getConfig } from "../config.js";
 import type { AppConfig } from "../config.js";
 import { getConfigDir } from "../paths.js";
 import { hasTupleSchemas, convertTupleSchemas } from "./tuple-schema.js";
+import type { CodexModelInfo } from "../models/model-store.js";
 
 /** Subset of model config used by translation functions. */
 export type ModelConfigOverride = Pick<
@@ -77,6 +78,89 @@ export function budgetToEffort(budget: number | undefined): string | undefined {
   if (budget < 8000) return "medium";
   if (budget < 20000) return "high";
   return "xhigh";
+}
+
+/**
+ * Relative ordering of reasoning effort levels — used by
+ * `clampReasoningEffortToModel` to find the closest supported level, and by
+ * `isRecognizedReasoningEffort` to recognize known level names.
+ *
+ * Cross-checked against three real sources: production model metadata
+ * (gpt-5.6-sol / terra advertise low/medium/high/xhigh/max/ultra), the
+ * official effort values in Claude Code's docs, and the `none`/`minimal`
+ * levels already accepted by the request schema. Unknown strings rank -1
+ * (below every real level).
+ */
+const REASONING_EFFORT_RANK: Readonly<Record<string, number>> = {
+  none: 0,
+  minimal: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  xhigh: 5,
+  max: 6,
+  ultra: 7,
+};
+
+/**
+ * Whether a string is a known reasoning effort level name.
+ *
+ * Used by `translateAnthropicToCodexRequest` to validate free-text effort
+ * values (e.g. `output_config.effort`) before feeding them into the priority
+ * chain: unrecognized values are treated as "client did not provide this
+ * field" so the next source in the chain takes over, rather than guessing a
+ * clamp direction for a value we don't understand.
+ */
+export function isRecognizedReasoningEffort(effort: string): boolean {
+  return Object.hasOwn(REASONING_EFFORT_RANK, effort);
+}
+
+export interface ReasoningEffortClampResult {
+  /** The final level to use — equals the input when no clamping happened. */
+  effort: string;
+  /** Whether clamping occurred (effort not in the model's supported list). */
+  clamped: boolean;
+  /** The model's declared supported levels (for diagnostics). */
+  supported: string[];
+}
+
+/**
+ * Clamp a requested reasoning effort to the target model's supported range.
+ *
+ * Why: the Codex upstream neither errors nor degrades when sent an
+ * unsupported effort — the connection stalls and times out (observed 502s on
+ * gpt-5.4-mini + "max"). Now that `output_config.effort` is actually honored
+ * (previously silently stripped by the schema), this hazard became reachable
+ * in practice, so we clamp before sending.
+ *
+ * Strategy: clamp to the *nearest* supported level by rank distance — above
+ * the model's max → clamp to max; below its min → clamp to min; a level that
+ * falls between supported ones → the closer one. Ties go to the LOWER level:
+ * clamping up costs the user money and latency, clamping down only lowers
+ * quality, so when uncertain we never charge the user more.
+ *
+ * Models that declare no supported levels (empty list, e.g. pure image
+ * models) are passed through unchanged — without data we won't pretend to
+ * judge. Unknown level strings (rank -1) resolve to the lowest supported
+ * level, the cheaper direction.
+ */
+export function clampReasoningEffortToModel(
+  effort: string,
+  modelInfo: Pick<CodexModelInfo, "supportedReasoningEfforts"> | undefined,
+): ReasoningEffortClampResult {
+  const supported = (modelInfo?.supportedReasoningEfforts ?? []).map((e) => e.reasoningEffort);
+  if (supported.length === 0 || supported.includes(effort)) {
+    return { effort, clamped: false, supported };
+  }
+  const rankOf = (e: string): number => REASONING_EFFORT_RANK[e] ?? -1;
+  const requestedRank = rankOf(effort);
+  const nearest = [...supported].sort((a, b) => {
+    const distanceDelta = Math.abs(rankOf(a) - requestedRank) - Math.abs(rankOf(b) - requestedRank);
+    if (distanceDelta !== 0) return distanceDelta;
+    // Ties go to the lower level (see function docs).
+    return rankOf(a) - rankOf(b);
+  })[0];
+  return { effort: nearest ?? effort, clamped: true, supported };
 }
 
 /**

--- a/src/types/anthropic.ts
+++ b/src/types/anthropic.ts
@@ -118,6 +118,17 @@ export const AnthropicMessagesRequestSchema = z.object({
       AnthropicThinkingAdaptiveSchema,
     ])
     .optional(),
+  // output_config.effort carries Claude Code's explicitly selected reasoning
+  // effort level. With adaptive thinking Claude Code sends
+  // `thinking: {type:"adaptive"}` without budget_tokens, so the effort level
+  // travels here instead. `.passthrough()` keeps future subfields (format,
+  // task_budget, ...) from being silently stripped the way effort once was.
+  output_config: z
+    .object({
+      effort: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
   // Tool-related fields. Custom tools are converted to Codex function tools;
   // Anthropic hosted web search is converted to Codex hosted web_search.
   tools: z.array(z.union([

--- a/tests/unit/translation/anthropic-to-codex.test.ts
+++ b/tests/unit/translation/anthropic-to-codex.test.ts
@@ -19,6 +19,14 @@ vi.mock("@src/paths.js", () => ({
   getConfigDir: vi.fn(() => "/tmp/test-config"),
 }));
 
+// The clamp/isRecognized mocks below mirror the real implementations' behavior
+// (not stubbed as identity) because the output_config.effort tests depend on
+// their actual semantics: unsupported levels clamp to the nearest supported
+// one, empty/unknown values fall back to the next priority source.
+const REASONING_EFFORT_RANK: Record<string, number> = {
+  none: 0, minimal: 1, low: 2, medium: 3, high: 4, xhigh: 5, max: 6, ultra: 7,
+};
+
 vi.mock("@src/translation/shared-utils.js", () => ({
   buildInstructions: vi.fn((text: string) => text),
   budgetToEffort: vi.fn((budget: number | undefined) => {
@@ -28,6 +36,22 @@ vi.mock("@src/translation/shared-utils.js", () => ({
     if (budget < 20000) return "high";
     return "xhigh";
   }),
+  isRecognizedReasoningEffort: vi.fn((effort: string) => Object.hasOwn(REASONING_EFFORT_RANK, effort)),
+  clampReasoningEffortToModel: vi.fn(
+    (effort: string, modelInfo: { supportedReasoningEfforts?: { reasoningEffort: string }[] } | undefined) => {
+      const supported = (modelInfo?.supportedReasoningEfforts ?? []).map((e) => e.reasoningEffort);
+      if (supported.length === 0 || supported.includes(effort)) {
+        return { effort, clamped: false, supported };
+      }
+      const rankOf = (e: string) => REASONING_EFFORT_RANK[e] ?? -1;
+      const requestedRank = rankOf(effort);
+      const nearest = [...supported].sort((a, b) => {
+        const d = Math.abs(rankOf(a) - requestedRank) - Math.abs(rankOf(b) - requestedRank);
+        return d !== 0 ? d : rankOf(a) - rankOf(b);
+      })[0];
+      return { effort: nearest ?? effort, clamped: true, supported };
+    },
+  ),
 }));
 
 vi.mock("@src/translation/tool-format.js", () => ({
@@ -44,6 +68,43 @@ vi.mock("@src/models/model-store.js", () => ({
   }),
   getModelInfo: vi.fn((id: string) => {
     if (id === "gpt-5.4") return { defaultReasoningEffort: "medium" };
+    // Supports up to xhigh — mirrors real gpt-5.4-mini, exposes the clamp path.
+    if (id === "limited-effort-model") {
+      return {
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "" },
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+          { reasoningEffort: "xhigh", description: "" },
+        ],
+      };
+    }
+    // Supports through max/ultra — mirrors real gpt-5.6-sol.
+    if (id === "full-effort-model") {
+      return {
+        defaultReasoningEffort: "low",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "" },
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+          { reasoningEffort: "xhigh", description: "" },
+          { reasoningEffort: "max", description: "" },
+          { reasoningEffort: "ultra", description: "" },
+        ],
+      };
+    }
+    // Mirrors real gpt-5.4-pro: no low tier — clamps low up to medium, not xhigh.
+    if (id === "no-low-model") {
+      return {
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+          { reasoningEffort: "xhigh", description: "" },
+        ],
+      };
+    }
     return undefined;
   }),
 }));
@@ -472,6 +533,207 @@ describe("translateAnthropicToCodexRequest", () => {
       );
       // adaptive without budget → undefined, no config default → no effort set
       expect(result.reasoning?.effort).toBeUndefined();
+    });
+  });
+
+  // ── output_config.effort ─────────────────────────────────────────────
+  // Real Claude Code sends the user's explicit effort selection in
+  // `output_config.effort` (adaptive thinking never carries budget_tokens).
+  // These tests lock the priority chain and the clamp behavior.
+
+  describe("output_config.effort", () => {
+    it("takes priority over thinking.budget_tokens", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          // budgetToEffort(500) would yield "low"; output_config.effort must win.
+          thinking: { type: "adaptive", budget_tokens: 500 } as never,
+          output_config: { effort: "high" },
+        }),
+      );
+      expect(result.reasoning?.effort).toBe("high");
+    });
+
+    it("applies standalone (real adaptive mode: only output_config, no budget)", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "xhigh" },
+        }),
+      );
+      expect(result.reasoning?.effort).toBe("xhigh");
+    });
+
+    it("does not affect the existing chain when absent", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          thinking: { type: "enabled", budget_tokens: 5000 },
+        }),
+      );
+      expect(result.reasoning?.effort).toBe("medium");
+    });
+
+    it("clamps to the model's max and logs a warning when requested effort is unsupported", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "limited-effort-model",
+            output_config: { effort: "max" },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("xhigh");
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const logged = warnSpy.mock.calls[0]?.[0] as string;
+        expect(logged).toContain("phase=effort_clamped");
+        expect(logged).toContain("requested=max");
+        expect(logged).toContain("clamped_to=xhigh");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("passes through unchanged on models that support the requested effort", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "full-effort-model",
+            output_config: { effort: "max" },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("max");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("passes through unchanged when the model declares no effort metadata", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "totally-unknown-model",
+            output_config: { effort: "ultra" },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("ultra");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("ignores non-string effort and falls back to the next source", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          output_config: { effort: 123 } as never,
+          thinking: { type: "enabled", budget_tokens: 5000 },
+        }),
+      );
+      expect(result.reasoning?.effort).toBe("medium");
+    });
+
+    it("treats empty-string effort as not provided instead of dropping the whole chain", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({
+          output_config: { effort: "" },
+          thinking: { type: "enabled", budget_tokens: 5000 },
+        }),
+      );
+      // Decisive assertion: falls back to thinking's medium, not undefined.
+      expect(result.reasoning?.effort).toBe("medium");
+      expect(result.reasoning?.effort).not.toBeUndefined();
+    });
+
+    it("falls back to the config default when empty-string effort has no next source", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({ output_config: { effort: "" } }),
+        makeModelConfig({ default_reasoning_effort: "medium" }),
+      );
+      expect(result.reasoning?.effort).toBe("medium");
+    });
+
+    it("does not turn whitespace effort into the model's max via clamping", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "full-effort-model",
+            output_config: { effort: "   " },
+            thinking: { type: "enabled", budget_tokens: 5000 },
+          }),
+        );
+        // Decisive: must be thinking's medium, not max (the clamp would produce).
+        expect(result.reasoning?.effort).toBe("medium");
+        expect(result.reasoning?.effort).not.toBe("max");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("trims a valid level with surrounding whitespace (\" high \" → high)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "limited-effort-model",
+            output_config: { effort: " high " },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("high");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("treats an unrecognized level name as not provided and falls back to thinking", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "full-effort-model",
+            output_config: { effort: "banana" },
+            thinking: { type: "enabled", budget_tokens: 5000 },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("medium");
+        expect(result.reasoning?.effort).not.toBe("banana");
+        expect(result.reasoning?.effort).not.toBe("ultra");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("falls back to the config default for unrecognized effort with no next source", () => {
+      const result = translateAnthropicToCodexRequest(
+        makeRequest({ model: "full-effort-model", output_config: { effort: "banana" } }),
+        makeModelConfig({ default_reasoning_effort: "medium" }),
+      );
+      expect(result.reasoning?.effort).toBe("medium");
+    });
+
+    it("clamps low up to the model's min (medium), not its max (xhigh), on models without a low tier", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const result = translateAnthropicToCodexRequest(
+          makeRequest({
+            model: "no-low-model",
+            output_config: { effort: "low" },
+          }),
+        );
+        expect(result.reasoning?.effort).toBe("medium");
+        expect(result.reasoning?.effort).not.toBe("xhigh");
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const logged = warnSpy.mock.calls[0]?.[0] as string;
+        expect(logged).toContain("requested=low");
+        expect(logged).toContain("clamped_to=medium");
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/unit/translation/shared-utils.test.ts
+++ b/tests/unit/translation/shared-utils.test.ts
@@ -17,8 +17,9 @@ vi.mock("@src/config.js", () => ({
   })),
 }));
 
-import { budgetToEffort, buildInstructions } from "@src/translation/shared-utils.js";
+import { budgetToEffort, buildInstructions, clampReasoningEffortToModel, isRecognizedReasoningEffort } from "@src/translation/shared-utils.js";
 import { getConfig } from "@src/config.js";
+import type { CodexModelInfo } from "@src/models/model-store.js";
 
 describe("budgetToEffort", () => {
   it("returns undefined for 0", () => {
@@ -97,5 +98,116 @@ describe("budgetToEffort additional edge cases", () => {
 
   it("returns 'xhigh' for very large budget (100000)", () => {
     expect(budgetToEffort(100000)).toBe("xhigh");
+  });
+});
+
+describe("isRecognizedReasoningEffort", () => {
+  it("recognizes every known level", () => {
+    for (const e of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]) {
+      expect(isRecognizedReasoningEffort(e)).toBe(true);
+    }
+  });
+
+  it("rejects empty strings, case variants, and unknown names", () => {
+    expect(isRecognizedReasoningEffort("")).toBe(false);
+    expect(isRecognizedReasoningEffort("High")).toBe(false); // case-sensitive, no guessing
+    expect(isRecognizedReasoningEffort("banana")).toBe(false);
+  });
+});
+
+describe("clampReasoningEffortToModel", () => {
+  function model(efforts: string[]): Pick<CodexModelInfo, "supportedReasoningEfforts"> {
+    return { supportedReasoningEfforts: efforts.map((e) => ({ reasoningEffort: e, description: "" })) };
+  }
+
+  it("passes through a requested level that is in the supported list", () => {
+    const result = clampReasoningEffortToModel("high", model(["low", "medium", "high", "xhigh"]));
+    expect(result).toEqual({ effort: "high", clamped: false, supported: ["low", "medium", "high", "xhigh"] });
+  });
+
+  it("clamps to the model's max when requested above it", () => {
+    // Real gpt-5.4-mini shape: supports up to xhigh, client asks for max.
+    const result = clampReasoningEffortToModel("max", model(["low", "medium", "high", "xhigh"]));
+    expect(result.effort).toBe("xhigh");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("clamps to the model's min when requested below it", () => {
+    // Real gpt-5.4-pro shape: medium/high/xhigh, no low. Client asking for
+    // the cheapest low must NOT get the most expensive xhigh.
+    const result = clampReasoningEffortToModel("low", model(["medium", "high", "xhigh"]));
+    expect(result.effort).toBe("medium");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("clamps minimal to the model's min too", () => {
+    const result = clampReasoningEffortToModel("minimal", model(["medium", "high", "xhigh"]));
+    expect(result.effort).toBe("medium");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("clamps to the nearest supported level when requested between supported ones", () => {
+    // Model supports only low and xhigh; medium(3) is distance 1 from low(2)
+    // and distance 2 from xhigh(5) → low.
+    const result = clampReasoningEffortToModel("medium", model(["low", "xhigh"]));
+    expect(result.effort).toBe("low");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("breaks rank-distance ties toward the lower level", () => {
+    // Model supports only low and high; medium(3) is distance 1 from both →
+    // must pick low, never charge the user more when uncertain.
+    const result = clampReasoningEffortToModel("medium", model(["low", "high"]));
+    expect(result.effort).toBe("low");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("single-level models always clamp to that one level", () => {
+    // Real gpt-5-2-pro shape: single "medium" level.
+    for (const requested of ["none", "minimal", "low", "high", "xhigh", "max", "ultra"]) {
+      const result = clampReasoningEffortToModel(requested, model(["medium"]));
+      expect(result.effort).toBe("medium");
+      expect(result.clamped).toBe(true);
+    }
+  });
+
+  it("does not clamp when the requested level equals the model's max", () => {
+    const result = clampReasoningEffortToModel("xhigh", model(["low", "medium", "high", "xhigh"]));
+    expect(result.clamped).toBe(false);
+    expect(result.effort).toBe("xhigh");
+  });
+
+  it("passes through max on models that support it", () => {
+    const result = clampReasoningEffortToModel("max", model(["low", "medium", "high", "xhigh", "max", "ultra"]));
+    expect(result.clamped).toBe(false);
+    expect(result.effort).toBe("max");
+  });
+
+  it("passes through unchanged when modelInfo is undefined", () => {
+    const result = clampReasoningEffortToModel("ultra", undefined);
+    expect(result).toEqual({ effort: "ultra", clamped: false, supported: [] });
+  });
+
+  it("passes through unchanged when the supported list is empty", () => {
+    const result = clampReasoningEffortToModel("high", model([]));
+    expect(result).toEqual({ effort: "high", clamped: false, supported: [] });
+  });
+
+  it("finds the nearest level regardless of declaration order", () => {
+    const result = clampReasoningEffortToModel("ultra", model(["xhigh", "low", "high", "medium"]));
+    expect(result.effort).toBe("xhigh");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("clamps unknown level strings to the lowest supported level (cheaper direction)", () => {
+    const result = clampReasoningEffortToModel("banana", model(["low", "medium", "high"]));
+    expect(result.effort).toBe("low");
+    expect(result.clamped).toBe(true);
+  });
+
+  it("clamps unknown strings to the lowest supported level even when the list has no lower tiers", () => {
+    const result = clampReasoningEffortToModel("banana", model(["high", "xhigh"]));
+    expect(result.effort).toBe("high");
+    expect(result.clamped).toBe(true);
   });
 });

--- a/tests/unit/types/anthropic-schema.test.ts
+++ b/tests/unit/types/anthropic-schema.test.ts
@@ -91,4 +91,54 @@ describe("AnthropicMessagesRequestSchema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  // output_config.effort carries Claude Code's explicitly selected reasoning
+  // effort. It must survive schema parsing (zod objects silently strip
+  // undeclared fields), otherwise the user's choice is dropped before the
+  // translation layer ever sees it.
+  describe("output_config", () => {
+    it("preserves output_config.effort instead of stripping it", () => {
+      const result = AnthropicMessagesRequestSchema.safeParse({
+        ...BASE_REQUEST,
+        output_config: { effort: "max" },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output_config?.effort).toBe("max");
+      }
+    });
+
+    it("accepts requests without output_config", () => {
+      const result = AnthropicMessagesRequestSchema.safeParse(BASE_REQUEST);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output_config).toBeUndefined();
+      }
+    });
+
+    it("accepts output_config without effort", () => {
+      const result = AnthropicMessagesRequestSchema.safeParse({
+        ...BASE_REQUEST,
+        output_config: { format: { type: "json_schema" } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("preserves undeclared subfields via passthrough (future-proofing)", () => {
+      const result = AnthropicMessagesRequestSchema.safeParse({
+        ...BASE_REQUEST,
+        output_config: {
+          effort: "high",
+          task_budget: { type: "tokens", total: 64000 },
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.output_config).toEqual({
+          effort: "high",
+          task_budget: { type: "tokens", total: 64000 },
+        });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Claude Code sends the user's explicit reasoning effort selection in `output_config.effort` (adaptive thinking never carries `budget_tokens`). That field wasn't declared on the Anthropic request schema, so zod silently stripped it before the translation layer ever saw it — the user's effort choice was dropped and only `budget_tokens`-derived effort was applied instead. No error, no warning: the request just quietly used a different effort level than the one the client asked for.

Separately, when a resolved effort level isn't supported by the target model, the Codex upstream doesn't reject the request — it stalls and eventually times out with a 502, which is a much worse failure mode than degrading to a supported level.

## Solution

- Declare `output_config.effort` on the Anthropic request schema (with passthrough, so future subfields aren't silently stripped again).
- Give it top priority in the effort resolution chain: `output_config.effort > thinking > suffix > config default`.
- Validate the value: empty/whitespace/unknown level names fall through to the next source in the chain instead of short-circuiting it; a recognized value is trimmed (`" high "` resolves to `"high"`).
- Clamp the resolved effort to the target model's supported levels instead of letting the upstream stall/502 on an unsupported one. Ties clamp to the lower level, so we never silently charge the user for a higher effort than requested when the exact level isn't available.

## Testing

- 14 new unit/integration test cases across `tests/unit/translation/anthropic-to-codex.test.ts` and related files, covering the priority chain, validation fallback, and clamping behavior (including the tie-to-lower-level case).
- Full suite passes: `npx vitest run tests/unit tests/e2e` (266 files / 2675 tests).
- `npx tsc --noEmit` clean.
- `npm run build:web` clean.

Based on the current `dev` branch (`3133ddb`).
