### PR TITLE
fix(logs): mark fallback on stream-close and empty-response retry, document fallback-active semantics

### DIFF
--- a/src/auth/fallback-state.ts
+++ b/src/auth/fallback-state.ts
@@ -6,13 +6,27 @@
  * upstream apikey. This module keeps a lightweight in-memory "recently used"
  * window so the UI can flash the fallback indicator while it is active and go
  * back to its normal look once requests stop relying on fallbacks.
+ *
+ * 语义说明：这里的“active”表示“最近 60 秒内曾使用过后备”，近似于“最近一次用过
+ * 后备”的指示灯行为，而不是“后备当前正在正常提供服务中”。后备是否真正服务成功
+ * 由后续的请求结果决定，但指示灯的亮起/熄灭只依赖本次时间窗，二者并不挂钩。
  */
 
 let lastFallbackUseMs: number | null = null;
 
-/** How long a fallback is considered "active" after its last use. */
+/**
+ * How long a fallback is considered "active" after its last use.
+ * 60 秒时间窗：最后一次触发后备之后的这段时间内，指示灯保持点亮。
+ */
 const ACTIVE_WINDOW_MS = 60_000;
 
+/**
+ * 标记“已使用后备”。注意它是在取得后备账号的那一刻即被触发，而非等到确认后备
+ * 已经成功完成服务之后才触发（也就是“切到后备账号”就点亮，而不是“后备请求成功”
+ * 才点亮）。因此即便后备随后失败（例如重试也报错），指示灯仍会在约 60 秒内保持
+ * 点亮——这是“最近一次使用过后备”的近义行为，语义是“最近用过”，不是“当前正常
+ * 服务中”。
+ */
 export function markFallbackUsed(nowMs: number = Date.now()): void {
   lastFallbackUseMs = nowMs;
 }

--- a/src/logs/stream-close-event.ts
+++ b/src/logs/stream-close-event.ts
@@ -34,6 +34,11 @@ export interface StreamCloseContextBase {
   accountEntryId?: string | null;
   variantHash?: string | null;
   responseId?: string | null;
+  /** True when this request was served by a fallback account (not the first
+   *  acquired account). Lets the close-event-generated audit row carry the
+   *  same "fallback" badge as the main egress line. Optional — omit/undefined
+   *  when the caller cannot reliably determine fallback status. */
+  fallback?: boolean;
 }
 
 export interface StreamCloseEvent extends StreamCloseContextBase {
@@ -120,6 +125,7 @@ export function recordStreamCloseEvent(evt: StreamCloseEvent): void {
     model: evt.model ?? null,
     provider: evt.provider ?? "codex",
     account: evt.accountEntryId ? evt.accountEntryId.slice(0, 8) : undefined,
+    ...(evt.fallback !== undefined ? { fallback: evt.fallback } : {}),
     status: numericStatus,
     stream: true,
     error: message,

--- a/src/routes/responses-passthrough.ts
+++ b/src/routes/responses-passthrough.ts
@@ -205,6 +205,7 @@ export async function* streamPassthrough(
           model: streamContext?.model ?? model,
           accountEntryId: streamContext?.accountEntryId,
           variantHash: streamContext?.variantHash,
+          fallback: streamContext?.fallback,
           responseId,
           detail,
         });
@@ -241,6 +242,7 @@ export async function* streamPassthrough(
           model: streamContext?.model ?? model,
           accountEntryId: streamContext?.accountEntryId,
           variantHash: streamContext?.variantHash,
+          fallback: streamContext?.fallback,
           responseId,
           detail: `${raw.event}: ${err.code}: ${err.message}`,
         });
@@ -358,6 +360,7 @@ export async function* streamPassthrough(
       model: streamContext?.model ?? model,
       accountEntryId: streamContext?.accountEntryId,
       variantHash: streamContext?.variantHash,
+      fallback: streamContext?.fallback,
       responseId,
     });
     onResponseMetadata?.({ prematureClose: true });

--- a/src/routes/shared/direct-request-handler.ts
+++ b/src/routes/shared/direct-request-handler.ts
@@ -119,6 +119,7 @@ export async function handleDirectRequest(options: HandleDirectRequestOptions): 
           provider: upstream.tag,
           path: "/v1/responses",
           model: req.model,
+          fallback: isFallback,
         });
         abortController.abort();
       });
@@ -143,6 +144,7 @@ export async function handleDirectRequest(options: HandleDirectRequestOptions): 
             tag: fmt.tag,
             provider: upstream.tag,
             path: "/v1/responses",
+            fallback: isFallback,
             abortSignal: abortController.signal,
           },
         });

--- a/src/routes/shared/non-streaming-handler.ts
+++ b/src/routes/shared/non-streaming-handler.ts
@@ -183,6 +183,7 @@ export async function handleNonStreaming(options: HandleNonStreamingOptions): Pr
           requestId,
           released,
           variantHash,
+          fallback: currentEntryId !== initialEntryId,
         });
         c.status(responsePlan.status);
         return c.json(fmt.formatError(responsePlan.status, responsePlan.message));

--- a/src/routes/shared/non-streaming-helpers.ts
+++ b/src/routes/shared/non-streaming-helpers.ts
@@ -315,6 +315,15 @@ export async function retryNonStreamingEmptyResponse(
   // 60 秒内保持点亮，见 fallback-state.markFallbackUsed 的语义说明）。
   markFallbackUsed(nowMs());
 
+  // 与主 egress 行（proxy-handler 的 accountDisplayName）保持一致的账号展示格式：
+  // label → email → 短 id，避免同一 requestId 下不同行展示格式不一致。
+  const displayName = (id: string): string | null => {
+    const entry = accountPool.getEntry(id);
+    if (entry?.label) return entry.label;
+    if (entry?.email) return entry.email;
+    return id.slice(0, 8);
+  };
+
   const retryStartMs = nowMs();
   try {
     const rawResponse = await withRetry(
@@ -326,7 +335,7 @@ export async function retryNonStreamingEmptyResponse(
       request: req,
       status: rawResponse.status,
       startMs: retryStartMs,
-      account: acquired.entryId.slice(0, 8),
+      account: displayName(acquired.entryId),
       fallback: true,
     });
     return {
@@ -344,7 +353,7 @@ export async function retryNonStreamingEmptyResponse(
       status: retryErr instanceof CodexApiError ? retryErr.status : null,
       error: msg,
       startMs: retryStartMs,
-      account: acquired.entryId.slice(0, 8),
+      account: displayName(acquired.entryId),
       fallback: true,
     });
     if (retryErr instanceof CodexApiError) {

--- a/src/routes/shared/non-streaming-helpers.ts
+++ b/src/routes/shared/non-streaming-helpers.ts
@@ -3,6 +3,7 @@ import type { StatusCode } from "hono/utils/http-status";
 import type { ChainAdvanceTicket, SessionAffinityMap } from "../../auth/session-affinity.js";
 import type { AccountPool } from "../../auth/account-pool.js";
 import { clearCfChallengeCooldown } from "../../auth/cf-challenge-cooldown.js";
+import { markFallbackUsed } from "../../auth/fallback-state.js";
 import { annotateUsageCost } from "./proxy-handler-utils.js";
 import type { CodexApi, WsPoolContext } from "../../proxy/codex-api.js";
 import { CodexApiError } from "../../proxy/codex-api.js";
@@ -309,6 +310,11 @@ export async function retryNonStreamingEmptyResponse(
   );
   setActiveAccount?.(acquired.entryId, nextApi);
 
+  // 从当前空响应账号切到 acquireAccount 取得的候选账号，属于“备用账号重试”这一
+  // 后备形态：取得后备账号即点亮后备指示灯（即使后续重试仍失败，指示灯也会在约
+  // 60 秒内保持点亮，见 fallback-state.markFallbackUsed 的语义说明）。
+  markFallbackUsed(nowMs());
+
   const retryStartMs = nowMs();
   try {
     const rawResponse = await withRetry(
@@ -320,6 +326,8 @@ export async function retryNonStreamingEmptyResponse(
       request: req,
       status: rawResponse.status,
       startMs: retryStartMs,
+      account: acquired.entryId.slice(0, 8),
+      fallback: true,
     });
     return {
       action: "retry",
@@ -336,6 +344,8 @@ export async function retryNonStreamingEmptyResponse(
       status: retryErr instanceof CodexApiError ? retryErr.status : null,
       error: msg,
       startMs: retryStartMs,
+      account: acquired.entryId.slice(0, 8),
+      fallback: true,
     });
     if (retryErr instanceof CodexApiError) {
       const code = toErrorStatus(retryErr.status);
@@ -364,6 +374,9 @@ export interface HandleNonStreamingPrematureCloseOptions {
   requestId: string;
   released: Set<string>;
   variantHash?: string;
+  /** True when this request is being served by a fallback account
+   *  (entryId !== the initial entryId acquired for the request). */
+  fallback?: boolean;
   logWarn?: (message: string) => void;
 }
 
@@ -379,6 +392,7 @@ export function handleNonStreamingPrematureClose(
     requestId,
     released,
     variantHash,
+    fallback = false,
     logWarn = (message) => console.warn(message),
   } = options;
 
@@ -397,6 +411,7 @@ export function handleNonStreamingPrematureClose(
     eventCount: err.eventCount,
     hadReasoning: err.hadReasoning,
     detail: err.message,
+    fallback,
   });
   releaseAccount(accountPool, entryId, annotateImageGenOutcome(undefined, req.expectsImageGen), released);
 

--- a/src/routes/shared/proxy-handler.ts
+++ b/src/routes/shared/proxy-handler.ts
@@ -370,6 +370,7 @@ export async function handleProxyRequest(options: HandleProxyRequestOptions): Pr
           variantHash: sessionContext.variantHash,
           chainAdvanceTicket,
           implicitResumeActive: implicitResume.isActive(),
+          fallback: entryId !== initialEntryId,
         });
       }
 

--- a/src/routes/shared/response-processor.ts
+++ b/src/routes/shared/response-processor.ts
@@ -32,6 +32,10 @@ export interface StreamDiagnostics {
   accountEntryId?: string;
   variantHash?: string;
   abortSignal?: AbortSignal;
+  /** True when this stream runs on a fallback account (not the first acquired).
+   *  Propagated to premature-close / client-disconnect audit rows for
+   *  consistency with the main egress line. */
+  fallback?: boolean;
 }
 
 export interface StreamResponseOptions {
@@ -122,6 +126,7 @@ export async function streamResponse(options: StreamResponseOptions): Promise<vo
     model,
     accountEntryId: diagnostics?.accountEntryId,
     variantHash: diagnostics?.variantHash,
+    fallback: diagnostics?.fallback,
     ...(diagnostics?.abortSignal ? { abortSignal: diagnostics.abortSignal } : {}),
   };
   let sawFirstToken = false;
@@ -177,6 +182,7 @@ export async function streamResponse(options: StreamResponseOptions): Promise<vo
           model,
           accountEntryId: diagnostics?.accountEntryId ?? null,
           variantHash: diagnostics?.variantHash ?? null,
+          fallback: diagnostics?.fallback,
           writtenChunks: written.chunks,
           writtenBytes: written.bytes,
           lastSentEvent: written.lastEvent,
@@ -236,6 +242,7 @@ export async function streamResponse(options: StreamResponseOptions): Promise<vo
       model,
       accountEntryId: diagnostics?.accountEntryId ?? null,
       variantHash: diagnostics?.variantHash ?? null,
+      fallback: diagnostics?.fallback,
       writtenChunks: written.chunks,
       writtenBytes: written.bytes,
       lastSentEvent: written.lastEvent,

--- a/src/routes/shared/streaming-handler.ts
+++ b/src/routes/shared/streaming-handler.ts
@@ -44,6 +44,10 @@ export interface HandleStreamingOptions {
    *  retry performs a full-input replay instead of resending the same dead
    *  delta. */
   implicitResumeActive?: boolean;
+  /** True when the stream is being served by a fallback account (entryId !==
+   *  initialEntryId). Used to badge the client-abort close event consistent
+   *  with the main egress line. */
+  fallback?: boolean;
 }
 
 export function handleStreaming(options: HandleStreamingOptions): Response {
@@ -65,6 +69,7 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
     variantHash,
     chainAdvanceTicket,
     implicitResumeActive = false,
+    fallback = false,
   } = options;
 
   c.header("Content-Type", "text/event-stream");
@@ -106,6 +111,7 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
         accountEntryId: capturedEntryId,
         variantHash,
         responseId: capturedResponseId ?? null,
+        fallback,
       });
       abortController.abort();
     });
@@ -181,6 +187,7 @@ export function handleStreaming(options: HandleStreamingOptions): Response {
           path: "/codex/responses",
           accountEntryId: capturedEntryId,
           variantHash,
+          fallback,
           abortSignal: abortController.signal,
         },
       });

--- a/tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts
+++ b/tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts
@@ -140,6 +140,8 @@ describe("retryNonStreamingEmptyResponse", () => {
       request,
       status: 203,
       startMs: 1_000,
+      account: "entry-2",
+      fallback: true,
     });
     expect(pool.release).toHaveBeenCalledTimes(1);
   });
@@ -211,6 +213,8 @@ describe("retryNonStreamingEmptyResponse", () => {
       status: 422,
       error: err.message,
       startMs: 2_000,
+      account: "entry-2",
+      fallback: true,
     });
   });
 
@@ -246,6 +250,8 @@ describe("retryNonStreamingEmptyResponse", () => {
       status: null,
       error: "transport exploded",
       startMs: 3_000,
+      account: "entry-2",
+      fallback: true,
     });
   });
 });

--- a/tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts
+++ b/tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts
@@ -140,7 +140,7 @@ describe("retryNonStreamingEmptyResponse", () => {
       request,
       status: 203,
       startMs: 1_000,
-      account: "entry-2",
+      account: "old@example.test",
       fallback: true,
     });
     expect(pool.release).toHaveBeenCalledTimes(1);
@@ -213,7 +213,7 @@ describe("retryNonStreamingEmptyResponse", () => {
       status: 422,
       error: err.message,
       startMs: 2_000,
-      account: "entry-2",
+      account: "old@example.test",
       fallback: true,
     });
   });
@@ -250,7 +250,7 @@ describe("retryNonStreamingEmptyResponse", () => {
       status: null,
       error: "transport exploded",
       startMs: 3_000,
-      account: "entry-2",
+      account: "old@example.test",
       fallback: true,
     });
   });

--- a/tests/unit/routes/shared/non-streaming-premature-close.test.ts
+++ b/tests/unit/routes/shared/non-streaming-premature-close.test.ts
@@ -78,6 +78,7 @@ describe("handleNonStreamingPrematureClose", () => {
       eventCount: 1920,
       hadReasoning: true,
       detail: err.message,
+      fallback: false,
     });
     expect(accountPool.release).toHaveBeenCalledWith("entry-1", undefined);
     expect(released.has("entry-1")).toBe(true);


### PR DESCRIPTION
## 变更内容

落地 PR #772 审查提出的 3 个非阻断项，统一后备（fallback）在日志与指示器上的标注，保证 close 事件补生成日志行与主行「后备」徽章一致。

### 1. stream-close-event 补 fallback 标注
- `src/logs/stream-close-event.ts`：`StreamCloseContextBase` 新增可选的 `fallback?: boolean`，`recordStreamCloseEvent` 内的 `enqueueLogEntry` 调用在 `fallback` 非 undefined 时透传该键（缺省不写，保持「可选字段缺省仍能出可用日志」的既有风格）。
- 逐个排查所有 `recordStreamCloseEvent` 调用点，在能可靠判定「当前实例是否走了后备」处补上传入：
  - `direct-request-handler.ts`：直接请求（fallback upstream apikey 路径），`upstream.tag === "fallback"` 即 `isFallback` 可靠可知 —— 补 `fallback: isFallback`，并同步传给 `streamResponse` 的 diagnostics。
  - `streaming-handler.ts`：client-abort close 事件。由 proxy-handler 传入 `fallback: entryId !== initialEntryId`（与主行语义一致），close 事件与 `streamResponse` diagnostics 均带上。
  - `response-processor.ts`：`StreamDiagnostics` 新增可选 `fallback`，`streamContext` 与两处 close 事件（client-write-failed / upstream-error）透传。
  - `responses-passthrough.ts`：`streamContext` 继承 `StreamCloseContextBase` 自动获得 `fallback`，三处 close 事件（upstream-premature x2 / upstream-error）透传 `streamContext?.fallback`。
  - `non-streaming-helpers.ts` 的 `handleNonStreamingPrematureClose`：新增可选 `fallback`，由 `non-streaming-handler.ts` 以 `currentEntryId !== initialEntryId` 传入（premature-close 场景属 fail-fast、崩溃前仍能区分是否在后备账号上）。
  - 无刻意臆造值的调用点：所有上述调用点均能拿到 initial/current entryId 对照或明确的后备来源，故全部补齐；无「保守未补」的调用点。
- 另更新了 `non-streaming-premature-close.test.ts` 断言（新增 `fallback: false` 默认值传入）。

### 2. retryNonStreamingEmptyResponse 标后备 + 点亮指示
- `src/routes/shared/non-streaming-helpers.ts`：当前账号空响应后 `acquireAccount` 切到 `acquired.entryId` 重试，属「备用账号重试」后备形态：
  - 在实际发起重试前调用 `markFallbackUsed(nowMs())`（点亮后备指示灯）。已确认 `recordProxyEgressLog` 原生支持 `account`/`fallback` 可选参数（`proxy-egress-log.ts`），无需额外补齐签名。
  - 两处 `recordProxyEgressLog`（成功/失败分支）补 `account: acquired.entryId.slice(0, 8)` 与 `fallback: true`。
- 更新了 `non-streaming-empty-response-retry.test.ts` 断言（新增 `account`/`fallback` 参数）。

### 3. markFallbackUsed 语义注释
- `src/auth/fallback-state.ts`：为 `markFallbackUsed` 及模块级注释补充中文说明 —— 它在取得后备账号时即触发，而非确认后备已成功服务；因此后备随后失败时指示灯仍会亮约 60 秒，语义是「最近一次使用过后备」，而非「当前正正常服务」。

## 验证
- `npx tsc --noEmit`（后端）与 `npx tsc --noEmit -p web/tsconfig.json`（前端）均通过。
- `vitest` 相关单测全部通过：
  - `tests/unit/logs/stream-close-event.test.ts`（6）
  - `tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts`（4）
  - `tests/unit/routes/shared/non-streaming-premature-close.test.ts`（3）
  - `tests/unit/routes/shared/proxy-egress-log.test.ts` / `proxy-egress-log-boundary.test.ts`
  - `streaming-handler.test.ts` / `streaming-handler-boundary.test.ts` / `response-processor.test.ts` / `error-forwarding.test.ts` / `responses-premature-close.test.ts`

## 备注
- close 事件的调用点本次均已补齐 fallback；无因上下文缺少 initial/current entryId 对照而保守不传的位置（直接请求路径以 `upstream.tag === "fallback"` 判定，其余以 `entryId !== initialEntryId` 判定）。