### PR TITLE
test(ci): align electron smoke wiring tests with parallelized release workflow

### DIFF
--- a/tests/unit/ci/electron-smoke-script.test.ts
+++ b/tests/unit/ci/electron-smoke-script.test.ts
@@ -162,14 +162,6 @@ function stepBlock(source: string, name: string): string {
 }
 
 describe("release workflow smoke wiring", () => {
-  it("runs stale release asset cleanup through bash on Windows-compatible matrix jobs", () => {
-    const workflow = readFileSync(RELEASE_WORKFLOW, "utf-8");
-    const block = stepBlock(workflow, "Clean stale release assets");
-
-    expect(block).toContain("shell: bash");
-    expect(block).toContain("[ -z \"$ASSETS\" ] && exit 0");
-  });
-
   it("uses PowerShell smoke on Windows and bash smoke on non-Windows platforms", () => {
     const workflow = readFileSync(RELEASE_WORKFLOW, "utf-8");
     const windowsBlock = stepBlock(workflow, "Smoke test packaged binary (win)");
@@ -183,14 +175,11 @@ describe("release workflow smoke wiring", () => {
     expect(unixBlock).toContain("run: bash .github/scripts/electron-smoke.sh");
   });
 
-  it("gives mac x64 packaged smoke extra startup time", () => {
+  it("passes the matrix architecture to the smoke script on non-Windows platforms", () => {
     const workflow = readFileSync(RELEASE_WORKFLOW, "utf-8");
-    const block = workflow.match(
-      /- name: Smoke test packaged binary \(mac-x64\)[\s\S]*?run: bash \.github\/scripts\/electron-smoke\.sh/,
-    )?.[0] ?? "";
+    const unixBlock = stepBlock(workflow, "Smoke test packaged binary (${{ matrix.platform }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }})");
 
-    expect(block).toContain("MAC_ARCH: x64");
-    expect(block).toContain("SMOKE_TIMEOUT: 180");
+    expect(unixBlock).toContain("MAC_ARCH: ${{ matrix.arch }}");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing dev-branch backend-tests failure in `tests/unit/ci/electron-smoke-script.test.ts`.

Commit `ef96bfb` (parallelize mac builds + electron/cargo caches) rewrote `.github/workflows/release.yml` but did not update the smoke-wiring tests, which still asserted the old structure:

- `MAC_ARCH: x64` — now the dynamic `MAC_ARCH: ${{ matrix.arch }}`
- a dedicated `Clean stale release assets` bash step — no longer exists
- `SMOKE_TIMEOUT: 180` mac-x64 override — removed when mac builds were parallelized

This left CI red on every open PR (independently of their own changes).

## Changes

- Remove the obsolete `Clean stale release assets` test (the step is gone).
- Replace the `mac-x64 smoke startup time` test with an assertion that the non-Windows smoke step passes `MAC_ARCH: ${{ matrix.arch }}`, matching the current workflow and keeping mac-arch wiring guarded.

## Verification

- `npx vitest run tests/unit/ci/electron-smoke-script.test.ts -t "release workflow smoke wiring"` → 2 passed.