### PR TITLE
feat(models): route official-shaped models without per-model allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - 新增 E2E 测试覆盖账号 CRUD、管理员设置、Dashboard 登录三条关键 HTTP 路径（47 个新用例）：`tests/e2e/accounts.test.ts`（list / add / delete / reset-usage / label / cookies / batch-delete / batch-status / export / quota-warnings）、`tests/e2e/admin-settings.test.ts`（rotation / settings / general / quota 四组 GET+POST）、`tests/e2e/dashboard-login.test.ts`（login / logout / status + 速率限制）。（closes #376 partial）
 - Dashboard 新增侧栏导航布局，并支持在设置中切换回顶部标签栏旧版布局（`web/src/App.tsx`、`web/src/components/Sidebar.tsx`）。
 
+### Changed
+
+- 官方模型识别改为按名称形态前缀放行（`gpt*` / `codex*` / `oN*`），不再要求模型已收录于本地 catalog：当后端/账号尚未下发的新官方模型（如 `gpt-6-astra`）被客户端请求时，不再返回 `404 model_not_found` 或静默回退默认模型，而是按原名透传交由上游裁决；`resolveModelId` 对官方形态模型原样解析、不回退默认。边界保持不变：非官方形态的未知模型仍 `404`，裸 `codex` 哨兵仍解析为默认模型（`src/models/model-store.ts`）。
+
 ### Fixed
 
 - 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。

--- a/src/models/model-store.ts
+++ b/src/models/model-store.ts
@@ -165,6 +165,22 @@ function normalizeAliases(input: Record<string, string> | undefined): Record<str
   return aliases;
 }
 
+/**
+ * Whether a model name matches the shape of an official Codex/OpenAI model,
+ * e.g. `gpt-6-astra`, `gpt-5.6-sol`, `gpt-oss-*`, `codex-mini`, `o1`/`o3`/`o4`.
+ *
+ * This is a *shape* check, not an allowlist. It lets newly released models that
+ * aren't in the local catalog yet be routed upstream without a per-model code
+ * change. Whether a given name is actually served is decided by the upstream
+ * backend. Mirrors the regex used in `UpstreamRouter#isKnownCodexModel` so both
+ * code paths agree on what is "official-looking".
+ */
+const OFFICIAL_MODEL_SHAPE = /^(?:gpt|codex|o\d[\w.-]*)/i;
+
+function isOfficialCodexShape(modelId: string): boolean {
+  return OFFICIAL_MODEL_SHAPE.test(modelId.trim());
+}
+
 // ── Class ────────────────────────────────────────────────────────────
 
 export class ModelStore {
@@ -269,6 +285,11 @@ export class ModelStore {
     const resolved = this.resolveAliasChain(trimmed);
     if (resolved !== trimmed) return resolved;
     if (this.catalog.some((m) => m.id === resolved)) return resolved;
+    // The bare `codex` sentinel means "use the default model", not a literal ID.
+    if (resolved === "codex") return this.defaultModelFn();
+    // Recognized-but-not-catalogued official models route as-is rather than
+    // silently falling back to the default model.
+    if (isOfficialCodexShape(resolved)) return resolved;
     return this.defaultModelFn();
   }
 
@@ -276,7 +297,11 @@ export class ModelStore {
     const trimmed = input.trim();
     if (!trimmed) return false;
 
-    if (this.aliases[trimmed] || this.catalog.some((m) => m.id === trimmed)) {
+    if (
+      this.aliases[trimmed]
+      || this.catalog.some((m) => m.id === trimmed)
+      || isOfficialCodexShape(trimmed)
+    ) {
       return true;
     }
 
@@ -289,13 +314,17 @@ export class ModelStore {
     }
 
     return !!this.aliases[stripped.modelName]
-      || this.catalog.some((m) => m.id === stripped.modelName);
+      || this.catalog.some((m) => m.id === stripped.modelName)
+      || isOfficialCodexShape(stripped.modelName);
   }
 
   parseModelName(input: string): ParsedModelName {
     const trimmed = input.trim();
 
-    if (this.aliases[trimmed] || this.catalog.some((m) => m.id === trimmed)) {
+    if (
+      this.aliases[trimmed]
+      || this.catalog.some((m) => m.id === trimmed)
+    ) {
       return { modelId: this.resolveModelId(trimmed), serviceTier: null, reasoningEffort: null };
     }
 

--- a/tests/unit/models/model-store.test.ts
+++ b/tests/unit/models/model-store.test.ts
@@ -505,6 +505,16 @@ aliases: {}
       expect(isRecognizedModelName("totally-unknown-low")).toBe(false);
       expect(isRecognizedModelName("totally-unknown-high-fast")).toBe(false);
     });
+
+    it("accepts official-shaped models not present in the catalog (e.g. gpt-6)", () => {
+      expect(isRecognizedModelName("gpt-6-astra")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-astra-high-fast")).toBe(true);
+      expect(isRecognizedModelName("gpt-6")).toBe(true);
+      expect(isRecognizedModelName("gpt-6-fast")).toBe(true);
+      expect(isRecognizedModelName("gpt-reserve")).toBe(true);
+      expect(isRecognizedModelName("gpt-reserve-high")).toBe(true);
+      expect(isRecognizedModelName("o4-mini-high")).toBe(true);
+    });
   });
 
   describe("isRequestableModel", () => {
@@ -528,11 +538,28 @@ aliases: {}
       expect(isRequestableModel("my-model-high")).toBe(true);
     });
 
-    it("rejects unknown model names", () => {
+    it("rejects empty and non-official-shaped model names", () => {
       expect(isRequestableModel("")).toBe(false);
-      expect(isRequestableModel("gpt-9999")).toBe(false);
       expect(isRequestableModel("totally-unknown-high-fast")).toBe(false);
-      expect(isRequestableModel("codex-foo")).toBe(false);
+    });
+
+    it("accepts any official-shaped model name (support decided upstream)", () => {
+      // Recognized-by-shape official models pass through to the upstream backend
+      // instead of being rejected here; support is decided at the edge.
+      expect(isRequestableModel("gpt-9999")).toBe(true);
+      expect(isRequestableModel("codex-foo")).toBe(true);
+      expect(isRequestableModel("o1")).toBe(true);
+      expect(isRequestableModel("o4-mini-high")).toBe(true);
+    });
+
+    it("accepts newly released gpt-6 family without static definitions", () => {
+      // gpt-6-astra / gpt-reserve are not in the catalog/aliases/custom, yet they
+      // must be requestable so clients aren't 404'd or silently downgraded.
+      expect(isRequestableModel("gpt-6-astra")).toBe(true);
+      expect(isRequestableModel("gpt-6-astra-high-fast")).toBe(true);
+      expect(isRequestableModel("gpt-6")).toBe(true);
+      expect(isRequestableModel("gpt-reserve")).toBe(true);
+      expect(resolveModelId("gpt-6-astra")).toBe("gpt-6-astra");
     });
   });
 
@@ -832,6 +859,7 @@ aliases: {}
 
       applyBackendModelsForPlan("team", []);
       expect(getModelPlanTypes("gpt-5.3-codex")).toEqual([]);
+      expect(isRecognizedModelName("gpt-5.3-codex")).toBe(true);
       expect(getModelInfo("gpt-5.3-codex")).toBeUndefined();
     });
   });

--- a/tests/unit/routes/responses-compact.test.ts
+++ b/tests/unit/routes/responses-compact.test.ts
@@ -162,7 +162,7 @@ describe("POST /v1/responses/compact", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: "gpt-4o",
+        model: "totally-unknown",
         input: [{ role: "user", content: "Hi" }],
       }),
     });

--- a/tests/unit/routes/responses-default-tools.test.ts
+++ b/tests/unit/routes/responses-default-tools.test.ts
@@ -122,26 +122,26 @@ describe("Responses default_tools injection", () => {
     expect(mockState.capturedReq?.codexRequest.tools).toBeUndefined();
   });
 
-  it("rejects an unrecognized model with model_not_found instead of falling back to default", async () => {
-    const app = createResponsesRoutes(accountPool, undefined, undefined, undefined, clientKeyPool);
-    const res = await app.request("/v1/responses", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: "Bearer master-key-123",
-      },
-      body: JSON.stringify({
-        model: "gpt-9999",
-        input: [{ role: "user", content: "Hi" }],
-      }),
-    });
+  it("accepts an official-shaped model not in the catalog (support decided upstream)", async () => {
+      const app = createResponsesRoutes(accountPool, undefined, undefined, undefined, clientKeyPool);
+      const res = await app.request("/v1/responses", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer master-key-123",
+        },
+        body: JSON.stringify({
+          model: "gpt-6-astra",
+          input: [{ role: "user", content: "Hi" }],
+        }),
+      });
 
-    expect(res.status).toBe(404);
-    const body = await res.json();
-    expect(body.error?.code).toBe("model_not_found");
-    expect(body.error?.param).toBe("model");
-    expect(mockState.capturedReq).toBeNull();
-  });
+      // gpt-6-astra is not in the catalog, but it matches the official-model
+      // shape — it must be routed upstream rather than 404'd or downgraded.
+      expect(res.status).toBe(200);
+      expect(mockState.capturedReq).toBeTruthy();
+      expect(mockState.capturedReq?.codexRequest.model).toBe("gpt-6-astra");
+    });
 
   it("accepts a suffixed codex sentinel model (codex-high-fast) instead of 404", async () => {
     const app = createResponsesRoutes(accountPool, undefined, undefined, undefined, clientKeyPool);


### PR DESCRIPTION
## Summary

将官方模型识别从「逐模型 allowlist」改为**按名称形态前缀放行**（gpt* / codex* / oN*），免去每个新发布模型都要改代码维护静态表。修复根因：当后端/账号尚未下发新官方模型（如 gpt-6-astra）时，客户端请求原本会返回 404 model_not_found 或被静默降级为默认模型，现改为按原名透传、交由上游裁决，与 UpstreamRouter.isKnownCodexModel 的既有正则对齐。

## Changes

- 新增 isOfficialCodexShape()，按官方形态前缀识别（src/models/model-store.ts）
- isRecognizedModelName / isRequestableModel 对官方形态放行（含带推理后缀形式），不再逐个枚举
- resolveModelId 对官方形态模型原样解析、不回退默认，并清理冗余分支；裸 codex 哨兵仍解析默认
- 补充单测并更新既有断言（tests/unit/models/model-store.test.ts、tests/unit/routes/responses-*.test.ts）
- CHANGELOG 新增 ### Changed 条目

## Test Plan

- [x] npx tsc --noEmit — 通过
- [x] npx vitest run tests/unit/models/model-store.test.ts — 62 通过
- [x] npx vitest run tests/unit/routes/responses-* tests/unit/ollama — 105 断言通过

## Notes

- 边界保持：非官方形态的未知模型（如 totally-unknown）仍返回 404。
- 与 #774（gpt-6 静态定义）解耦：本 PR 负责「免维护可路由」，静态表作为元数据 / 前端可选增强，建议 #774 收缩为元数据+定价部分。