### PR TITLE
fix(ui): use official logo as brand mark in header and sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixed
 
 - 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。
+- 修复 Dashboard 顶部导航栏与侧栏「Codex Proxy」左侧品牌图标错误的问题：将手绘六边形 SVG 替换为官方 Logo 图片（`web/public/icon.png`），与桌面端 / Web 应用图标保持一致。（`web/src/components/Header.tsx`、`web/src/components/Sidebar.tsx`）
 - 修复并统一桌面端与 Web 端应用图标与 Logo：生成包含 Windows 完整多分辨率的 `icon.ico`、Web `favicon.ico` / `icon.png`，Electron 主进程窗口配置中注入应用图标并移除 `electron-builder` 的 `signAndEditExecutable: false` 以确保可执行文件与任务栏/桌面快捷方式正确嵌入图标；统一 Dashboard 顶部导航栏 Logo 为品牌立方体图标。（`packages/electron/`、`web/`、`scripts/build/generate-ico.ps1`）
 - 移除 Dashboard 顶部导航栏与侧栏重复展示的「服务运行中」状态徽标（`web/src/components/Header.tsx`）。
 - 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -82,12 +82,7 @@ export function Header({ onAddAccount, onCheckUpdate, onOpenUpdateModal, checkin
         <div class={`flex w-full ${showBrand ? "max-w-[960px] justify-between" : "max-w-none justify-between lg:justify-end"} items-center gap-4`}>
           {/* Logo & Title */}
           {showBrand ? <div class="flex min-w-0 items-center gap-3">
-            <div class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary-action text-white shadow-sm shadow-primary/20">
-              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" aria-hidden="true">
-                <path d="m12 2.75 7.5 4.3v9.9L12 21.25l-7.5-4.3v-9.9L12 2.75Z" />
-                <path d="m8.5 9.25 3.5 2 3.5-2M8.5 14.75l3.5-2 3.5 2M12 11.25v4" />
-              </svg>
-            </div>
+            <img src="/icon.png" alt="Codex Proxy" class="size-8 shrink-0 object-contain" />
             <h1 class="text-[0.9rem] font-bold tracking-tight whitespace-nowrap overflow-hidden text-ellipsis min-w-0">Codex Proxy</h1>
           </div> : <div class="flex items-center gap-2 lg:hidden">
             {onOpenSidebar && <button onClick={onOpenSidebar} class="rounded-lg p-2 text-slate-500 hover:bg-slate-100 dark:text-text-dim dark:hover:bg-border-dark" aria-label={t("openSidebar")}>
@@ -95,12 +90,7 @@ export function Header({ onAddAccount, onCheckUpdate, onOpenUpdateModal, checkin
                 <path d="M4 6h16M4 12h16M4 18h16" />
               </svg>
             </button>}
-            <div class="flex size-8 items-center justify-center rounded-lg bg-primary-action text-white shadow-sm shadow-primary/20">
-              <svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" aria-hidden="true">
-                <path d="m12 2.75 7.5 4.3v9.9L12 21.25l-7.5-4.3v-9.9L12 2.75Z" />
-                <path d="m8.5 9.25 3.5 2 3.5-2M8.5 14.75l3.5-2 3.5 2M12 11.25v4" />
-              </svg>
-            </div>
+            <img src="/icon.png" alt="Codex Proxy" class="size-8 shrink-0 object-contain" />
             <span class="text-sm font-bold tracking-tight">Codex Proxy</span>
           </div>}
           {/* Actions */}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -24,12 +24,7 @@ function NavIcon({ name }: { name: IconName }) {
 
 function BrandMark() {
   return (
-    <div class="flex size-9 shrink-0 items-center justify-center rounded-xl bg-primary-action text-white shadow-sm shadow-primary/20">
-      <svg class="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" aria-hidden="true">
-        <path d="m12 2.75 7.5 4.3v9.9L12 21.25l-7.5-4.3v-9.9L12 2.75Z" />
-        <path d="m8.5 9.25 3.5 2 3.5-2M8.5 14.75l3.5-2 3.5 2M12 11.25v4" />
-      </svg>
-    </div>
+    <img src="/icon.png" alt="Codex Proxy" class="size-9 shrink-0 object-contain" />
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace the hand-drawn hexagon SVG brand mark (introduced in #767) with the official codex-proxy logo image (`web/public/icon.png`) in the Header (desktop + mobile) and the Sidebar.
- Brand marks now match the desktop/web app icons and favicon.

## Test Plan
- [x] `npm run build` (web) passes

## Notes
- Closes the regression where the brand icon next to "Codex Proxy" was wrong.