### PR TITLE
fix(web): prevent accidental text selection and element dragging

### DIFF
--- a/web/src/components/AccountTable.tsx
+++ b/web/src/components/AccountTable.tsx
@@ -230,7 +230,7 @@ export function AccountTable({
                     class="rounded border-gray-300 dark:border-border-dark text-primary focus:ring-primary cursor-pointer"
                   />
                 </label>
-                <span class="flex-1 min-w-0 text-sm font-medium truncate text-slate-700 dark:text-text-main">
+                <span class="flex-1 min-w-0 text-sm font-medium truncate text-slate-700 dark:text-text-main allow-select">
                   {acct.label ? `${acct.label} (${acct.email})` : acct.email}
                 </span>
                 <span class="w-20 hidden sm:flex justify-center">

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export function Footer({ updateStatus }: FooterProps) {
       <div class="container mx-auto px-4 flex flex-col items-center gap-2">
         {/* Version info */}
         <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[0.75rem] text-slate-400 dark:text-text-dim font-mono">
-          <span>Proxy v{proxyVersion}{proxyCommit ? ` (${proxyCommit})` : ""}</span>
+          <span>Codex Proxy v{proxyVersion}{proxyCommit ? ` (${proxyCommit})` : ""}</span>
           <span class="text-slate-300 dark:text-border-dark">&middot;</span>
           <span>Codex Desktop {codexVersion ? `v${codexVersion}` : "—"}</span>
         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -128,3 +128,41 @@ pre::-webkit-scrollbar-thumb:hover { background: #8b949e; }
 .electron-mac header > div > div {
   padding-left: 72px;
 }
+
+/* ── UI chrome: prevent accidental text selection & element dragging ── */
+body {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* Keep native selection only where it is genuinely useful. */
+input,
+textarea,
+select,
+[contenteditable="true"],
+pre,
+code,
+kbd,
+samp,
+.selectable,
+.allow-select {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* Images and inline icons should never be dragged around. */
+img,
+svg,
+picture {
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+/* Interactive controls should never be dragged like a floating ghost. */
+button,
+[role="button"],
+a,
+summary,
+label {
+  -webkit-user-drag: none;
+}

--- a/web/src/pages/ClientKeysPage.tsx
+++ b/web/src/pages/ClientKeysPage.tsx
@@ -361,7 +361,7 @@ export const ClientKeysPage: FunctionalComponent<ClientKeysPageProps> = ({
                           </div>
                         )}
                       </td>
-                      <td class="py-3.5 px-4 font-mono text-slate-600 dark:text-text-dim">
+                      <td class="py-3.5 px-4 font-mono text-slate-600 dark:text-text-dim allow-select">
                         {k.key_masked}
                       </td>
                       <td class="py-3.5 px-4">


### PR DESCRIPTION
## Summary
- Rename footer version label from "Proxy v..." to "Codex Proxy v..." to match the brand.
- Globally disable text selection on UI chrome, re-enabling it only for inputs, selects, textareas, and code blocks.
- Disable element dragging for images, inline SVG icons, and interactive controls (buttons/links).
- Keep genuinely-copyable data selectable: account email and masked client key.

## Why
UI buttons/images should not be draggable and chrome text should not be selectable in this Electron dashboard. Verified with `npm run build:web` (build passes) and a sub-agent code review (approved).

## Test plan
- `npm run build:web` succeeds.
- Footer shows "Codex Proxy v..."; buttons/images are not draggable; chrome text is not selectable; inputs, code blocks, account email, and masked client keys remain selectable.