### PR TITLE
fix(web): constrain account proxy selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级（含 `readOnly` 与字号保护适配移动端），解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入并暴露 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 精确基于该响应头判定会话过期，彻底杜绝添加第三方 Key 或非会话 401 响应时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`shared/utils/clipboard.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
 - 修复分发 Key（Client Access Keys）页面创建与编辑弹窗背景透明问题：修正非标准 Tailwind 类名（`bg-surface-light`、`bg-surface-dark`、`border-border-light` 等），采用标准 `bg-white dark:bg-card-dark` 与 `border-slate-200 dark:border-border-dark` 确保弹窗遮罩及背景不透明显示。（`web/src/pages/ClientKeysPage.tsx`）
 
+### Fixed
+
+- 修复首页已连接账户卡片的代理选择器在窄屏下横向溢出（`web/src/components/AccountCard.tsx`）
+
 ### Added
 
 - 自定义 API Key 新增可选 `codex-responses` wire：针对要求 Codex 客户端上下文的标准 Responses API 上游，使用 Bearer API key、Codex 会话/窗口/安装实例元数据与 SSE；不改变现有 `chat` / `responses` 默认行为，也不支持 Embeddings。

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -457,14 +457,14 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
 
       {/* Proxy selector */}
       {proxies && onProxyChange && (
-        <div class="flex items-center justify-between text-[0.78rem] mt-2 pt-2 border-t border-slate-100 dark:border-border-dark">
-          <span class="text-slate-500 dark:text-text-dim">{t("proxyAssignment")}</span>
+        <div class="flex min-w-0 items-center justify-between gap-3 text-[0.78rem] mt-2 pt-2 border-t border-slate-100 dark:border-border-dark">
+          <span class="shrink-0 text-slate-500 dark:text-text-dim">{t("proxyAssignment")}</span>
           <select
             value={account.proxyId || "global"}
             onChange={(e) =>
               onProxyChange(account.id, (e.target as HTMLSelectElement).value)
             }
-            class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-border-dark bg-white dark:bg-bg-dark text-slate-700 dark:text-text-main focus:outline-none focus:ring-1 focus:ring-primary cursor-pointer"
+            class="min-w-0 w-0 flex-1 text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-border-dark bg-white dark:bg-bg-dark text-slate-700 dark:text-text-main focus:outline-none focus:ring-1 focus:ring-primary cursor-pointer"
           >
             <option value="global">{t("globalDefault")}</option>
             <option value="direct">{t("directNoProxy")}</option>


### PR DESCRIPTION
## Summary

修复首页已连接账户卡片中的代理选择器在窄屏下横向溢出的问题。通过补充 flex 收缩约束，使选择器始终限制在卡片可用宽度内。

Fix the proxy selector overflow in connected account cards on narrow screens by adding flex shrink constraints so the selector stays within the card width.

## Changes

- 为代理选择器行增加 `min-w-0` 和间距约束（`web/src/components/AccountCard.tsx`）
- 为代理标签增加 `shrink-0`
- 使代理选择器使用 `min-w-0 w-0 flex-1`
- 更新 CHANGELOG

## Test Plan

- [x] `npm run test:web`
- [x] `npm run build`
- [x] 使用真实账号和代理数据在桌面端、390px 移动端验证无横向溢出

## Notes

本地验证实例使用指定配置目录运行于 `http://127.0.0.1:8081/`。

## Linked Issues

无