### PR TITLE
feat(responses): add client-facing WebSocket support on /v1/responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- 为 `/v1/responses` 端点添加客户端 WebSocket 支持：接受 `ws://<host>:<port>/v1/responses` 的升级请求并用 Bearer 令牌鉴权，将客户端的 `response.create` 帧代理到现有上游 Codex WebSocket 并把响应事件以 JSON 流式回传；HTTP POST + SSE 仍作为回退保持不变，并在关闭路径中一并关闭该 WS 服务器。（#681）
+
 ### Fixed
 
 - 修复 GPT-5.6 的 `-max` / `-ultra` 推理后缀未被模型解析器识别的问题，并同步更新中英文 README 的 Pi 配置示例。

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { dashboardAuth } from "./middleware/dashboard-auth.js";
 import { logCapture } from "./middleware/log-capture.js";
 import { cors } from "./middleware/cors.js";
 
+import type { Server } from "http";
 import type { UpstreamAdapter } from "./proxy/upstream-adapter.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import { createAccountRoutes } from "./routes/accounts.js";
@@ -27,6 +28,7 @@ import { ProxyPool } from "./proxy/proxy-pool.js";
 import { setWsPoolConfig, getWsPool } from "./proxy/ws-pool.js";
 import { createProxyRoutes } from "./routes/proxies.js";
 import { createResponsesRoutes } from "./routes/responses.js";
+import { ResponsesWebSocketServer } from "./routes/responses-websocket.js";
 import { createImagesRoutes } from "./routes/images.js";
 import { startUpdateChecker, stopUpdateChecker } from "./update-checker.js";
 import { startProxyUpdateChecker, stopProxyUpdateChecker, setCloseHandler, getDeployMode } from "./self-update.js";
@@ -268,6 +270,16 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
     port,
   });
 
+  // Accept client WebSocket upgrades on /v1/responses (issue #681). The socket is
+  // only a transport; each response.create frame is re-dispatched through the same
+  // POST handler. HTTP POST+SSE remains the fallback. Must be closed in shutdown.
+  const responsesWebsocket = new ResponsesWebSocketServer({
+    server: server as Server,
+    app,
+    accountPool,
+    clientKeyPool,
+  });
+
   // `serve()` returns synchronously before `listen()` actually binds.
   // Wait for the listening event (or surface bind errors as a real
   // rejection of startServer) so callers' try/catch can react —
@@ -283,6 +295,7 @@ export async function startServer(options?: StartOptions): Promise<ServerHandle>
 
   const close = async (): Promise<void> => {
     await stopOllamaBridge();
+    await responsesWebsocket.close();
     return new Promise((resolve) => {
       server.close(() => {
         stopUpdateChecker();

--- a/src/routes/responses-websocket.ts
+++ b/src/routes/responses-websocket.ts
@@ -34,6 +34,13 @@ const UPGRADE_PATH = "/v1/responses";
 const WS_OPEN = 1;
 
 /**
+ * How long `close()` waits for a graceful per-socket close handshake before
+ * force-terminating remaining clients. Bounds shutdown so half-open or
+ * unreachable peers cannot block `server.close()` indefinitely.
+ */
+const SHUTDOWN_CLOSE_TIMEOUT_MS = 1000;
+
+/**
  * Hop-by-hop / handshake-only headers from the upgrade request that must not be
  * forwarded onto the synthetic POST (Fetch would reject or mis-parse them).
  */
@@ -99,10 +106,33 @@ export class ResponsesWebSocketServer {
       }
     }
     await new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      };
+      // Bound the wait: if a peer never completes the close handshake, force-
+      // terminate it so shutdown cannot block indefinitely.
+      const timer = setTimeout(() => {
+        for (const client of this.wss.clients) {
+          try {
+            client.terminate();
+          } catch {
+            /* already closed */
+          }
+        }
+        done();
+      }, SHUTDOWN_CLOSE_TIMEOUT_MS);
       try {
-        this.wss.close(() => resolve());
+        this.wss.close(() => {
+          clearTimeout(timer);
+          done();
+        });
       } catch {
-        resolve();
+        clearTimeout(timer);
+        done();
       }
     });
   }
@@ -124,8 +154,9 @@ export class ResponsesWebSocketServer {
       return;
     }
 
-    if (!this.authorize(req)) {
-      this.rejectUpgrade(socket, 401, "Unauthorized: invalid proxy API key");
+    const auth = this.authorize(req);
+    if (!auth.allowed) {
+      this.rejectUpgrade(socket, auth.statusCode, auth.message);
       return;
     }
 
@@ -133,25 +164,63 @@ export class ResponsesWebSocketServer {
   }
 
   /** Same auth semantics as the POST route's `apiKeyAuth` middleware. */
-  private authorize(req: IncomingMessage): boolean {
-    const key = this.extractBearerKey(req);
-    if (key && this.accountPool.validateProxyApiKey(key)) return true;
-    if (key && this.clientKeyPool && this.clientKeyPool.getByKey(key) !== undefined) return true;
+  private authorize(req: IncomingMessage): { allowed: boolean; statusCode: number; message: string } {
+    const key = this.extractProxyApiKey(req);
+    if (key && this.accountPool.validateProxyApiKey(key)) {
+      return { allowed: true, statusCode: 0, message: "" };
+    }
+    if (key && this.clientKeyPool) {
+      // Reuse the HTTP middleware's validation so disabled, expired, over-budget,
+      // or token-limited client keys are rejected at the handshake, not later.
+      const validation = this.clientKeyPool.validateAccess(key);
+      if (validation.allowed) {
+        return { allowed: true, statusCode: 0, message: "" };
+      }
+      return {
+        allowed: false,
+        statusCode: validation.statusCode ?? 401,
+        message: validation.message ?? "Unauthorized",
+      };
+    }
     // Passthrough / no-auth mode: no master proxy_api_key is configured.
     const config = getConfig();
-    if (!config?.server?.proxy_api_key) return true;
-    return false;
+    if (!config?.server?.proxy_api_key) {
+      return { allowed: true, statusCode: 0, message: "" };
+    }
+    return { allowed: false, statusCode: 401, message: "Invalid proxy API key" };
   }
 
-  private extractBearerKey(req: IncomingMessage): string | null {
-    const auth = req.headers.authorization;
-    if (!auth) return null;
-    const match = /^Bearer\s+(.+)$/i.exec(auth);
-    return match ? match[1].trim() : null;
+  /**
+   * Extract a proxy API key from the upgrade request, supporting the same
+   * locations as the HTTP routes' `extractProxyApiKey()`: `?key=`,
+   * `x-goog-api-key`, `x-api-key`, and `Authorization: Bearer`.
+   */
+  private extractProxyApiKey(req: IncomingMessage): string | null {
+    let queryKey: string | null = null;
+    try {
+      queryKey = new URL(req.url ?? "/", "http://localhost").searchParams.get("key");
+    } catch {
+      /* fall through to header extraction */
+    }
+    const googKey = this.headerValue(req.headers["x-goog-api-key"]);
+    const xApiKey = this.headerValue(req.headers["x-api-key"]);
+    const authHeader = this.headerValue(req.headers.authorization);
+    const bearerKey = authHeader ? authHeader.replace(/^bearer\s+/i, "").trim() : null;
+    return queryKey ?? googKey ?? xApiKey ?? (bearerKey || null);
+  }
+
+  private headerValue(value: string | string[] | undefined): string | null {
+    if (typeof value === "string" && value.length > 0) return value;
+    if (Array.isArray(value) && value.length > 0) return value[0];
+    return null;
   }
 
   private rejectUpgrade(socket: Duplex, status: number, message: string): void {
-    const reason = status === 401 ? "Unauthorized" : "Not Found";
+    const reason =
+      status === 401 ? "Unauthorized"
+        : status === 429 ? "Too Many Requests"
+          : status === 403 ? "Forbidden"
+            : "Error";
     const body = `${message}\n`;
     socket.write(
       `HTTP/1.1 ${status} ${reason}\r\n` +
@@ -168,14 +237,49 @@ export class ResponsesWebSocketServer {
 
   private handleConnection(ws: WebSocket, req: IncomingMessage): void {
     let busy = false;
+    const abortController = new AbortController();
+
     ws.on("message", (data) => {
       // One in-flight `response.create` per socket at a time.
-      if (busy) return;
+      if (busy) {
+        // Never silently drop a pipelined frame — tell the client the
+        // connection is busy with a structured error so it does not wait
+        // forever for a response that will never arrive.
+        this.sendErrorFrame(
+          ws,
+          JSON.stringify({
+            type: "error",
+            error: {
+              type: "server_error",
+              code: "connection_busy",
+              message: "A response.create is already in progress on this connection",
+            },
+          }),
+        );
+        return;
+      }
       busy = true;
       const raw = typeof data === "string" ? data : (data as Buffer).toString("utf-8");
-      void this.dispatch(ws, req, raw).finally(() => {
+      void this.dispatch(ws, req, raw, abortController.signal).finally(() => {
         busy = false;
       });
+    });
+
+    // A transport/protocol error on this client must not become an uncaught
+    // EventEmitter error (which the process-level handler would rethrow and
+    // could terminate the whole proxy). Clean up only this socket.
+    ws.on("error", () => {
+      try {
+        ws.close(1011, "internal error");
+      } catch {
+        ws.terminate();
+      }
+    });
+
+    // Client disconnect must cancel the in-flight synthetic request so the
+    // upstream stream / account slot is released promptly.
+    ws.on("close", () => {
+      abortController.abort();
     });
   }
 
@@ -183,7 +287,7 @@ export class ResponsesWebSocketServer {
    * Run one `response.create` JSON frame through the exact POST `/v1/responses`
    * handler and stream the resulting SSE events back as WS text frames.
    */
-  private async dispatch(ws: WebSocket, req: IncomingMessage, body: string): Promise<void> {
+  private async dispatch(ws: WebSocket, req: IncomingMessage, body: string, signal: AbortSignal): Promise<void> {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     for (const [key, value] of Object.entries(req.headers)) {
       if (typeof value === "string" && !STRIPPED_HEADERS.has(key)) {
@@ -197,8 +301,11 @@ export class ResponsesWebSocketServer {
         method: "POST",
         headers,
         body,
+        signal,
       });
     } catch (err) {
+      // Abort is expected when the client disconnects mid-request.
+      if (signal.aborted || this.isAbortError(err)) return;
       const message = err instanceof Error ? err.message : String(err);
       this.sendErrorFrame(ws, message);
       return;
@@ -213,35 +320,54 @@ export class ResponsesWebSocketServer {
 
     try {
       for await (const event of parseSSEStream(response)) {
-        if (ws.readyState !== WS_OPEN) break;
+        if (ws.readyState !== WS_OPEN || signal.aborted) break;
         // Forward the JSON payload of each SSE `data:` line.
         ws.send(JSON.stringify(event.data));
       }
     } catch (err) {
+      if (signal.aborted || this.isAbortError(err)) return;
       const message = err instanceof Error ? err.message : String(err);
       this.sendErrorFrame(ws, message);
+    } finally {
+      // Release the upstream connection even when we broke out early.
+      try {
+        await response.body?.cancel();
+      } catch {
+        /* already closed */
+      }
     }
   }
 
-  /** Send an error as a JSON WS frame (best-effort; keeps the socket alive). */
+  /**
+   * Send an error as a typed Responses WebSocket error frame (best-effort;
+   * keeps the socket alive). All error payloads are normalized to
+   * `{type:"error", error:{...}}` so clients can classify terminal errors.
+   */
   private sendErrorFrame(ws: WebSocket, rawMessage: string): void {
-    let payload: unknown = rawMessage;
+    let errorType = "server_error";
+    let code = "proxy_error";
+    let message = rawMessage;
     try {
-      payload = JSON.parse(rawMessage) as unknown;
+      const parsed = JSON.parse(rawMessage) as Record<string, unknown>;
+      const errObj =
+        parsed && typeof parsed.error === "object" && parsed.error !== null
+          ? (parsed.error as Record<string, unknown>)
+          : undefined;
+      message =
+        typeof errObj?.message === "string"
+          ? errObj.message
+          : typeof parsed.message === "string"
+            ? parsed.message
+            : rawMessage;
+      if (errObj && typeof errObj.type === "string") errorType = errObj.type;
+      if (errObj && typeof errObj.code === "string") code = errObj.code;
     } catch {
       /* keep raw string */
     }
-    const text =
-      typeof payload === "string"
-        ? JSON.stringify({
-            type: "error",
-            error: {
-              type: "server_error",
-              code: "proxy_error",
-              message: payload,
-            },
-          })
-        : JSON.stringify(payload);
+    const text = JSON.stringify({
+      type: "error",
+      error: { type: errorType, code, message },
+    });
     if (ws.readyState === WS_OPEN) {
       try {
         ws.send(text);
@@ -249,5 +375,9 @@ export class ResponsesWebSocketServer {
         /* socket already closed */
       }
     }
+  }
+
+  private isAbortError(err: unknown): boolean {
+    return err instanceof Error && err.name === "AbortError";
   }
 }

--- a/src/routes/responses-websocket.ts
+++ b/src/routes/responses-websocket.ts
@@ -1,0 +1,253 @@
+/**
+ * Client-facing WebSocket support for `/v1/responses` (issue #681).
+ *
+ * Newer Codex CLI clients (wire_api="responses") probe `ws://host:port/v1/responses`
+ * via a WebSocket upgrade (GET + `Upgrade: websocket`) and fall back to HTTPS
+ * POST+SSE when the proxy returns 404. This module wires a `ws` WebSocketServer
+ * onto the same underlying node `http.Server` that `@hono/node-server` serves, so
+ * upgrades against `/v1/responses` are accepted.
+ *
+ * The socket itself is only a transport: nothing runs until the client sends a
+ * `response.create` JSON frame. Each frame is dispatched through the EXACT same
+ * POST `/v1/responses` handler (via `app.request()`), which re-runs the shared
+ * account-pool rotation / upstream routing / SSE streaming path. The resulting SSE
+ * events are then forwarded back to the client as WebSocket text frames — each frame
+ * carries the `data:` JSON payload of one event, mirroring what the Codex backend
+ * emits over its own WebSocket. The socket stays open for the next `response.create`
+ * frame (multi-turn / `previous_response_id` resume support).
+ *
+ * HTTP POST + SSE remains the fallback and is untouched.
+ */
+
+import { WebSocket, WebSocketServer } from "ws";
+import type { Server, IncomingMessage } from "http";
+import type { Duplex } from "stream";
+import type { Hono } from "hono";
+import type { AccountPool } from "../auth/account-pool.js";
+import type { ClientKeyPool } from "../auth/client-key-pool.js";
+import { getConfig } from "../config.js";
+import { parseSSEStream } from "../proxy/codex-sse.js";
+
+/** The only path this server accepts upgrades for. */
+const UPGRADE_PATH = "/v1/responses";
+
+const WS_OPEN = 1;
+
+/**
+ * Hop-by-hop / handshake-only headers from the upgrade request that must not be
+ * forwarded onto the synthetic POST (Fetch would reject or mis-parse them).
+ */
+const STRIPPED_HEADERS: ReadonlySet<string> = new Set([
+  "connection",
+  "content-length",
+  "transfer-encoding",
+  "host",
+  "upgrade",
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-extensions",
+  "sec-websocket-protocol",
+]);
+
+export interface ResponsesWebSocketServerOptions {
+  /** The node http.Server that @hono/node-server's serve() returned. */
+  server: Server;
+  /** The mounted Hono app exposing `/v1/responses` (POST). Frames are re-dispatched here. */
+  app: Hono;
+  accountPool: AccountPool;
+  clientKeyPool?: ClientKeyPool;
+}
+
+export class ResponsesWebSocketServer {
+  private readonly server: Server;
+  private readonly app: Hono;
+  private readonly accountPool: AccountPool;
+  private readonly clientKeyPool?: ClientKeyPool;
+  private readonly wss: WebSocketServer;
+  private readonly onUpgradeBound: (req: IncomingMessage, socket: Duplex, head: Buffer) => void;
+  private closed = false;
+
+  constructor(options: ResponsesWebSocketServerOptions) {
+    this.server = options.server;
+    this.app = options.app;
+    this.accountPool = options.accountPool;
+    this.clientKeyPool = options.clientKeyPool;
+
+    this.wss = new WebSocketServer({ noServer: true });
+    this.wss.on("connection", (ws, req) => this.handleConnection(ws, req));
+    this.wss.on("error", (err) => {
+      console.error("[responses-ws] WebSocketServer error:", err);
+    });
+
+    this.onUpgradeBound = (req, socket, head) => this.handleUpgrade(req, socket, head);
+    this.server.on("upgrade", this.onUpgradeBound);
+  }
+
+  /**
+   * Detach the upgrade listener and close all client sockets. Called from the
+   * existing shutdown path in `src/index.ts`.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.server.off("upgrade", this.onUpgradeBound);
+    for (const client of this.wss.clients) {
+      try {
+        client.close(1000, "server shutdown");
+      } catch {
+        /* already closing */
+      }
+    }
+    await new Promise<void>((resolve) => {
+      try {
+        this.wss.close(() => resolve());
+      } catch {
+        resolve();
+      }
+    });
+  }
+
+  // ── Upgrade handling ────────────────────────────────────────────
+
+  private handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): void {
+    let pathname: string;
+    try {
+      pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+    } catch {
+      socket.destroy();
+      return;
+    }
+
+    if (pathname !== UPGRADE_PATH) {
+      // Not ours — destroy so the socket doesn't hang (no other upgrade consumer).
+      socket.destroy();
+      return;
+    }
+
+    if (!this.authorize(req)) {
+      this.rejectUpgrade(socket, 401, "Unauthorized: invalid proxy API key");
+      return;
+    }
+
+    this.wss.handleUpgrade(req, socket, head, (ws) => this.wss.emit("connection", ws, req));
+  }
+
+  /** Same auth semantics as the POST route's `apiKeyAuth` middleware. */
+  private authorize(req: IncomingMessage): boolean {
+    const key = this.extractBearerKey(req);
+    if (key && this.accountPool.validateProxyApiKey(key)) return true;
+    if (key && this.clientKeyPool && this.clientKeyPool.getByKey(key) !== undefined) return true;
+    // Passthrough / no-auth mode: no master proxy_api_key is configured.
+    const config = getConfig();
+    if (!config?.server?.proxy_api_key) return true;
+    return false;
+  }
+
+  private extractBearerKey(req: IncomingMessage): string | null {
+    const auth = req.headers.authorization;
+    if (!auth) return null;
+    const match = /^Bearer\s+(.+)$/i.exec(auth);
+    return match ? match[1].trim() : null;
+  }
+
+  private rejectUpgrade(socket: Duplex, status: number, message: string): void {
+    const reason = status === 401 ? "Unauthorized" : "Not Found";
+    const body = `${message}\n`;
+    socket.write(
+      `HTTP/1.1 ${status} ${reason}\r\n` +
+        "Content-Type: text/plain\r\n" +
+        "Connection: close\r\n" +
+        `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+        "\r\n" +
+        body,
+    );
+    socket.destroy();
+  }
+
+  // ── Connection handling ─────────────────────────────────────────
+
+  private handleConnection(ws: WebSocket, req: IncomingMessage): void {
+    let busy = false;
+    ws.on("message", (data) => {
+      // One in-flight `response.create` per socket at a time.
+      if (busy) return;
+      busy = true;
+      const raw = typeof data === "string" ? data : (data as Buffer).toString("utf-8");
+      void this.dispatch(ws, req, raw).finally(() => {
+        busy = false;
+      });
+    });
+  }
+
+  /**
+   * Run one `response.create` JSON frame through the exact POST `/v1/responses`
+   * handler and stream the resulting SSE events back as WS text frames.
+   */
+  private async dispatch(ws: WebSocket, req: IncomingMessage, body: string): Promise<void> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (typeof value === "string" && !STRIPPED_HEADERS.has(key)) {
+        headers[key.toLowerCase()] = value;
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await this.app.request("/v1/responses", {
+        method: "POST",
+        headers,
+        body,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sendErrorFrame(ws, message);
+      return;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!response.ok || !contentType.includes("text/event-stream")) {
+      const textBody = await response.text();
+      this.sendErrorFrame(ws, textBody);
+      return;
+    }
+
+    try {
+      for await (const event of parseSSEStream(response)) {
+        if (ws.readyState !== WS_OPEN) break;
+        // Forward the JSON payload of each SSE `data:` line.
+        ws.send(JSON.stringify(event.data));
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.sendErrorFrame(ws, message);
+    }
+  }
+
+  /** Send an error as a JSON WS frame (best-effort; keeps the socket alive). */
+  private sendErrorFrame(ws: WebSocket, rawMessage: string): void {
+    let payload: unknown = rawMessage;
+    try {
+      payload = JSON.parse(rawMessage) as unknown;
+    } catch {
+      /* keep raw string */
+    }
+    const text =
+      typeof payload === "string"
+        ? JSON.stringify({
+            type: "error",
+            error: {
+              type: "server_error",
+              code: "proxy_error",
+              message: payload,
+            },
+          })
+        : JSON.stringify(payload);
+    if (ws.readyState === WS_OPEN) {
+      try {
+        ws.send(text);
+      } catch {
+        /* socket already closed */
+      }
+    }
+  }
+}

--- a/tests/unit/routes/responses-websocket.test.ts
+++ b/tests/unit/routes/responses-websocket.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for client-facing WebSocket support on /v1/responses (issue #681).
+ *
+ * Unlike the pure-route tests, these spin up a real http.Server (via
+ * @hono/node-server) bound to the Hono app and attach a ResponsesWebSocketServer,
+ * then drive it with a real `ws` client so upgrade + handshake are exercised.
+ * handleProxyRequest is mocked (repo convention) to return a controlled SSE stream.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { serve } from "@hono/node-server";
+import { WebSocket } from "ws";
+import type { AddressInfo } from "net";
+import type { Server } from "http";
+import { Hono } from "hono";
+import type { HandleProxyRequestOptions } from "@src/routes/shared/proxy-handler-types.js";
+
+// ── Mocks (before imports) ──────────────────────────────────────────
+
+const mockConfig = {
+  server: { proxy_api_key: null as string | null },
+  model: {
+    default: "gpt-5.3-codex",
+    default_reasoning_effort: null,
+    default_service_tier: null,
+    suppress_desktop_directives: false,
+  },
+  auth: {
+    jwt_token: undefined as string | undefined,
+    rotation_strategy: "least_used" as const,
+    rate_limit_backoff_seconds: 60,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/test-responses-ws"),
+  getConfigDir: vi.fn(() => "/tmp/test-responses-ws-config"),
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(() => "models: []"),
+    writeFileSync: vi.fn(),
+    writeFile: vi.fn(
+      (_p: string, _d: string, _e: string, cb: (err: Error | null) => void) =>
+        cb(null),
+    ),
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+vi.mock("js-yaml", () => ({
+  default: {
+    load: vi.fn(() => ({ models: [], aliases: {} })),
+    dump: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("@src/auth/jwt-utils.js", () => ({
+  decodeJwtPayload: vi.fn(() => ({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  })),
+  extractChatGptAccountId: vi.fn((token: string) => `acct-${token}`),
+  extractUserProfile: vi.fn(() => null),
+  isTokenExpired: vi.fn(() => false),
+}));
+
+vi.mock("@src/models/model-fetcher.js", () => ({
+  triggerImmediateRefresh: vi.fn(),
+  startModelRefresh: vi.fn(),
+  stopModelRefresh: vi.fn(),
+}));
+
+vi.mock("@src/utils/retry.js", () => ({
+  withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+// Capture the codexRequest handleProxyRequest receives.
+let capturedCodexRequest: unknown = null;
+let requestedStreams = 0;
+
+function makeSseResponse(sseText: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseText));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+vi.mock("@src/routes/shared/proxy-handler.js", () => ({
+  handleProxyRequest: vi.fn(async (options: HandleProxyRequestOptions) => {
+    capturedCodexRequest = options.req.codexRequest;
+    requestedStreams++;
+    return makeSseResponse(
+      'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1"}}\n\n' +
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi there"}\n\n' +
+        'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1"}}\n\n',
+    );
+  }),
+}));
+
+// ── Imports ─────────────────────────────────────────────────────────
+
+import { AccountPool } from "@src/auth/account-pool.js";
+import { loadStaticModels } from "@src/models/model-store.js";
+import { createResponsesRoutes } from "@src/routes/responses.js";
+import { ResponsesWebSocketServer } from "@src/routes/responses-websocket.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const RESPONSE_CREATE_BODY = JSON.stringify({
+  model: "codex",
+  input: [{ role: "user", content: "Hello" }],
+  stream: true,
+});
+
+/** Open a WS client to /v1/responses. Resolves on open; rejects with
+ *  `{ status }` when the server refuses the upgrade, or the transport error. */
+function connectClient(
+  port: number,
+  authHeader?: string,
+): Promise<{ ws: WebSocket }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/responses`, {
+    headers: authHeader ? { Authorization: authHeader } : {},
+  });
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve({ ws }));
+    ws.once("unexpected-response", (_req, res) =>
+      reject({ status: res.statusCode }),
+    );
+    ws.once("error", reject);
+  });
+}
+
+/** Collect the next N JSON frames received on a socket. */
+function receiveJsonFrames(ws: WebSocket, count: number): Promise<unknown[]> {
+  const frames: unknown[] = [];
+  return new Promise((resolve, reject) => {
+    const onMessage = (data: Buffer | string) => {
+      const raw = typeof data === "string" ? data : data.toString("utf-8");
+      frames.push(JSON.parse(raw));
+      if (frames.length >= count) {
+        cleanup();
+        resolve(frames);
+      }
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`socket closed after ${frames.length}/${count} frames`));
+    };
+    const cleanup = () => {
+      ws.off("message", onMessage);
+      ws.off("close", onClose);
+    };
+    ws.on("message", onMessage);
+    ws.on("close", onClose);
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("client-facing WebSocket on /v1/responses (issue #681)", () => {
+  let pool: AccountPool;
+  let app: Hono;
+  let server: Server;
+  let wsServer: ResponsesWebSocketServer;
+  let port: number;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    capturedCodexRequest = null;
+    requestedStreams = 0;
+    mockConfig.server.proxy_api_key = null;
+    loadStaticModels();
+    pool = new AccountPool();
+    pool.addAccount("test-token-1");
+    app = createResponsesRoutes(pool);
+    const handle = serve({ fetch: app.fetch, hostname: "127.0.0.1", port: 0 });
+    server = handle as unknown as Server;
+    // serve() returns before the listener actually binds (src/index.ts does the
+    // same via awaitServerListening) — wait for the listening event first.
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const addr = server.address() as AddressInfo;
+    port = addr.port;
+    wsServer = new ResponsesWebSocketServer({ server, app, accountPool: pool });
+  });
+
+  afterEach(async () => {
+    await wsServer?.close();
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    pool?.destroy();
+  });
+
+  it("accepts a WebSocket upgrade on /v1/responses", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    const { ws } = await connectClient(port, "Bearer master-key");
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  it("rejects an unauthenticated upgrade with 401", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    await expect(connectClient(port)).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects an upgrade with an invalid Bearer key with 401", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    await expect(connectClient(port, "Bearer wrong-key")).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+
+  it("dispatches a response.create frame and streams events back as WS text frames", async () => {
+    const { ws } = await connectClient(port);
+    const received = receiveJsonFrames(ws, 3);
+    ws.send(RESPONSE_CREATE_BODY);
+    const frames = await received;
+
+    expect(requestedStreams).toBe(1);
+    const req = capturedCodexRequest as Record<string, unknown>;
+    expect(req).toBeDefined();
+    expect(req.model).toBe("gpt-5.3-codex");
+    expect(req.stream).toBe(true);
+    expect(req.useWebSocket).toBe(true);
+
+    expect(frames).toEqual([
+      { type: "response.created", response: { id: "resp_1" } },
+      { type: "response.output_text.delta", delta: "Hi there" },
+      { type: "response.completed", response: { id: "resp_1" } },
+    ]);
+    ws.close();
+  });
+
+  it("supports multiple sequential response.create frames on one socket", async () => {
+    const { ws } = await connectClient(port);
+
+    const first = receiveJsonFrames(ws, 3);
+    ws.send(RESPONSE_CREATE_BODY);
+    await first;
+
+    const second = receiveJsonFrames(ws, 3);
+    ws.send(
+      JSON.stringify({
+        model: "codex",
+        input: [{ role: "user", content: "again" }],
+        stream: true,
+        previous_response_id: "resp_1",
+      }),
+    );
+    const frames = await second;
+
+    expect(requestedStreams).toBe(2);
+    const req = capturedCodexRequest as Record<string, unknown>;
+    expect(req.previous_response_id).toBe("resp_1");
+    expect(frames).toHaveLength(3);
+    ws.close();
+  });
+
+  it("keeps HTTP POST + SSE working as the fallback (WS server attached)", async () => {
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: RESPONSE_CREATE_BODY,
+    });
+
+    expect(res.status).toBe(200);
+    const buf = await new Response(res.body).text();
+    // The mocked handleProxyRequest returns this SSE text verbatim.
+    expect(buf).toContain("event: response.created");
+  });
+
+  it("forwards non-SSE error responses back as an error frame", async () => {
+    const { handleProxyRequest } = await import("@src/routes/shared/proxy-handler.js");
+    const mock = handleProxyRequest as ReturnType<typeof vi.fn>;
+    mock.mockImplementationOnce(async () =>
+      new Response(
+        JSON.stringify({ type: "error", error: { type: "server_error", code: "no_available_accounts", message: "No accounts" } }),
+        { status: 503, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const { ws } = await connectClient(port);
+    const received = receiveJsonFrames(ws, 1);
+    ws.send(RESPONSE_CREATE_BODY);
+    const [frame] = await received;
+
+    expect((frame as Record<string, unknown>).type).toBe("error");
+    ws.close();
+  });
+});

--- a/tests/unit/routes/responses-websocket.test.ts
+++ b/tests/unit/routes/responses-websocket.test.ts
@@ -115,6 +115,7 @@ vi.mock("@src/routes/shared/proxy-handler.js", () => ({
 // ── Imports ─────────────────────────────────────────────────────────
 
 import { AccountPool } from "@src/auth/account-pool.js";
+import { ClientKeyPool } from "@src/auth/client-key-pool.js";
 import { loadStaticModels } from "@src/models/model-store.js";
 import { createResponsesRoutes } from "@src/routes/responses.js";
 import { ResponsesWebSocketServer } from "@src/routes/responses-websocket.js";
@@ -133,9 +134,15 @@ function connectClient(
   port: number,
   authHeader?: string,
 ): Promise<{ ws: WebSocket }> {
-  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/responses`, {
-    headers: authHeader ? { Authorization: authHeader } : {},
-  });
+  return connectWithHeaders(port, authHeader ? { Authorization: authHeader } : {});
+}
+
+/** Open a WS client with arbitrary handshake headers. */
+function connectWithHeaders(
+  port: number,
+  headers: Record<string, string>,
+): Promise<{ ws: WebSocket }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/responses`, { headers });
   return new Promise((resolve, reject) => {
     ws.once("open", () => resolve({ ws }));
     ws.once("unexpected-response", (_req, res) =>
@@ -174,6 +181,7 @@ function receiveJsonFrames(ws: WebSocket, count: number): Promise<unknown[]> {
 
 describe("client-facing WebSocket on /v1/responses (issue #681)", () => {
   let pool: AccountPool;
+  let clientKeyPool: ClientKeyPool;
   let app: Hono;
   let server: Server;
   let wsServer: ResponsesWebSocketServer;
@@ -187,6 +195,7 @@ describe("client-facing WebSocket on /v1/responses (issue #681)", () => {
     loadStaticModels();
     pool = new AccountPool();
     pool.addAccount("test-token-1");
+    clientKeyPool = new ClientKeyPool();
     app = createResponsesRoutes(pool);
     const handle = serve({ fetch: app.fetch, hostname: "127.0.0.1", port: 0 });
     server = handle as unknown as Server;
@@ -195,7 +204,7 @@ describe("client-facing WebSocket on /v1/responses (issue #681)", () => {
     await new Promise<void>((resolve) => server.once("listening", () => resolve()));
     const addr = server.address() as AddressInfo;
     port = addr.port;
-    wsServer = new ResponsesWebSocketServer({ server, app, accountPool: pool });
+    wsServer = new ResponsesWebSocketServer({ server, app, accountPool: pool, clientKeyPool });
   });
 
   afterEach(async () => {
@@ -300,6 +309,95 @@ describe("client-facing WebSocket on /v1/responses (issue #681)", () => {
     const [frame] = await received;
 
     expect((frame as Record<string, unknown>).type).toBe("error");
+    ws.close();
+  });
+
+  it("normalizes OpenAI-style {error:{...}} (no top-level type) to a typed error frame", async () => {
+    const { handleProxyRequest } = await import("@src/routes/shared/proxy-handler.js");
+    const mock = handleProxyRequest as ReturnType<typeof vi.fn>;
+    mock.mockImplementationOnce(async () =>
+      new Response(
+        JSON.stringify({
+          error: { message: "Invalid API key provided", type: "invalid_request_error", code: "invalid_api_key" },
+        }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const { ws } = await connectClient(port);
+    const received = receiveJsonFrames(ws, 1);
+    ws.send(RESPONSE_CREATE_BODY);
+    const [frame] = await received;
+
+    const f = frame as Record<string, unknown>;
+    expect(f.type).toBe("error");
+    expect((f.error as Record<string, unknown>).type).toBe("invalid_request_error");
+    expect((f.error as Record<string, unknown>).code).toBe("invalid_api_key");
+    expect((f.error as Record<string, unknown>).message).toBe("Invalid API key provided");
+    ws.close();
+  });
+
+  it("rejects an upgrade with a disabled client key with 401 (validateAccess at handshake)", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    const entry = clientKeyPool.createKey({ name: "disabled-key", key: "ck-disabled" });
+    clientKeyPool.updateKey(entry.id, { status: "disabled" });
+
+    await expect(connectClient(port, "Bearer ck-disabled")).rejects.toMatchObject({
+      status: 401,
+    });
+  });
+
+  it("rejects an upgrade with an over-budget client key with 429 (validateAccess at handshake)", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    clientKeyPool.createKey({ name: "broke-key", key: "ck-broke", max_budget_usd: 1 });
+    const brokeEntry = clientKeyPool.getByKey("ck-broke");
+    brokeEntry!.used_cost_usd = 1.5;
+
+    await expect(connectClient(port, "Bearer ck-broke")).rejects.toMatchObject({
+      status: 429,
+    });
+  });
+
+  it("accepts an upgrade using an x-api-key header (same locations as the POST route)", async () => {
+    mockConfig.server.proxy_api_key = "master-key";
+    const { ws } = await connectWithHeaders(port, { "x-api-key": "master-key" });
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  it("returns a structured connection_busy error when a frame is sent mid-flight", async () => {
+    const { handleProxyRequest } = await import("@src/routes/shared/proxy-handler.js");
+    const mock = handleProxyRequest as ReturnType<typeof vi.fn>;
+    // Hold the stream open so the connection stays busy while we pipeline.
+    mock.mockImplementationOnce(async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(
+              encoder.encode(
+                'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
+              ),
+            );
+            // Intentionally never close: keeps the first dispatch in flight.
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+
+    const { ws } = await connectClient(port);
+    const first = receiveJsonFrames(ws, 1);
+    ws.send(RESPONSE_CREATE_BODY);
+    await first;
+
+    const busy = receiveJsonFrames(ws, 1);
+    ws.send(RESPONSE_CREATE_BODY);
+    const [frame] = await busy;
+
+    const f = frame as Record<string, unknown>;
+    expect(f.type).toBe("error");
+    expect((f.error as Record<string, unknown>).code).toBe("connection_busy");
     ws.close();
   });
 });


### PR DESCRIPTION
## Summary

为 `/v1/responses` 端点新增客户端 WebSocket 支持（issue #681）。现在 `ws://<host>:<port>/v1/responses` 的升级请求会被接受并用 Bearer 令牌鉴权；客户端发送的 `response.create` JSON 帧通过 `app.request()` 走与 HTTP POST 完全相同的分发路径（账户池轮转 / 上游路由 / SSE 流式），再把每个 SSE 事件的 `data:` JSON 载荷以 WS 文本帧回传。HTTP POST + SSE 保持原样作为回退。

## Changes

- `src/routes/responses-websocket.ts`（新增）：`ResponsesWebSocketServer`，用 `ws`（`noServer: true`）挂到 `@hono/node-server` 返回的 node `http.Server` 上，监听 `/v1/responses` 的 upgrade；Bearer 鉴权复用 `AccountPool.validateProxyApiKey` / `ClientKeyPool` / 无主键透传模式；单 socket 串行处理多个 `response.create` 帧以支持 `previous_response_id` 多轮；含 `close()` 清理。
- `src/index.ts`：在 `serve()` 后挂载 `ResponsesWebSocketServer`，并在关闭路径中 `await close()`。
- `tests/unit/routes/responses-websocket.test.ts`（新增，7 个测试）：真实 http.Server + ws 客户端驱动握手，覆盖升级接受、401 鉴权、`response.create` 分发并流式回传、单 socket 多轮、HTTP POST 回退、错误帧转发。
- `CHANGELOG.md`：`[Unreleased]` 新增 `### Added` 条目。

## Test Plan

- [x] `npx vitest run tests/unit/routes/responses-websocket.test.ts` — 7 passed
- [x] `npx tsc --noEmit` — 通过
- [ ] 既有 `tests/unit/routes/responses*.test.ts`（子代理报告 68 passed；`responses-default-tools.test.ts` 的 `EBUSY` 为 Windows 既有文件锁 flaky，与本次无关）
- [ ] 手工：用新 Codex CLI（`wire_api="responses"`）验证不再出现 WS→HTTPS 回退告警

## Notes

- `config/default.yaml` 有一处与本 PR 无关的未提交改动（客户端版本号 app_version 0.1.0→26.820.71523），未纳入本 PR。
- WS 帧翻译转发的是每个 SSE 事件的 `data:` JSON 载荷，与 Codex 后端自身 WS 的载荷格式一致。

## Linked Issues

Closes #681