### PR TITLE
fix(web): reliably serve /icon.png and /favicon.ico from build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - 修复 Dashboard 底栏在更新状态尚未缓存时无法显示 Codex Desktop 版本的问题，并更新 2026 年版权文案。
 - 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。
 - 修复 Dashboard 顶部导航栏与侧栏「Codex Proxy」左侧品牌图标错误的问题：将手绘六边形 SVG 替换为官方 Logo 图片（`web/public/icon.png`），与桌面端 / Web 应用图标保持一致。（`web/src/components/Header.tsx`、`web/src/components/Sidebar.tsx`）
+- 修复上一条改动后在桌面 / 生产构建中品牌图标与 favicon 仍显示裂图的问题：后端 Web 路由对非哈希资源改为显式读文件返回（此前挂载在精确路径上的 `serveStatic` 无法推导相对路径，`/icon.png`、`/favicon.ico` 始终 404）。（`src/routes/web.ts`）
 - 修复并统一桌面端与 Web 端应用图标与 Logo：生成包含 Windows 完整多分辨率的 `icon.ico`、Web `favicon.ico` / `icon.png`，Electron 主进程窗口配置中注入应用图标并移除 `electron-builder` 的 `signAndEditExecutable: false` 以确保可执行文件与任务栏/桌面快捷方式正确嵌入图标；统一 Dashboard 顶部导航栏 Logo 为品牌立方体图标。（`packages/electron/`、`web/`、`scripts/build/generate-ico.ps1`）
 - 移除 Dashboard 顶部导航栏与侧栏重复展示的「服务运行中」状态徽标（`web/src/components/Header.tsx`）。
 - 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）

--- a/src/routes/web.ts
+++ b/src/routes/web.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { readFileSync, existsSync } from "fs";
 import { resolve } from "path";
@@ -42,8 +43,20 @@ export function createWebRoutes(
   // them explicitly here, otherwise GET /icon.png (and /favicon.ico) 404s in
   // production builds — dev works only because the Vite dev server serves
   // web/public/ directly.
-  app.get("/icon.png", serveStatic({ root: publicDir }));
-  app.get("/favicon.ico", serveStatic({ root: publicDir }));
+  // NOTE: use an explicit file handler rather than serveStatic — mounted on an
+  // exact path serveStatic cannot derive the relative file and always 404s.
+  const servePublicFile = (file: string, contentType: string) => (c: Context): Response | Promise<Response> => {
+    const filePath = resolve(publicDir, file);
+    if (!existsSync(filePath)) return c.notFound();
+    const data = readFileSync(filePath);
+    return new Response(data, {
+      status: 200,
+      headers: { "Content-Type": contentType },
+    });
+  };
+
+  app.get("/icon.png", servePublicFile("icon.png", "image/png"));
+  app.get("/favicon.ico", servePublicFile("favicon.ico", "image/x-icon"));
 
   app.get("/", (c) => {
     try {


### PR DESCRIPTION
## Summary

Dashboard 顶部品牌图标在桌面 / 生产构建中仍显示裂图。根因：品牌标记改用 `<img src="/icon.png">` 后，后端只对 `/assets/*` 提供了静态服务；此前 PR #781 把 `serveStatic` 挂载在精确路径上，但该实现无法推导相对文件路径，`/icon.png`、`/favicon.ico` 依旧 404。

本 PR 改为对这两个非哈希 public 资源显式读文件返回并设置正确的 `Content-Type`，不再依赖 `serveStatic` 的路径解析。

验证：在随机空闲端口启动真实服务，`/icon.png` 返回 200（8777 字节，合法 PNG），`/favicon.ico` 返回 200；`npx tsc --noEmit` 通过。

## Files

- `src/routes/web.ts`：新增 `servePublicFile` 显式处理器，注册 `/icon.png`、`/favicon.ico`
- `CHANGELOG.md`：`[Unreleased] ### Fixed` 补一条

## Notes

需要重新构建 / 发布桌面版后生效；已安装的旧版本（如 2.1.4）无法绕过。