### PR TITLE
fix: avoid false 403 in dashboard connection test

### DIFF
--- a/src/proxy/codex-usage.ts
+++ b/src/proxy/codex-usage.ts
@@ -12,7 +12,7 @@ import {
   type CodexUsageResponse,
 } from "./codex-types.js";
 
-function usageUrls(baseUrl: string): string[] {
+export function usageUrls(baseUrl: string): string[] {
   const trimmed = baseUrl.replace(/\/+$/, "");
   if (trimmed.includes("/backend-api")) {
     return [`${trimmed}/wham/usage`, `${trimmed}/codex/usage`];

--- a/src/routes/admin/connection.ts
+++ b/src/routes/admin/connection.ts
@@ -3,6 +3,7 @@ import type { AccountPool } from "../../auth/account-pool.js";
 import { getConfig } from "../../config.js";
 import { getTransport, getTransportInfo } from "../../tls/transport.js";
 import { buildHeaders } from "../../fingerprint/manager.js";
+import { usageUrls } from "../../proxy/codex-usage.js";
 
 export function createConnectionRoutes(accountPool: AccountPool): Hono {
   const app = new Hono();
@@ -78,9 +79,18 @@ export function createConnectionRoutes(accountPool: AccountPool): Hono {
         try {
           const transport = getTransport();
           const config = getConfig();
-          const url = `${config.api.base_url}/codex/usage`;
+          const urls = usageUrls(config.api.base_url);
           const headers = buildHeaders(acquired.token, acquired.accountId);
-          const resp = await transport.get(url, headers, 15);
+          let resp: { status: number; body: string } | undefined;
+          for (const [index, url] of urls.entries()) {
+            try {
+              resp = await transport.get(url, headers, 15);
+              if (resp.status >= 200 && resp.status < 400) break;
+            } catch (err) {
+              if (index === urls.length - 1) throw err;
+            }
+          }
+          if (!resp) throw new Error("No usage endpoint available");
           const latency = Date.now() - upstreamStart;
           if (resp.status >= 200 && resp.status < 400) {
             checks.push({

--- a/tests/unit/routes/connection.test.ts
+++ b/tests/unit/routes/connection.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AccountPool } from "../../../src/auth/account-pool.js";
+import { createConnectionRoutes } from "../../../src/routes/admin/connection.js";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  baseUrl: "https://chatgpt.com/backend-api",
+}));
+vi.mock("../../../src/config.js", () => ({
+  getConfig: () => ({ api: { base_url: mocks.baseUrl } }),
+}));
+vi.mock("../../../src/tls/transport.js", () => ({
+  getTransport: () => ({ get: mocks.get }),
+  getTransportInfo: () => ({ initialized: true, type: "native", impersonate: false }),
+}));
+vi.mock("../../../src/fingerprint/manager.js", () => ({
+  buildHeaders: () => ({ Authorization: "Bearer test-token" }),
+}));
+
+function setup(active = true) {
+  const pool = {
+    getPoolSummary: () => ({ active: active ? 1 : 0, total: 1 }),
+    acquire: vi.fn(() => ({ token: "test-token", accountId: "account", entryId: "entry" })),
+    releaseWithoutCounting: vi.fn(),
+  };
+  const app = createConnectionRoutes(pool as unknown as AccountPool);
+  return { pool, request: () => app.request("/admin/test-connection", { method: "POST" }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.get.mockReset();
+  mocks.baseUrl = "https://chatgpt.com/backend-api";
+});
+
+describe("connection test usage endpoints", () => {
+  it("passes via wham when the legacy endpoint would return a challenge", async () => {
+    mocks.get.mockImplementation(async (url: string) => url.endsWith("/wham/usage")
+      ? { status: 200, body: "{}" }
+      : { status: 403, body: "Enable JavaScript and cookies to continue" });
+    const { pool, request } = setup();
+    const body = await (await request()).json();
+    expect(body.overall).toBe("pass");
+    expect(mocks.get).toHaveBeenCalledExactlyOnceWith(
+      "https://chatgpt.com/backend-api/wham/usage",
+      { Authorization: "Bearer test-token" }, 15,
+    );
+    expect(pool.releaseWithoutCounting).toHaveBeenCalledExactlyOnceWith("entry");
+  });
+
+  it.each(["http", "transport"])("falls back after a %s failure", async (failure) => {
+    if (failure === "http") mocks.get.mockResolvedValueOnce({ status: 404, body: "" });
+    else mocks.get.mockRejectedValueOnce(new Error("timeout"));
+    mocks.get.mockResolvedValueOnce({ status: 200, body: "{}" });
+    const { request } = setup();
+    expect((await (await request()).json()).overall).toBe("pass");
+    expect(mocks.get.mock.calls.map(([url]) => url)).toEqual([
+      "https://chatgpt.com/backend-api/wham/usage",
+      "https://chatgpt.com/backend-api/codex/usage",
+    ]);
+  });
+
+  it("supports custom base URLs and strips trailing slashes", async () => {
+    mocks.baseUrl = "https://proxy.example///";
+    mocks.get.mockResolvedValueOnce({ status: 404, body: "" });
+    mocks.get.mockResolvedValueOnce({ status: 200, body: "{}" });
+    const { request } = setup();
+    expect((await (await request()).json()).overall).toBe("pass");
+    expect(mocks.get.mock.calls.map(([url]) => url)).toEqual([
+      "https://proxy.example/api/codex/usage",
+      "https://proxy.example/codex/usage",
+    ]);
+  });
+
+  it("reports upstream HTTP failures and releases the account", async () => {
+    mocks.get.mockResolvedValue({ status: 403, body: "Forbidden" });
+    const { pool, request } = setup();
+    const body = await (await request()).json();
+    expect(body.overall).toBe("fail");
+    expect(body.checks.find((check: { name: string }) => check.name === "upstream"))
+      .toMatchObject({ status: "fail", detail: "HTTP 403", error: "Upstream returned 403" });
+    expect(pool.releaseWithoutCounting).toHaveBeenCalledExactlyOnceWith("entry");
+  });
+
+  it("reports transport failures and releases the account", async () => {
+    mocks.get.mockRejectedValue(new Error("connection refused"));
+    const { pool, request } = setup();
+    const body = await (await request()).json();
+    expect(body.overall).toBe("fail");
+    expect(body.checks.find((check: { name: string }) => check.name === "upstream"))
+      .toMatchObject({ status: "fail", error: "connection refused" });
+    expect(pool.releaseWithoutCounting).toHaveBeenCalledExactlyOnceWith("entry");
+  });
+
+  it("skips upstream requests when there are no active accounts", async () => {
+    const { pool, request } = setup(false);
+    const body = await (await request()).json();
+    expect(body.overall).toBe("fail");
+    expect(mocks.get).not.toHaveBeenCalled();
+    expect(pool.acquire).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The dashboard connection test can report an upstream HTTP 403 even when the account's usage endpoint is reachable. In a local Docker deployment, `/backend-api/codex/usage` returned an HTML JavaScript/cookie challenge, while `/backend-api/wham/usage` returned HTTP 200 with the same account and transport.

Reuse the usage URL list already used by `fetchUsage` so the diagnostic prefers `/wham/usage` for backend-api URLs and `/api/codex/usage` for custom base URLs, with `/codex/usage` as a fallback. Try the fallback after an HTTP or transport failure, while preserving the diagnostic response shape and account release behavior.

Validation:
- `npx vitest run tests/unit/routes/connection.test.ts` — 7 tests passed, covering the reported false failure, HTTP/transport fallback, custom base URLs, failure reporting, and no active accounts.
- `npx tsc --noEmit` — passed.
- Local Docker endpoint correction: `/admin/test-connection` returned all four checks passing and upstream HTTP 200. Actual model inference was not tested.