### PR TITLE
fix(auth,admin): preserve 429 locks, hot-apply rotation strategy, honor refresh_interval_minutes

### DIFF
--- a/src/auth/active-quota-refresher.ts
+++ b/src/auth/active-quota-refresher.ts
@@ -16,6 +16,22 @@ import type { CodexQuota } from "./types.js";
 const DEFAULT_TICK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const MIN_REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes minimum gap per account
 
+/**
+ * Resolve the scan tick interval and the per-account minimum refresh gap from
+ * `quota.refresh_interval_minutes`. When unset (undefined) or 0, the historical
+ * defaults (15 min tick / 30 min min-gap) are used. Exported for unit testing;
+ * production wiring is `quota.refresh_interval_minutes === 0` in default.yaml.
+ */
+export function resolveRefreshIntervals(
+  minutes: number | undefined | null,
+): { tickMs: number; minGapMs: number } {
+  const configuredMs = typeof minutes === "number" && minutes > 0 ? minutes * 60_000 : null;
+  return {
+    tickMs: configuredMs ?? DEFAULT_TICK_INTERVAL_MS,
+    minGapMs: configuredMs ?? MIN_REFRESH_INTERVAL_MS,
+  };
+}
+
 export class ActiveQuotaRefresher {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
@@ -42,12 +58,7 @@ export class ActiveQuotaRefresher {
    * (15 min tick / 30 min gap) are used.
    */
   private resolveIntervals(): { tickMs: number; minGapMs: number } {
-    const minutes = getConfig().quota?.refresh_interval_minutes;
-    const configuredMs = typeof minutes === "number" && minutes > 0 ? minutes * 60_000 : null;
-    return {
-      tickMs: configuredMs ?? DEFAULT_TICK_INTERVAL_MS,
-      minGapMs: configuredMs ?? MIN_REFRESH_INTERVAL_MS,
-    };
+    return resolveRefreshIntervals(getConfig().quota?.refresh_interval_minutes ?? null);
   }
 
   start(): void {

--- a/src/auth/active-quota-refresher.ts
+++ b/src/auth/active-quota-refresher.ts
@@ -11,6 +11,7 @@ import { jitter } from "../utils/jitter.js";
 import type { AccountPool } from "./account-pool.js";
 import type { ProxyPool } from "../proxy/proxy-pool.js";
 import type { CookieJar } from "../proxy/cookie-jar.js";
+import type { CodexQuota } from "./types.js";
 
 const DEFAULT_TICK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 const MIN_REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes minimum gap per account
@@ -35,6 +36,20 @@ export class ActiveQuotaRefresher {
     this.proxyPool = options?.proxyPool;
   }
 
+  /**
+   * Resolve the scan tick interval and the per-account minimum refresh gap from
+   * `quota.refresh_interval_minutes`. When unset (or 0) the historical defaults
+   * (15 min tick / 30 min gap) are used.
+   */
+  private resolveIntervals(): { tickMs: number; minGapMs: number } {
+    const minutes = getConfig().quota?.refresh_interval_minutes;
+    const configuredMs = typeof minutes === "number" && minutes > 0 ? minutes * 60_000 : null;
+    return {
+      tickMs: configuredMs ?? DEFAULT_TICK_INTERVAL_MS,
+      minGapMs: configuredMs ?? MIN_REFRESH_INTERVAL_MS,
+    };
+  }
+
   start(): void {
     this.stopped = false;
     const config = getConfig();
@@ -43,7 +58,7 @@ export class ActiveQuotaRefresher {
       return;
     }
 
-    this.scheduleNext(DEFAULT_TICK_INTERVAL_MS);
+    this.scheduleNext(this.resolveIntervals().tickMs);
     console.log("[ActiveQuotaRefresher] Active Quota Refresher started");
   }
 
@@ -84,7 +99,7 @@ export class ActiveQuotaRefresher {
 
         // Anti-abuse: ensure minimum time gap between active refreshes per account.
         const lastRefresh = this.lastRefreshedAt.get(entry.id) ?? 0;
-        if (now - lastRefresh < MIN_REFRESH_INTERVAL_MS) continue;
+        if (now - lastRefresh < this.resolveIntervals().minGapMs) continue;
 
         console.log(`[ActiveQuotaRefresher] Actively refreshing quota for ${entry.id} (${entry.email ?? "?"}) (locked=${isLocked}, dirty=${isDirty})`);
         
@@ -102,7 +117,7 @@ export class ActiveQuotaRefresher {
           ).getUsage();
 
           const quota = toQuota(usage);
-          this.pool.updateCachedQuota(entry.id, quota);
+          this.pool.updateCachedQuota(entry.id, preserveLearnedLocks(entry.cachedQuota, quota));
         } catch (err) {
           console.warn(`[ActiveQuotaRefresher] Failed to fetch quota for account ${entry.id}:`, err instanceof Error ? err.message : err);
         }
@@ -113,7 +128,7 @@ export class ActiveQuotaRefresher {
     } catch (err) {
       console.warn("[ActiveQuotaRefresher] Error during tick:", err instanceof Error ? err.message : err);
     } finally {
-      this.scheduleNext(DEFAULT_TICK_INTERVAL_MS);
+      this.scheduleNext(this.resolveIntervals().tickMs);
     }
   }
 
@@ -124,4 +139,88 @@ export class ActiveQuotaRefresher {
       void this.tick();
     }, intervalMs);
   }
+}
+
+/**
+ * Merge a freshly fetched quota with any 429-learned locks already cached on
+ * the entry. The `/usage` endpoint is sometimes inconsistent with the
+ * enforcement layer (especially for free-plan accounts): it can report an
+ * account as available while `/codex/responses` still answers 429. Without
+ * this guard, such an optimistic answer would silently clear the lock, the
+ * account re-enters rotation, and the next real request wastes a full payload
+ * upload + failover latency before being 429'd again.
+ *
+ * A learned lock whose `reset_at` is still in the future is kept until it
+ * passes; once the window resets the fresh quota applies normally and the
+ * account auto-unlocks. (Primary, secondary, code_review and per-model buckets
+ * are all protected.)
+ */
+export function preserveLearnedLocks(
+  existing: CodexQuota | null | undefined,
+  fresh: CodexQuota,
+): CodexQuota {
+  const nowSec = Date.now() / 1000;
+  const isFutureLock = (
+    cur: { limit_reached?: boolean; reset_at?: number | null } | null | undefined,
+  ): boolean => cur?.limit_reached === true && cur.reset_at != null && cur.reset_at > nowSec;
+
+  const merged: CodexQuota = { ...fresh };
+
+  if (isFutureLock(existing?.rate_limit) && !fresh.rate_limit.limit_reached) {
+    merged.rate_limit = {
+      ...fresh.rate_limit,
+      allowed: false,
+      limit_reached: true,
+      used_percent: Math.max(fresh.rate_limit.used_percent ?? 0, 100),
+      reset_at: existing!.rate_limit.reset_at,
+    };
+  }
+
+  const secondaryExisting = existing?.secondary_rate_limit;
+  if (isFutureLock(secondaryExisting) && !merged.secondary_rate_limit?.limit_reached) {
+    const freshWindow = merged.secondary_rate_limit;
+    merged.secondary_rate_limit = {
+      used_percent: freshWindow?.used_percent ?? 100,
+      remaining_percent: freshWindow?.remaining_percent,
+      reset_at: secondaryExisting!.reset_at,
+      limit_window_seconds: freshWindow?.limit_window_seconds ?? secondaryExisting!.limit_window_seconds,
+      limit_reached: true,
+    };
+  }
+
+  const reviewExisting = existing?.code_review_rate_limit;
+  if (isFutureLock(reviewExisting) && !merged.code_review_rate_limit?.limit_reached) {
+    const freshWindow = merged.code_review_rate_limit;
+    merged.code_review_rate_limit = {
+      allowed: freshWindow?.allowed ?? false,
+      limit_reached: true,
+      used_percent: freshWindow?.used_percent ?? 100,
+      remaining_percent: freshWindow?.remaining_percent,
+      reset_at: reviewExisting!.reset_at,
+      limit_window_seconds: freshWindow?.limit_window_seconds ?? reviewExisting!.limit_window_seconds,
+    };
+  }
+
+  if (existing?.rate_limits_by_limit_id) {
+    const freshBuckets = merged.rate_limits_by_limit_id ?? {};
+    merged.rate_limits_by_limit_id = { ...freshBuckets };
+    for (const [limitId, cur] of Object.entries(existing.rate_limits_by_limit_id)) {
+      if (isFutureLock(cur) && !freshBuckets[limitId]?.limit_reached) {
+        const freshBucket = freshBuckets[limitId];
+        merged.rate_limits_by_limit_id[limitId] = {
+          limit_id: freshBucket?.limit_id ?? cur.limit_id,
+          limit_name: freshBucket?.limit_name ?? cur.limit_name,
+          allowed: freshBucket?.allowed ?? false,
+          limit_reached: true,
+          used_percent: freshBucket?.used_percent ?? 100,
+          remaining_percent: freshBucket?.remaining_percent,
+          reset_at: cur.reset_at,
+          limit_window_seconds: freshBucket?.limit_window_seconds ?? cur.limit_window_seconds,
+          secondary_rate_limit: freshBucket?.secondary_rate_limit ?? cur.secondary_rate_limit,
+        };
+      }
+    }
+  }
+
+  return merged;
 }

--- a/src/routes/admin/settings.ts
+++ b/src/routes/admin/settings.ts
@@ -4,6 +4,7 @@ import { getConfig, getLocalConfigPath, reloadAllConfigs, ROTATION_STRATEGIES } 
 import { logStore } from "../../logs/store.js";
 import { mutateYaml } from "../../utils/yaml-mutate.js";
 import { isLocalhostRequest } from "../../utils/is-localhost.js";
+import type { AccountPool } from "../../auth/account-pool.js";
 import {
   getRoutableCodexHostModelAllowedModels,
   IMAGE_HOST_MODEL_CLIENT_ID,
@@ -47,7 +48,7 @@ function normalizeModelAliases(input: unknown): {
   return { aliases, error: null };
 }
 
-export function createSettingsRoutes(): Hono {
+export function createSettingsRoutes(accountPool?: AccountPool): Hono {
   const app = new Hono();
 
 
@@ -73,6 +74,11 @@ export function createSettingsRoutes(): Hono {
       (data.auth as Record<string, unknown>).rotation_strategy = body.rotation_strategy;
     });
     reloadAllConfigs();
+
+    // Hot-apply the strategy: the pool captures the strategy once at
+    // construction, so without this the change only takes effect after a
+    // restart (the running process would keep the old strategy).
+    accountPool?.setRotationStrategy(body.rotation_strategy as "least_used" | "round_robin" | "sticky");
 
     const updated = getConfig();
     return c.json({

--- a/src/routes/web.ts
+++ b/src/routes/web.ts
@@ -53,7 +53,7 @@ export function createWebRoutes(
   app.route("/", createHealthRoutes(accountPool));
   app.route("/", createUpdateRoutes());
   app.route("/", createConnectionRoutes(accountPool));
-  app.route("/", createSettingsRoutes());
+  app.route("/", createSettingsRoutes(accountPool));
   app.route("/", createOllamaAdminRoutes());
   app.route("/", createUsageStatsRoutes(accountPool, usageStats));
   app.route("/", createLogRoutes());

--- a/tests/unit/auth/active-quota-refresher.test.ts
+++ b/tests/unit/auth/active-quota-refresher.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for issue #753 Bug 1 fix: preserveLearnedLocks must not let an
+ * optimistic /usage answer clear a 429-learned lock whose reset_at is still
+ * in the future — otherwise the exhausted account re-enters rotation and
+ * wastes a full payload upload + failover latency on every cycle.
+ */
+
+import { describe, it, expect } from "vitest";
+import { preserveLearnedLocks } from "@src/auth/active-quota-refresher.js";
+import type { CodexQuota } from "@src/auth/types.js";
+
+const NOW = Math.floor(Date.now() / 1000);
+
+function quota(overrides: Partial<CodexQuota> = {}): CodexQuota {
+  return {
+    plan_type: "free",
+    rate_limit: {
+      allowed: true,
+      limit_reached: false,
+      used_percent: 30,
+      reset_at: NOW + 3600,
+      limit_window_seconds: 3600,
+    },
+    secondary_rate_limit: null,
+    code_review_rate_limit: null,
+    ...overrides,
+  };
+}
+
+describe("preserveLearnedLocks", () => {
+  it("keeps a future primary lock when /usage reports available", () => {
+    const existing = quota({
+      rate_limit: {
+        allowed: false,
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: NOW + 28 * 24 * 3600,
+        limit_window_seconds: 3600,
+      },
+    });
+    const fresh = quota({ rate_limit: { allowed: true, limit_reached: false, used_percent: 40, reset_at: null, limit_window_seconds: null } });
+
+    const merged = preserveLearnedLocks(existing, fresh);
+    expect(merged.rate_limit.limit_reached).toBe(true);
+    expect(merged.rate_limit.allowed).toBe(false);
+    expect(merged.rate_limit.used_percent).toBe(100);
+    expect(merged.rate_limit.reset_at).toBe(existing.rate_limit.reset_at);
+  });
+
+  it("unlocks once the lock reset_at has passed", () => {
+    const existing = quota({
+      rate_limit: {
+        allowed: false,
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: NOW - 60, // already passed
+        limit_window_seconds: 3600,
+      },
+    });
+    const fresh = quota({ rate_limit: { allowed: true, limit_reached: false, used_percent: 40, reset_at: null, limit_window_seconds: null } });
+
+    const merged = preserveLearnedLocks(existing, fresh);
+    expect(merged.rate_limit.limit_reached).toBe(false);
+    expect(merged.rate_limit.allowed).toBe(true);
+  });
+
+  it("applies a fresh exhausted quota as-is", () => {
+    const existing = quota();
+    const fresh = quota({
+      rate_limit: {
+        allowed: false,
+        limit_reached: true,
+        used_percent: 100,
+        reset_at: NOW + 3600,
+        limit_window_seconds: 3600,
+      },
+    });
+
+    const merged = preserveLearnedLocks(existing, fresh);
+    expect(merged.rate_limit.limit_reached).toBe(true);
+    expect(merged.rate_limit.reset_at).toBe(fresh.rate_limit.reset_at);
+  });
+
+  it("keeps future secondary and code_review locks", () => {
+    const existing = quota({
+      secondary_rate_limit: { limit_reached: true, used_percent: 100, reset_at: NOW + 3600, limit_window_seconds: 3600 },
+      code_review_rate_limit: { allowed: false, limit_reached: true, used_percent: 100, reset_at: NOW + 7200, limit_window_seconds: 3600 },
+    });
+    const fresh = quota({
+      secondary_rate_limit: { limit_reached: false, used_percent: 20, reset_at: null, limit_window_seconds: null },
+      code_review_rate_limit: { allowed: true, limit_reached: false, used_percent: 20, reset_at: null, limit_window_seconds: null },
+    });
+
+    const merged = preserveLearnedLocks(existing, fresh);
+    expect(merged.secondary_rate_limit?.limit_reached).toBe(true);
+    expect(merged.secondary_rate_limit?.reset_at).toBe(existing.secondary_rate_limit?.reset_at);
+    expect(merged.code_review_rate_limit?.limit_reached).toBe(true);
+    expect(merged.code_review_rate_limit?.reset_at).toBe(existing.code_review_rate_limit?.reset_at);
+  });
+
+  it("keeps a future per-model bucket lock", () => {
+    const existing = quota({
+      rate_limits_by_limit_id: {
+        codex_bengalfox: {
+          limit_id: "codex_bengalfox",
+          limit_name: "codex_bengalfox",
+          allowed: false,
+          limit_reached: true,
+          used_percent: 100,
+          remaining_percent: 0,
+          reset_at: NOW + 3600,
+          limit_window_seconds: 3600,
+          secondary_rate_limit: null,
+        },
+      },
+    });
+    const fresh = quota({
+      rate_limits_by_limit_id: {
+        codex_bengalfox: {
+          limit_id: "codex_bengalfox",
+          limit_name: "codex_bengalfox",
+          allowed: true,
+          limit_reached: false,
+          used_percent: 20,
+          remaining_percent: 80,
+          reset_at: null,
+          limit_window_seconds: null,
+          secondary_rate_limit: null,
+        },
+      },
+    });
+
+    const merged = preserveLearnedLocks(existing, fresh);
+    expect(merged.rate_limits_by_limit_id?.codex_bengalfox?.limit_reached).toBe(true);
+    expect(merged.rate_limits_by_limit_id?.codex_bengalfox?.reset_at).toBe(
+      existing.rate_limits_by_limit_id?.codex_bengalfox?.reset_at,
+    );
+  });
+
+  it("returns fresh unchanged when there is no existing lock", () => {
+    const fresh = quota({ rate_limit: { allowed: true, limit_reached: false, used_percent: 20, reset_at: null, limit_window_seconds: null } });
+    const merged = preserveLearnedLocks(undefined, fresh);
+    expect(merged).toEqual(fresh);
+  });
+});

--- a/tests/unit/auth/quota-lock-escape.test.ts
+++ b/tests/unit/auth/quota-lock-escape.test.ts
@@ -18,6 +18,7 @@ import { createMockConfig } from "@helpers/config.js";
 import { setConfigForTesting, resetConfigForTesting } from "@src/config.js";
 import { AccountPool } from "@src/auth/account-pool.js";
 import { hasReachedCachedQuota } from "@src/auth/quota-skip.js";
+import { resolveRefreshIntervals } from "@src/auth/active-quota-refresher.js";
 import type { CodexQuota } from "@src/auth/types.js";
 
 // ── helpers ─────────────────────────────────────────────────────────────────
@@ -195,5 +196,39 @@ describe("Bug 3 — hasReachedCachedQuota checks rate_limits_by_limit_id", () =>
     const entry = pool.getEntry(id)!;
     expect(hasReachedCachedQuota(entry)).toBe(false);
     expect(pool.hasAvailableAccounts()).toBe(true);
+  });
+});
+
+// ── Bug (Issue #753): refresh_interval_minutes resolution ───────────────────
+// Unconfigured (default.yaml ships 0) must fall back to the historical
+// 15 min tick / 30 min min-gap; an explicitly configured value must be honored.
+
+describe("resolveRefreshIntervals (Issue #753)", () => {
+  it("falls back to 15 min tick / 30 min gap when interval is 0", () => {
+    expect(resolveRefreshIntervals(0)).toEqual({
+      tickMs: 15 * 60_000,
+      minGapMs: 30 * 60_000,
+    });
+  });
+
+  it("falls back when interval is unset or non-positive", () => {
+    expect(resolveRefreshIntervals(undefined)).toEqual({
+      tickMs: 15 * 60_000,
+      minGapMs: 30 * 60_000,
+    });
+    expect(resolveRefreshIntervals(null)).toEqual({
+      tickMs: 15 * 60_000,
+      minGapMs: 30 * 60_000,
+    });
+    expect(resolveRefreshIntervals(-1)).toEqual({
+      tickMs: 15 * 60_000,
+      minGapMs: 30 * 60_000,
+    });
+  });
+
+  it("honors an explicitly configured interval", () => {
+    const { tickMs, minGapMs } = resolveRefreshIntervals(10);
+    expect(tickMs).toBe(10 * 60_000);
+    expect(minGapMs).toBe(10 * 60_000);
   });
 });

--- a/tests/unit/routes/rotation-settings.test.ts
+++ b/tests/unit/routes/rotation-settings.test.ts
@@ -78,6 +78,7 @@ const mockPool = {
   getAll: vi.fn(() => []),
   acquire: vi.fn(),
   release: vi.fn(),
+  setRotationStrategy: vi.fn(),
 } as unknown as Parameters<typeof createWebRoutes>[0];
 
 describe("GET /admin/rotation-settings", () => {
@@ -156,6 +157,27 @@ describe("POST /admin/rotation-settings", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("hot-applies the strategy on the pool without requiring a restart", async () => {
+    const app = createWebRoutes(mockPool);
+    const res = await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rotation_strategy: "round_robin" }),
+    });
+    expect(res.status).toBe(200);
+    expect(mockPool.setRotationStrategy).toHaveBeenCalledWith("round_robin");
+  });
+
+  it("does not touch the pool for invalid strategies", async () => {
+    const app = createWebRoutes(mockPool);
+    await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rotation_strategy: "random" }),
+    });
+    expect(mockPool.setRotationStrategy).not.toHaveBeenCalled();
   });
 
 });


### PR DESCRIPTION
Closes #753

## 背景

Issue #753 报告了三个相互独立但都与配额/轮换管理相关的子 bug：

1. **429 学到的锁被乐观 /usage 刷新覆盖**：`ActiveQuotaRefresher` 主动刷新时，上游 `/usage` 有时与执行层不一致（特别是 free 计划），会报告可用，从而悄悄清掉之前 429 学到的锁。账号重新进入轮换，下一次真实请求会白上传一整个 payload + failover 延迟后才再次被 429。
2. **rotation-settings 修改后不热生效**：`POST /admin/rotation-settings` 只改 YAML 并 reload 配置，但 `AccountPool` 在构造时只捕获一次策略，运行中的进程仍然沿用旧策略，必须重启才生效。
3. **quota.refresh_interval_minutes 未使用**：刷新器扫表 tick 间隔与每账号最小刷新间隔写死为 15/30 分钟，配置里的 `quota.refresh_interval_minutes` 完全没有被读取。

## 改动

- **Bug 1** — 新增 `preserveLearnedLocks()`：把新拉取的配额与缓存中仍有效的 429 锁合并。`reset_at` 仍在未来的锁会被保留（primary / secondary / code_review / per-model buckets 全覆盖），直到窗口过去才自动解锁，之后新配额正常生效。
- **Bug 3** — 新增 `resolveIntervals()`：`ActiveQuotaRefresher` 的 tick 与每账号最小刷新间隔优先读取 `quota.refresh_interval_minutes`，未配置时回退到历史默认值。
- **Bug 2** — `createSettingsRoutes` 接收 `AccountPool`，`POST /admin/rotation-settings` 在校验通过后调用 `pool.setRotationStrategy()` 热应用；`web.ts` 传入 `accountPool`。

## 测试

- 新增 `tests/unit/auth/active-quota-refresher.test.ts`：覆盖 primary/secondary/code_review/per-model 锁保留、锁过期后解锁、无既有锁时原样返回。
- `tests/unit/routes/rotation-settings.test.ts`：新增热生效断言（合法策略调用 `setRotationStrategy`，非法策略不调用）。
- 相关单元测试全绿，`tsc --noEmit` 通过。
