### PR TITLE
fix(web): hide disabled proxies from selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### Fixed
 
+- 代理选择器不再显示已禁用的代理，批量均分仅使用 active 代理（`web/src/components/{AccountCard,AccountTable,BulkActions,RuleAssign}.tsx`）
 - 修复默认 hosted tools 的协议兼容：按工具 `type` 通用判重，保留 Anthropic Messages 在全局默认列表为空时的 Web Search fallback，基于最终注入后的工具统计图片请求，并将默认 `image_generation` 结果分别转换为 Anthropic `tool_use` 与 Gemini `inlineData`；新增路由、翻译、集成测试及真实上游 Web Search / 图片生成连续 3 次验证。（`src/routes/shared/default-tools.ts`、`src/routes/{chat,gemini,messages,responses}.ts`、`src/translation/codex-to-{anthropic,gemini}.ts`、`tests/{unit,integration,real}`）
 - Retry early upstream `server_error` responses once on a different account before streaming, while preserving already-started streams and formatting errors according to client protocol.
 - 修复 `promote-dev-to-master` 将同一 commit 上历史 Electron release 失败记录误当作当前 CI 失败的问题：晋升门禁现在只读取该 commit 最新的 `ci-quality.yml` 结果，并支持分页读取 workflow runs，避免一次临时发布下载错误在成功重试后永久阻塞 `dev → master`，并补充回归测试（`.github/scripts/check-promote-ci.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/promote-ci-gate.test.ts`）

--- a/web/src/components/AccountCard.test.tsx
+++ b/web/src/components/AccountCard.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Account } from "../../../shared/types";
+import type { Account, ProxyEntry } from "../../../shared/types";
 
 vi.mock("../../../shared/i18n/context", () => ({
   useT: () => (key: string) => key,
@@ -62,6 +62,33 @@ describe("AccountCard Codex fingerprint control", () => {
 
     expect(control.checked).toBe(false);
     expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("AccountCard proxy selector", () => {
+  afterEach(() => cleanup());
+
+  it("does not show disabled proxies", () => {
+    const proxies: ProxyEntry[] = [
+      { id: "active-proxy", name: "Active proxy", url: "http://active", status: "active", health: null, addedAt: "" },
+      { id: "unreachable-proxy", name: "Unreachable proxy", url: "http://unreachable", status: "unreachable", health: null, addedAt: "" },
+      { id: "disabled-proxy", name: "Disabled proxy", url: "http://disabled", status: "disabled", health: null, addedAt: "" },
+    ];
+
+    const { container } = render(
+      <AccountCard
+        account={account()}
+        index={0}
+        onDelete={vi.fn(async () => null)}
+        proxies={proxies}
+        onProxyChange={vi.fn()}
+      />,
+    );
+
+    const optionLabels = Array.from(container.querySelectorAll("select option"), (option) => option.textContent);
+    expect(optionLabels).toContain("Active proxy");
+    expect(optionLabels).toContain("Unreachable proxy");
+    expect(optionLabels).not.toContain("Disabled proxy");
   });
 });
 

--- a/web/src/components/AccountCard.tsx
+++ b/web/src/components/AccountCard.tsx
@@ -469,7 +469,7 @@ export function AccountCard({ account, index, onDelete, proxies, onProxyChange, 
             <option value="global">{t("globalDefault")}</option>
             <option value="direct">{t("directNoProxy")}</option>
             <option value="auto">{t("autoRoundRobin")}</option>
-            {proxies.map((p) => (
+            {proxies.filter((p) => p.status !== "disabled").map((p) => (
               <option key={p.id} value={p.id}>
                 {p.name}
                 {p.health?.exitIp ? ` (${p.health.exitIp})` : ""}

--- a/web/src/components/AccountTable.tsx
+++ b/web/src/components/AccountTable.tsx
@@ -272,7 +272,7 @@ export function AccountTable({
                       <option value="global">{t("globalDefault")}</option>
                       <option value="direct">{t("directNoProxy")}</option>
                       <option value="auto">{t("autoRoundRobin")}</option>
-                      {proxies.map((p) => (
+                      {proxies.filter((p) => p.status !== "disabled").map((p) => (
                         <option key={p.id} value={p.id}>
                           {p.name}
                           {p.health?.exitIp ? ` (${p.health.exitIp})` : ""}

--- a/web/src/components/BulkActions.tsx
+++ b/web/src/components/BulkActions.tsx
@@ -50,7 +50,7 @@ export function BulkActions({
             <option value="global">{t("globalDefault")}</option>
             <option value="direct">{t("directNoProxy")}</option>
             <option value="auto">{t("autoRoundRobin")}</option>
-            {proxies.map((p) => (
+            {proxies.filter((p) => p.status !== "disabled").map((p) => (
               <option key={p.id} value={p.id}>
                 {p.name}
               </option>
@@ -69,7 +69,7 @@ export function BulkActions({
         {/* Even distribute */}
         <button
           onClick={onEvenDistribute}
-          disabled={proxies.length === 0}
+          disabled={!proxies.some((p) => p.status === "active")}
           class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           {t("evenDistribute")}

--- a/web/src/components/ProxyGroupList.tsx
+++ b/web/src/components/ProxyGroupList.tsx
@@ -37,7 +37,7 @@ export function ProxyGroupList({ accounts, proxies, selectedGroup, onSelectGroup
   groups.push({ id: "global", label: t("globalDefault"), count: countMap.get("global") || 0 });
 
   // Proxy entries
-  for (const p of proxies) {
+  for (const p of proxies.filter((proxy) => proxy.status !== "disabled")) {
     groups.push({ id: p.id, label: p.name, count: countMap.get(p.id) || 0 });
   }
 

--- a/web/src/components/RuleAssign.test.tsx
+++ b/web/src/components/RuleAssign.test.tsx
@@ -1,0 +1,33 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from "@testing-library/preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProxyEntry } from "../../../shared/types";
+
+vi.mock("../../../shared/i18n/context", () => ({
+  useT: () => (key: string) => key,
+}));
+
+import { RuleAssign } from "./RuleAssign";
+
+const proxies: ProxyEntry[] = [
+  { id: "active-proxy", name: "Active proxy", url: "http://active", status: "active", health: null, addedAt: "" },
+  { id: "disabled-proxy", name: "Disabled proxy", url: "http://disabled", status: "disabled", health: null, addedAt: "" },
+];
+
+describe("RuleAssign", () => {
+  afterEach(() => cleanup());
+
+  it("does not show disabled proxies as assignment targets", () => {
+    render(
+      <RuleAssign
+        proxies={proxies}
+        selectedCount={1}
+        onAssign={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Active proxy")).toBeTruthy();
+    expect(screen.queryByText("Disabled proxy")).toBeNull();
+  });
+});

--- a/web/src/components/RuleAssign.tsx
+++ b/web/src/components/RuleAssign.tsx
@@ -37,7 +37,9 @@ export function RuleAssign({ proxies, selectedCount, onAssign, onClose }: RuleAs
   const allTargets = [
     { id: "global", label: t("globalDefault"), status: "active" as const },
     { id: "direct", label: t("directNoProxy"), status: "active" as const },
-    ...proxies.map((p) => ({ id: p.id, label: p.name, status: p.status })),
+    ...proxies
+      .filter((p) => p.status !== "disabled")
+      .map((p) => ({ id: p.id, label: p.name, status: p.status })),
   ];
 
   return (

--- a/web/src/pages/ProxySettings.tsx
+++ b/web/src/pages/ProxySettings.tsx
@@ -122,7 +122,7 @@ export function ProxySettings({ embedded }: { embedded?: boolean } = {}) {
               >
                 <option value="__all__">{t("allAccounts")} ({data.accounts.length})</option>
                 <option value="global">{t("globalDefault")}</option>
-                {data.proxies.map((p) => (
+                {data.proxies.filter((p) => p.status !== "disabled").map((p) => (
                   <option key={p.id} value={p.id}>{p.name}</option>
                 ))}
                 <option value="direct">{t("directNoProxy")}</option>


### PR DESCRIPTION
## Summary

代理选择器现在不会显示已禁用的代理，避免用户将新账号或批量操作分配到不可用代理。已有账号的历史绑定不会被自动改写。

Proxy selectors no longer show disabled proxies, preventing new assignments and bulk operations from targeting unavailable proxies. Existing account assignments are not rewritten automatically.

## Changes

- 账号卡片、账号表格和批量分配选择器排除 `disabled` 代理。
- 规则分配目标和移动端代理分组筛选排除 `disabled` 代理。
- 批量均分仅使用 `active` 代理。
- 新增账号卡片与规则分配回归测试。

- Account card, account table, and bulk assignment selectors exclude `disabled` proxies.
- Rule-assignment targets and mobile proxy-group filters exclude `disabled` proxies.
- Even distribution uses `active` proxies only.
- Added regression coverage for account-card and rule-assignment selectors.

## Test Plan

- [x] `npm run build`
- [x] `npx vitest run` in `web/` (11 files, 41 tests)
- [x] `npx tsc --noEmit` in `web/`
- [x] `git diff --check`

## Notes

`unreachable` proxies remain visible for manual selection; only proxies with status `disabled` are hidden.

## Linked Issues

None.