### PR TITLE
feat(models): support GPT-6 Astra and GPT-Reserve models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Added
 
+- 支持 OpenAI GPT-6 Astra 系列（`gpt-6-astra`、`gpt-6-astra-aeon` 及别名 `gpt-6`）与 GPT-Reserve（`gpt-reserve`）：内置静态模型元数据与推理级别定义（`/v1/models/catalog` 可见），`gpt-6` 别名解析到 `gpt-6-astra`，可路由性已由 #776 的名称形态放行覆盖；同步适配 1,050,000 上下文窗口、Ollama 桥接架构系列识别与官方定价估算（`src/models/model-store.ts`、`src/ollama/bridge.ts`、`config/model-pricing.yaml`、`README.md`）。
 - 重构 Dashboard UI 视觉体系与设置交互逻辑：
   - 移除窗口顶部菜单栏，并将窗口标题统一为「Codex Proxy」（`packages/electron/electron/main.ts`、`web/index.html`）。
   - 全局优化浅色与深色色彩体系及统一系统/等宽字体层级渲染（`web/src/index.css`、`web/tailwind.config.ts`）。

--- a/README.md
+++ b/README.md
@@ -243,6 +243,9 @@ curl http://localhost:8080/v1/chat/completions \
 
 | 模型 ID              | 推理等级                                      | 当前上下文     | 最大上下文     | 最大输出    | 输出 | 说明                                    |
 | ------------------ | ----------------------------------------- | --------- | --------- | ------- | -- | ------------------------------------- |
+| `gpt-6-astra`      | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-6 前沿旗舰：复杂推理与端到端 Agent 编码（`gpt-6` 为其别名） |
+| `gpt-6-astra-aeon` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-6 长程多 Agent 编排与深度推理变体            |
+| `gpt-reserve`      | low / medium / high / xhigh / max         | 272,000   | 872,000   | 128,000 | 文本 | 快速高性价比 Agent 编码模型（全计划开放）            |
 | `gpt-5.6-sol`      | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 旗舰：复杂推理与编码（默认；`gpt-5.6` 为其别名） |
 | `gpt-5.6-terra`    | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 智能与成本平衡                       |
 | `gpt-5.6-luna`     | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | 文本 | GPT-5.6 高性价比 / 高吞吐                    |

--- a/README_EN.md
+++ b/README_EN.md
@@ -194,6 +194,9 @@ If you see streaming AI text, the setup is working. If you get 401, double-check
 
 | Model ID | Reasoning | Current context | Max context | Max output | Output | Description |
 |----------|-----------|-----------------|-------------|------------|--------|-------------|
+| `gpt-6-astra` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-6 frontier flagship for complex reasoning & coding (`gpt-6` is an alias) |
+| `gpt-6-astra-aeon` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-6 variant for long-horizon multi-agent tasks & deep reasoning |
+| `gpt-reserve` | low / medium / high / xhigh / max | 272,000 | 872,000 | 128,000 | text | Fast and affordable agentic coding model (all plans) |
 | `gpt-5.6-sol` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 flagship for complex reasoning & coding (default; `gpt-5.6` is an alias) |
 | `gpt-5.6-terra` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 balanced intelligence and cost |
 | `gpt-5.6-luna` | low / medium / high / xhigh / max / ultra | 1,050,000 | 1,050,000 | 128,000 | text | GPT-5.6 cost-efficient / high-throughput |

--- a/config/model-pricing.yaml
+++ b/config/model-pricing.yaml
@@ -53,6 +53,18 @@ models:
     input_usd_per_million: 0.2
     cached_input_usd_per_million: 0.02
     output_usd_per_million: 1.2
+  gpt-6-astra:
+    input_usd_per_million: 10
+    cached_input_usd_per_million: 1
+    output_usd_per_million: 50
+  gpt-6-astra-aeon:
+    input_usd_per_million: 10
+    cached_input_usd_per_million: 1
+    output_usd_per_million: 50
+  gpt-reserve:
+    input_usd_per_million: 0.2
+    cached_input_usd_per_million: 0.02
+    output_usd_per_million: 1.2
   gpt-image-2:
     input_usd_per_million: 5
     cached_input_usd_per_million: 1.25

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -122,6 +122,90 @@ const EFFORT_SUFFIXES = new Set(["none", "minimal", "low", "medium", "high", "xh
 /** ChatGPT UI selectors that are not valid Codex model IDs. */
 const CHATGPT_ONLY_MODEL_IDS = new Set(["auto"]);
 
+export const KNOWN_OFFICIAL_MODELS: ReadonlyMap<string, CodexModelInfo> = new Map<string, CodexModelInfo>([
+  [
+    "gpt-6-astra",
+    {
+      id: "gpt-6-astra",
+      displayName: "GPT-6 Astra",
+      description: "Flagship frontier model for complex reasoning, coding, and end-to-end agentic work.",
+      isDefault: false,
+      contextWindow: 1050000,
+      maxContextWindow: 1050000,
+      maxOutputTokens: 128000,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportedReasoningEfforts: [
+        { reasoningEffort: "low", description: "Fast responses with lighter reasoning" },
+        { reasoningEffort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+        { reasoningEffort: "high", description: "Greater reasoning depth for complex problems" },
+        { reasoningEffort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+        { reasoningEffort: "max", description: "Maximum reasoning depth for the hardest problems" },
+        { reasoningEffort: "ultra", description: "Maximum reasoning with automatic task delegation" },
+      ],
+      defaultReasoningEffort: "medium",
+      supportsPersonality: false,
+      upgrade: null,
+      source: "static",
+    },
+  ],
+  [
+    "gpt-6-astra-aeon",
+    {
+      id: "gpt-6-astra-aeon",
+      displayName: "GPT-6 Astra Aeon",
+      description: "Specialized variant for long-horizon multi-agent tasks and extended reasoning runs.",
+      isDefault: false,
+      contextWindow: 1050000,
+      maxContextWindow: 1050000,
+      maxOutputTokens: 128000,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportedReasoningEfforts: [
+        { reasoningEffort: "low", description: "Fast responses with lighter reasoning" },
+        { reasoningEffort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+        { reasoningEffort: "high", description: "Greater reasoning depth for complex problems" },
+        { reasoningEffort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+        { reasoningEffort: "max", description: "Maximum reasoning depth for the hardest problems" },
+        { reasoningEffort: "ultra", description: "Maximum reasoning with automatic task delegation" },
+      ],
+      defaultReasoningEffort: "high",
+      supportsPersonality: false,
+      upgrade: null,
+      source: "static",
+    },
+  ],
+  [
+    "gpt-reserve",
+    {
+      id: "gpt-reserve",
+      displayName: "GPT-Reserve",
+      description: "Fast and affordable agentic coding model.",
+      isDefault: false,
+      contextWindow: 272000,
+      maxContextWindow: 872000,
+      maxOutputTokens: 128000,
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportedReasoningEfforts: [
+        { reasoningEffort: "low", description: "Fast responses with lighter reasoning" },
+        { reasoningEffort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+        { reasoningEffort: "high", description: "Greater reasoning depth for complex problems" },
+        { reasoningEffort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+        { reasoningEffort: "max", description: "Maximum reasoning depth for the hardest problems" },
+      ],
+      defaultReasoningEffort: "medium",
+      supportsPersonality: false,
+      upgrade: null,
+      source: "static",
+    },
+  ],
+]);
+
+export const BUILTIN_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  "gpt-6": "gpt-6-astra",
+};
+
 function isAdmittedBackendModel(model: Pick<CodexModelInfo, "id">): boolean {
   return !CHATGPT_ONLY_MODEL_IDS.has(model.id);
 }
@@ -288,7 +372,7 @@ export class ModelStore {
     // The bare `codex` sentinel means "use the default model", not a literal ID.
     if (resolved === "codex") return this.defaultModelFn();
     // Recognized-but-not-catalogued official models route as-is rather than
-    // silently falling back to the default model.
+    // silently falling back to the default model (shape check from #776).
     if (isOfficialCodexShape(resolved)) return resolved;
     return this.defaultModelFn();
   }
@@ -342,11 +426,15 @@ export class ModelStore {
   }
 
   getModelInfo(modelId: string): CodexModelInfo | undefined {
-    return this.catalog.find((m) => m.id === modelId);
+    const key = BUILTIN_MODEL_ALIASES[modelId] ?? modelId;
+    return this.catalog.find((m) => m.id === key) ?? KNOWN_OFFICIAL_MODELS.get(key);
   }
 
   getModelCatalog(): CodexModelInfo[] {
-    return [...this.catalog];
+    const staticModels = [...KNOWN_OFFICIAL_MODELS.values()].filter(
+      (m) => !this.catalog.some((c) => c.id === m.id),
+    );
+    return [...this.catalog, ...staticModels];
   }
 
   getModelAliases(): Record<string, string> {
@@ -488,7 +576,7 @@ export class ModelStore {
     const seen = new Set<string>();
 
     for (let depth = 0; depth < 20; depth++) {
-      const target = this.aliases[current]?.trim();
+      const target = (this.aliases[current] ?? BUILTIN_MODEL_ALIASES[current])?.trim();
       if (!target) return current;
       if (seen.has(current) || seen.has(target)) return input.trim();
       seen.add(current);

--- a/src/ollama/bridge.ts
+++ b/src/ollama/bridge.ts
@@ -54,6 +54,10 @@ class OllamaBridgeError extends Error {
 }
 
 const CONTEXT_WINDOW_OVERRIDES = new Map<string, number>([
+  // GPT-6 family (GA 2026-09-03) — 1 M token context window
+  ["gpt-6-astra", 1050000],
+  ["gpt-6-astra-aeon", 1050000],
+  ["gpt-6", 1050000],
   // GPT-5.6 family (GA 2026-07-09) — 1 M token context window
   ["gpt-5.6-sol", 1050000],
   ["gpt-5.6-terra", 1050000],
@@ -64,6 +68,7 @@ const CONTEXT_WINDOW_OVERRIDES = new Map<string, number>([
   ["gpt-5.4-pro", 400000],
   ["gpt-5.4-mini", 400000],
   ["gpt-5.4-nano", 400000],
+  ["gpt-reserve", 872000],
   ["gpt-5.3-codex", 272000],
   ["gpt-5.3-codex-spark", 272000],
   ["gpt-5.2", 272000],
@@ -119,6 +124,7 @@ function responseHeaders(init: HeadersInit, request?: Request, corsAllowNullOrig
 
 function inferFamily(modelId: string): string {
   const normalized = modelId.toLowerCase();
+  if (normalized.startsWith("gpt-6")) return "gpt-6";
   if (normalized.startsWith("gpt-5.6")) return "gpt-5.6";
   if (normalized.startsWith("gpt-5.5")) return "gpt-5.5";
   if (normalized.startsWith("gpt-5.4")) return "gpt-5.4";
@@ -126,6 +132,7 @@ function inferFamily(modelId: string): string {
   if (normalized.startsWith("gpt-5.2")) return "gpt-5.2";
   if (normalized.startsWith("gpt-5.1")) return "gpt-5.1";
   if (normalized.startsWith("gpt-oss")) return "gpt-oss";
+  if (normalized.startsWith("gpt-reserve")) return "gpt-reserve";
   if (normalized.startsWith("codex")) return "codex";
   return normalized.split(/[:/-]/, 1)[0] || normalized;
 }

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -66,6 +66,7 @@ import {
   getModelAliases,
   applyBackendModels,
   getModelPlanTypes,
+  KNOWN_OFFICIAL_MODELS,
   applyBackendModelsForPlan,
 } from "@src/models/model-store.js";
 
@@ -147,7 +148,7 @@ describe("ModelStore", () => {
   describe("loadStaticModels", () => {
     it("loads models from YAML", () => {
       const catalog = getModelCatalog();
-      expect(catalog.length).toBe(4);
+      expect(catalog.length).toBe(4 + KNOWN_OFFICIAL_MODELS.size);
       expect(catalog[0].id).toBe("gpt-5.4");
     });
 
@@ -204,7 +205,7 @@ aliases:
 
       loadStaticModels("/tmp/test-config");
 
-      expect(getModelCatalog().map((m) => m.id)).toEqual(["cached-only"]);
+      expect(getModelCatalog().map((m) => m.id)).toEqual(["cached-only", ...KNOWN_OFFICIAL_MODELS.keys()]);
       expect(getModelInfo("auto")).toBeUndefined();
       expect(getModelAliases()).toEqual({});
       expect(getModelInfo("cached-only")!.source).toBe("backend");
@@ -500,6 +501,17 @@ aliases: {}
       expect(isRecognizedModelName("local-simple-high-fast")).toBe(true);
     });
 
+    it("accepts known official models (gpt-6-astra, gpt-reserve) and aliases", () => {
+      expect(isRecognizedModelName("gpt-6-astra")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-astra-aeon")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-astra-high")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-astra-ultra-fast")).toBe(true);
+      expect(isRecognizedModelName("gpt-6")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-fast")).toBe(true);
+      expect(isRecognizedModelName("gpt-reserve")).toBe(true);
+      expect(isRecognizedModelName("gpt-reserve-high")).toBe(true);
+    });
+
     it("rejects unknown model names even with valid-looking suffixes", () => {
       expect(isRecognizedModelName("totally-unknown")).toBe(false);
       expect(isRecognizedModelName("totally-unknown-low")).toBe(false);
@@ -564,6 +576,13 @@ aliases: {}
   });
 
   describe("getModelInfo", () => {
+    it("returns model info for known official model gpt-6-astra", () => {
+      const info = getModelInfo("gpt-6-astra");
+      expect(info).toBeDefined();
+      expect(info!.displayName).toBe("GPT-6 Astra");
+      expect(info!.contextWindow).toBe(1_050_000);
+      expect(info!.maxOutputTokens).toBe(128_000);
+    });
     it("returns model info by ID", () => {
       const info = getModelInfo("gpt-5.4");
       expect(info).toBeDefined();
@@ -582,6 +601,15 @@ aliases: {}
 
     it("returns undefined for unknown ID", () => {
       expect(getModelInfo("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("getModelCatalog", () => {
+    it("exposes static official models alongside the live catalog", () => {
+      const ids = getModelCatalog().map((m) => m.id);
+      expect(ids).toContain("gpt-6-astra");
+      expect(ids).toContain("gpt-6-astra-aeon");
+      expect(ids).toContain("gpt-reserve");
     });
   });
 

--- a/tests/unit/ollama/bridge.test.ts
+++ b/tests/unit/ollama/bridge.test.ts
@@ -141,9 +141,11 @@ describe("Ollama bridge routes", () => {
   });
 
   it.each([
+    ["gpt-6-astra", "gpt-6", 1050000],
     ["gpt-5.6-sol", "gpt-5.6", 1050000],
     ["gpt-5.5", "gpt-5.5", 400000],
     ["gpt-5.4-mini", "gpt-5.4", 400000],
+    ["gpt-reserve", "gpt-reserve", 872000],
   ])(
     "returns context metadata for %s and can suppress vision capability",
     async (model, architecture, contextLength) => {


### PR DESCRIPTION
## Summary

支持 OpenAI 今日发布的 GPT-6 Astra 系列（`gpt-6-astra`、`gpt-6-astra-aeon` 及 `gpt-6` 别名）与 GPT-Reserve（`gpt-reserve`）。通过内置静态模型定义与别名解析，避免在本地账号为 Free 或未动态下发新模型时，客户端请求被错误拦截（404 model_not_found）或静默降级为默认模型；同步配置 105 万上下文窗口覆盖、Ollama 桥接系列识别以及官方 API 定价估算。

## Changes

- **模型识别与路由**（`src/models/model-store.ts`）：
  - 增加 `KNOWN_OFFICIAL_MODELS` 静态内置模型定义（`gpt-6-astra`、`gpt-6-astra-aeon`、`gpt-reserve`），支持完整的推理档位（`low` ~ `ultra`）与 1,050,000 上下文规格。
  - 增加内置别名 `gpt-6` -> `gpt-6-astra`。
  - 调整 `isRecognizedModelName`、`resolveModelId`、`getModelInfo`、`parseModelName` 兼容内置模型，防止请求被白名单拦截或静默回退默认模型。
- **Ollama 桥接**（`src/ollama/bridge.ts`）：
  - `CONTEXT_WINDOW_OVERRIDES` 增加 `gpt-6-astra`、`gpt-6-astra-aeon`、`gpt-6`（1,050,000 tokens）以及 `gpt-reserve`（872,000 tokens）。
  - `inferFamily` 增加 `gpt-6` 与 `gpt-reserve` 系列判定。
- **API 定价估算**（`config/model-pricing.yaml`）：
  - 增加 `gpt-6-astra` / `gpt-6-astra-aeon` 官方定价（Input $10 / Cached $1 / Output $50 每百万 tokens）与 `gpt-reserve` 计费配置。
- **文档更新**（`README.md`、`README_EN.md`、`CHANGELOG.md`）：
  - 模型表格与变更日志补充相关模型说明。
- **单元测试**（`tests/unit/models/model-store.test.ts`、`tests/unit/ollama/bridge.test.ts`）：
  - 补充 GPT-6 Astra 与 GPT-Reserve 的模型识别、别名映射、推理级别组合解析及 Ollama 显示元数据测试。

## Test Plan

- [x] `npm run build` (前端构建 + TypeScript 编译无报错)
- [x] `npx vitest run tests/unit/models/model-store.test.ts tests/unit/ollama/bridge.test.ts tests/unit/auth/usage-pricing.test.ts tests/unit/routes/responses-compact.test.ts tests/unit/routes/responses-default-tools.test.ts` (108/108 全部通过)