### PR TITLE
fix(logs): surface fallback flag in stream-close error log context

### DIFF
--- a/src/logs/stream-close-event.ts
+++ b/src/logs/stream-close-event.ts
@@ -105,6 +105,7 @@ export function recordStreamCloseEvent(evt: StreamCloseEvent): void {
       accountEntryId: evt.accountEntryId,
       variantHash: evt.variantHash,
       responseId: evt.responseId,
+      fallback: evt.fallback === true ? true : undefined,
       eventCount: evt.eventCount,
       hadReasoning: evt.hadReasoning,
       closeCode: evt.closeCode,


### PR DESCRIPTION
## Summary

把 PR #773 审查时遗留的非阻断项②落地：stream-close 事件的 **Errors tab（appendErrorLog）context 也带上 fallback 标记**，便于在 Errors 页区分该关闭事件是否发生在后备请求上。

## Changes

- \src/logs/stream-close-event.ts\：\ecordStreamCloseEvent\ 的 \ppendErrorLog\ context 新增 \allback\（仅在 \vt.fallback === true\ 时写出，避免噪声；与 enqueueLogEntry 路径的 in-memory 日志既有 fallback 标记保持一致）。

## Test Plan

- [x] \
px tsc --noEmit\ 通过
- [x] \
px vitest run tests/unit/logs/stream-close-event.test.ts\ 6/6 通过

Refs #773