### PR TITLE
fix(quota): preserve reset credits across passive rate limit updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。
 - 修复并统一桌面端与 Web 端应用图标与 Logo：生成包含 Windows 完整多分辨率的 `icon.ico`、Web `favicon.ico` / `icon.png`，Electron 主进程窗口配置中注入应用图标并移除 `electron-builder` 的 `signAndEditExecutable: false` 以确保可执行文件与任务栏/桌面快捷方式正确嵌入图标；统一 Dashboard 顶部导航栏 Logo 为品牌立方体图标。（`packages/electron/`、`web/`、`scripts/build/generate-ico.ps1`）
 - 移除 Dashboard 顶部导航栏与侧栏重复展示的「服务运行中」状态徽标（`web/src/components/Header.tsx`）。
 - 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）

--- a/src/auth/account-registry.ts
+++ b/src/auth/account-registry.ts
@@ -570,15 +570,18 @@ export class AccountRegistry {
   updateCachedQuota(entryId: string, quota: CodexQuota): void {
     const entry = this.accounts.get(entryId);
     if (!entry) return;
-    // Preserve previously known credits when the incoming quota lacks them.
+    // Preserve previously known credits and reset credits when the incoming quota lacks them.
     // The passive header-driven path (rateLimitToQuota in proxy-rate-limit.ts)
-    // does not carry credit balance — only /codex/usage body (toQuota) does.
-    // Without this merge, every /codex/responses call would wipe credits.
+    // does not carry credit balance or rate limit reset credits — only /codex/usage body (toQuota) does.
+    // Without this merge, every /codex/responses call would wipe credits and reset credits.
+    let mergedQuota: CodexQuota = { ...quota };
     if (quota.credits == null && entry.cachedQuota?.credits != null) {
-      entry.cachedQuota = { ...quota, credits: entry.cachedQuota.credits };
-    } else {
-      entry.cachedQuota = quota;
+      mergedQuota.credits = entry.cachedQuota.credits;
     }
+    if (quota.reset_credits_available == null && entry.cachedQuota?.reset_credits_available != null) {
+      mergedQuota.reset_credits_available = entry.cachedQuota.reset_credits_available;
+    }
+    entry.cachedQuota = mergedQuota;
     entry.quotaFetchedAt = new Date().toISOString();
     entry.quotaVerifyRequired = false; // Reset the dirty flag on fresh update
     this.schedulePersist();

--- a/src/auth/active-quota-refresher.ts
+++ b/src/auth/active-quota-refresher.ts
@@ -177,6 +177,13 @@ export function preserveLearnedLocks(
 
   const merged: CodexQuota = { ...fresh };
 
+  if (fresh.credits == null && existing?.credits != null) {
+    merged.credits = existing.credits;
+  }
+  if (fresh.reset_credits_available == null && existing?.reset_credits_available != null) {
+    merged.reset_credits_available = existing.reset_credits_available;
+  }
+
   if (isFutureLock(existing?.rate_limit) && !fresh.rate_limit.limit_reached) {
     merged.rate_limit = {
       ...fresh.rate_limit,

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -300,6 +300,9 @@ export function createAccountRoutes(pool: AccountPool, scheduler: RefreshSchedul
     try {
       const api = new CodexApi(entry.token, entry.accountId, cookieJar, id, proxyPool?.resolveProxyUrl(id));
       const resetCredits = await api.getResetCredits();
+      if (typeof resetCredits.available_count === "number" && entry.cachedQuota) {
+        pool.updateCachedQuota(id, { ...entry.cachedQuota, reset_credits_available: resetCredits.available_count });
+      }
       return c.json(resetCredits);
     } catch (err) {
       if (isTokenInvalidError(err)) {
@@ -363,6 +366,11 @@ export function createAccountRoutes(pool: AccountPool, scheduler: RefreshSchedul
         pool.updateCachedQuota(id, quota);
       } catch {
         // quota cache not updated — caller can refresh manually via GET /auth/accounts/:id/quota
+        const currentQuota = pool.getEntry(id)?.cachedQuota;
+        if (currentQuota?.reset_credits_available && currentQuota.reset_credits_available > 0) {
+          quota = { ...currentQuota, reset_credits_available: currentQuota.reset_credits_available - 1 };
+          pool.updateCachedQuota(id, quota);
+        }
       }
       return c.json({ success: true, quota });
     } catch (err) {

--- a/tests/unit/auth/account-pool-quota.test.ts
+++ b/tests/unit/auth/account-pool-quota.test.ts
@@ -122,6 +122,57 @@ describe("AccountPool quota methods", () => {
       const entry = pool.getEntry(id);
       expect(entry?.cachedQuota?.credits?.balance).toBe(42);
     });
+
+    it("preserves existing reset_credits_available when new quota lacks them (header-driven passive update)", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "reset-credits-1", planType: "plus" }));
+      pool.updateCachedQuota(id, makeQuota({
+        reset_credits_available: 2,
+      }));
+      pool.updateCachedQuota(id, makeQuota({
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          used_percent: 45,
+          reset_at: Math.floor(Date.now() / 1000) + 1800,
+          limit_window_seconds: 18000,
+        },
+      }));
+      const entry = pool.getEntry(id);
+      expect(entry?.cachedQuota?.reset_credits_available).toBe(2);
+      expect(entry?.cachedQuota?.rate_limit.used_percent).toBe(45);
+    });
+
+    it("preserves existing reset_credits_available when new quota explicitly carries null", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "reset-credits-null", planType: "plus" }));
+      pool.updateCachedQuota(id, makeQuota({
+        reset_credits_available: 3,
+      }));
+      pool.updateCachedQuota(id, makeQuota({
+        reset_credits_available: null,
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          used_percent: 50,
+          reset_at: Math.floor(Date.now() / 1000) + 1800,
+          limit_window_seconds: 18000,
+        },
+      }));
+      const entry = pool.getEntry(id);
+      expect(entry?.cachedQuota?.reset_credits_available).toBe(3);
+      expect(entry?.cachedQuota?.rate_limit.used_percent).toBe(50);
+    });
+
+    it("overwrites reset_credits_available when new quota explicitly provides a number (e.g. 0 after consume)", () => {
+      const id = pool.addAccount(createValidJwt({ accountId: "reset-credits-consume", planType: "plus" }));
+      pool.updateCachedQuota(id, makeQuota({
+        reset_credits_available: 1,
+      }));
+      pool.updateCachedQuota(id, makeQuota({
+        reset_credits_available: 0,
+      }));
+      const entry = pool.getEntry(id);
+      expect(entry?.cachedQuota?.reset_credits_available).toBe(0);
+    });
   });
 
   describe("applyRateLimit429 (replaces markQuotaExhausted)", () => {

--- a/tests/unit/routes/account-reset-credits.test.ts
+++ b/tests/unit/routes/account-reset-credits.test.ts
@@ -97,7 +97,14 @@ describe("Account reset credits routes", () => {
       expect(json.error).toContain("disabled");
     });
 
-    it("returns reset credits snapshot on success", async () => {
+    it("returns reset credits snapshot on success and syncs to cachedQuota", async () => {
+      pool.updateCachedQuota(accountId, {
+        plan_type: "plus",
+        rate_limit: { allowed: true, limit_reached: false, used_percent: 10, reset_at: 1789000000, limit_window_seconds: 18000 },
+        secondary_rate_limit: null,
+        code_review_rate_limit: null,
+      });
+
       mockGetResetCredits.mockResolvedValueOnce({
         available_count: 2,
         credits: [{ id: "c1", status: "available" }],
@@ -109,6 +116,9 @@ describe("Account reset credits routes", () => {
       const json = await res.json();
       expect(json.available_count).toBe(2);
       expect(json.credits).toHaveLength(1);
+
+      const entry = pool.getEntry(accountId);
+      expect(entry?.cachedQuota?.reset_credits_available).toBe(2);
     });
 
     it("returns 502 when upstream call fails", async () => {


### PR DESCRIPTION
## Summary
- 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 reset_credits_available，并在重置卡查询与消耗逻辑中同步更新账号配额缓存。

## Test Plan
- npm run build
- npx vitest run tests/unit/auth/account-pool-quota.test.ts tests/unit/routes/account-reset-credits.test.ts