### PR TITLE
fix(models): support GPT-5.6 max and ultra suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- 修复 GPT-5.6 的 `-max` / `-ultra` 推理后缀未被模型解析器识别的问题，并同步更新中英文 README 的 Pi 配置示例。
 - Docker 镜像版本号显示错误（始终显示 2.0.77 而非实际发布版本）：`docker-publish.yml` 构建时通过 `--build-arg PROXY_VERSION` 将版本注入镜像，`Dockerfile` 将其写入 `ENV PROXY_VERSION`，`getProxyInfo()` 优先读取该环境变量，容器内无 `.git` 时也能正确报告版本。（#677，关联 issue #676）
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ curl http://localhost:8080/v1/chat/completions \
 
 | 模型 ID | 推理等级 | 当前上下文 | 最大上下文 | 最大输出 | 输出 | 说明 |
 |---------|---------|------------|------------|----------|------|------|
-| `gpt-5.6-sol` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 旗舰：复杂推理与编码（默认；`gpt-5.6` 为其别名） |
-| `gpt-5.6-terra` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 智能与成本平衡 |
-| `gpt-5.6-luna` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 高性价比 / 高吞吐 |
+| `gpt-5.6-sol` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 旗舰：复杂推理与编码（默认；`gpt-5.6` 为其别名） |
+| `gpt-5.6-terra` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 智能与成本平衡 |
+| `gpt-5.6-luna` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 高性价比 / 高吞吐 |
 | `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | 文本 | 复杂编码、研究和真实工作流 |
 | `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | 文本 | 日常编码强模型 |
 | `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | — | 128,000 | 文本 | 5.4 轻量版 |
@@ -228,7 +228,7 @@ curl http://localhost:8080/v1/chat/completions \
 | `gpt-oss-20b` | low / medium / high | 131,072 | — | — | 文本 | 开源 20B 模型 |
 | `gpt-image-2` | — | — | — | — | 图像 | 图像生成工具后端（通过 `image_generation` 调用） |
 
-> **后缀**：任意 chat 模型名后追加 `-fast` 启用 Fast 模式，`-high`/`-low` 切换推理等级。例如：`gpt-5.6-sol-fast`、`gpt-5.6-sol-high-fast`。图像模型（`gpt-image-2`）不支持后缀。
+> **后缀**：任意 chat 模型名后追加 `-fast` 启用 Fast 模式，`-high`/`-low`/`-max`/`-ultra` 切换推理等级。例如：`gpt-5.6-sol-fast`、`gpt-5.6-sol-high-fast`、`gpt-5.6-sol-max`、`gpt-5.6-sol-ultra`。图像模型（`gpt-image-2`）不支持后缀。
 >
 > **Plan Routing**：不同 plan（free/plus/team/business）的账号自动路由到各自支持的模型，模型可用性以登录账号对应的 Codex 后端返回为准，不要按旧的 Plus-only 表理解。模型列表由后端动态获取，自动同步；只要模型出现在 Dashboard / `/v1/models/catalog` 中，就可以作为请求里的 `model` 使用。
 >
@@ -463,17 +463,17 @@ aider --model openai/gpt-5.6-sol
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         },
         {
-          "id": "gpt-5.5",
-          "name": "Codex GPT-5.5",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-terra",
+          "name": "Codex GPT-5.6 Terra",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -495,10 +495,10 @@ aider --model openai/gpt-5.6-sol
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -518,10 +518,10 @@ aider --model openai/gpt-5.6-sol
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -532,7 +532,7 @@ aider --model openai/gpt-5.6-sol
 
 启动运行：
 ```bash
-pi --provider codex-proxy --model gpt-5.4
+pi --provider codex-proxy --model gpt-5.6-sol
 ```
 
 ### Ollama 兼容客户端

--- a/README_EN.md
+++ b/README_EN.md
@@ -189,9 +189,9 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 
 | Model ID | Reasoning | Current context | Max context | Max output | Output | Description |
 |----------|-----------|-----------------|-------------|------------|--------|-------------|
-| `gpt-5.6-sol` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 flagship for complex reasoning & coding (default; `gpt-5.6` is an alias) |
-| `gpt-5.6-terra` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 balanced intelligence and cost |
-| `gpt-5.6-luna` | low / medium / high / xhigh | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 cost-efficient / high-throughput |
+| `gpt-5.6-sol` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 flagship for complex reasoning & coding (default; `gpt-5.6` is an alias) |
+| `gpt-5.6-terra` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 balanced intelligence and cost |
+| `gpt-5.6-luna` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 cost-efficient / high-throughput |
 | `gpt-5.5` | low / medium / high / xhigh | 272,000 | 272,000 | 128,000 | text | Complex coding, research, and real-world work |
 | `gpt-5.4` | low / medium / high / xhigh | 272,000 | 1,000,000 | 128,000 | text | Strong model for everyday coding |
 | `gpt-5.4-mini` | low / medium / high / xhigh | 400,000 | — | 128,000 | text | GPT-5.4 lightweight model |
@@ -203,7 +203,7 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 | `gpt-oss-20b` | low / medium / high | 131,072 | — | — | text | Open-source 20B model |
 | `gpt-image-2` | — | — | — | — | image | Image-generation tool backend, invoked via `image_generation` |
 
-> **Suffixes**: Append `-fast` to any chat model for Fast mode, `-high`/`-low` for reasoning effort. E.g. `gpt-5.6-sol-fast`, `gpt-5.6-sol-high-fast`. The image model (`gpt-image-2`) does not take suffixes.
+> **Suffixes**: Append `-fast` to any chat model for Fast mode, and `-high`/`-low`/`-max`/`-ultra` for reasoning effort. E.g. `gpt-5.6-sol-fast`, `gpt-5.6-sol-high-fast`, `gpt-5.6-sol-max`, `gpt-5.6-sol-ultra`. The image model (`gpt-image-2`) does not take suffixes.
 >
 > **Plan Routing**: Accounts on different plans auto-route to the models returned for that account by the Codex backend. Do not treat old Plus-only notes as fixed model access rules. Models are dynamically fetched and auto-synced; if a model appears in the Dashboard or `/v1/models/catalog`, it can be used as the request `model`.
 >
@@ -420,17 +420,17 @@ Edit `~/.pi/agent/models.json`:
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         },
         {
-          "id": "gpt-5.5",
-          "name": "Codex GPT-5.5",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-terra",
+          "name": "Codex GPT-5.6 Terra",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -452,10 +452,10 @@ Edit `~/.pi/agent/models.json`:
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -475,10 +475,10 @@ Edit `~/.pi/agent/models.json`:
       "apiKey": "your-api-key",
       "models": [
         {
-          "id": "gpt-5.4",
-          "name": "Codex GPT-5.4",
-          "contextWindow": 200000,
-          "maxTokens": 8192,
+          "id": "gpt-5.6-sol",
+          "name": "Codex GPT-5.6 Sol",
+          "contextWindow": 1050000,
+          "maxTokens": 128000,
           "input": ["text", "image"]
         }
       ]
@@ -489,7 +489,7 @@ Edit `~/.pi/agent/models.json`:
 
 Run Pi:
 ```bash
-pi --provider codex-proxy --model gpt-5.4
+pi --provider codex-proxy --model gpt-5.6-sol
 ```
 
 ### Ollama-Compatible Clients

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -118,7 +118,7 @@ interface NormalizedModelWithMeta extends CodexModelInfo {
 // ── Constants ────────────────────────────────────────────────────────
 
 const SERVICE_TIER_SUFFIXES = new Set(["fast", "flex"]);
-const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
 /** ChatGPT UI selectors that are not valid Codex model IDs. */
 const CHATGPT_ONLY_MODEL_IDS = new Set(["auto"]);
 

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -437,6 +437,12 @@ aliases: {}
       expect(result.reasoningEffort).toBe("xhigh");
     });
 
+    it.each(["max", "ultra"])("strips -%s suffix as reasoning_effort", (effort) => {
+      const result = parseModelName(`gpt-5.4-${effort}`);
+      expect(result.modelId).toBe("gpt-5.4");
+      expect(result.reasoningEffort).toBe(effort);
+    });
+
     it("strips -low suffix as reasoning_effort", () => {
       const result = parseModelName("gpt-5.4-low");
       expect(result.modelId).toBe("gpt-5.4");
@@ -473,6 +479,8 @@ aliases: {}
     it("accepts known model IDs with suffixes", () => {
       expect(isRecognizedModelName("gpt-5.4-low")).toBe(true);
       expect(isRecognizedModelName("gpt-5.4-high-fast")).toBe(true);
+      expect(isRecognizedModelName("gpt-5.4-max")).toBe(true);
+      expect(isRecognizedModelName("gpt-5.4-ultra-fast")).toBe(true);
     });
 
     it("accepts configured aliases with suffixes", () => {


### PR DESCRIPTION
## Summary

中文：这是 #697 合并后的 follow-up 修复。补齐 GPT-5.6 的 `-max` / `-ultra` 模型后缀解析，避免请求被错误回退到默认模型；同时同步中英文 README 的 Pi 配置示例、上下文/输出上限和推理后缀说明。

English: Follow-up fixes for merged PR #697. GPT-5.6 `-max` / `-ultra` model suffixes are now parsed instead of falling back to the configured default, and the Pi examples in both READMEs are aligned with the GPT-5.6 defaults and limits.

## Changes

- Add `max` and `ultra` to model suffix parsing and recognition, with regression tests in `tests/unit/models/model-store.test.ts`.
- Update GPT-5.6 reasoning-level tables and suffix examples in `README.md` and `README_EN.md`.
- Replace stale GPT-5.4/GPT-5.5 Pi examples with GPT-5.6 values and add the missing Unreleased changelog entry.

## Test Plan

- [x] `vitest run tests/unit/models/model-store.test.ts tests/unit/translation/shared-utils.test.ts` — 84 tests passed.
- [x] `tsc --noEmit` passed.
- [x] `git diff --check HEAD^ HEAD` passed.
- [ ] Full `vitest run` — 280 files passed; 13 CI shell-script tests fail only because the Windows WSL bash bridge strips the `C:\\...` worktree path. The affected tests do not touch the changed model code.

## Notes

- #697 is already merged, so this is a follow-up PR targeting `dev`.
- The local `dev` worktree contains pre-existing uncommitted changes and was not modified.

## Linked Issues

Refs #697