### PR TITLE
fix(routes): reject unrecognized models on responses endpoints instead of silent default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）
 - 修复 GPT-5.6 的 `-max` / `-ultra` 推理后缀未被模型解析器识别的问题，并同步更新中英文 README 的 Pi 配置示例。
 - Docker 镜像版本号显示错误（始终显示 2.0.77 而非实际发布版本）：`docker-publish.yml` 构建时通过 `--build-arg PROXY_VERSION` 将版本注入镜像，`Dockerfile` 将其写入 `ENV PROXY_VERSION`，`getProxyInfo()` 优先读取该环境变量，容器内无 `.git` 时也能正确报告版本。（#677，关联 issue #676）
 

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -666,6 +666,19 @@ export function isRequestableModel(input: string): boolean {
   if (trimmed === "codex") return true;
   const defaultModel = getConfig().model.default;
   if (defaultModel && trimmed === defaultModel) return true;
+
+  // The `codex` sentinel has no catalog entry, so a model built from it with a
+  // known suffix (e.g. `codex-high-fast`, `codex-fast`) would not be found by
+  // isRecognizedModelName. Strip known suffixes first: if the base name is the
+  // sentinel or the configured default model, the suffixed form is requestable
+  // too. Unknown names such as `gpt-9999` still fall through and are rejected.
+  const stripped = stripKnownModelSuffixes(trimmed);
+  if (stripped.modelName !== trimmed) {
+    if (stripped.modelName === "codex" || (defaultModel && stripped.modelName === defaultModel)) {
+      return true;
+    }
+  }
+
   return _instance.isRecognizedModelName(trimmed);
 }
 

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -651,6 +651,24 @@ export function resolveModelId(input: string): string {
   return _instance.resolveModelId(input);
 }
 
+/**
+ * Whether a client-supplied model name is requestable through the default
+ * Codex/account path (as opposed to an api-key/adapter route).
+ *
+ * Treats the "codex" sentinel (used when a client omits the model) and the
+ * configured default model as valid, since both legitimately resolve to the
+ * default model. Any other name that is neither a catalog entry nor an alias
+ * is unrecognised and should be rejected rather than silently defaulted.
+ */
+export function isRequestableModel(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed) return false;
+  if (trimmed === "codex") return true;
+  const defaultModel = getConfig().model.default;
+  if (defaultModel && trimmed === defaultModel) return true;
+  return _instance.isRecognizedModelName(trimmed);
+}
+
 export function isRecognizedModelName(input: string): boolean {
   return _instance.isRecognizedModelName(input);
 }

--- a/src/routes/responses-compact.ts
+++ b/src/routes/responses-compact.ts
@@ -14,7 +14,7 @@ import { sanitizeCodexInputItems } from "../proxy/reasoning-input-sanitizer.js";
 import type { UsageInfo } from "../translation/codex-event-extractor.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
 import { supportsCodexAuxiliaryJson } from "../proxy/upstream-adapter.js";
-import { parseModelName, resolveModelId } from "../models/model-store.js";
+import { parseModelName, resolveModelId, isRequestableModel } from "../models/model-store.js";
 import { handleDirectRequest } from "./shared/direct-request-handler.js";
 import { acquireAccount, releaseAccount } from "./shared/account-acquisition.js";
 import { handleCodexApiError } from "./shared/proxy-error-handler.js";
@@ -72,6 +72,23 @@ export async function handleCompact(
       path: "responses/compact",
       body: directModel === rawModel ? body : { ...body, model: directModel },
       model: directModel,
+    });
+  }
+
+  if (
+    compactRouteMatch?.kind !== "api-key"
+    && compactRouteMatch?.kind !== "adapter"
+    && !isRequestableModel(rawModel)
+  ) {
+    c.status(404);
+    return c.json({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        code: "model_not_found",
+        message: `Model '${rawModel}' not found`,
+        param: "model",
+      },
     });
   }
 

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -20,7 +20,7 @@ import { getConfig } from "../config.js";
 import { apiKeyAuth } from "../middleware/api-key-auth.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { prepareSchema, isRecord } from "../translation/shared-utils.js";
-import { parseModelName, resolveModelId, buildDisplayModelName } from "../models/model-store.js";
+import { parseModelName, resolveModelId, buildDisplayModelName, isRequestableModel } from "../models/model-store.js";
 import { handleProxyRequest } from "./shared/proxy-handler.js";
 import { handleDirectRequest } from "./shared/direct-request-handler.js";
 import type { UpstreamRouter } from "../proxy/upstream-router.js";
@@ -133,8 +133,25 @@ export function createResponsesRoutes(
       });
     }
 
-    const routeMatch = upstreamRouter?.resolveMatch(rawModel);
-    const allowUnauthenticated = routeMatch?.kind === "api-key" || routeMatch?.kind === "adapter";
+    const routeMatch = upstreamRouter?.resolveMatch(rawModel)
+      ?? (isRequestableModel(rawModel)
+        ? { kind: "codex" as const }
+        : { kind: "not-found" as const });
+
+    if (routeMatch.kind === "not-found") {
+      c.status(404);
+      return c.json({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          code: "model_not_found",
+          message: `Model '${rawModel}' not found`,
+          param: "model",
+        },
+      });
+    }
+
+    const allowUnauthenticated = routeMatch.kind === "api-key" || routeMatch.kind === "adapter";
     const authErr = checkAuth(c, accountPool, allowUnauthenticated);
     if (authErr) return authErr;
 

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -58,6 +58,7 @@ import { readFileSync as realReadFileSync } from "fs";
 import {
   loadStaticModels,
   isRecognizedModelName,
+  isRequestableModel,
   parseModelName,
   resolveModelId,
   getModelInfo,
@@ -503,6 +504,35 @@ aliases: {}
       expect(isRecognizedModelName("totally-unknown")).toBe(false);
       expect(isRecognizedModelName("totally-unknown-low")).toBe(false);
       expect(isRecognizedModelName("totally-unknown-high-fast")).toBe(false);
+    });
+  });
+
+  describe("isRequestableModel", () => {
+    it("accepts the codex sentinel and its suffixed forms", () => {
+      expect(isRequestableModel("codex")).toBe(true);
+      expect(isRequestableModel("codex-fast")).toBe(true);
+      expect(isRequestableModel("codex-high-fast")).toBe(true);
+      expect(isRequestableModel("codex-low")).toBe(true);
+    });
+
+    it("accepts the configured default model and its suffixed forms", () => {
+      expect(isRequestableModel("gpt-5.3-codex")).toBe(true);
+      expect(isRequestableModel("gpt-5.3-codex-high-fast")).toBe(true);
+    });
+
+    it("accepts known catalog models and aliases with suffixes", () => {
+      mockConfiguredAliases["my-model"] = "gpt-5.4";
+      loadStaticModels("/tmp/test-config");
+      expect(isRequestableModel("gpt-5.4")).toBe(true);
+      expect(isRequestableModel("gpt-5.4-high-fast")).toBe(true);
+      expect(isRequestableModel("my-model-high")).toBe(true);
+    });
+
+    it("rejects unknown model names", () => {
+      expect(isRequestableModel("")).toBe(false);
+      expect(isRequestableModel("gpt-9999")).toBe(false);
+      expect(isRequestableModel("totally-unknown-high-fast")).toBe(false);
+      expect(isRequestableModel("codex-foo")).toBe(false);
     });
   });
 

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -157,6 +157,23 @@ describe("POST /v1/responses/compact", () => {
     expect(body).toEqual({ output: [{ role: "user", content: "compacted" }] });
   });
 
+  it("rejects an unrecognized model with model_not_found instead of falling back to default", async () => {
+    const res = await app.request("/v1/responses/compact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        input: [{ role: "user", content: "Hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("model_not_found");
+    expect(body.error.param).toBe("model");
+    expect(capturedCompactRequest).toBeNull();
+  });
+
   it("routes compact requests for runtime API-key models to direct upstream", async () => {
     const upstreamRouter = {
       resolveMatch: vi.fn(() => ({ kind: "adapter", adapter: { tag: "custom-upstream" } })),

--- a/tests/unit/routes/responses-default-tools.test.ts
+++ b/tests/unit/routes/responses-default-tools.test.ts
@@ -121,4 +121,25 @@ describe("Responses default_tools injection", () => {
     expect(res.status).toBe(200);
     expect(mockState.capturedReq?.codexRequest.tools).toBeUndefined();
   });
+
+  it("rejects an unrecognized model with model_not_found instead of falling back to default", async () => {
+    const app = createResponsesRoutes(accountPool, undefined, undefined, undefined, clientKeyPool);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer master-key-123",
+      },
+      body: JSON.stringify({
+        model: "gpt-9999",
+        input: [{ role: "user", content: "Hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error?.code).toBe("model_not_found");
+    expect(body.error?.param).toBe("model");
+    expect(mockState.capturedReq).toBeNull();
+  });
 });

--- a/tests/unit/routes/responses-default-tools.test.ts
+++ b/tests/unit/routes/responses-default-tools.test.ts
@@ -142,4 +142,23 @@ describe("Responses default_tools injection", () => {
     expect(body.error?.param).toBe("model");
     expect(mockState.capturedReq).toBeNull();
   });
+
+  it("accepts a suffixed codex sentinel model (codex-high-fast) instead of 404", async () => {
+    const app = createResponsesRoutes(accountPool, undefined, undefined, undefined, clientKeyPool);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer master-key-123",
+      },
+      body: JSON.stringify({
+        model: "codex-high-fast",
+        input: [{ role: "user", content: "Hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockState.capturedReq).toBeTruthy();
+    expect(mockState.capturedReq?.codexRequest.reasoning?.effort).toBe("high");
+  });
 });


### PR DESCRIPTION
## Summary

修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题。现在与 `/v1/chat/completions` 行为一致：未识别的模型返回 `404 model_not_found`，不再悄悄替换成默认模型。

## Changes

- `src/models/model-store.ts`：新增 `isRequestableModel`，识别请求级模型（`codex` 哨兵与配置默认模型视为可请求）。
- `src/routes/responses.ts`：模型验证改用 `isRequestableModel` / `upstreamRouter.resolveMatch`，未识别模型返回 `404 model_not_found`。
- `src/routes/responses-compact.ts`：同理，未识别的模型返回 `404 model_not_found` 而非回退默认。
- 为两个端点补充了拒绝未识别模型的单元测试。

## Test Plan

- [x] `npx vitest run tests/unit/routes/responses-compact.test.ts tests/unit/routes/responses-default-tools.test.ts`（24 个断言全部通过；Windows 上 sqlite 文件锁导致的 `EBUSY` 为既有 flaky 问题，位于 afterAll 清理阶段，与断言无关）

## Linked Issues

Closes #660