### PR TITLE
ci: build native addon in quality gate before vitest run

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -51,6 +51,28 @@ jobs:
       - name: Build web assets
         run: npm run build:web
 
+      # build.test.ts spins up the bundled server.mjs in a native Node
+      # subprocess, which requires the codex-tls native addon for the current
+      # platform (resolved from native/ via binDir/../native). Commit-shipped
+      # .node binaries only cover win32/darwin, so build linux here.
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: actions/cache@v4
+        with:
+          path: native/target
+          key: native-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('native/Cargo.lock') }}
+          restore-keys: native-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Install native addon dependencies
+        working-directory: native
+        run: npm ci
+
+      - name: Build native addon
+        working-directory: native
+        run: npm run build
+
       - name: Run root vitest test suite
         run: npm test
 


### PR DESCRIPTION
## Problem

`backend-tests` in the quality gate (ubuntu) fails:

```
server.mjs starts up, serves models, accounts, and client-keys via SQLite,
and shuts down cleanly in native Node subprocess
→ subprocess exited 10: Cannot find module 'codex-tls-linux-x64-gnu'
```

Root cause: `packages/electron/__tests__/build.test.ts` (#734) starts the bundled `server.mjs` in a native Node subprocess. The server resolves the `codex-tls` native addon as `<binDir>/../native` and must load `native/codex-tls.linux-x64-gnu.node` on Linux. Only win32/darwin `.node` binaries are committed; nothing builds the linux binding on CI. Pre-existing failure on `dev`.

## Fix

Mirror the native addon build used by `release.yml` into the backend-tests job: rust-toolchain → cargo cache → `npm ci` → `npm run build` (`napi build --platform --release`), which emits `native/codex-tls.linux-x64-gnu.node` on the ubuntu runner so the smoke test can load it.