### PR TITLE
fix(build): replace broken AGENTS.md symlink with a plain file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-CLAUDE.md
-
 ## 多 Agent 工作流
 
 - 仅在用户明确授权或任务明确要求时启用；完整规则见 `docs/MULTI_AGENT_WORKFLOW.md`。


### PR DESCRIPTION
## 问题

\AGENTS.md\ 在 git 中被提交为一个**损坏的符号链接**：其 target 不是路径 \CLAUDE.md\，而是整篇文档文本（998 字节）。仓库中也从未跟踪过 \CLAUDE.md\。

Runner 镜像升级（git 2.55）后，Windows release 构建在 \ctions/checkout\ 阶段因 \rror: unable to create symlink AGENTS.md: Filename too long\ 失败，导致 v2.0.94 三平台构建整体 marked failure、发布会卡住（v2.0.94 未被标记为 latest）。

## 修复

将 \AGENTS.md\ 从损坏 symlink 转换为普通文件（内容为其应有的多 Agent 工作流文档），任何平台 checkout 时都不再创建符号链接。

\\\
mode change 120000 => 100644 AGENTS.md
\\\
