### PR TITLE
test(portable): require native addons for all target platforms

### DIFF
--- a/scripts/portable/test-portable.mjs
+++ b/scripts/portable/test-portable.mjs
@@ -209,6 +209,24 @@ function archiveContract(entries, extract, options) {
       "; found: " + nativeFiles.join(", "),
     );
   }
+  // The all-platforms archive must contain one native addon for every target
+  // triple the release matrix produces. A cross-platform name collision could
+  // otherwise silently overwrite one addon with another, and each CI job only
+  // checks its own platform, so a missing platform would go unnoticed.
+  const REQUIRED_NATIVE_TARGETS = [
+    ["win32", "x64"],
+    ["darwin", "arm64"],
+    ["darwin", "x64"],
+    ["linux", "x64"],
+  ];
+  for (const [targetPlatform, targetArch] of REQUIRED_NATIVE_TARGETS) {
+    const targetSuffixes = nativeCandidates(targetPlatform, targetArch);
+    assert(
+      targetSuffixes.some((suffix) => nativeFiles.some((name) => name.includes(suffix))),
+      "Portable all-platforms archive is missing native addon for " +
+        targetPlatform + "/" + targetArch + "; found: " + nativeFiles.join(", "),
+    );
+  }
 
   const hostFiles = [...files.keys()].filter(
     (name) => name.startsWith("hosts/webview2/") && name.endsWith(".exe"),


### PR DESCRIPTION
Follow-up to #778. The archive test only asserts a native addon for the platform the test runs on, so a cross-platform basename collision or a missing platform in the all-platforms archive goes silently unnoticed. Add an assertion that every target triple the release matrix produces (win32-x64, darwin-arm64, darwin-x64, linux-x64) is present.