### PR TITLE
test(e2e): add Account CRUD, Admin settings, Dashboard login E2E coverage (partial #376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Added
 
 - 为 `/v1/responses` 端点添加客户端 WebSocket 支持：接受 `ws://<host>:<port>/v1/responses` 的升级请求并用 Bearer 令牌鉴权，将客户端的 `response.create` 帧代理到现有上游 Codex WebSocket 并把响应事件以 JSON 流式回传；HTTP POST + SSE 仍作为回退保持不变，并在关闭路径中一并关闭该 WS 服务器。（#681）
+- 新增 E2E 测试覆盖账号 CRUD、管理员设置、Dashboard 登录三条关键 HTTP 路径（47 个新用例）：`tests/e2e/accounts.test.ts`（list / add / delete / reset-usage / label / cookies / batch-delete / batch-status / export / quota-warnings）、`tests/e2e/admin-settings.test.ts`（rotation / settings / general / quota 四组 GET+POST）、`tests/e2e/dashboard-login.test.ts`（login / logout / status + 速率限制）。（closes #376 partial）
 
 ### Fixed
 

--- a/tests/e2e/accounts.test.ts
+++ b/tests/e2e/accounts.test.ts
@@ -1,0 +1,351 @@
+/**
+ * E2E tests for account CRUD routes.
+ *
+ * Covers:
+ * - GET  /auth/accounts               — list
+ * - POST /auth/accounts               — add (valid token, invalid token)
+ * - DELETE /auth/accounts/:id         — remove (found, 404)
+ * - POST /auth/accounts/:id/reset-usage
+ * - PATCH /auth/accounts/:id/label
+ * - GET/POST/DELETE /auth/accounts/:id/cookies
+ * - POST /auth/accounts/batch-delete
+ * - POST /auth/accounts/batch-status
+ * - GET  /auth/accounts/export
+ * - GET  /auth/quota/warnings
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import "@helpers/e2e-setup.js";
+import { createValidJwt } from "@helpers/jwt.js";
+
+import { Hono } from "hono";
+import { requestId } from "@src/middleware/request-id.js";
+import { errorHandler } from "@src/middleware/error-handler.js";
+import { createAccountRoutes } from "@src/routes/accounts.js";
+import { AccountPool } from "@src/auth/account-pool.js";
+import { RefreshScheduler } from "@src/auth/refresh-scheduler.js";
+import { CookieJar } from "@src/proxy/cookie-jar.js";
+
+let app: Hono;
+let pool: AccountPool;
+let scheduler: RefreshScheduler;
+let cookieJar: CookieJar;
+
+beforeAll(() => {
+  pool = new AccountPool();
+  scheduler = new RefreshScheduler(pool);
+  cookieJar = new CookieJar();
+
+  app = new Hono();
+  app.use("*", requestId);
+  app.use("*", errorHandler);
+  app.route("/", createAccountRoutes(pool, scheduler, cookieJar));
+});
+
+afterAll(() => {
+  scheduler.destroy();
+  pool.destroy();
+});
+
+beforeEach(() => {
+  // Reset pool between tests
+  for (const { id } of pool.getAccounts()) {
+    pool.removeAccount(id);
+  }
+});
+
+// ── GET /auth/accounts ───────────────────────────────────────────
+
+describe("GET /auth/accounts", () => {
+  it("returns empty list when no accounts", async () => {
+    const res = await app.request("/auth/accounts");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accounts: unknown[]; persistence_health: unknown };
+    expect(body.accounts).toEqual([]);
+    expect(body).toHaveProperty("persistence_health");
+  });
+
+  it("returns accounts with id, email, status fields", async () => {
+    pool.addAccount(createValidJwt({ accountId: "acct-list-1", email: "list@test.com" }));
+
+    const res = await app.request("/auth/accounts");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accounts: Array<{ id: string; email: string; status: string }> };
+    expect(body.accounts).toHaveLength(1);
+    expect(body.accounts[0].id).toBeTruthy();
+    expect(body.accounts[0].email).toBe("list@test.com");
+    expect(body.accounts[0].status).toBe("active");
+  });
+});
+
+// ── POST /auth/accounts ──────────────────────────────────────────
+
+describe("POST /auth/accounts", () => {
+  it("adds a valid JWT token and returns account info", async () => {
+    const token = createValidJwt({ accountId: "acct-add-1", email: "add@test.com" });
+    const res = await app.request("/auth/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; account: { email: string; status: string } };
+    expect(body.success).toBe(true);
+    expect(body.account.email).toBe("add@test.com");
+    expect(body.account.status).toBe("active");
+  });
+
+  it("returns 400 for invalid token", async () => {
+    const res = await app.request("/auth/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: "not.a.valid.jwt" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBeTruthy();
+  });
+
+  it("returns 400 when neither token nor refreshToken provided", async () => {
+    const res = await app.request("/auth/accounts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── DELETE /auth/accounts/:id ────────────────────────────────────
+
+describe("DELETE /auth/accounts/:id", () => {
+  it("removes an existing account", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-del-1" }));
+
+    const res = await app.request(`/auth/accounts/${id}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(pool.getAccounts()).toHaveLength(0);
+  });
+
+  it("returns 404 for unknown id", async () => {
+    const res = await app.request("/auth/accounts/nonexistent-id", { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── POST /auth/accounts/:id/reset-usage ──────────────────────────
+
+describe("POST /auth/accounts/:id/reset-usage", () => {
+  it("resets usage for existing account", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-reset-1" }));
+
+    const res = await app.request(`/auth/accounts/${id}/reset-usage`, { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 404 for unknown account", async () => {
+    const res = await app.request("/auth/accounts/no-such-id/reset-usage", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── PATCH /auth/accounts/:id/label ───────────────────────────────
+
+describe("PATCH /auth/accounts/:id/label", () => {
+  it("sets a label on an account", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-label-1" }));
+
+    const res = await app.request(`/auth/accounts/${id}/label`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ label: "my-label" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+
+    // Verify label is persisted via account list
+    const listRes = await app.request("/auth/accounts");
+    const listBody = await listRes.json() as { accounts: Array<{ id: string; label?: string }> };
+    const acct = listBody.accounts.find((a) => a.id === id);
+    expect(acct?.label).toBe("my-label");
+  });
+
+  it("clears the label when set to null", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-label-2" }));
+
+    await app.request(`/auth/accounts/${id}/label`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ label: "temp" }),
+    });
+
+    const res = await app.request(`/auth/accounts/${id}/label`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ label: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+
+    const listRes = await app.request("/auth/accounts");
+    const listBody = await listRes.json() as { accounts: Array<{ id: string; label?: string | null }> };
+    const acct = listBody.accounts.find((a) => a.id === id);
+    expect(acct?.label ?? null).toBeNull();
+  });
+});
+
+// ── Cookie endpoints ──────────────────────────────────────────────
+
+describe("cookie routes", () => {
+  it("GET returns null when no cookies set", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-cookie-1" }));
+
+    const res = await app.request(`/auth/accounts/${id}/cookies`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { cookies: unknown; hint?: string };
+    expect(body.cookies).toBeNull();
+    expect(body.hint).toBeTruthy();
+  });
+
+  it("POST sets cookies and GET returns them", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-cookie-2" }));
+
+    const setRes = await app.request(`/auth/accounts/${id}/cookies`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cookies: "cf_clearance=abc123; __cf_bm=xyz" }),
+    });
+    expect(setRes.status).toBe(200);
+    const setBody = await setRes.json() as { success: boolean; cookies: Record<string, string> };
+    expect(setBody.success).toBe(true);
+    expect(setBody.cookies).toHaveProperty("cf_clearance");
+
+    const getRes = await app.request(`/auth/accounts/${id}/cookies`);
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json() as { cookies: Record<string, string> };
+    expect(getBody.cookies).toHaveProperty("cf_clearance");
+  });
+
+  it("DELETE clears cookies", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-cookie-3" }));
+    await app.request(`/auth/accounts/${id}/cookies`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cookies: "cf_clearance=abc123" }),
+    });
+
+    const delRes = await app.request(`/auth/accounts/${id}/cookies`, { method: "DELETE" });
+    expect(delRes.status).toBe(200);
+    const delBody = await delRes.json() as { success: boolean };
+    expect(delBody.success).toBe(true);
+
+    const getRes = await app.request(`/auth/accounts/${id}/cookies`);
+    const getBody = await getRes.json() as { cookies: unknown };
+    expect(getBody.cookies).toBeNull();
+  });
+
+  it("returns 404 for unknown account on cookie endpoints", async () => {
+    const get = await app.request("/auth/accounts/ghost/cookies");
+    expect(get.status).toBe(404);
+
+    const post = await app.request("/auth/accounts/ghost/cookies", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cookies: "cf=x" }),
+    });
+    expect(post.status).toBe(404);
+
+    const del = await app.request("/auth/accounts/ghost/cookies", { method: "DELETE" });
+    expect(del.status).toBe(404);
+  });
+});
+
+// ── Batch operations ──────────────────────────────────────────────
+
+describe("POST /auth/accounts/batch-delete", () => {
+  it("deletes multiple accounts by id", async () => {
+    const id1 = pool.addAccount(createValidJwt({ accountId: "acct-batch-1a" }));
+    const id2 = pool.addAccount(createValidJwt({ accountId: "acct-batch-1b" }));
+
+    const res = await app.request("/auth/accounts/batch-delete", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: [id1, id2] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(pool.getAccounts()).toHaveLength(0);
+  });
+});
+
+describe("POST /auth/accounts/batch-status", () => {
+  it("sets accounts to disabled", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-bstatus-1" }));
+
+    const res = await app.request("/auth/accounts/batch-status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: [id], status: "disabled" }),
+    });
+
+    expect(res.status).toBe(200);
+    const entry = pool.getEntry(id);
+    expect(entry?.status).toBe("disabled");
+  });
+
+  it("returns 400 for invalid status value", async () => {
+    const id = pool.addAccount(createValidJwt({ accountId: "acct-bstatus-2" }));
+
+    const res = await app.request("/auth/accounts/batch-status", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ids: [id], status: "invalid-status" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /auth/accounts/export ─────────────────────────────────────
+
+describe("GET /auth/accounts/export", () => {
+  it("returns JSON with accounts array", async () => {
+    pool.addAccount(createValidJwt({ accountId: "acct-export-1", email: "export@test.com" }));
+
+    const res = await app.request("/auth/accounts/export");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accounts: unknown[] };
+    expect(Array.isArray(body.accounts)).toBe(true);
+    expect(body.accounts).toHaveLength(1);
+  });
+
+  it("returns empty array when no accounts", async () => {
+    const res = await app.request("/auth/accounts/export");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { accounts: unknown[] };
+    expect(body.accounts).toHaveLength(0);
+  });
+});
+
+// ── GET /auth/quota/warnings ──────────────────────────────────────
+
+describe("GET /auth/quota/warnings", () => {
+  it("returns warnings array and updatedAt", async () => {
+    const res = await app.request("/auth/quota/warnings");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { warnings: unknown[]; updatedAt: unknown };
+    expect(Array.isArray(body.warnings)).toBe(true);
+    expect(body).toHaveProperty("updatedAt");
+  });
+});

--- a/tests/e2e/accounts.test.ts
+++ b/tests/e2e/accounts.test.ts
@@ -38,7 +38,7 @@ beforeAll(() => {
 
   app = new Hono();
   app.use("*", requestId);
-  app.use("*", errorHandler);
+  app.onError(errorHandler);
   app.route("/", createAccountRoutes(pool, scheduler, cookieJar));
 });
 

--- a/tests/e2e/admin-settings.test.ts
+++ b/tests/e2e/admin-settings.test.ts
@@ -1,0 +1,273 @@
+/**
+ * E2E tests for admin settings routes.
+ *
+ * Covers full HTTP pipeline (routing, middleware, auth gating, response shape):
+ * - GET/POST /admin/rotation-settings
+ * - GET/POST /admin/settings
+ * - GET/POST /admin/general-settings
+ * - GET/POST /admin/quota-settings
+ *
+ * Self-contained mocks — no transport required (no upstream calls).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mutable mock config ───────────────────────────────────────────
+
+const mockConfig = {
+  server: {
+    port: 8080,
+    proxy_api_key: null as string | null,
+    trust_proxy: false,
+  },
+  tls: {
+    proxy_url: null as string | null,
+    force_http11: false,
+  },
+  model: {
+    default: "gpt-5.4",
+    default_reasoning_effort: null as string | null,
+    inject_desktop_context: false,
+    suppress_desktop_directives: true,
+    aliases: {} as Record<string, string>,
+  },
+  auth: {
+    rotation_strategy: "least_used",
+    refresh_enabled: true,
+    refresh_margin_seconds: 300,
+    refresh_concurrency: 2,
+    max_concurrent_per_account: 3 as number | null,
+    request_interval_ms: 50 as number | null,
+  },
+  update: { auto_update: true, auto_download: false, show_update_dialog: false },
+  logs: { enabled: false, capacity: 2000, capture_body: false, llm_only: true },
+  usage_stats: { history_retention_days: null as number | null, credits_per_usd: 25 },
+  quota: {
+    refresh_interval_minutes: 5,
+    warning_thresholds: { primary: [80, 90], secondary: [80, 90] },
+    skip_exhausted: true,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+  getLocalConfigPath: vi.fn(() => "/tmp/codex-e2e-settings/local.yaml"),
+  reloadAllConfigs: vi.fn(),
+  ROTATION_STRATEGIES: ["least_used", "round_robin", "sticky"],
+}));
+
+vi.mock("@src/utils/yaml-mutate.js", () => ({
+  mutateYaml: vi.fn(),
+}));
+
+vi.mock("@src/logs/store.js", () => ({
+  logStore: { setState: vi.fn() },
+}));
+
+vi.mock("@hono/node-server/conninfo", () => ({
+  getConnInfo: vi.fn(() => ({ remote: { address: "127.0.0.1" } })),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/codex-e2e-settings"),
+  getConfigDir: vi.fn(() => "/tmp/codex-e2e-settings/config"),
+}));
+
+// ── App setup ────────────────────────────────────────────────────
+
+import { Hono } from "hono";
+import { requestId } from "@src/middleware/request-id.js";
+import { errorHandler } from "@src/middleware/error-handler.js";
+import { createSettingsRoutes } from "@src/routes/admin/settings.js";
+
+const app = new Hono();
+app.use("*", requestId);
+app.use("*", errorHandler);
+app.route("/", createSettingsRoutes());
+
+beforeEach(() => {
+  mockConfig.server.proxy_api_key = null;
+});
+
+// ── Rotation settings ─────────────────────────────────────────────
+
+describe("GET /admin/rotation-settings", () => {
+  it("returns current rotation strategy", async () => {
+    const res = await app.request("/admin/rotation-settings");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rotation_strategy: string };
+    expect(body.rotation_strategy).toBe("least_used");
+  });
+});
+
+describe("POST /admin/rotation-settings", () => {
+  it("accepts valid strategy when no API key configured", async () => {
+    const res = await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rotation_strategy: "round_robin" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 when API key required but missing from request", async () => {
+    mockConfig.server.proxy_api_key = "adminkey";
+
+    const res = await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rotation_strategy: "sticky" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts request with correct API key in Authorization header", async () => {
+    mockConfig.server.proxy_api_key = "adminkey";
+
+    const res = await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "authorization": "Bearer adminkey",
+      },
+      body: JSON.stringify({ rotation_strategy: "sticky" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for invalid strategy value", async () => {
+    const res = await app.request("/admin/rotation-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rotation_strategy: "unknown-strategy" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── Proxy API key settings ────────────────────────────────────────
+
+describe("GET /admin/settings", () => {
+  it("returns proxy_api_key (null when not set)", async () => {
+    const res = await app.request("/admin/settings");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { proxy_api_key: string | null };
+    expect(body).toHaveProperty("proxy_api_key");
+    expect(body.proxy_api_key).toBeNull();
+  });
+});
+
+describe("POST /admin/settings", () => {
+  it("sets a new proxy_api_key when none currently configured", async () => {
+    const res = await app.request("/admin/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ proxy_api_key: "new-secret" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 when changing key without current key in header", async () => {
+    mockConfig.server.proxy_api_key = "existing-key";
+
+    const res = await app.request("/admin/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ proxy_api_key: "new-key" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── General settings ──────────────────────────────────────────────
+
+describe("GET /admin/general-settings", () => {
+  it("returns all expected fields", async () => {
+    const res = await app.request("/admin/general-settings");
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body).toHaveProperty("port");
+    expect(body).toHaveProperty("refresh_enabled");
+    expect(body).toHaveProperty("default_reasoning_effort");
+    expect(body).toHaveProperty("max_concurrent_per_account");
+    expect(body).toHaveProperty("logs_enabled");
+    expect(body).toHaveProperty("auto_update");
+    expect(body).toHaveProperty("model_aliases");
+  });
+});
+
+describe("POST /admin/general-settings", () => {
+  it("accepts valid settings update", async () => {
+    const res = await app.request("/admin/general-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ logs_enabled: true, refresh_enabled: false }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 401 when API key required but not provided", async () => {
+    mockConfig.server.proxy_api_key = "admin123";
+
+    const res = await app.request("/admin/general-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ logs_enabled: true }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Quota settings ────────────────────────────────────────────────
+
+describe("GET /admin/quota-settings", () => {
+  it("returns refresh_interval_minutes, warning_thresholds, skip_exhausted", async () => {
+    const res = await app.request("/admin/quota-settings");
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      refresh_interval_minutes: number;
+      warning_thresholds: { primary: number[]; secondary: number[] };
+      skip_exhausted: boolean;
+    };
+    expect(body.refresh_interval_minutes).toBe(5);
+    expect(Array.isArray(body.warning_thresholds.primary)).toBe(true);
+    expect(typeof body.skip_exhausted).toBe("boolean");
+  });
+});
+
+describe("POST /admin/quota-settings", () => {
+  it("accepts valid quota update", async () => {
+    const res = await app.request("/admin/quota-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refresh_interval_minutes: 10, skip_exhausted: false }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 400 for negative refresh_interval_minutes", async () => {
+    const res = await app.request("/admin/quota-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refresh_interval_minutes: -1 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for out-of-range warning thresholds", async () => {
+    const res = await app.request("/admin/quota-settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ warning_thresholds: { primary: [150] } }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/e2e/admin-settings.test.ts
+++ b/tests/e2e/admin-settings.test.ts
@@ -132,6 +132,7 @@ describe("POST /admin/rotation-settings", () => {
 
   it("accepts request with correct API key in Authorization header", async () => {
     mockConfig.server.proxy_api_key = "adminkey";
+    mockConnInfo.remote.address = "203.0.113.10";
 
     const res = await app.request("/admin/rotation-settings", {
       method: "POST",

--- a/tests/e2e/admin-settings.test.ts
+++ b/tests/e2e/admin-settings.test.ts
@@ -65,7 +65,7 @@ vi.mock("@src/logs/store.js", () => ({
 }));
 
 vi.mock("@hono/node-server/conninfo", () => ({
-  getConnInfo: vi.fn(() => ({ remote: { address: "127.0.0.1" } })),
+  getConnInfo: vi.fn(() => mockConnInfo),
 }));
 
 vi.mock("@src/paths.js", () => ({
@@ -73,20 +73,26 @@ vi.mock("@src/paths.js", () => ({
   getConfigDir: vi.fn(() => "/tmp/codex-e2e-settings/config"),
 }));
 
+// Mutable remote address so auth-gating tests can simulate a non-localhost client.
+const mockConnInfo = { remote: { address: "127.0.0.1" } };
+
 // ── App setup ────────────────────────────────────────────────────
 
 import { Hono } from "hono";
 import { requestId } from "@src/middleware/request-id.js";
 import { errorHandler } from "@src/middleware/error-handler.js";
+import { dashboardAuth } from "@src/middleware/dashboard-auth.js";
 import { createSettingsRoutes } from "@src/routes/admin/settings.js";
 
 const app = new Hono();
 app.use("*", requestId);
-app.use("*", errorHandler);
+app.use("*", dashboardAuth);
+app.onError(errorHandler);
 app.route("/", createSettingsRoutes());
 
 beforeEach(() => {
   mockConfig.server.proxy_api_key = null;
+  mockConnInfo.remote.address = "127.0.0.1";
 });
 
 // ── Rotation settings ─────────────────────────────────────────────
@@ -114,6 +120,7 @@ describe("POST /admin/rotation-settings", () => {
 
   it("returns 401 when API key required but missing from request", async () => {
     mockConfig.server.proxy_api_key = "adminkey";
+    mockConnInfo.remote.address = "203.0.113.10";
 
     const res = await app.request("/admin/rotation-settings", {
       method: "POST",
@@ -173,6 +180,7 @@ describe("POST /admin/settings", () => {
 
   it("returns 401 when changing key without current key in header", async () => {
     mockConfig.server.proxy_api_key = "existing-key";
+    mockConnInfo.remote.address = "203.0.113.10";
 
     const res = await app.request("/admin/settings", {
       method: "POST",
@@ -214,6 +222,7 @@ describe("POST /admin/general-settings", () => {
 
   it("returns 401 when API key required but not provided", async () => {
     mockConfig.server.proxy_api_key = "admin123";
+    mockConnInfo.remote.address = "203.0.113.10";
 
     const res = await app.request("/admin/general-settings", {
       method: "POST",

--- a/tests/e2e/dashboard-login.test.ts
+++ b/tests/e2e/dashboard-login.test.ts
@@ -1,0 +1,187 @@
+/**
+ * E2E tests for dashboard auth routes.
+ *
+ * Covers:
+ * - POST /auth/dashboard-login  — correct password, wrong password, rate limit, no key
+ * - POST /auth/dashboard-logout — clears session cookie
+ * - GET  /auth/dashboard-status — required/authenticated states
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock config (mutable so tests can change proxy_api_key) ──────
+
+const mockConfig = {
+  server: {
+    proxy_api_key: "secret123" as string | null,
+    trust_proxy: false,
+  },
+  session: {
+    ttl_minutes: 60,
+  },
+};
+
+vi.mock("@src/config.js", () => ({
+  getConfig: vi.fn(() => mockConfig),
+}));
+
+vi.mock("@hono/node-server/conninfo", () => ({
+  getConnInfo: vi.fn(() => ({ remote: { address: "1.2.3.4" } })),
+}));
+
+vi.mock("@src/paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/codex-e2e-dashboard"),
+  getConfigDir: vi.fn(() => "/tmp/codex-e2e-dashboard/config"),
+}));
+
+// ── App setup ────────────────────────────────────────────────────
+
+import { Hono } from "hono";
+import { requestId } from "@src/middleware/request-id.js";
+import { errorHandler } from "@src/middleware/error-handler.js";
+import { createDashboardAuthRoutes, _resetRateLimitForTest } from "@src/routes/dashboard-login.js";
+
+const app = new Hono();
+app.use("*", requestId);
+app.use("*", errorHandler);
+app.route("/", createDashboardAuthRoutes());
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function login(password: string) {
+  return app.request("/auth/dashboard-login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ password }),
+  });
+}
+
+function extractSession(setCookie: string | null): string | null {
+  if (!setCookie) return null;
+  const match = setCookie.match(/_codex_session=([^;]+)/);
+  return match ? match[1] : null;
+}
+
+beforeEach(() => {
+  _resetRateLimitForTest();
+  mockConfig.server.proxy_api_key = "secret123";
+  mockConfig.server.trust_proxy = false;
+});
+
+// ── GET /auth/dashboard-status ────────────────────────────────────
+
+describe("GET /auth/dashboard-status", () => {
+  it("returns required:false when no proxy_api_key configured", async () => {
+    mockConfig.server.proxy_api_key = null;
+
+    const res = await app.request("/auth/dashboard-status");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { required: boolean; authenticated: boolean };
+    expect(body.required).toBe(false);
+    expect(body.authenticated).toBe(true);
+  });
+
+  it("returns required:true, authenticated:false when key set but no session", async () => {
+    const res = await app.request("/auth/dashboard-status");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { required: boolean; authenticated: boolean };
+    expect(body.required).toBe(true);
+    expect(body.authenticated).toBe(false);
+  });
+
+  it("returns authenticated:true with a valid session cookie", async () => {
+    const loginRes = await login("secret123");
+    const sessionId = extractSession(loginRes.headers.get("set-cookie"));
+    expect(sessionId).toBeTruthy();
+
+    const res = await app.request("/auth/dashboard-status", {
+      headers: { cookie: `_codex_session=${sessionId}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { authenticated: boolean };
+    expect(body.authenticated).toBe(true);
+  });
+});
+
+// ── POST /auth/dashboard-login ────────────────────────────────────
+
+describe("POST /auth/dashboard-login", () => {
+  it("succeeds with correct password and sets session cookie", async () => {
+    const res = await login("secret123");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(res.headers.get("set-cookie")).toMatch(/_codex_session=/);
+  });
+
+  it("returns 401 with wrong password", async () => {
+    const res = await login("wrong-password");
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBeTruthy();
+  });
+
+  it("returns 400 when no password field", async () => {
+    const res = await app.request("/auth/dashboard-login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const res = await app.request("/auth/dashboard-login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rate-limits after 5 consecutive failures", async () => {
+    for (let i = 0; i < 5; i++) {
+      const r = await login("wrong");
+      expect(r.status).toBe(401);
+    }
+    const blocked = await login("secret123");
+    expect(blocked.status).toBe(429);
+  });
+
+  it("returns 400 when password is empty string (even with no key configured)", async () => {
+    mockConfig.server.proxy_api_key = null;
+    // Empty string is falsy — validation rejects it before key comparison
+    const res = await app.request("/auth/dashboard-login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /auth/dashboard-logout ───────────────────────────────────
+
+describe("POST /auth/dashboard-logout", () => {
+  it("clears the session cookie", async () => {
+    const loginRes = await login("secret123");
+    const sessionId = extractSession(loginRes.headers.get("set-cookie"));
+    expect(sessionId).toBeTruthy();
+
+    const logoutRes = await app.request("/auth/dashboard-logout", {
+      method: "POST",
+      headers: { cookie: `_codex_session=${sessionId}` },
+    });
+    expect(logoutRes.status).toBe(200);
+    const body = await logoutRes.json() as { success: boolean };
+    expect(body.success).toBe(true);
+
+    // Cleared cookie: Max-Age=0
+    expect(logoutRes.headers.get("set-cookie")).toMatch(/Max-Age=0/);
+  });
+
+  it("succeeds even when no session cookie provided", async () => {
+    const res = await app.request("/auth/dashboard-logout", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/e2e/dashboard-login.test.ts
+++ b/tests/e2e/dashboard-login.test.ts
@@ -43,7 +43,7 @@ import { createDashboardAuthRoutes, _resetRateLimitForTest } from "@src/routes/d
 
 const app = new Hono();
 app.use("*", requestId);
-app.use("*", errorHandler);
+app.onError(errorHandler);
 app.route("/", createDashboardAuthRoutes());
 
 // ── Helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

从已关闭的 PR #604 提取 E2E 测试工作，补齐 #376 剩余缺口（Account CRUD / Admin settings / Dashboard login）。

新增 47 个 E2E 用例（3 个文件），走完整 HTTP 管线（routing、middleware、auth、序列化）：

- `tests/e2e/accounts.test.ts`（21 例）— Account CRUD：list / add（含 400 校验）/ delete / reset-usage / label / cookies（GET/POST/DELETE）/ batch-delete / batch-status / export / quota-warnings
- `tests/e2e/admin-settings.test.ts`（15 例）— Admin settings：rotation / settings / general / quota 四组 GET+POST，含 auth-gating（非 localhost + 缺 key → 401）与 400 校验
- `tests/e2e/dashboard-login.test.ts`（11 例）— Dashboard auth：login / logout / status + 速率限制（5 次失败 → 429）

## 与原 PR #604 的差异

- 适配当前 dev 架构：`errorHandler` 由中间件改为 `onError` 挂载
- admin 401 鉴权已从路由内迁至全局 `dashboardAuth` 中间件，测试改为挂载该中间件并用非 localhost 地址触发拦截，保留原鉴权断言

## Test Plan

- [x] 3 个新文件 47/47 通过（`npx vitest run tests/e2e/accounts.test.ts tests/e2e/admin-settings.test.ts tests/e2e/dashboard-login.test.ts`）
- [x] `npx tsc --noEmit` — 0 错误

closes #376 (partial)
