### PR TITLE
fix(web): improve logs dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Dashboard 日志页面完善深色模式适配，补齐筛选控件、统计卡片、详情抽屉和 JSON 代码块的深色状态；复制 JSON 成功后改为绿色反馈（`web/src/pages/LogsPage.tsx`）。
 - 账号持久化从 `accounts.json` 主存储迁移到 `accounts.sqlite`，启动时自动从旧 JSON 迁移并继续保留 `accounts.json` 镜像用于降级/回滚；批量导入改为持久化批处理，避免每个账号同步重写整份 JSON 导致大批量导入卡死。（#657）
 - 重构：消除类型守卫 `isRecord` 的多处重复声明（收拢翻译层与路由层到 `shared-utils.ts`）
 - 重构：合并推理预算映射表 `REASONING_EFFORT_BUDGET`（提取为 `shared-utils.ts` 的公共常量）

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -143,7 +143,9 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
       <div class="flex items-center gap-3 flex-wrap">
         <button
           class={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            logs.state?.enabled ? "bg-primary-container text-primary" : "bg-slate-200 text-slate-600"
+            logs.state?.enabled
+              ? "bg-primary-container text-primary"
+              : "bg-slate-200 dark:bg-border-dark text-slate-600 dark:text-text-dim"
           }`}
           onClick={() => logs.setLogState({ enabled: !logs.state?.enabled })}
         >
@@ -153,10 +155,10 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
         <button
           class={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
             !logs.state?.enabled
-              ? "bg-slate-100 text-slate-400 cursor-not-allowed"
+              ? "bg-slate-100 dark:bg-border-dark/60 text-slate-400 dark:text-text-dim cursor-not-allowed"
               : logs.state?.paused
                 ? "bg-warning-container text-warning"
-                : "bg-slate-200 text-slate-600"
+                : "bg-slate-200 dark:bg-border-dark text-slate-600 dark:text-text-dim"
           }`}
           onClick={() => logs.state?.enabled && logs.setLogState({ paused: !logs.state?.paused })}
           disabled={!logs.state?.enabled}
@@ -171,7 +173,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
               class={`px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
                 logs.direction === dir
                   ? "bg-primary-action text-white shadow-sm"
-                  : "text-slate-600 dark:text-text-dim hover:text-slate-900"
+                  : "text-slate-600 dark:text-text-dim hover:text-slate-900 dark:hover:text-text-main"
               }`}
               onClick={() => logs.setDirection(dir)}
             >
@@ -196,14 +198,14 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
         />
 
         <button
-          class="px-3 py-1.5 rounded-lg text-xs font-medium bg-rose-50 dark:bg-rose-950/40 text-rose-600 dark:text-rose-400 border border-rose-200/60 dark:border-rose-800 hover:bg-rose-100 transition-colors"
+          class="px-3 py-1.5 rounded-lg text-xs font-medium bg-rose-50 dark:bg-rose-950/40 text-rose-600 dark:text-rose-400 border border-rose-200/60 dark:border-rose-800 hover:bg-rose-100 dark:hover:bg-rose-900/60 transition-colors"
           onClick={() => void logs.clearLogs()}
           title={t("logsClear")}
         >
           {t("logsClear")}
         </button>
 
-        <div class="text-xs text-slate-500 font-medium ml-auto">
+        <div class="text-xs text-slate-500 dark:text-text-dim font-medium ml-auto">
           {t("logsCount", { count: logs.total })}
         </div>
       </div>
@@ -211,46 +213,46 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
       {/* Observability Metrics Banner */}
       <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsAvgTtft")}</div>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsAvgTtft")}</div>
           <div class="text-lg font-semibold text-slate-800 dark:text-white mt-1">
             {formatDuration(stats.avgTtft)}
           </div>
         </div>
 
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsAvgSpeed")}</div>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsAvgSpeed")}</div>
           <div class="text-lg font-semibold text-emerald-600 dark:text-emerald-400 mt-1">
             {formatSpeed(stats.avgSpeed)}
           </div>
         </div>
 
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsAvgLatency")}</div>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsAvgLatency")}</div>
           <div class="text-lg font-semibold text-slate-800 dark:text-white mt-1">
             {formatDuration(stats.avgLatency)}
           </div>
         </div>
 
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsTotalCost")}</div>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsTotalCost")}</div>
           <div class="text-lg font-semibold text-amber-600 dark:text-amber-400 mt-1">
             {stats.totalCost > 0 ? `$${stats.totalCost.toFixed(4)}` : "$0.00"}
           </div>
         </div>
 
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsTokens")}</div>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsTokens")}</div>
           <div class="text-lg font-semibold text-slate-800 dark:text-white mt-1">
             {formatTokens(stats.totalInputTokens + stats.totalOutputTokens)}
           </div>
-          <div class="text-[10px] text-slate-400">
+          <div class="text-[10px] text-slate-400 dark:text-text-dim">
             {formatTokens(stats.totalInputTokens)} in / {formatTokens(stats.totalOutputTokens)} out
           </div>
         </div>
 
         <div class="p-3 bg-white dark:bg-bg-dark border border-slate-200 dark:border-border-dark rounded-lg shadow-sm">
-          <div class="text-[11px] text-slate-500 font-medium">{t("logsSuccessRate")}</div>
-          <div class={`text-lg font-semibold mt-1 ${stats.successRate >= 95 ? "text-green-600" : "text-amber-500"}`}>
+          <div class="text-[11px] text-slate-500 dark:text-text-dim font-medium">{t("logsSuccessRate")}</div>
+          <div class={`text-lg font-semibold mt-1 ${stats.successRate >= 95 ? "text-green-600 dark:text-green-400" : "text-amber-500 dark:text-amber-400"}`}>
             {stats.successRate}%
           </div>
         </div>
@@ -262,7 +264,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
         <div class="flex-1 min-w-0">
           <div class="border border-slate-200 dark:border-border-dark rounded-lg overflow-hidden bg-white dark:bg-bg-dark shadow-sm">
             <div class="w-full">
-              <div class="flex items-center text-xs text-slate-500 font-medium px-3 py-2.5 bg-slate-50 dark:bg-bg-dark border-b border-slate-200 dark:border-border-dark gap-2">
+              <div class="flex items-center text-xs text-slate-500 dark:text-text-dim font-medium px-3 py-2.5 bg-slate-50 dark:bg-bg-dark border-b border-slate-200 dark:border-border-dark gap-2">
                 <div class="w-[68px] shrink-0">{t("logsTime")}</div>
                 <div class="w-[38px] shrink-0 text-center">{t("logsStatus")}</div>
                 <div class="w-[42px] shrink-0 text-center">{t("logsDirection")}</div>
@@ -274,10 +276,10 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
               </div>
 
               {logs.loading && (
-                <div class="p-6 text-center text-xs text-slate-500">{t("logsLoading")}</div>
+                <div class="p-6 text-center text-xs text-slate-500 dark:text-text-dim">{t("logsLoading")}</div>
               )}
               {!logs.loading && list.length === 0 && (
-                <div class="p-6 text-center text-xs text-slate-500">{t("logsEmpty")}</div>
+                <div class="p-6 text-center text-xs text-slate-500 dark:text-text-dim">{t("logsEmpty")}</div>
               )}
 
               <div class="max-h-[520px] overflow-y-auto divide-y divide-slate-100 dark:divide-border-dark">
@@ -299,7 +301,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                       }`}
                       onClick={() => logs.selectLog(logs.selected?.id === row.id ? null : row.id)}
                     >
-                      <div class="w-[68px] shrink-0 text-slate-500 font-mono text-[11px] truncate">{row.time}</div>
+                      <div class="w-[68px] shrink-0 text-slate-500 dark:text-text-dim font-mono text-[11px] truncate">{row.time}</div>
                       <div class="w-[38px] shrink-0 text-center">
                         <span class={`inline-block px-1.5 py-0.5 rounded text-[10px] font-mono font-medium ${statusClass}`}>
                           {row.status ?? "-"}
@@ -321,7 +323,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                           {row.model || row.path}
                         </div>
                         {row.model && (
-                          <div class="text-[10px] text-slate-400 truncate">{row.path}</div>
+                          <div class="text-[10px] text-slate-400 dark:text-text-dim truncate">{row.path}</div>
                         )}
                       </div>
                       <div class="w-[58px] shrink-0 font-mono text-right text-slate-600 dark:text-slate-300 text-[11px]">
@@ -343,7 +345,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
 
                 <div class="flex items-center justify-between px-3 py-2.5 border-t border-slate-200 dark:border-border-dark text-xs text-slate-500 bg-slate-50 dark:bg-bg-dark">
                   <button
-                    class="px-2.5 py-1 rounded bg-white dark:bg-border-dark border border-slate-200 dark:border-border-dark disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-50 transition-colors"
+                      class="px-2.5 py-1 rounded bg-white dark:bg-border-dark text-slate-600 dark:text-text-dim border border-slate-200 dark:border-border-dark disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
                     disabled={!logs.hasPrev}
                     onClick={logs.prevPage}
                   >
@@ -351,7 +353,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                   </button>
                   <span class="font-medium">{t("logsPageSummary", { total: logs.total, range: pageInfo })}</span>
                   <button
-                    class="px-2.5 py-1 rounded bg-white dark:bg-border-dark border border-slate-200 dark:border-border-dark disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-50 transition-colors"
+                      class="px-2.5 py-1 rounded bg-white dark:bg-border-dark text-slate-600 dark:text-text-dim border border-slate-200 dark:border-border-dark disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
                     disabled={!logs.hasNext}
                     onClick={logs.nextPage}
                   >
@@ -382,7 +384,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                       class={`px-2 py-0.5 text-[11px] rounded font-medium transition-colors ${
                         detailTab === "formatted"
                           ? "bg-white dark:bg-bg-dark text-primary shadow-sm"
-                          : "text-slate-500 hover:text-slate-900"
+                          : "text-slate-500 dark:text-text-dim hover:text-slate-900 dark:hover:text-text-main"
                       }`}
                       onClick={() => setDetailTab("formatted")}
                     >
@@ -392,7 +394,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                       class={`px-2 py-0.5 text-[11px] rounded font-medium transition-colors ${
                         detailTab === "raw"
                           ? "bg-white dark:bg-bg-dark text-primary shadow-sm"
-                          : "text-slate-500 hover:text-slate-900"
+                          : "text-slate-500 dark:text-text-dim hover:text-slate-900 dark:hover:text-text-main"
                       }`}
                       onClick={() => setDetailTab("raw")}
                     >
@@ -401,7 +403,11 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                   </div>
 
                   <button
-                    class="px-2 py-1 rounded bg-slate-100 dark:bg-border-dark hover:bg-slate-200 text-slate-600 dark:text-text-dim text-[11px] font-medium transition-colors"
+                    class={`px-2 py-1 rounded text-[11px] font-medium transition-colors ${
+                      copied
+                        ? "bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800"
+                        : "bg-slate-100 dark:bg-border-dark text-slate-600 dark:text-text-dim hover:bg-slate-200 dark:hover:bg-slate-700"
+                    }`}
                     onClick={copyDetailsJson}
                   >
                     {copied ? t("logsCopied") : t("logsCopyJson")}
@@ -425,28 +431,28 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                     {/* KPI 4-Card Grid */}
                     <div class="grid grid-cols-2 gap-2">
                       <div class="p-2.5 rounded-lg bg-slate-50 dark:bg-border-dark/30 border border-slate-200/60 dark:border-border-dark">
-                        <div class="text-[10px] text-slate-400 font-medium">{t("logsTtft")}</div>
+                        <div class="text-[10px] text-slate-400 dark:text-text-dim font-medium">{t("logsTtft")}</div>
                         <div class="text-base font-semibold font-mono text-slate-800 dark:text-white mt-0.5">
                           {formatDuration(logs.selected.ttftMs)}
                         </div>
                       </div>
 
                       <div class="p-2.5 rounded-lg bg-slate-50 dark:bg-border-dark/30 border border-slate-200/60 dark:border-border-dark">
-                        <div class="text-[10px] text-slate-400 font-medium">{t("logsSpeed")}</div>
+                        <div class="text-[10px] text-slate-400 dark:text-text-dim font-medium">{t("logsSpeed")}</div>
                         <div class="text-base font-semibold font-mono text-emerald-600 dark:text-emerald-400 mt-0.5">
                           {formatSpeed(logs.selected.tokensPerSecond)}
                         </div>
                       </div>
 
                       <div class="p-2.5 rounded-lg bg-slate-50 dark:bg-border-dark/30 border border-slate-200/60 dark:border-border-dark">
-                        <div class="text-[10px] text-slate-400 font-medium">{t("logsCost")}</div>
+                        <div class="text-[10px] text-slate-400 dark:text-text-dim font-medium">{t("logsCost")}</div>
                         <div class="text-base font-semibold font-mono text-amber-600 dark:text-amber-400 mt-0.5">
                           {formatCost(logs.selected.costUsd)}
                         </div>
                       </div>
 
                       <div class="p-2.5 rounded-lg bg-slate-50 dark:bg-border-dark/30 border border-slate-200/60 dark:border-border-dark">
-                        <div class="text-[10px] text-slate-400 font-medium">{t("logsLatency")}</div>
+                        <div class="text-[10px] text-slate-400 dark:text-text-dim font-medium">{t("logsLatency")}</div>
                         <div class="text-base font-semibold font-mono text-slate-800 dark:text-white mt-0.5">
                           {logs.selected.latencyMs != null ? `${logs.selected.latencyMs}ms` : "-"}
                         </div>
@@ -461,20 +467,20 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                         </div>
                         <div class="grid grid-cols-2 gap-2 text-[11px]">
                           <div>
-                            <span class="text-slate-400">{t("logsPromptTokens")}:</span>{" "}
+                            <span class="text-slate-400 dark:text-text-dim">{t("logsPromptTokens")}:</span>{" "}
                             <span class="font-mono font-medium">{logs.selected.usage.input_tokens ?? 0}</span>
                           </div>
                           <div>
-                            <span class="text-slate-400">{t("logsCompletionTokens")}:</span>{" "}
+                            <span class="text-slate-400 dark:text-text-dim">{t("logsCompletionTokens")}:</span>{" "}
                             <span class="font-mono font-medium">{logs.selected.usage.output_tokens ?? 0}</span>
                           </div>
                           {logs.selected.usage.cached_tokens != null && logs.selected.usage.cached_tokens > 0 && (
                             <div class="col-span-2">
-                              <span class="text-slate-400">{t("logsCachedTokens")}:</span>{" "}
+                              <span class="text-slate-400 dark:text-text-dim">{t("logsCachedTokens")}:</span>{" "}
                               <span class="font-mono font-medium text-primary">
                                 {logs.selected.usage.cached_tokens}
                                 {logs.selected.usage.input_tokens > 0 && (
-                                  <span class="text-xs text-slate-400 ml-1">
+                                  <span class="text-xs text-slate-400 dark:text-text-dim ml-1">
                                     ({((logs.selected.usage.cached_tokens / logs.selected.usage.input_tokens) * 100).toFixed(1)}%)
                                   </span>
                                 )}
@@ -483,7 +489,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                           )}
                           {logs.selected.usage.reasoning_tokens != null && logs.selected.usage.reasoning_tokens > 0 && (
                             <div class="col-span-2">
-                              <span class="text-slate-400">{t("logsReasoningTokens")}:</span>{" "}
+                              <span class="text-slate-400 dark:text-text-dim">{t("logsReasoningTokens")}:</span>{" "}
                               <span class="font-mono font-medium text-indigo-600 dark:text-indigo-400">
                                 {logs.selected.usage.reasoning_tokens}
                               </span>
@@ -499,28 +505,28 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                         {t("logsMetadata")}
                       </div>
                       <div class="flex justify-between py-0.5 border-b border-slate-100 dark:border-border-dark">
-                        <span class="text-slate-400">{t("logsRequestId")}</span>
+                        <span class="text-slate-400 dark:text-text-dim">{t("logsRequestId")}</span>
                         <span class="font-mono text-slate-700 dark:text-slate-200 select-all">{logs.selected.requestId}</span>
                       </div>
                       {logs.selected.model && (
                         <div class="flex justify-between py-0.5 border-b border-slate-100 dark:border-border-dark">
-                          <span class="text-slate-400">{t("logsModel")}</span>
+                          <span class="text-slate-400 dark:text-text-dim">{t("logsModel")}</span>
                           <span class="font-medium text-slate-700 dark:text-slate-200">{logs.selected.model}</span>
                         </div>
                       )}
                       {logs.selected.provider && (
                         <div class="flex justify-between py-0.5 border-b border-slate-100 dark:border-border-dark">
-                          <span class="text-slate-400">{t("logsProvider")}</span>
+                          <span class="text-slate-400 dark:text-text-dim">{t("logsProvider")}</span>
                           <span class="text-slate-700 dark:text-slate-200">{logs.selected.provider}</span>
                         </div>
                       )}
                       <div class="flex justify-between py-0.5 border-b border-slate-100 dark:border-border-dark">
-                        <span class="text-slate-400">{t("logsPath")}</span>
+                        <span class="text-slate-400 dark:text-text-dim">{t("logsPath")}</span>
                         <span class="font-mono text-slate-700 dark:text-slate-200">{logs.selected.method} {logs.selected.path}</span>
                       </div>
                       {logs.selected.stream !== undefined && (
                         <div class="flex justify-between py-0.5">
-                          <span class="text-slate-400">{t("logsStreaming")}</span>
+                          <span class="text-slate-400 dark:text-text-dim">{t("logsStreaming")}</span>
                           <span class="text-slate-700 dark:text-slate-200">
                             {logs.selected.stream ? t("logsStreaming") : t("logsNonStreaming")}
                           </span>
@@ -534,7 +540,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                         <div class="px-3 py-1.5 bg-slate-50 dark:bg-border-dark/50 text-[11px] font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-border-dark flex justify-between items-center">
                           <span>{t("logsRequestPayload")}</span>
                         </div>
-                        <pre class="p-3 bg-slate-900 text-slate-100 text-[11px] font-mono whitespace-pre-wrap overflow-x-auto max-h-48">
+                        <pre class="p-3 bg-slate-900 dark:bg-[#0b1220] text-slate-100 text-[11px] font-mono whitespace-pre-wrap overflow-x-auto max-h-48">
                           {JSON.stringify(logs.selected.request, null, 2)}
                         </pre>
                       </div>
@@ -546,7 +552,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                         <div class="px-3 py-1.5 bg-slate-50 dark:bg-border-dark/50 text-[11px] font-semibold text-slate-700 dark:text-slate-200 border-b border-slate-200 dark:border-border-dark">
                           <span>{t("logsResponsePayload")}</span>
                         </div>
-                        <pre class="p-3 bg-slate-900 text-slate-100 text-[11px] font-mono whitespace-pre-wrap overflow-x-auto max-h-48">
+                        <pre class="p-3 bg-slate-900 dark:bg-[#0b1220] text-slate-100 text-[11px] font-mono whitespace-pre-wrap overflow-x-auto max-h-48">
                           {logs.selected.error
                             ? logs.selected.error
                             : JSON.stringify(logs.selected.response, null, 2)}
@@ -555,7 +561,7 @@ export function LogsPage({ embedded = false }: { embedded?: boolean }) {
                     )}
                   </div>
                 ) : (
-                  <pre class="bg-slate-900 text-slate-100 p-3 rounded-lg text-[11px] font-mono whitespace-pre-wrap overflow-auto max-h-[520px]">
+                  <pre class="bg-slate-900 dark:bg-[#0b1220] text-slate-100 p-3 rounded-lg text-[11px] font-mono whitespace-pre-wrap overflow-auto max-h-[520px]">
                     {JSON.stringify(logs.selected, null, 2)}
                   </pre>
                 )}

--- a/web/src/pages/__tests__/logs.test.tsx
+++ b/web/src/pages/__tests__/logs.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/preact";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/preact";
 import { I18nProvider } from "../../../../shared/i18n/context";
 
 const mockLogs = vi.hoisted(() => ({
@@ -15,6 +15,10 @@ const mockGeneralSettings = vi.hoisted(() => ({
   useGeneralSettings: vi.fn(),
 }));
 
+const mockClipboard = vi.hoisted(() => ({
+  clipboardCopy: vi.fn(async () => true),
+}));
+
 vi.mock("../../../../shared/hooks/use-logs", () => ({
   useLogs: mockLogs.useLogs,
 }));
@@ -25,6 +29,10 @@ vi.mock("../../../../shared/hooks/use-settings", () => ({
 
 vi.mock("../../../../shared/hooks/use-general-settings", () => ({
   useGeneralSettings: mockGeneralSettings.useGeneralSettings,
+}));
+
+vi.mock("../../../../shared/utils/clipboard", () => ({
+  clipboardCopy: mockClipboard.clipboardCopy,
 }));
 
 import { LogsPage } from "../LogsPage";
@@ -152,6 +160,34 @@ describe("LogsPage", () => {
       </I18nProvider>,
     );
     expect(screen.queryByText("Details")).toBeNull();
+  });
+
+  it("shows a green success state after copying JSON", async () => {
+    mockGeneralSettings.useGeneralSettings.mockReturnValue(makeGeneralSettings());
+    mockLogs.useLogs.mockReturnValue(
+      makeLogsState({
+        selected: {
+          id: "1",
+          requestId: "r1",
+          direction: "ingress",
+          ts: "2026-04-15T00:00:01.000Z",
+          method: "POST",
+          path: "/v1/messages",
+          model: "gpt-5.5",
+        },
+      }),
+    );
+
+    renderLogsPage();
+    const copyButton = screen.getByText("Copy JSON").closest("button");
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeTruthy();
+      expect(copyButton?.className).toContain("text-green-700");
+    });
+    expect(mockClipboard.clipboardCopy).toHaveBeenCalledTimes(1);
   });
 
   it("renders zero latency as 0ms", () => {


### PR DESCRIPTION
## Summary

完善 Dashboard 日志页面的深色模式适配，补齐筛选控件、统计卡片、日志表格、详情抽屉、页签、分页和 JSON 代码块的深色状态；复制 JSON 成功后显示绿色反馈，提升深色主题下的可读性和操作反馈。

Improve dark-mode support for the Dashboard Logs page by covering filter controls, KPI cards, the log table, details drawer, tabs, pagination, and JSON code blocks. JSON copy success now uses an explicit green feedback state for better readability and interaction feedback in dark themes.

## Changes

- 完善日志页浅色/深色状态及 hover、disabled 样式：`web/src/pages/LogsPage.tsx`
- 将“Copied! / 已复制!”复制成功状态改为绿色背景、文字和边框：`web/src/pages/LogsPage.tsx`
- 增加复制 JSON 成功态回归测试：`web/src/pages/__tests__/logs.test.tsx`
- 更新未发布变更记录：`CHANGELOG.md`

## Test Plan

- [x] `npm exec -- vitest run src/pages/__tests__/logs.test.tsx`（8 passed）
- [x] `npm run build`
- [x] `git diff --check`
- [ ] 手动在浏览器中切换深色模式并查看日志详情抽屉

## Notes

- 当前分支已 rebase 到最新 `origin/dev`。
- 仓库未安装 pre-push 校验脚本，因此已手动运行完整 `npm run build`。
- This PR does not change backend behavior or public API contracts.