### PR TITLE
fix(web): serve /icon.png and /favicon.ico to fix broken top-left logo

### DIFF
--- a/src/routes/web.ts
+++ b/src/routes/web.ts
@@ -37,6 +37,14 @@ export function createWebRoutes(
     await next();
   }, serveStatic({ root: publicDir }));
 
+  // Vite copies web/public/ (brand icon + favicon) to the build-output root;
+  // they are not content-hashed, so they do not fall under /assets/*. Serve
+  // them explicitly here, otherwise GET /icon.png (and /favicon.ico) 404s in
+  // production builds — dev works only because the Vite dev server serves
+  // web/public/ directly.
+  app.get("/icon.png", serveStatic({ root: publicDir }));
+  app.get("/favicon.ico", serveStatic({ root: publicDir }));
+
   app.get("/", (c) => {
     try {
       const html = readFileSync(webIndexPath, "utf-8");


### PR DESCRIPTION
The top-left brand icon renders as a broken image in production builds.

Root cause: Header/Sidebar use `<img src="/icon.png">` and index.html links `/favicon.ico` + `/icon.png`. Vite copies `web/public/*` into the build-output root, but the backend only statically serves `/assets/*` (immutable, content-hashed). So absolute `/icon.png` and `/favicon.ico` requests 404 in packaged builds, while dev works because the Vite dev server serves `web/public/` directly.

Fix: serve `/icon.png` and `/favicon.ico` via `serveStatic({ root: publicDir })` in `src/routes/web.ts`.

Tested: `npm run typecheck:scripts` passes.