### PR TITLE
refactor(web): unify toolbar button style across all pages

### DIFF
--- a/.github/scripts/sync-changelog-series.mjs
+++ b/.github/scripts/sync-changelog-series.mjs
@@ -1,0 +1,181 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const EMPTY_UNRELEASED_NOTICE = "> 暂无已记录的变更。";
+const REPOSITORY_URL = "https://github.com/icebear0828/codex-proxy";
+
+export function resolveSeries(version) {
+  const match = /^(\d+)\.(\d+)\.\d+(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error(`Expected a semantic version, received ${version}`);
+  }
+  return `${match[1]}.${match[2]}`;
+}
+
+function trimBlankLines(lines) {
+  let first = 0;
+  let last = lines.length;
+  while (first < last && lines[first].trim() === "") first += 1;
+  while (last > first && lines[last - 1].trim() === "") last -= 1;
+  return lines.slice(first, last);
+}
+
+function findSectionEnd(lines, start) {
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (lines[index].startsWith("## ")) return index;
+  }
+  return lines.length;
+}
+
+function splitCategorySections(lines) {
+  const sections = [];
+  let current = null;
+  for (const line of lines) {
+    if (line.startsWith("### ")) {
+      if (current) sections.push(current);
+      current = { heading: line, body: [] };
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+function mergeCategorySections(pendingLines, targetLines) {
+  const pending = splitCategorySections(pendingLines);
+  const target = splitCategorySections(targetLines);
+  if (pending.length === 0 || target.length === 0) {
+    return trimBlankLines([...pendingLines, "", ...targetLines]);
+  }
+
+  const targetByHeading = new Map(target.map((section) => [section.heading, section]));
+  const merged = pending.map((section) => {
+    const existing = targetByHeading.get(section.heading);
+    if (!existing) return section;
+    targetByHeading.delete(section.heading);
+    return {
+      heading: section.heading,
+      body: trimBlankLines([
+        ...trimBlankLines(section.body),
+        "",
+        ...trimBlankLines(existing.body),
+      ]),
+    };
+  });
+  for (const section of target) {
+    if (targetByHeading.has(section.heading)) merged.push(section);
+  }
+
+  return trimBlankLines(merged.flatMap((section, index) => [
+    ...(index > 0 ? [""] : []),
+    section.heading,
+    "",
+    ...trimBlankLines(section.body),
+  ]));
+}
+
+function seriesHeading(series) {
+  return `## [v${series}.x](${REPOSITORY_URL}/releases?q=${series}) - Unreleased`;
+}
+
+export function syncChangelogSeries(markdown, series) {
+  if (!/^\d+\.\d+$/.test(series)) {
+    throw new Error(`Expected a major.minor series, received ${series}`);
+  }
+
+  const eol = markdown.includes("\r\n") ? "\r\n" : "\n";
+  const hasTrailingNewline = markdown.endsWith("\n");
+  const lines = markdown.split(/\r?\n/);
+  if (hasTrailingNewline) lines.pop();
+
+  const unreleasedIndex = lines.indexOf("## [Unreleased]");
+  if (unreleasedIndex === -1) {
+    throw new Error("CHANGELOG.md is missing its ## [Unreleased] section");
+  }
+
+  const unreleasedEnd = findSectionEnd(lines, unreleasedIndex);
+  const pendingLines = trimBlankLines(
+    lines.slice(unreleasedIndex + 1, unreleasedEnd).filter((line) => line !== EMPTY_UNRELEASED_NOTICE),
+  );
+  const targetPrefix = `## [v${series}.x]`;
+  const targetIndex = lines.findIndex((line) => line.startsWith(targetPrefix));
+
+  if (pendingLines.length === 0 && targetIndex !== -1) {
+    return markdown;
+  }
+
+  const normalizedUnreleased = ["", EMPTY_UNRELEASED_NOTICE, ""];
+  if (targetIndex === -1) {
+    const remaining = lines.slice(unreleasedEnd);
+    const result = [
+      ...lines.slice(0, unreleasedIndex + 1),
+      ...normalizedUnreleased,
+      seriesHeading(series),
+      ...(pendingLines.length > 0 ? ["", ...pendingLines] : []),
+      ...(remaining.length > 0 ? [""] : []),
+      ...remaining,
+    ];
+    return `${trimBlankLines(result).join(eol)}${hasTrailingNewline ? eol : ""}`;
+  }
+
+  const targetEnd = findSectionEnd(lines, targetIndex);
+  const targetBody = trimBlankLines(lines.slice(targetIndex + 1, targetEnd));
+  const mergedTargetBody = mergeCategorySections(pendingLines, targetBody);
+  const afterTarget = lines.slice(targetEnd);
+  const result = [
+    ...lines.slice(0, unreleasedIndex + 1),
+    ...normalizedUnreleased,
+    ...lines.slice(unreleasedEnd, targetIndex + 1),
+    ...(mergedTargetBody.length > 0 ? ["", ...mergedTargetBody] : []),
+    ...(mergedTargetBody.length > 0 && afterTarget.length > 0 ? [""] : []),
+    ...afterTarget,
+  ];
+  return `${trimBlankLines(result).join(eol)}${hasTrailingNewline ? eol : ""}`;
+}
+
+function parseArguments(argv) {
+  const options = { check: false, series: undefined };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--check") {
+      options.check = true;
+      continue;
+    }
+    if (argument === "--series") {
+      options.series = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+  return options;
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+  const changelogPath = resolve(root, "CHANGELOG.md");
+  const packagePath = resolve(root, "package.json");
+  const packageVersion = JSON.parse(readFileSync(packagePath, "utf8")).version;
+  const series = options.series ?? resolveSeries(packageVersion);
+  const current = readFileSync(changelogPath, "utf8");
+  const updated = syncChangelogSeries(current, series);
+
+  if (options.check) {
+    if (updated !== current) {
+      console.error(`CHANGELOG.md must be synchronized into v${series}.x before release`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  if (updated !== current) {
+    writeFileSync(changelogPath, updated);
+    console.log(`Synchronized CHANGELOG.md into v${series}.x`);
+  }
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -45,6 +45,7 @@ jobs:
               exit 0
             fi
             echo "New series ${SERIES}.x — will start at ${SERIES}.0"
+            node .github/scripts/sync-changelog-series.mjs --check --series "$SERIES"
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "new_series=true" >> "$GITHUB_OUTPUT"
             echo "series=$SERIES" >> "$GITHUB_OUTPUT"
@@ -74,6 +75,8 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          node .github/scripts/sync-changelog-series.mjs --check --series "$SERIES"
 
           echo "Found $NEW_COMMITS new commit(s) since $LAST_TAG"
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-changelog-series.yml
+++ b/.github/workflows/sync-changelog-series.yml
@@ -1,0 +1,42 @@
+name: Sync changelog release series
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-changelog-series
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: dev
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Move unreleased entries into the active release series
+        run: node .github/scripts/sync-changelog-series.mjs
+
+      - name: Commit synchronized changelog
+        run: |
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md is already synchronized"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs: sync changelog release series [skip ci]"
+          git push origin HEAD:dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ## [Unreleased]
 
-> 暂无已记录的变更。
+### Changed
+
+- 统一各页面工具栏按钮风格：管理账号（`AccountBulkActions`）、API Keys（`ApiKeyManager`）、代理池（`ProxyPool`）、错误页面（`ErrorsPage`）的顶部与行内按钮全部改用 `accountToolbarControlClass` / `accountToolbarIconClass`，与首页账号列表工具栏保持一致；代理池及错误页面的文字操作按钮改为纯图标按钮（tooltip 保留文字），批量操作栏按钮样式一致化。（`web/src/components/AccountBulkActions.tsx`、`web/src/components/ApiKeyManager.tsx`、`web/src/components/ProxyPool.tsx`、`web/src/pages/AccountManagement.tsx`、`web/src/pages/ErrorsPage.tsx`）
+
 
 ## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,105 +8,209 @@
 
 ## [Unreleased]
 
+> 暂无已记录的变更。
+
+## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
+
 ### Added
 
 - 新增 Linux x64 musl TLS native addon 构建与验证流程，并将 `codex-tls.linux-x64-musl.node` 接入 No-Node Lite 的构建和发布包，使 Lite 可在 Alpine 等 musl Linux 环境中使用。（`native/package.json`、`scripts/native/`、`scripts/portable/`、`.github/workflows/native-musl-ci.yml`）
+
 - 新增可选 No-Node Lite Browser/Server 发行版：保留现有 Electron 安装包不变，额外提供 `codex-proxy-<版本>-no-node-lite-all-platforms.tar.xz`，包含后端、前端资源、各平台 native addon 和启动器，支持无图形界面的 server 模式以及浏览器模式；Windows 通过 MSYS2 MinGW 构建 x86/x64 WebView2 host，并可选携带 Evergreen Bootstrapper。（`scripts/portable/`、`.github/workflows/lite-ci.yml`、`.github/workflows/release.yml`）
+
 - 支持 OpenAI GPT-6 Astra 系列（`gpt-6-astra`、`gpt-6-astra-aeon` 及别名 `gpt-6`）与 GPT-Reserve（`gpt-reserve`）：内置静态模型元数据与推理级别定义（`/v1/models/catalog` 可见），`gpt-6` 别名解析到 `gpt-6-astra`，可路由性已由 #776 的名称形态放行覆盖；同步适配 1,050,000 上下文窗口、Ollama 桥接架构系列识别与官方定价估算（`src/models/model-store.ts`、`src/ollama/bridge.ts`、`config/model-pricing.yaml`、`README.md`）。
+
 - 重构 Dashboard UI 视觉体系与设置交互逻辑：
   - 移除窗口顶部菜单栏，并将窗口标题统一为「Codex Proxy」（`packages/electron/electron/main.ts`、`web/index.html`）。
   - 全局优化浅色与深色色彩体系及统一系统/等宽字体层级渲染（`web/src/index.css`、`web/tailwind.config.ts`）。
   - 新增独立「信息」Tab 页（`#/info`），归拢 API 配置、Anthropic SDK 配置、代码示例及连通性测试只读卡片（`web/src/pages/InfoPage.tsx`、`web/src/navigation.ts`、`shared/i18n/`）。
   - 改版设置界面（`#/settings`）：重新组织分类设置项，升级为项级即时生效机制（修改后行内显示 `✅` 保存按钮，点击转圈加载，生效后平滑淡出，需重启项显示 `🔄 等待重启` 徽章），移除底部全局保存按钮（`web/src/components/`）。
+
 - 请求日志新增「账号 / 后备」列：展示每条请求实际服务的账号（label / 邮箱 / ID 短标识），走了后备（备用账号重试或后备上游 apikey）时显示橙色「后备」徽章；详情抽屉同步展示账号信息（`src/logs/`、`src/routes/shared/proxy-*.ts`、`shared/hooks/use-logs.ts`、`web/src/pages/LogsPage.tsx`、`shared/i18n/`）。
+
 - 首页「后备上游 (API Key)」卡片新增运行状态指示：请求切到后备（备用账号或后备上游）时卡片橙色高亮并脉冲闪动，显示「后备中」徽章；停止走后约 60 秒内自动恢复（`src/auth/fallback-state.ts`、`src/routes/accounts.ts`、`shared/hooks/use-accounts.ts`、`web/src/components/FallbackUpstreamCard.tsx`）。
 
 - 通用设置新增「更新到测试版 (Beta)」选项（默认关闭）：开启后自动更新检查将包含测试版（GitHub Releases 预发布版本与 Docker `-beta.` 标签），Electron 客户端同步开启测试版通道（`config/default.yaml`、`src/routes/admin/`、`src/self-update.ts`、`web/src/components/GeneralSettings.tsx`、`shared/i18n/`）。
 
 - 控制台新增日語 (ja)、繁體中文 (台灣, zh-TW)、繁體中文 (香港, zh-HK) 完整語言字典與本地化支援，並將頂部導航列語言切換升級為多語言下拉選擇器（`shared/i18n/`、`web/src/components/Header.tsx`、`shared/utils/format.ts`）。
+
 - 新增「后备上游 (API Key)」账户类型：配置一个 baseUrl + apiKey，固定走 Responses 接口，仅在所有账号均不可用时作为最后兜底启用；添加账户弹窗可添加，账户列表末尾独占一行展示，支持卡片上编辑/删除，仅允许配置一个。（`src/auth/fallback-upstream.ts`、`src/routes/accounts.ts`、`src/routes/shared/proxy-handler.ts`、`web/src/components/FallbackUpstreamCard.tsx`、`web/src/components/AddAccount.tsx`）
-- 为 `/v1/responses` 端点添加客户端 WebSocket 支持：接受 `ws://<host>:<port>/v1/responses` 的升级请求并用 Bearer 令牌鉴权，将客户端的 `response.create` 帧代理到现有上游 Codex WebSocket 并把响应事件以 JSON 流式回传；HTTP POST + SSE 仍作为回退保持不变，并在关闭路径中一并关闭该 WS 服务器。（#681）
-- 新增 E2E 测试覆盖账号 CRUD、管理员设置、Dashboard 登录三条关键 HTTP 路径（47 个新用例）：`tests/e2e/accounts.test.ts`（list / add / delete / reset-usage / label / cookies / batch-delete / batch-status / export / quota-warnings）、`tests/e2e/admin-settings.test.ts`（rotation / settings / general / quota 四组 GET+POST）、`tests/e2e/dashboard-login.test.ts`（login / logout / status + 速率限制）。（closes #376 partial）
-- Dashboard 新增侧栏导航布局，并支持在设置中切换回顶部标签栏旧版布局（`web/src/App.tsx`、`web/src/components/Sidebar.tsx`）。
 
 ### Changed
 
 - 官方模型识别改为按名称形态前缀放行（`gpt*` / `codex*` / `oN*`），不再要求模型已收录于本地 catalog：当后端/账号尚未下发的新官方模型（如 `gpt-6-astra`）被客户端请求时，不再返回 `404 model_not_found` 或静默回退默认模型，而是按原名透传交由上游裁决；`resolveModelId` 对官方形态模型原样解析、不回退默认。边界保持不变：非官方形态的未知模型仍 `404`，裸 `codex` 哨兵仍解析为默认模型（`src/models/model-store.ts`）。
 
+- 点击「添加账户」不再立即弹出授权网页，改为弹出对话框展示授权 URL，提供「复制」与「打开链接」按钮，由用户自行选择打开时机；下方保留 RT（Refresh Token）输入与导入入口。（`web/src/components/AddAccount.tsx`、`shared/hooks/use-accounts.ts`）
+
 ### Fixed
 
 - 修复 Dashboard 底栏在更新状态尚未缓存时无法显示 Codex Desktop 版本的问题，并更新 2026 年版权文案。
+
 - 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。
+
 - 修复 Dashboard 顶部导航栏与侧栏「Codex Proxy」左侧品牌图标错误的问题：将手绘六边形 SVG 替换为官方 Logo 图片（`web/public/icon.png`），与桌面端 / Web 应用图标保持一致。（`web/src/components/Header.tsx`、`web/src/components/Sidebar.tsx`）
+
 - 修复上一条改动后在桌面 / 生产构建中品牌图标与 favicon 仍显示裂图的问题：后端 Web 路由对非哈希资源改为显式读文件返回（此前挂载在精确路径上的 `serveStatic` 无法推导相对路径，`/icon.png`、`/favicon.ico` 始终 404）。（`src/routes/web.ts`）
+
 - 修复并统一桌面端与 Web 端应用图标与 Logo：生成包含 Windows 完整多分辨率的 `icon.ico`、Web `favicon.ico` / `icon.png`，Electron 主进程窗口配置中注入应用图标并移除 `electron-builder` 的 `signAndEditExecutable: false` 以确保可执行文件与任务栏/桌面快捷方式正确嵌入图标；统一 Dashboard 顶部导航栏 Logo 为品牌立方体图标。（`packages/electron/`、`web/`、`scripts/build/generate-ico.ps1`）
+
 - 移除 Dashboard 顶部导航栏与侧栏重复展示的「服务运行中」状态徽标（`web/src/components/Header.tsx`）。
-- 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）
-- 修复 GPT-5.6 的 `-max` / `-ultra` 推理后缀未被模型解析器识别的问题，并同步更新中英文 README 的 Pi 配置示例。
-- Docker 镜像版本号显示错误（始终显示 2.0.77 而非实际发布版本）：`docker-publish.yml` 构建时通过 `--build-arg PROXY_VERSION` 将版本注入镜像，`Dockerfile` 将其写入 `ENV PROXY_VERSION`，`getProxyInfo()` 优先读取该环境变量，容器内无 `.git` 时也能正确报告版本。（#677，关联 issue #676）
 
-### Changed
-
-- 点击「添加账户」不再立即弹出授权网页，改为弹出对话框展示授权 URL，提供「复制」与「打开链接」按钮，由用户自行选择打开时机；下方保留 RT（Refresh Token）输入与导入入口。（`web/src/components/AddAccount.tsx`、`shared/hooks/use-accounts.ts`）
-- Dashboard 日志页面完善深色模式适配，补齐筛选控件、统计卡片、详情抽屉和 JSON 代码块的深色状态；复制 JSON 成功后改为绿色反馈（`web/src/pages/LogsPage.tsx`）。
-- 默认模型与 Claude/Anthropic 推荐档位切换到 GPT-5.6 家族：`config/default.yaml` 默认模型改为 `gpt-5.6-sol`；Dashboard Anthropic Setup 预设与 Claude Code 指南改为 Opus → `gpt-5.6-sol` / Sonnet → `gpt-5.6-terra` / Haiku → `gpt-5.6-luna`；README / API 文档模型表与客户端示例同步更新（`config/default.yaml`、`web/src/components/AnthropicSetup.tsx`、`.github/guides/claude-code-setup.md`、`README.md`、`README_EN.md`、`API.md`、`API_CN.md`）
-- 账号持久化从 `accounts.json` 主存储迁移到 `accounts.sqlite`，启动时自动从旧 JSON 迁移并继续保留 `accounts.json` 镜像用于降级/回滚；批量导入改为持久化批处理，避免每个账号同步重写整份 JSON 导致大批量导入卡死。（#657）
-- 重构：消除类型守卫 `isRecord` 的多处重复声明（收拢翻译层与路由层到 `shared-utils.ts`）
-- 重构：合并推理预算映射表 `REASONING_EFFORT_BUDGET`（提取为 `shared-utils.ts` 的公共常量）
-- 重构：精简别名（删除 `gemini-to-codex.ts` 里的 `flattenParts` 别名）
-- 重构：治理并归并过度拆分的文件（收拢 `src/routes/shared/` 下的 `non-streaming-*.ts` 为统一的 `non-streaming-helpers.ts` 并更新对应测试）
-- 重构：抽象路由层的 JSON 拦截与 API Key 校验（提取统一的 API Key 提取器 `extractProxyApiKey`；由全局 `errorHandler` 统一拦截 SyntaxError 带来的 JSON 解析失败并返回 400）
-- 更新 `README_EN.md` 中过时的模型推荐说明以匹配最新的模型别名映射（`README_EN.md`）
-
-- 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级（含 `readOnly` 与字号保护适配移动端），解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入并暴露 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 精确基于该响应头判定会话过期，彻底杜绝添加第三方 Key 或非会话 401 响应时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`shared/utils/clipboard.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
-- 修复分发 Key（Client Access Keys）页面创建与编辑弹窗背景透明问题：修正非标准 Tailwind 类名（`bg-surface-light`、`bg-surface-dark`、`border-border-light` 等），采用标准 `bg-white dark:bg-card-dark` 与 `border-slate-200 dark:border-border-dark` 确保弹窗遮罩及背景不透明显示。（`web/src/pages/ClientKeysPage.tsx`）
-
-### Fixed
-
-- 修复首页已连接账户卡片的代理选择器在窄屏下横向溢出（`web/src/components/AccountCard.tsx`）
-- 用量统计页面的折线图改为平滑曲线，提升趋势查看体验（`web/src/components/UsageChart.tsx`）
+## [v2.0.x](https://github.com/icebear0828/codex-proxy/releases?q=2.0) - 2026-03-25 至 2026-08-31
 
 ### Added
 
+- 为 `/v1/responses` 端点添加客户端 WebSocket 支持：接受 `ws://<host>:<port>/v1/responses` 的升级请求并用 Bearer 令牌鉴权，将客户端的 `response.create` 帧代理到现有上游 Codex WebSocket 并把响应事件以 JSON 流式回传；HTTP POST + SSE 仍作为回退保持不变，并在关闭路径中一并关闭该 WS 服务器。（#681）
+
+- 新增 E2E 测试覆盖账号 CRUD、管理员设置、Dashboard 登录三条关键 HTTP 路径（47 个新用例）：`tests/e2e/accounts.test.ts`（list / add / delete / reset-usage / label / cookies / batch-delete / batch-status / export / quota-warnings）、`tests/e2e/admin-settings.test.ts`（rotation / settings / general / quota 四组 GET+POST）、`tests/e2e/dashboard-login.test.ts`（login / logout / status + 速率限制）。（closes #376 partial）
+
+- Dashboard 新增侧栏导航布局，并支持在设置中切换回顶部标签栏旧版布局（`web/src/App.tsx`、`web/src/components/Sidebar.tsx`）。
+
 - `codex-responses` API-key wire 补齐 Codex 客户端 JSON 辅助端点：standalone Web Search `/v1/alpha/search`、远程压缩 `/v1/responses/compact`、图片生成/编辑 `/v1/images/generations|edits`（同时支持无 `/v1` 别名）。所有请求按 body `model` 走现有 UpstreamRouter，仅允许声明该能力的 adapter，使用固定 method/path 白名单并替换为上游 API key；JSON body、状态码和响应体透明转发，过滤 hop-by-hop 与 `Set-Cookie` 响应头，未知路径 fail-closed。
+
 - 自定义 API Key 新增可选 `codex-responses` wire：针对要求 Codex 客户端上下文的标准 Responses API 上游，使用 Bearer API key、Codex 会话/窗口/安装实例元数据与 SSE；不改变现有 `chat` / `responses` 默认行为，也不支持 Embeddings。
+
 - 新增按账号显式启用的 Codex `session_id` 指纹收敛模式，默认保持关闭；启用后仅将 HTTP/WebSocket 的上游 `session_id` 收敛为账号级稳定值，不合并 installation、conversation、window、turn 或 prompt-cache identity。Dashboard 提供风险确认开关，账号切换、空响应重试与 failover 均继承各自账号配置，旧持久化数据和非法模式安全回退为 `off`。（`src/auth/`、`src/proxy/codex-api.ts`、`src/routes/shared/`、`web/src/components/AccountCard.tsx`）
+
 - 日志可观测性与性能监控增强：为项目日志页面与数据链路添加全方位的可观测性指标捕获，包括首字延迟（TTFT）、单次预估金额（USD Cost）、Token 吐字生成速率（tok/s）、总执行耗时（Latency/Duration）及详细 Token 用量（Prompt / Completion / Reasoning / Cache Hit Rate）。在 Dashboard Logs 页面新增顶部可观测性概览看板（平均首字延迟、平均吐字速率、平均总耗时、总预估金额、Token 吞吐及请求成功率）、增强型列表表格列与 4 宫格性能详情抽屉；支持一键清空内存日志；补齐中英双语国际化支持。（`src/logs/metrics.ts`、`src/logs/store.ts`、`src/logs/entry.ts`、`src/routes/shared/streaming-handler.ts`、`src/routes/shared/non-streaming-handler.ts`、`src/routes/shared/direct-request-handler.ts`、`web/src/pages/LogsPage.tsx`、`shared/hooks/use-logs.ts`、`shared/i18n/translations.ts`）
+
 - Release Notes 改为 LLM 双语生成（替换并删除此前的逐词替换字典 `translate-notes.js`，机翻词盐根因）：新增 `summarize-release-notes.mjs` 调 OpenAI-compatible endpoint（secrets：`RELEASE_NOTES_BASE_URL/API_KEY/MODEL`）按 Electron 用户视角输出「✨ 本次更新」中文亮点 + 英文对照 + 折叠完整 commit 清单；输出强校验（JSON 契约、必须含 CJK、条数上限），LLM 不可用/校验失败时回退按 type 分组的纯英文列表，脚本永不非零退出（notes 问题不阻塞发版）；notes 过滤规则对齐 bump 的 `SKIP_RELEASE_PATTERN`（排除 chore/docs/ci/test/refactor/style）；已用真实 gateway 连调 3 次验证双语产出（`.github/scripts/summarize-release-notes.mjs`、`.github/scripts/generate-release-notes.sh`、`tests/unit/ci/summarize-release-notes.test.ts`、`tests/unit/ci/release-notes-script.test.ts`）
+
 - CI 发版通知 webhook：release 成功/失败、promote 成功/ff 前提破坏时 POST 纯文本到 `NOTIFY_WEBHOOK_URL` secret（ntfy 开箱可用）；secret 未配置时静默跳过、永不阻塞流水线（`.github/scripts/notify-webhook.sh`、`.github/workflows/release.yml`、`.github/workflows/promote-dev-to-master.yml`）
+
 - 自定义 API Key 的 Upstream protocol 新增 Anthropic Messages / Gemini generateContent 选项，并支持对应 base URL、模型列表获取与底层转发（`shared/hooks/use-api-keys.ts`、`src/auth/api-key-model-cache.ts`、`src/proxy/adapter-factory.ts`、`web/src/components/ApiKeyManager.tsx`）。
+
 - 修复并支持自定义 Anthropic & Gemini Upstream Base URL 与 ProxyPool 健康检查 URL（硬编码审计与修复）：在 `config-schema.ts` 的 `providers.anthropic` 和 `providers.gemini` 中添加可选的 `base_url` 字段，且在 `tls` 中添加 `health_check_url`（默认为 `https://api.ipify.org?format=json`）。通过构造函数将配置传入 `AnthropicUpstream` 和 `GeminiUpstream` 并在请求中动态调用；修改 `ProxyPool` 的 `healthCheck` 获取动态的健康检查 URL。新增 `tests/unit/proxy/adapter-factory.test.ts` 与 `tests/unit/config-schema.test.ts` 相关测试以保障 TDD。（`src/config-schema.ts`、`src/proxy/anthropic-upstream.ts`、`src/proxy/gemini-upstream.ts` 、`src/proxy/adapter-factory.ts`、`src/index.ts`、`src/proxy/proxy-pool.ts`、`tests/unit/config-schema.test.ts`、`tests/unit/proxy/adapter-factory.test.ts`）
+
 - Web 前端测试接入 CI 门禁:`web/` 是独立 package(非 root workspace)、用自己的 vitest(jsdom),其组件测试此前不被 root `npm test` 收录、不在任何自动化里跑。新增 root `test:web` 脚本(`cd web && npx vitest run`)和 `ci-quality.yml` 独立 `frontend-tests` job(`cd web && npm ci` + vitest),把现存 7 个 web 测试文件 16 用例纳入 PR 门禁;并给 `web/vite.config.ts` 补 `preact/devtools` / `preact/debug` alias——`@preact/preset-vite` 会把这两个 import 注入 `shared/` 文件,干净 `npm ci`(CI)从 web/ 外解析不到会在 import 阶段直接炸(本地因根 node_modules 有 preact 兜底而测不出)(`package.json`、`.github/workflows/ci-quality.yml`、`web/vite.config.ts`)
+
 - 第三方 API key 新增上游协议(wire)选择：OpenAI-family provider(`openai` / `openrouter` / `custom`)默认走 Chat Completions(`/chat/completions`，DeepSeek/Kimi/GLM 等只支持这一种),可显式 opt-in 走原生 Responses API(`/responses`，OpenAI 官方及支持 Responses 的网关用,保真度更高、少一次有损转换)。`ApiKeyEntry` 新增 `wire: "chat" | "responses"` 字段(旧数据 / anthropic / gemini 迁移为 `chat`);新增 `ResponsesUpstream` 适配器(近透传——内部表示本就是 Responses 形态,POST `/responses`,parseStream 直接透传原生 SSE);请求体按**白名单**只转发标准 Responses 生成字段(model/input/instructions/reasoning/tools/tool_choice/parallel_tool_calls/text/service_tier/prompt_cache_key/store),codex 内部路由字段、`client_metadata` 以及 OpenAI org 绑定的 `include: reasoning.encrypted_content` 一律不外发,`store:false` 保留(禁止第三方留存)。**已知限制**:`previous_response_id` 不转发(它是 chatgpt.com 作用域的 `resp_*`,第三方无法解析,直连路径本就无 affinity),即第三方 Responses 后端不支持服务端续链,与 Chat Completions 一致。转发集 = `CodexResponsesRequest` 上的生成字段全集;codex-proxy 内部模型从不携带的标准 Responses 控制项(temperature/top_p/max_output_tokens/stop/seed/response_format 等)因此不外发,与 chat wire 行为一致。`adapter-factory` 按 `wire` 在 `OpenAIUpstream` / `ResponsesUpstream` 间分流,anthropic/gemini 忽略 `wire`;**明确不做自动 fallback**(首请求延迟翻倍 + 各家错误语义不一 + 流式中途切不回)。Dashboard 添加 key 表单对 OpenAI-family 显示 Upstream protocol 选择器(默认 Chat Completions),并提示多数第三方只支持 Chat Completions。新增 `tests/unit/proxy/responses-upstream.test.ts`(5)、`tests/unit/proxy/adapter-factory.test.ts`(3,wire 路由)、`api-key-pool` wire 默认 + 旧数据迁移用例、`ApiKeyManager.test.tsx` wire 选择器用例(`src/proxy/responses-upstream.ts`、`src/proxy/adapter-factory.ts`、`src/auth/api-key-pool.ts`、`src/routes/api-keys.ts`、`shared/hooks/use-api-keys.ts`、`web/src/components/ApiKeyManager.tsx`)
+
 - CORS allowlist 配置：新增 `server.cors` 配置项和 `CORS_ALLOWED_HOSTS` 环境变量，允许指定外部 hostname 访问 API 兼容路由；配置支持纯 hostname 或带 scheme 前缀两种写法；loopback 始终放行不受 allowlist 影响。（#596，感谢 [@aeltorio](https://github.com/aeltorio)）
+
 - Docker entrypoint 自动检测 `CODEX_ARCH`：`uname -m` 映射 `aarch64→arm64`、`x86_64→x64`，未知架构直通；已预设时不覆盖。（#595，感谢 [@aeltorio](https://github.com/aeltorio)）
+
 - TLS 改用 OS 证书库（`rustls-tls-native-roots`）：corporate SSL inspection / Cloudflare Access Zero Trust 环境下 proxy 可直接使用系统信任的 CA 而无需额外配置。（#599，感谢 [@FlavienKlr](https://github.com/FlavienKlr) 提供 Windows + Cloudflare Access 实测验证）
+
 - 代理配置面板新增"粘贴 URL"模式：添加代理时可直接粘贴完整 URL（`http://user:pass@host:port` 或 `socks5://...`），无需逐字段填写；前端切换按钮中英双语；修复 `handleAdd` `useCallback` 缺失 `urlMode`/`newRawUrl` 依赖导致 URL 模式完全无法提交的问题；`resetForm` 现在同时重置 `urlMode` 状态（`web/src/components/ProxyPool.tsx`、`shared/hooks/use-proxies.ts`、`shared/i18n/translations.ts`）
+
 - Dashboard 新增 Plus / Pro / PAYG 账号的 credit 余额可视化与账号池总览（Phase 1，零新增上游 traffic）：`CodexUsageResponse.credits` 此前被打成 `unknown` 全量丢弃，现在 `toQuota()` 把 `has_credits / unlimited / overage_limit_reached / balance` 解析进新 `CodexQuota.credits` 槽，并把 `balance` 从 upstream 的十进制字符串转成 number（malformed payload 防御性返回 null 而不是 NaN）；`AccountRegistry.updateCachedQuota` 在收到不带 credits 字段的 quota（passive header path）时保留之前已知的 credit 余额，防止每次 `/codex/responses` 响应抹掉初始 warmup 拿到的余额；新增 `usage_stats.credits_per_usd` 配置项（默认 25，即 1000 credits = $40），dashboard 端按此换算 USD 显示。前端 `AccountCard` 在 `has_credits=true` 或 `unlimited=true` 的账号上新增一行 Credit Balance（balance + USD 换算 或 "Unlimited" 标签 或 overage 红字提示），Plus 账号 has_credits=false 时整行不渲染；新增 `PoolOverview` 卡片在 `/` 主页 AccountList 上方汇总账号池：active / quota_exhausted 数量、所有携带 credits 的账号余额合计与 USD 折算、secondary used% 最高的账号 + 重置时间。新增 `formatCredits` / `creditsToUsd` / `formatUsd` 共享格式化工具，shared 类型 `AccountQuota.credits` 透传到前端。新增 `tests/unit/auth/quota-utils.test.ts` 5 个 credits 用例、`tests/unit/auth/account-pool-quota.test.ts` 2 个 updateCachedQuota credits-preserve 用例、`shared/utils/__tests__/format-credits.test.ts` 11 个格式化工具用例、`tests/unit/web/pool-overview-stats.test.ts` 7 个聚合算法用例、`tests/unit/config-schema.test.ts` 补 `credits_per_usd` 默认值断言。i18n 中英新增 8 个新键（`src/proxy/codex-types.ts`、`src/auth/types.ts`、`src/auth/quota-utils.ts`、`src/auth/account-registry.ts`、`src/config-schema.ts`、`src/proxy/codex-api.ts`、`shared/types.ts`、`shared/utils/format.ts`、`shared/i18n/translations.ts`、`web/src/App.tsx`、`web/src/components/AccountCard.tsx`、`web/src/components/PoolOverview.tsx`）
+
 - 第三方 API key 增加 capability 分层与 OpenAI-compatible embeddings 代理：旧 key 自动按 `chat` 迁移，新增/导入/导出支持 `capabilities`，`/v1/embeddings` 只使用显式标记 `embeddings` 的 OpenAI/OpenRouter/custom key 并直连上游 `/embeddings`；Dashboard API Keys 表单新增 Chat / Embeddings 复选框和手动模型输入，避免静态 catalog 卡住 embedding/custom model。启动时无持久 key 也会创建 runtime router，后续在面板添加的 key 无需重启即可参与 chat 直连；chat 直连模型在配置 `proxy_api_key` 时补齐代理 key 校验。新增单元、前端表单和真实 OpenRouter embeddings 3 连 E2E 验证（`src/auth/api-key-pool.ts`、`src/routes/api-keys.ts`、`src/routes/embeddings.ts`、`src/proxy/upstream-router-bootstrap.ts`、`src/routes/chat.ts`、`web/src/components/ApiKeyManager.tsx`、`tests/unit/routes/embeddings.test.ts`、`web/src/components/ApiKeyManager.test.tsx`）
+
 - Account transfer compatibility with Cockpit Tools / Sub2API / CPA: normalized quota windows now include `remaining_percent` while preserving `used_percent`; successful `GET /auth/accounts/:id/quota` calls update cached quota; account import accepts Cockpit Tools portable objects, direct `accessToken` / `refresh_token`, Sub2API exports, raw arrays, and `text/plain` token lines; account export adds `format=cockpit_tools|sub2api|cpa` alongside existing `full|minimal`; Dashboard import/export now sends JSON or token-line files without forcing `{ accounts: [...] }` and exposes the export format selector. Docs now record the `/backend-api/wham/usage` active quota path and compatibility formats (`src/auth/quota-utils.ts`, `src/proxy/rate-limit-headers.ts`, `src/routes/accounts.ts`, `src/services/account-transfer-formats.ts`, `shared/account-transfer-client.ts`, `shared/hooks/use-accounts.ts`, `web/src/components/AccountImportExport.tsx`, `docs/architecture/auth/quota.md`, `docs/architecture/auth/import-export.md`, `docs/todo/cockpit-tools-quota-import-export.md`).
+
 - 支持 Dashboard 配置模型映射与本地自定义模型目录：`data/local.yaml` 可把客户端模型名映射到 Codex 模型、带 provider 前缀的第三方模型或已有 `model_routing` 目标；Dashboard → Settings → 模型映射可直接增删 alias 并热加载后端；`model.custom_models` 可把自定义 Codex-compatible ID 加入 `/v1/models/catalog` 并支持 `-fast` / `-high` 等后缀。ModelStore 会用本地 alias 覆盖静态 `config/models.yaml` alias，UpstreamRouter 会在内置 Claude/Gemini 自动路由前解析 alias，并在直连 provider 请求中把 outgoing `model` 改写为映射目标。新增 schema / model-store / upstream-router / route direct guard / Dashboard 组件测试覆盖配置默认值、静态 alias 覆盖、custom catalog、provider target 路由、四类直连接口（Chat / Messages / Responses / Gemini）的目标模型透传和 UI 持久化（`src/config-schema.ts`、`src/models/model-store.ts`、`src/proxy/upstream-router.ts`、`src/routes/admin/settings.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/responses.ts`、`src/routes/gemini.ts`、`web/src/components/ModelAliasSettings.tsx`、`tests/unit/config-schema.test.ts`、`tests/unit/models/model-store.test.ts`、`tests/unit/proxy/upstream-router.test.ts`、`tests/unit/routes/general-settings.test.ts`、`tests/unit/routes/upstream-auth-bypass.test.ts`、`web/src/components/ModelAliasSettings.test.tsx`）
+
 - Stream-close 事件结构化落盘到 Errors tab + 审计 log：`premature stream close` / `stream-client-abort` / `stream-client-disconnect` / `stream-error` 此前只走 `console.warn` 进 `dev-YYYY-MM-DD.log`，需要 grep 才能定位，且生产模式没有 tee；新增 `src/logs/stream-close-event.ts` 把这些事件同时写到 `data/error-log.jsonl`（Errors tab 按签名分组 + 角标计数）和 `logStore`（`/admin/logs` 审计流）。覆盖 7 个调用点：`proxy-handler.ts` 两处 client abort + 一处 `UpstreamPrematureCloseError`（带 eventCount / hadReasoning / responseId / variantHash）、`response-processor.ts` 两处（`client-write-failed` 带 writtenChunks/Bytes/lastSentEvent；`upstream-error` 带 upstreamStatus）、`responses.ts` 两处 `streamPassthrough` 内部 EOF（rid / accountEntryId / variantHash 通过 `FormatAdapter.streamTranslator` 的 `streamContext` option 由 `response-processor` 透传，其它 adapter 兼容性接收并忽略）。顺手修 `error-log.ts:readAppVersion` 在 config 未加载时崩溃（unit-test 路径会撞到），改为 try/catch 兜底回退 "unknown"。新增 `tests/unit/logs/stream-close-event.test.ts` 6 个单测覆盖 4 种 kind + 缺失 rid 兜底 + numeric upstreamStatus → audit status 透传 + direct upstream provider/path；Errors tab 展开分组时会显示 sample context。下次复现 premature close 直接看 Errors tab 按 `StreamUpstreamPrematureClose` 分组拉 rid + account + closeCode，不用再 grep dev 日志（`src/logs/stream-close-event.ts`、`src/logs/error-log.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/shared/response-processor.ts`、`src/routes/responses.ts`、`tests/unit/logs/stream-close-event.test.ts`）
+
 - Opt-in 上游请求/响应 dumper：新增 `src/utils/debug-dump.ts`，环境变量 `CODEX_PROXY_DEBUG_DUMP=1` 启用时把每次上游请求 + 流式 chunk + 终止状态 + 错误写入 `/tmp/codex-proxy-dump-<startupMs>.jsonl`（一行一事件）；未启用时所有 hook 是 `if (debugDumpEnabled())` 守护下的纯 boolean check，零开销。在 `src/routes/shared/proxy-handler.ts` 加 1 个 hook（`request`，含 rid/tag/entryId/conv/implicitResumeActive/resumeReason/payload），在 `src/routes/shared/response-processor.ts` 加 3 个 hook（`upstream-chunk` 截断到 16KB、`stream-finish` 含 chunks/bytes/sawTerminal、`stream-error` 含 status/msg/body 截断到 4KB）。**privacy 警告**：dump 文件包含完整 request payload（含用户 prompt）和上游响应，路径在启动时打印一次提示 sensitive 性质。日常排查"账号轮换重试风暴" / "premature stream close" 等偶发错误时 opt-in 启用，问题复现后再 opt-out
+
 - Pre-publish artifact smoke 拦在 stable 之前（#479）：`release.yml` 把 4 个平台（mac arm64 / mac x64 / win / linux）的 Pack step 从 `--publish always` 改成 `--publish never`，新增跨平台 smoke step 用 `.github/scripts/electron-smoke.sh` 启动打包好的 binary、tail 日志拿 `Server started on port N`、curl `/health`、清进程；smoke 失败直接阻塞 `gh release upload`，artifact 不会进 GitHub Release（坏的就不发）。Linux 装 `libfuse2 + xvfb` 起虚拟显示，Windows 用 `win-unpacked/*.exe` 跳过 NSIS 安装；smoke 失败时通过 `actions/upload-artifact@v4` 把日志保留 7 天给排查。新增 `tests/unit/ci/electron-smoke-script.test.ts` 6 个单测，覆盖脚本的 fail-loud 路径（缺 RUNNER_OS / RELEASE_DIR / AppImage / 不支持的 OS），保证脚本本身坏掉时不会沉默通过。CI 时间增量约 +5 分钟（Linux 最快，Windows 需研究 GHA windows-latest 的 GUI 启动行为，首次 PR 可能要回炉）（`.github/scripts/electron-smoke.sh`、`.github/workflows/release.yml`、`tests/unit/ci/electron-smoke-script.test.ts`）
+
 - Dashboard Errors tab + Header 浮起 badge + 渲染进程错误捕获（observability，#480 PR-2）：新增 `Errors` tab（按 `name + first stack frame` 聚合，按 last_seen 降序，可展开看 sample stack；折叠后只显示一行）；Header 右侧多一个红色 pulsing badge 显示未读错误数（>99 显示 `99+`），点击跳 `#/errors`；渲染进程注册 `window.addEventListener('error')` + `unhandledrejection` 在 `main.tsx` `render()` 之前，每条事件 fetch POST `/admin/error-logs/report`（不走 IPC，复用同源 dashboardAuth）；`useErrorLogs` / `useErrorLogsCount` hook 30s 轮询；i18n 中英双语；`mark all read` 按钮调 `/admin/error-logs/seen` 推进 cursor；新增前端 web bundle +8KB gzipped（`web/src/error-capture.ts`、`web/src/pages/ErrorsPage.tsx`、`shared/hooks/use-error-logs.ts`、`web/src/App.tsx`、`web/src/components/Header.tsx`、`web/src/main.tsx`、`shared/i18n/translations.ts`、`tests/unit/web/error-capture.test.ts`、`shared/hooks/use-error-logs.test.ts`）
+
 - 本地 uncaught error log（observability foundation，#480 PR-1）：进程级 `uncaughtException` / `unhandledRejection` 自动落盘到 `data/error-log.jsonl`，单 backup 滚动（默认 10MB → `error-log.1.jsonl`），`context` 经 `redactJson` 脱敏 token / cookie / api_key / oauth；新增 4 个 admin 端点 `/admin/error-logs`（按 `name + first stack frame` 聚合）/ `/admin/error-logs/raw`（裸 JSONL tail）/ `/admin/error-logs/count`（含 unread）/ `/admin/error-logs/seen`（推进读游标）/ `/admin/error-logs/report`（renderer / 外部 POST 上报）；`uncaughtException` 走 `setImmediate(throw)` 保留 Node 默认崩溃语义，不会静默吞掉 fatal；新增 schema 节 `observability: { local_error_log: bool=true, max_log_bytes: int=10485760 }`；前端 Errors tab + 浮起 badge 由 PR-2 跟进（`src/logs/error-log.ts`、`src/routes/admin/error-logs.ts`、`src/config-schema.ts`、`src/index.ts`、`tests/unit/logs/error-log.test.ts`、`tests/unit/routes/admin/error-logs.test.ts`）
+
+- Dev 默认把 stdout/stderr tee 到 `logs/dev-YYYY-MM-DD.log`（`src/utils/log-file.ts` + `src/utils/install-dev-logger.ts`，`src/index.ts` 顶部 side-effect 引入）：之前 dev 日志只活在 `tsx watch` terminal 的 scrollback 里，关窗或滚出去就找不到，排查上游偶发 422 之类的错误拿不到证据。新模块按天打开 append fd，patch `process.stdout.write` / `process.stderr.write` 同步写入文件 + 调原函数；prod (`NODE_ENV=production`) / 测试 (`VITEST` / `NODE_ENV=test`) / `CODEX_PROXY_FILE_LOG=0` 三档 opt-out，`logs/` 已被 `*.log` gitignore 覆盖。`tests/unit/utils/log-file.test.ts` 7 个用例覆盖 stdout/stderr tee、目录递归创建、uninstall 还原、append 不截断、默认文件名格式
+
+- Dashboard 用量页新增「时段命中率（Range Hit Rate）」卡片：基于当前选中时间窗口聚合 `cached_tokens / input_tokens`，与原本的全局累计「Cache Hit Rate」卡并列，方便对比近窗口与历史命中率（`web/src/pages/UsageStats.tsx`、`shared/i18n/translations.ts`）
+
+- Dashboard 用量页新增独立的「Hit Rate Over Time」图：每个 bucket 渲染命中率折线 + 数据点 dot，hover 可见 `cached / input`；`input=0` 的 bucket 自动跳过（不渲染 0% 假命中），单数据点也用 dot 保证可见性（`web/src/components/UsageChart.tsx`）
+
+- Usage history `five_min` granularity（5 分钟桶）+ Dashboard 新增「5 min」粒度选项与「Last 1h / 6h」时间窗：snapshot 默认 5 分钟一记，新粒度等同于一桶一快照，方便排查刚发生的请求；旧的 hourly/daily 不变，按 granularity 自动收敛兼容窗口（`src/auth/usage-stats.ts`、`src/routes/admin/usage-stats.ts`、`shared/hooks/use-usage-stats.ts`、`web/src/pages/UsageStats.tsx`）
+
+- 共享纯函数 `formatHitRate` / `sumWindow` / `formatUsageNumber` 抽到 `shared/utils/usage-stats.ts`，配套 vitest 单测覆盖边界（input=0 → "—"、<0.01% 截断、windowed 求和等），UsageChart 与 UsageStats 复用同一份格式化逻辑（`shared/utils/usage-stats.ts`、`shared/utils/__tests__/usage-stats.test.ts`）
+
+- WebSocket 连接池新增 keepalive ping + liveness 检测（`src/proxy/ws-pool.ts`）：每个 `PersistentWs` 默认 25 s 发一次 WS ping 帧（`DEFAULT_PING_INTERVAL_MS`），抵消上游 LB / NAT / 防火墙的 idle timeout 静默 RST；同时跟踪 `lastActivityAt`（pong 或任何 message 都算 proof of life），超过 `livenessTimeoutMs`（默认 = 2.5 × ping interval ≈ 62.5 s）无上游信号则主动 `markDead`，避免下次 acquire 复用一个已经"OPEN 但实际死了"的连接。E2E 验证（设备 a → 本机 8080）：单 WS 撑满 10 轮 + 70 s idle gap，turn 6 跨越 gap 后 hit 仍 99.6%（与 turn 5 持平），0 次 `liveness timeout` 误杀。Busy 时跳 ping（streaming data frame 已 keepalive）。`pingIntervalMs: 0` 或 `livenessTimeoutMs: 0` 各自独立可禁用（`tests/unit/proxy/ws-pool.test.ts` 共 11 个新单测覆盖：ping 节奏 / dead 后停 / readyState 守卫 / busy 跳过 / 错误吞咽 / liveness 误杀 / pong 重置 / message 重置 / 默认值边界等）
+
+- `promote-dev-to-master.yml` 新增 `force_skip_soak` 手动 input（`.github/workflows/promote-dev-to-master.yml`）：原本 soak 检查取的是 dev HEAD 的 commit timestamp ≥ 24 h，正常 merge 节奏下每次新 commit 都会 reset 时钟，导致 master 长期卡死收不到 dev 的更新（实测多个 PR 堵了一周没晋升）。新 input 仅在手动 `workflow_dispatch` 时可用、默认 false（保持原 soak 行为）；schedule cron 走默认 false 不受影响。仅在 sync-back / merge commit "时间新但内容稳定" 的紧急晋升场景使用
+
+- 图像生成请求计数（成功 / 失败分流）：`AccountUsage` 新增 `image_request_count` / `image_request_failed_count`（含 window 维度）。请求时检测 `tools[].type === "image_generation"`，release 时按 `tool_usage.image_gen.output_tokens` 是否 > 0 分流到成功 / 失败计数；Free 账号被静默剥工具、上游 4xx/5xx、EmptyResponse 等失败路径也会写入 failed 计数。`/admin/usage-stats/summary` 新增 `total_image_request_count` / `total_image_request_failed_count`，Dashboard 用量页新增「Image Requests」卡片显示 `N ok · M failed`，AccountCard 在有图像活动时显示窗口请求成功 / 失败行
+
+- 图像生成 token 独立计数：上游 `tool_usage.image_gen.{input_tokens, output_tokens}`（`gpt-image-2` 单独账）从前一直被丢弃，现在贯穿全链路 —— `parseResponseData` / `extractImageGenUsage` 解析、`AccountUsage` 累加（含 window 维度）、`UsageSnapshot` / `UsageBaseline` 持久化、`/admin/usage-stats/summary` 暴露 `total_image_input_tokens` / `total_image_output_tokens`、Dashboard 用量页新增「Image Tokens (in/out)」卡片，AccountCard 在该账号有图像消费时多显示一行窗口图像 token；老 `usage-history.json` 缺新字段以 0 兜底，向后兼容
+
+- 图像生成真实压测：`tests/real/image-generation.test.ts`（vitest, `npm run test:real`）跑 `{gpt-5.4-mini, gpt-5.5} × {1024×1024, 3840×2160}` 矩阵，每组合 2 并发 × 2 轮断言 SSE 完整事件链 + 图片 base64 长度阈值 + `tool_usage.image_gen.output_tokens > 0`，最后校验 `/admin/usage-stats/summary` 的 image token 增量；`tests/bench/image-gen-bench.ts` 提供同矩阵的 p50/p95/min/max + 图像与主模型 token 均值 markdown 表
+
+- Dashboard 用量统计新增「缓存命中率」卡片：聚合所有账号 `cached_tokens / input_tokens` 比例，附带绝对值提示。后端 `AccountUsage` 与 `UsageSnapshot` 持久化 cached tokens（含 window 维度），`/admin/usage-stats/summary` 与 `/history` 同步暴露 `total_cached_tokens` / `cached_tokens` 字段；老数据以 0 兜底
+
+- 发版流程引入 `dev` 分支 + beta channel：`bump-electron-beta.yml` 在 dev push 时打 `vX.Y.Z-beta.SHA` tag 出预发布包；`promote-dev-to-master.yml` 每天 14:00 UTC 检查 dev soak ≥24h + CI 绿后 fast-forward 到 master，再由现有 `bump-electron.yml` 出 stable tag (`.github/workflows/`)
+
+- `update.allow_prerelease` 配置项（默认 `false`）：开启后本地 Electron 通过 electron-updater 接收 beta channel 推送的预发布版本，便于自己的安装实测 dev 改动 (`src/config-schema.ts`、`packages/electron/electron/auto-updater.ts`、`config/default.yaml`)
+
+- `config/models.yaml`: `gpt-5.5` (Plus-only general-purpose chat) and `gpt-image-2` (Plus-only image-generation backend) entered the static catalog
+
+- `CodexModelInfo.outputModalities` optional field on the model catalog interface to flag image-gen models apart from chat models (`src/models/model-store.ts`, `BackendModelEntry.output_modalities` also added for backend passthrough). `/v1/models/catalog` defaults missing values to `["text"]` so API output matches the documented contract.
+
+- README 新增图像生成小节 + 模型表 Output 列；`API.md` / `API_CN.md` 补 `image_generation` 工具参数矩阵、事件流、编辑模式文档
+
+- Dashboard: new Logs tab to inspect ingress/egress requests, with enable/pause controls, filters, search, and details panel.
+
+- 控制台新增日志页面：支持启用/暂停、方向筛选、搜索与详情查看，便于排查请求流向。
+
+- `auth.tier_priority` 配置项：按 plan 类型排序账号选择优先级（如 `["plus", "pro", "team", "free"]`），高优先级 tier 的账号在有可用时始终优先选择；默认 `null`（不启用），与所有轮转策略兼容 (#348)
+
+- `server.trust_proxy` config option (default `false`): when enabled, the real client IP is read from `X-Forwarded-For` / `X-Real-IP` headers instead of the raw socket address. Required for users who expose codex-proxy via tunnel software (frp, ngrok, etc.) so that dashboard auth works correctly — previously all tunnel traffic appeared as `127.0.0.1` and bypassed authentication even when `proxy_api_key` was set (#350)
+
+- 第三方 API Key 管理：支持 Anthropic / OpenAI / Gemini / OpenRouter 预设模型 + 自定义 provider，每个 key 绑定一个具体模型，运行时动态路由（优先于 config 固定 key），LRU 轮转多 key 负载均衡
+  - REST API：`GET/POST /auth/api-keys`、`GET /auth/api-keys/catalog`、`POST /auth/api-keys/import`、`GET /auth/api-keys/export`、批量删除、label/status 管理
+  - Dashboard 新增 API Keys tab：表单添加（御三家下拉选模型 / custom 手填）、import/export、toggle 启停、删除
+  - 持久化 `data/api-keys.json`，UpstreamRouter 优先级 0 匹配 pool entry
+
+- 加强伪装：Rust native transport（reqwest + rustls），TLS 指纹精确匹配真实 Codex Desktop；补齐 `x-openai-internal-codex-residency`、`x-client-request-id`、`x-codex-turn-state` 请求头
+
+- 账号探活：`POST /auth/accounts/health-check` 批量健康检查 + `POST /auth/accounts/:id/refresh` 单账号刷新，通过 OAuth refresh 探测存活状态，带 stagger 延迟和并发控制
+
+- Session affinity：同一对话链路由到同一账号，修复 `previous_response_id` 跨账号失效问题
+
+- `prompt_cache_key`：每个对话链生成唯一 UUID 传递给后端，启用 prompt cache
+
+- WebSocket 请求新增 `include: ["reasoning.encrypted_content"]`（reasoning 开启时自动设置）
+
+- 请求级监控日志：affinity hit/miss、payload 大小、usage 统计、大 payload 告警
+
+- E2E 测试：proxy-routes（36 cases）、dashboard-auth（9）、batch-label（11）、admin-general（11）、debug-routes（5）—— 覆盖率从 51% 提升至 ~75%
+
+- 单元测试：config-loader（16 cases）、config-schema（10）、codex-models（9）
+
+- account-import service 测试补充 RT rotation/fallback 2 cases
+
+- Claude Code Setup 卡片：Dashboard 按 Opus/Sonnet/Haiku/自定义 层级一键复制环境变量（推荐模型 gpt-5.4 / gpt-5.3-codex / gpt-5.4-mini）
 
 ### Fixed
 
+- 修复 `/v1/responses` 与 `/v1/responses/compact` 在客户端指定未收录模型时静默回退默认模型、响应 `model` 字段误报为默认模型的问题：与 `/v1/chat/completions` 行为一致，未识别模型返回 `404 model_not_found`；`codex` 哨兵与配置默认模型仍正常回退默认。（`src/routes/responses.ts`、`src/routes/responses-compact.ts`、`src/models/model-store.ts`，关联 issue #660）
+
+- 修复 GPT-5.6 的 `-max` / `-ultra` 推理后缀未被模型解析器识别的问题，并同步更新中英文 README 的 Pi 配置示例。
+
+- Docker 镜像版本号显示错误（始终显示 2.0.77 而非实际发布版本）：`docker-publish.yml` 构建时通过 `--build-arg PROXY_VERSION` 将版本注入镜像，`Dockerfile` 将其写入 `ENV PROXY_VERSION`，`getProxyInfo()` 优先读取该环境变量，容器内无 `.git` 时也能正确报告版本。（#677，关联 issue #676）
+
+- 修复首页已连接账户卡片的代理选择器在窄屏下横向溢出（`web/src/components/AccountCard.tsx`）
+
+- 用量统计页面的折线图改为平滑曲线，提升趋势查看体验（`web/src/components/UsageChart.tsx`）
+
 - 代理选择器不再显示已禁用的代理，批量均分仅使用 active 代理（`web/src/components/{AccountCard,AccountTable,BulkActions,RuleAssign}.tsx`）
+
 - 修复默认 hosted tools 的协议兼容：按工具 `type` 通用判重，保留 Anthropic Messages 在全局默认列表为空时的 Web Search fallback，基于最终注入后的工具统计图片请求，并将默认 `image_generation` 结果分别转换为 Anthropic `tool_use` 与 Gemini `inlineData`；新增路由、翻译、集成测试及真实上游 Web Search / 图片生成连续 3 次验证。（`src/routes/shared/default-tools.ts`、`src/routes/{chat,gemini,messages,responses}.ts`、`src/translation/codex-to-{anthropic,gemini}.ts`、`tests/{unit,integration,real}`）
+
 - Retry early upstream `server_error` responses once on a different account before streaming, while preserving already-started streams and formatting errors according to client protocol.
+
 - 修复 `promote-dev-to-master` 将同一 commit 上历史 Electron release 失败记录误当作当前 CI 失败的问题：晋升门禁现在只读取该 commit 最新的 `ci-quality.yml` 结果，并支持分页读取 workflow runs，避免一次临时发布下载错误在成功重试后永久阻塞 `dev → master`，并补充回归测试（`.github/scripts/check-promote-ci.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/promote-ci-gate.test.ts`）
 
 - 修复上游 WebSocket 首帧 `server_is_overloaded` 被当作普通 SSE 错误透传、最终表现为 `stream disconnected before completion` 的问题：现在在 HTTP 响应提交前映射为 503，进入账号切换/有限重试；已产生输出后不重放请求，且 `response.completed` 后的异常关闭不再误报未完成流。（`src/proxy/error-classification.ts`、`src/proxy/ws-pool.ts`、`src/proxy/ws-transport.ts`、`src/routes/shared/proxy-error-handler.ts`、`src/translation/codex-api-error-from-event.ts`）
 
 - 修复 Dashboard Errors tab 的“全部标记已读”和“删除”操作被 Settings Bearer-token middleware 拦截成 401 的问题；`/admin/error-logs*` 统一交给 dashboard session auth，避免 cookie 登录会话被误判失效并跳回登录页。（`src/routes/admin/settings.ts`、`tests/integration/error-logs-dashboard-auth.test.ts`）
+
 - 修复 release notes 生成脚本在 LLM endpoint 不可达时可能被 60s 默认请求超时拖慢测试的问题；新增 `RELEASE_NOTES_REQUEST_TIMEOUT_MS` 仅用于覆盖该脚本请求超时，生产默认仍为 60s。（`.github/scripts/summarize-release-notes.mjs`、`tests/unit/ci/summarize-release-notes.test.ts`）
+
 - 修复并强化 WebSocket 消息流的生命周期管理：通过缓冲早期元数据帧（如 `response.created`），延迟解析 HTTP 响应，从而解决由于内部限流事件导致的提前解析和挂起问题，并在重构中排除了首字时间（TTFT）超过 20s 会引发超时的隐患。（#678，感谢 [@zyycn](https://github.com/zyycn)）
+
 - 修复 promote soak 饿死：旧规则要求 dev HEAD 本身 ≥24h，活跃开发期每个新 commit 重置时钟导致 master 长期不晋升；新增 `select-promote-candidate.sh` 改为晋升「最新的、已泡满 24h 的 dev first-parent commit」（新鲜提交留在 dev 继续 soak、次日跟进），CI 门禁逐候选回退找绿；`force_skip_soak` 仍直接取 dev HEAD（`.github/scripts/select-promote-candidate.sh`、`.github/workflows/promote-dev-to-master.yml`、`tests/unit/ci/select-promote-candidate.test.ts`）
+
 - 修复 Docker 版本镜像被覆盖：`docker-publish.yml` 此前在 master 分支 push 时用 `max(package.json, 最新 stable tag)` 决定版本号，14:00 promote 后会用「晚于 tag 的代码」重打 `ghcr.io/...:vX.Y.Z` 镜像（镜像内容 ≠ git tag）；现在分支 push 只打 `latest` + `sha-<short>`，版本镜像仅由 `bump-electron.yml` dispatch 带 `tag` 输入、从 tag 源码构建（`.github/workflows/docker-publish.yml`、`.github/workflows/bump-electron.yml`）
+
 - 修复 release 空 body 窗口：`release.yml` notes 生成从最后一个 job 提前为第一个 job，此前 upload 步骤先 `gh release create --notes ""`、notes job 挂掉则 release 永久空 body（更新弹窗里用户看到空白）；stable release 创建时 `--latest=false`，全部平台 smoke 通过后才翻 `--latest`（构建窗口内 `/releases/latest` 始终指向上一个完整版本，auto-updater 不会撞到零资产 release）；构建全挂时自动删除零资产 release（保留 tag 可重试），防止 beta 渠道解析到空版本；顺带 release/build job Node 版本统一到 22（与 ci-quality 一致）（`.github/workflows/release.yml`）
+
 - 修复自定义 API Key 原生 wire 的 provider/wire 一致性问题：后端拒绝 built-in provider 的无效 wire/baseUrl 组合，custom 模型缓存按 wire 隔离，Anthropic 模型发现改用 x-api-key，Anthropic 上游请求接入 fetch dispatcher，Embeddings 路由拒绝 custom Anthropic/Gemini wire，并在前端切换 custom wire 时清空旧模型列表（src/routes/api-keys.ts、src/auth/api-key-model-cache.ts、src/proxy/anthropic-upstream.ts、src/routes/embeddings.ts、web/src/components/ApiKeyManager.tsx）。
 
 - 修复 Windows 本地缺少 POSIX shell 时 CI 脚本单测失败、Electron bundle 动态导入路径以及 `full-update` 子进程启动路径含空格的问题（`tests/unit/ci/*`、`packages/electron/__tests__/build.test.ts`、`scripts/build/full-update.ts`）。
@@ -114,115 +218,122 @@
 - 修复 Settings → API 配置默认模型下拉混入写死、别名和过期权限模型的问题：模型目录改为使用当前成功拉取的账号/plan 快照与缓存快照，成功刷新后不再增量保留已失效模型；缓存按 plan 持久化以保留未刷新 plan 的冷启动 fallback，并避免本地 custom models 被写入 backend cache；同时过滤非文本 chat 模型（`config/models.yaml`、`src/models/model-store.ts`、`src/routes/models.ts`、`shared/hooks/use-status.ts`）。
 
 - 修复了 Electron 强制覆盖 `server.host` 配置的问题：不再于启动 server 时硬编码 `host: "127.0.0.1"`，使其能正常使用配置文件 `local.yaml` 以及环境变量 `CODEX_PROXY_HOST` 的设置（`packages/electron/electron/main.ts`、`tests/unit/config-local-override.test.ts`）
+
 - 修复了当启用 `skip_exhausted` 模式时可能造成配额耗尽账号”死锁假死”以及本地被动重置引发”重置时间漂移”的隐患：通过新增 `ActiveQuotaRefresher` 后台主动心跳服务，对耗尽或重置前后的账号定期带 Jitter 主动校验；同时引入 “Drift-Defense” 防漂移验证，在本地脑补清零后，强制触发一次上游验证后再安全放行。（`src/auth/active-quota-refresher.ts`，`src/routes/shared/proxy-handler.ts`，`tests/integration/proxy-handler.test.ts`）
+
 - 修复了在会话亲和降级或账号切换时可能触发上游”连锁封号（cascading ban）”的安全隐患：当由于首选账号（拥有上一个 `previous_response_id` 对应的会话）不可用而发生 Failover 切换到新账号时，现在会主动在请求发送前剥离 `previous_response_id` 和 `turnState`，并清理旧的 Affinity 关系，避免将带有其他账号的会话标识发往上游导致连锁关联封号风险。（`src/routes/shared/proxy-handler.ts`，`tests/integration/proxy-handler.test.ts`）
+
 - 修复大上下文会话流式响应卡死（#597）：客户端经 ngrok / cloudflared 等隧道访问时，大上下文（~32-50K）下 gpt-5.x 在 reasoning 阶段可能数十秒不产出任何 output 字节，期间 SSE 连接全程静默，被隧道 / LB / NAT 的 idle 超时静默 FIN（日志表现为 `client-abort`），客户端表现为卡死、重启代理无效、只能砍历史降低上下文。`response-processor.ts` 的 `streamResponse` 现在在静默间隙按 `HEARTBEAT_INTERVAL_MS`（默认 15s，远低于常见 30-60s idle 超时）写入 SSE 注释行 `: ping\n\n` 保活——注释行被所有 SSE 解析器忽略，不污染 OpenAI/Anthropic/Gemini/Responses 任一格式的内容，也不计入 stream trace；活跃推流期间因 idle 判定不触发，零额外字节。两条流式路径（账号池 `streaming-handler.ts` + 直连 `direct-request-handler.ts`）一并补 `X-Accel-Buffering: no` 头，防止 nginx 类反代缓冲住心跳/增量。新增 `tests/unit/stream-heartbeat.test.ts` 5 个单测覆盖静默间隙触发、活跃不触发、流结束停表、`heartbeatMs=0` 关闭、默认间隔阈值（`src/routes/shared/response-processor.ts`、`src/routes/shared/streaming-handler.ts`、`src/routes/shared/direct-request-handler.ts`、`tests/unit/stream-heartbeat.test.ts`）
+
 - 修复直连路由转换 `developer` 角色消息时未过滤并发送到 Anthropic 导致报错 400 的隐患，现在会正确将 `developer`/`system` 消息合并拼接进顶级 `system` 字段（`src/translation/codex-request-to-anthropic.ts`）
+
 - 移除 README "最近更新" 区块的 CI 自动同步（删除 `sync-changelog.yml`，README 该小节静态化为指向 CHANGELOG.md 的链接）：该 workflow 每次在 master 上 push `docs: auto-sync changelog to README [skip ci]` commit 却从不回流 dev，是 `promote-dev-to-master.yml` 的 fast-forward 前提被持续破坏、promote 静默失败约 3 周的主因（master 13 个未回流提交里 6 个出自它）。改为静态链接从源头消除 master 单边漂移（`.github/workflows/sync-changelog.yml`、`README.md`）
+
 - 修复 Beta / Prerelease 标签的发布日志生成逻辑：改用基于 Git 拓扑结构的 `git describe` 动态计算前一个最近可达的祖先 Tag（PREV_TAG），彻底杜绝由于 Git SHA 字符降序 Semver 排序（`--sort=-v:refname`）导致错乱引用更晚 Tag 进而日志归零的问题；同时使 Prerelease 版本能正确计算其相对于最新 Stable Tag 的增量 commit，解决由于只筛选 Prerelease Tag 而物理跳过已发布 Stable 版本、导致每次 Dev 构建都大范围重复累入旧版本历史日志的问题（`.github/scripts/generate-release-notes.sh`、`tests/unit/ci/release-notes-script.test.ts`）。
+
 - 修复第三方后端并行 tool call 转 Anthropic 时 content_block index 碰撞导致工具入参丢失（#610）：第三方 OpenAI 兼容后端在一次响应里返回 ≥2 个 tool call 时，`openai-upstream.ts` 在流过程中逐个发 `output_item.added`、但把所有 `function_call_arguments.done` 憋到流结束后才统一发，导致事件顺序变成 `start(A) → start(B) → done(A) → done(B)`；而 `codex-to-anthropic.ts` 的流式状态机只有单个 `contentIndex` 计数器、`functionCallStart` 开 `tool_use` 块时不自增，两个 start 连续到达会抢占同一个 content block index，deltas 混入同一块、第二个工具调用入参被损坏/丢失（Claude Code 等多工具并行场景必现）。现在 `streamCodexToAnthropic` 维护 `callId → 块索引` 映射，`functionCallStart` 时分配并自增 `contentIndex`，`functionCallDelta` / `functionCallDone` 按 callId 路由到正确 index，支持多个同时打开的 `tool_use` 块（并对 done-without-start 做防御性兜底）。非流式 `collectCodexToAnthropicResponse` 路径本就按数组收集、不受影响。新增 `tests/unit/translation/codex-to-anthropic-parallel-tools.test.ts` 3 个单测覆盖：各 tool_use 块占独立 index、start/stop 一一配对无幽灵 index、交错 deltas 路由到正确块（`src/translation/codex-to-anthropic.ts`、`tests/unit/translation/codex-to-anthropic-parallel-tools.test.ts`）
+
 - Claude Messages 路径现在接受并保序透传 message-level system/developer role，未知 role 记录日志并降级为 user，避免新版 Claude Code 请求被 schema 拒绝或 role 顺序丢失（`src/types/anthropic.ts`、`src/translation/anthropic-to-codex.ts`）
+
 - `collectPassthrough` 在 `response.completed.response` 不含 `output` 字段时无法回填：条件从 `Array.isArray && length === 0` 改为 `!Array.isArray || length === 0`，覆盖 output 完全缺失的上游 shape。（#602，感谢 [@williamjameshandley](https://github.com/williamjameshandley)）
+
 - `/v1/chat/completions` 和 `/v1/messages` 路由在 `wantReasoning`/`wantThinking` 判断时现在读取翻译后的 `codexRequest.reasoning?.effort`，而非原始请求字段：此前仅当客户端显式传 `reasoning_effort` / `thinking.type` 时才向客户端透传推理摘要，通过 model suffix（如 `gpt-5.4-high`）或 `default_reasoning_effort` 配置注入的 effort 虽然正确发到上游，但 Codex 返回的 `response.reasoning_summary_text.delta` 被代理静默丢弃，导致客户端看不到任何推理内容、误以为 effort 无效（`src/routes/chat.ts`、`src/routes/messages.ts`、`tests/unit/translation/openai-to-codex.test.ts`）
+
 - 代理 host 字段粘贴完整 URL 时不再 double-prefix：`POST /api/proxies` body 的 `host` 如果是形如 `http://...` 或 `socks5://...` 的完整 URL，后端直接使用而不再拼接 protocol + port，避免生成 `http://http://...` 的畸形 URL；name 为空时自动回退到 URL 前，先去掉 username/password 防止凭证写入代理名称（`src/routes/proxies.ts`）
+
 - `SessionAffinityMap` 现在存储 instructions 的 SHA-256 hex hash 而非原始字符串，防止长 system prompt 请求在 affinity 记录里大量占用内存；implicit-resume 的 instructions 比对改为 hash 对比（`src/auth/session-affinity.ts`、`src/routes/shared/proxy-session-helpers.ts`、`src/routes/shared/proxy-session-context.ts`）；修复 null instructions（无 system prompt 的请求）通过 `?? undefined` 被转为 `undefined` 导致 hash 不落盘、下一轮 implicit-resume 比对必然失败的回归（`src/auth/session-affinity.ts`、`src/routes/shared/non-streaming-affinity.ts`、`src/routes/shared/streaming-handler.ts`）
+
 - Codex `developer` role 消息在翻译到 OpenAI 兼容格式时现在正确映射为 `system` role，避免不接受 `developer` role 的 provider 返回 400（`src/translation/codex-request-to-openai.ts`、`src/proxy/codex-types.ts`）
+
 - Release/promotion readiness fixes: `promote-dev-to-master.yml` now fails the workflow when `master` cannot fast-forward to `dev` instead of reporting a skipped success; `release.yml` runs stale asset cleanup under bash on every matrix runner and uses a dedicated PowerShell smoke script for Windows packaged Electron builds. Dashboard pool credit totals now use the persisted `usage_stats.credits_per_usd` value exposed by `/admin/general-settings`, and Anthropic cache-reporting tests now match the current contract where `input_tokens` excludes cached input while `cache_read_input_tokens` reports the hit count (`.github/workflows/promote-dev-to-master.yml`, `.github/workflows/release.yml`, `.github/scripts/electron-smoke.ps1`, `src/routes/admin/settings.ts`, `shared/hooks/use-general-settings.ts`, `web/src/App.tsx`, `web/src/components/PoolOverview.tsx`, `tests/unit/cache-reporting.test.ts`).
+
 - Dashboard 的"刷新配额"按钮现在真正刷新账号 quota：`GET /auth/accounts/:id/quota` 此前只把 `/codex/usage` 结果返回给 caller、不写回 `pool.cachedQuota`。所以当 OpenAI 做 promo / window grant 把 `secondary_window.used_percent` 重置为 0% 时，proxy 仍然显示重置前的 98–100%，要等下一次真实 `/codex/responses` 请求才被动靠 `x-codex-*` 响应头追上。同一条死路也让 Pro / PAYG 账号 `credits` 块永远进不了 cachedQuota（header path 根本不带 credits）。修复：`/auth/accounts/:id/quota` 拉取上游后立刻 `pool.updateCachedQuota(id, toQuota(usage))` 写回；前端 `AccountList.onRefreshQuota` 直接调用单账号 `GET /quota`，失败时输出 warning 后刷新列表缓存（`src/routes/accounts.ts`、`web/src/components/AccountList.tsx`）
+
 - `AccountRegistry.isAuthenticated()` 现在尊重 `quota.skip_exhausted` 配置：此前不论该开关如何配置，`isAuthenticated` 都会把 `cachedQuota` 已耗尽的活跃账号一律视作不可用，导致 `quota.skip_exhausted=false` 的部署在所有号都 `limit_reached=true` 但仍可被 `AccountLifecycle.acquire()` 取走的情况下，被 `accountPool.isAuthenticated()` 守门的路由（`/v1/chat/completions` / `/v1/messages` / `/v1/responses` / model 列表 / health）全部 401。现在 `isAuthenticated` 与 `hasAvailableAccounts` 用同一套规则：`skipExhausted ? !hasReachedCachedQuota(entry) : true`。配置默认值不变（默认仍跳过）。新增 5 个单测覆盖空池 / 默认 skip / 默认非 skip / `skip_exhausted=false` 配额耗尽路径 / disabled 账号 0 容忍（`src/auth/account-registry.ts`、`tests/unit/auth/account-pool-has-available.test.ts`）
+
 - Claude Code 2.1.84 计费头 strip 行为新增 rotation 变体回归覆盖：实测 Claude Code 把 `x-anthropic-billing-header: cc_version=...; cc_entrypoint=cli; cch=<5hex>;` 作为 `system[0]` 独立块下发，`cc_version` 后缀和 `cch` 每请求 reroll；新增 `it.each` 覆盖 5 个真实 `cc_version` 后缀（c8e / 76b / f51 / 5b4 / 4f3）与"两次不同 cch 产出同一份 `instructions`"的不变性断言，防止后续改 strip（如改 `startsWith` → 正则、或加 inline 清洗）意外让 `cch` 漏进 `instructions` 污染上游 prompt cache（`tests/unit/translation/anthropic-to-codex.test.ts`）
+
 - Dashboard Errors tab now has a real clear action: `DELETE /admin/error-logs` removes current + backup JSONL files and the read cursor so repeated `StreamUpstreamPrematureClose` groups can be cleared from the page instead of only marked read. Anthropic setup defaults now map Opus 4.7 → `gpt-5.5` and Sonnet 4.6 → `gpt-5.4`, and the built-in Anthropic API-key catalog lists Claude Opus 4.7 (`src/logs/error-log.ts`, `src/routes/admin/error-logs.ts`, `shared/hooks/use-error-logs.ts`, `web/src/pages/ErrorsPage.tsx`, `web/src/components/AnthropicSetup.tsx`, `src/auth/api-key-catalog.ts`).
+
 - Claude Code 的 `Read` 工具参数里如果 `pages` 传成空字符串或空白字符串，会在 Codex → Anthropic 转换时被自动剔除，避免 GPT-5.5 反复触发 `Read tool validation error: Invalid pages parameter: ""` 并重试隔离工作树；对应单测覆盖流式与非流式两条路径，以及非空 PDF 页码范围保留（`src/translation/codex-to-anthropic.ts`、`tests/unit/translation/codex-to-anthropic-read-pages.test.ts`）。
+
 - Dashboard egress log details now include Codex request `reasoning` and optional `service_tier`, so `/admin/logs` can show the actual reasoning effort sent upstream instead of only `model` / `stream` / `useWebSocket` (`src/routes/shared/proxy-egress-log.ts`, `tests/unit/routes/shared/proxy-egress-log.test.ts`).
+
 - implicit-resume 区分"真 missing tool call"与"client 自包含 full replay"：`evaluateImplicitResume` 现在新增 `inlineFunctionCallIds` 入参，由 `buildProxySessionContext` 通过 `getInlineFunctionCallIds(codexRequest.input)` 在调用前收集 input 里所有 `function_call` 项的 call_id。当 input 里的 function_call_output 全部能在 input 内找到对应 function_call（典型 Codex CLI `/compact` 或客户端 fallback 自包含 replay 场景），返回 `reason: "self_contained_replay"` 而不是 `missing_tool_calls`，proxy 走正常透传不再触发 payload guard 413。混合场景（部分 inline 部分 storage 都找不到）仍判 `missing_tool_calls` 防真 runaway。新增 4 个 `evaluateImplicitResume`/`getInlineFunctionCallIds`/`isSelfContainedReplay` 单测覆盖纯 inline、混合、空 output、incremental turn 四类（`src/routes/shared/proxy-session-helpers.ts`、`src/routes/shared/proxy-session-context.ts`、`tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts`、`tests/unit/routes/shared/proxy-session-context.test.ts`）。
+
 - 放宽 `/v1/responses` 的 missing-tool-call full-history replay guard 阈值：从 250KB / 80 items 提到 2MB / 1000 items。原阈值会把 Codex CLI `/compact` 之后正常的 client-driven full replay（实测 300-800KB / 100-800 items）误判成 runaway 风暴，连续 413 卡死对话。新阈值仍能挡真正失控的 multi-MB 重试循环，但不再误伤合法 fallback；测试侧把 padding 从 80 提到 1010 items 让 guard 仍能在新阈值下触发（`src/routes/shared/proxy-handler.ts`、`tests/integration/proxy-handler.test.ts`）。
+
 - 修复个别账号被 Cloudflare Bot Management `__cf_bm` cookie 反噬导致 `/codex/responses` 全 404、`/codex/usage` 仍正常的"配额没限却用不了"假死状态：根因是 proxy 此前在 warmup `GET /codex/usage` 时通过 `captureCookies` 把 CF 偶发下发的 `__cf_bm` 收进 jar，而 `__cf_bm` 是绑死 (IP + UA + TLS fingerprint + 时序) 的 30 分钟会话指纹 cookie——一旦 fingerprint 漂（proxy pool 切出口 IP / cookie 过期 / 时序变化），CF 在重保护路径就用空 body 404（CF "stealth deny" 模式）拒绝该 cookie 持有者，而轻保护路径继续放行，造成 `cachedQuota.rate_limit.limit_reached=false / used 78%` 但 `/codex/responses` 14 连 404 的诊断矛盾；24 个号里只这一个号偶然命中过 CF 下发，其它 cookie jar 全空的号反而都正常。修复两层：(1) `src/proxy/cookie-jar.ts` 加 `CAPTURABLE_COOKIE_NAMES = {cf_clearance}` 白名单，`captureRaw` 主动丢弃 `__cf_bm` 等非白名单 cookie，从源头不让毒 cookie 入 jar；admin API 的手动 `set()` 不受白名单约束方便调试。(2) `src/proxy/error-classification.ts` 新增 `isCfPathBlockError`（404 + trimmed body 为空）；`src/auth/cf-path-block-tracker.ts` 用 1 小时滑动窗口计数器追踪每个 entryId 的连续 CF block 次数；`src/routes/shared/proxy-error-handler.ts` 在 generic respond 之前加新分支——命中 CF block 时清这个号的 cookie jar、记录计数、`releaseBeforeRetry: true` 让请求 fail over 到不同号，同号 1h 内累计 ≥ 3 次自动 `markStatus("disabled")` 并 `appendErrorLog({ name: "CfPathBlockAutoDisable" })` 进 Errors tab；`src/services/account-mutation.ts` 在 dashboard re-enable 时 `resetCfPathBlock` 清计数避免历史欠账。新增 `tests/unit/auth/cf-path-block-tracker.test.ts`（4 个，计数 / 窗口过期 / reset / peek）、`tests/unit/proxy/error-classification.test.ts` `isCfPathBlockError` 一节（4 个分支）、`tests/unit/routes/shared/proxy-error-handler.test.ts` CF block retry/disable 路径（2 个，含非空 body 不误判），`tests/unit/proxy/cookie-jar.test.ts` 改写为白名单语义（+2，旧 `session_id` / `expired` 用例改用 `cf_clearance` 测通用 Max-Age 解析）。Full suite 2258 全绿（`src/proxy/cookie-jar.ts`、`src/proxy/error-classification.ts`、`src/auth/cf-path-block-tracker.ts`、`src/routes/shared/proxy-error-handler.ts`、`src/routes/shared/proxy-handler.ts`、`src/services/account-mutation.ts`、`tests/unit/proxy/cookie-jar.test.ts`、`tests/unit/proxy/error-classification.test.ts`、`tests/unit/auth/cf-path-block-tracker.test.ts`、`tests/unit/routes/shared/proxy-error-handler.test.ts`）
+
 - `/v1/responses` passthrough streaming / non-streaming paths now collect `function_call.call_id` from `response.output_item.done` and forward it through response metadata so implicit resume can validate following `function_call_output` turns instead of falling back to full-history replay. Oversized missing-tool-call replays are guarded with 413, and regression coverage now proves the issue red/green across the Responses format adapter (`src/routes/responses.ts`, `src/routes/shared/proxy-handler.ts`, `tests/unit/routes/responses-passthrough-metadata.test.ts`, `tests/integration/proxy-handler.test.ts`).
+
 - Release bump workflows now require runtime file changes in addition to meaningful commit subjects before tagging a beta or stable build. This prevents squash-promotion history divergence from re-counting old dev commits, and prevents workflow/docs/test-only fixes from producing empty Electron releases (`.github/workflows/bump-electron.yml`, `.github/workflows/bump-electron-beta.yml`, `tests/unit/ci/package-boundary.test.ts`).
+
 - Release bump workflows now skip the release-notes workflow hotfix subject itself, so promoting the stable-notes CI fix to `master` does not create an empty desktop release on the next scheduled bump (`.github/workflows/bump-electron.yml`, `.github/workflows/bump-electron-beta.yml`, `tests/unit/ci/package-boundary.test.ts`).
+
 - 修复 stable release notes 在手动 squash promotion 后只写 `fix: promote dev release fixes to master`、漏掉 dev 原始 PR 的问题：`release.yml` 改为调用 `.github/scripts/generate-release-notes.sh`，stable tag 若只有 promotion 内容且运行时代码树与 `origin/dev` 一致（忽略 README/package 版本文件），会回退使用 dev history 生成说明；新增单测覆盖正常 stable tag 与 squash promotion 两条路径（`.github/workflows/release.yml`、`.github/scripts/generate-release-notes.sh`、`tests/unit/ci/release-notes-script.test.ts`）。
+
 - Lockfile tarball sources now point to the official npm registry instead of `registry.npmmirror.com`, and the CI package boundary guard fails if any root/web/native lockfile resolves npm packages from a non-`registry.npmjs.org` host. Root production dependency audit is also clean after non-breaking lockfile updates for `hono`, `@hono/node-server`, `undici`, `minimatch`, and `brace-expansion`; the remaining full-audit finding is the existing Electron major-version upgrade requirement (`package-lock.json`, `web/package-lock.json`, `tests/unit/ci/package-boundary.test.ts`).
+
 - Update checker now keeps `config/default.yaml` in sync when it auto-applies a Codex Desktop appcast version, while still writing `data/version-state.json` for cold-start runtime overrides. When a matching `data/extracted-fingerprint.json` is present, the checker also carries `chromium_version` through to version state, YAML, and in-memory config so User-Agent and `sec-ch-ua` fingerprint fields do not drift. The checked-in default fingerprint is updated to Codex Desktop `26.506.31421` / build `2620` / Chromium `146` (`src/update-checker.ts`, `config/default.yaml`, `tests/unit/update-checker.test.ts`).
+
 - Root package boundary now has a CI-enforced guard for proxy package metadata, root/workspace lockfile version sync, core npm entrypoints, local `tsx` script targets, and strict TypeScript coverage for public update scripts. This also restores the public update script entrypoints plus their extraction pattern config that `package.json` and `update-scripts-path.test.ts` already referenced, keeps them trackable by removing stale ignore rules, prevents `promote-dev-to-master` from treating missing checks as green, makes the runtime update checker fork `full-update` only when `CODEX_DESKTOP_PATH` / `CODEX_APP_PATH` points at a local Codex Desktop source, and broadens model extraction to current `gpt-*` IDs such as `gpt-5-codex` (`package-lock.json`, `.gitignore`, `.github/workflows/ci-quality.yml`, `.github/workflows/promote-dev-to-master.yml`, `.github/workflows/bump-electron.yml`, `tsconfig.scripts.json`, `config/extraction-patterns.yaml`, `src/update-checker.ts`, `scripts/build/check-update.ts`, `scripts/build/apply-update.ts`, `scripts/build/full-update.ts`, `scripts/build/types.ts`, `scripts/build/vendor-types.d.ts`, `tests/unit/ci/package-boundary.test.ts`, `tests/unit/update-checker.test.ts`, `tests/unit/update-scripts-path.test.ts`).
+
 - Codex Desktop 指纹冷启动不再漂移：`loadMergedConfig()` 会把 `data/version-state.json` 合并进 `client.app_version/build_number`，并在匹配同版本的 `data/extracted-fingerprint.json` 可用时同步 `chromium_version`；显式 `data/local.yaml` 版本覆盖优先。`extract-fingerprint.ts` 也会优先解析 `desktopOriginator` 绑定并跳过 bundled plugin 的 `.app` 名称，避免把 `Codex Computer Use.app` 误当成 API originator（`src/config-loader.ts`、`scripts/build/extract-fingerprint.ts`、`tests/unit/config-loader.test.ts`、`tests/unit/update-scripts-originator.test.ts`、`tests/unit/update-scripts-path.test.ts`）
+
 - 同账号 `previous_response_not_found` / `unanswered_function_call` 恢复逻辑从 `proxy-handler.ts` 拆到独立 `proxy-retry-recovery.ts`，集中处理错误分类、日志前缀、stale affinity 清理、implicit-resume restore、清 `previous_response_id` / `turnState`；主 handler 只保留 loop guard 与 continue 编排。新增 helper 行为测试和 AST/import 边界测试防止 recovery 细节回流到 orchestrator（`src/routes/shared/proxy-retry-recovery.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-retry-recovery.test.ts`、`tests/unit/routes/shared/proxy-retry-recovery-boundary.test.ts`）
+
 - non-streaming empty-response retry 的 `/codex/responses` egress audit log 改复用 `proxy-egress-log.ts`，避免 `non-streaming-handler.ts` 直接拼 log-store entry；`recordProxyEgressLog` 新增可选 `error` 字段，补行为测试和边界测试防止 retry 分支重新硬编码 audit path（`src/routes/shared/proxy-egress-log.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/proxy-egress-log.test.ts`、`tests/unit/routes/shared/proxy-egress-log-boundary.test.ts`）
+
 - non-streaming EmptyResponse retry 的副作用从 collect loop 抽到独立 `non-streaming-empty-response-retry.ts`，集中处理空响应计数、旧账号 usage release、implicit-resume restore、新账号 acquire / CodexApi rebuild、retry upstream 与 egress success/error audit；`non-streaming-handler.ts` 只保留 collect lifecycle 和 JSON 渲染。新增 helper 行为测试与 AST/import 边界测试，锁住现有“不传 excludeIds”账号选择语义、retry 成功不释放新账号、CodexApiError 返回 response plan、非 Codex 错误原样抛出（`src/routes/shared/non-streaming-empty-response-retry.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-empty-response-retry.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/unit/routes/shared/proxy-egress-log-boundary.test.ts`）
+
 - non-streaming UpstreamPrematureClose fail-fast 副作用从 collect loop 抽到独立 `non-streaming-premature-close.ts`，集中处理账号邮箱日志、`StreamUpstreamPrematureClose` 结构化事件、release guard 与 image-generation 失败标记；`non-streaming-handler.ts` 继续只负责 504 JSON 渲染和 collect/retry 编排。新增 helper 行为测试和边界测试，锁住 `req.model` 归因、`variantHash` 透传、email fallback、已释放账号不重复 release（`src/routes/shared/non-streaming-premature-close.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-premature-close.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
+
 - streaming response chunk trace / terminal-event 判定 / diagnostic value / stream error status 从 `response-processor.ts` 抽到独立 `response-stream-trace.ts`，让 response processor 专注读写与事件记录编排；新增 helper 行为测试和边界测试锁住 `[DONE]`、`response.completed`、UTF-8 byte 计数与错误状态映射（`src/routes/shared/response-stream-trace.ts`、`src/routes/shared/response-processor.ts`、`tests/unit/routes/shared/response-stream-trace.test.ts`、`tests/unit/routes/shared/response-stream-trace-boundary.test.ts`）
+
 - `/v1/chat/completions` now accepts Cursor Agent / Responses-style compatibility payloads before validation: `input` is normalized into chat `messages`, flat function tools and named `custom` tools are converted to OpenAI function tools, and nested `reasoning.effort` maps to `reasoning_effort`. This prevents Cursor Agent provider mode from failing with `messages: Required` or `tools[].function: Required` before the proxy can translate the request (`src/types/openai.ts`, `tests/unit/types/openai-schemas.test.ts`, `tests/e2e/chat.test.ts`)
+
 - `accounts.json` 读取失败时再也不会把空账号池写回磁盘：`loadPersisted`（`src/auth/account-persistence.ts`）此前对 `readFileSync` / `JSON.parse` / `Array.isArray` 三种失败一律 `console.warn` + 返回 `{ entries: [], needsPersist: false }`，registry 用空 Map 起步后任意一次 mutation（refresh-scheduler tick、dashboard 操作、release()）就让 1s debounce 的 `schedulePersist` 把 `{ "accounts": [] }` 原子覆盖到正本——一次读盘抖动（杀软扫描锁定文件、NSIS 升级强杀进程的 `renameSync` race、AV 干扰）就够静默删库，Windows 用户从 2.0.72 升 2.0.73 时已经踩到。修复成三段：(1) `quarantineCorruptFile` 把不可解析的 `accounts.json` 重命名成 `accounts.json.corrupt-<ISO>.bak` 保留原始字节给 debug，并 `appendErrorLog({ source: "server", name: "AccountsFileLoadFailed", context: { reason, accountsFile, quarantined, backupPath, rawByteLength } })` 让 Errors tab 弹红色 badge——`loadPersisted` 把 JSON 先解成 `unknown` 再校验非空对象，覆盖 `null` / 数字 / 顶层数组 这些会让 `data.accounts` 直接抛的 payload；`createFsPersistence` 同时持一个 `quarantineActive` 闩，即便有 caller 跳过 registry 拿到 persistence 直接调 `save()` 也会被拒绝写盘，是 registry 持久化开关的二道防线。`src/logs/error-log.ts` 的 `readAppVersion` 也补上 `getConfig` 抛错的 try/catch，避免 quarantine 在 `loadConfig()` 之前触发时整条 `appendErrorLog` 被外层吞掉、事件从 `error-log.jsonl` 消失；(2) `AccountPersistence.load()` 返回新增 `loadFailed?: boolean` 与 `health?: { quarantined, backupPath }`，`AccountPool` 透传给 `new AccountRegistry(..., { persistDisabled: true })`，`schedulePersist` / `persistNow` 在 disabled 状态下提前 return，本会话内 in-memory CRUD 照常工作但 disk 不再被任意覆盖；(3) `GET /auth/accounts` 响应新增 `persistence_health: { ok, reason, message, quarantined, backupPath }` 字段，rename 成功走 `load_failed_quarantined` 提示用户从 `.bak` 恢复，rename 失败（杀软长锁 / 权限不足）走 `load_failed_unquarantined`，提示中不再承诺一个不存在的 `.bak`。`useAccounts` hook 拉出来后 `AccountManagement` 页面顶部渲染琥珀色 "Auto-save paused" 横幅指引恢复路径。文件缺失（首次启动）不算失败，`loadFailed=false`。配套测试：`tests/unit/auth/account-persistence-load-failsafe.test.ts` 10 个覆盖 malformed JSON / 0-byte / 错误 shape / 缺失文件 / 健康文件 / 时间戳避免冲突 / 顶层 `null` / 顶层非对象 / `save()` 在 quarantine 后短路 / `health.quarantined+backupPath` 透传；`tests/unit/auth/account-registry-persist-disabled.test.ts` 6 个覆盖 schedulePersist no-op / addAccount 仍在内存生效 / pool.isPersistDisabled() 透传 / 健康路径回归；`tests/unit/routes/accounts-persistence-health.test.ts` 4 个覆盖路由响应字段（健康 / 隔离成功 / 隔离失败 message 不带 .bak / 旧 persistence 实现未带 health 时回退到 quarantined reason）；`tests/unit/logs/error-log.test.ts` 加 1 个用例确认 `getConfig` 抛错时 `version: "unknown"` 也能完成写盘。i18n 中英文新增 `persistDisabledTitle` / `persistDisabledBody`（`src/auth/account-persistence.ts`、`src/auth/account-registry.ts`、`src/auth/account-pool.ts`、`src/routes/accounts.ts`、`src/logs/error-log.ts`、`shared/hooks/use-accounts.ts`、`web/src/pages/AccountManagement.tsx`、`shared/i18n/translations.ts`）
+
 - Dashboard 主题 token 改为 contrast-safe 语义色：把 `primary` 文本/选中色与 `primary-action` 实心按钮色拆开，补齐 success/warning/danger/info 与 avatar 的 foreground/container token，统一账号、代理、日志、错误、设置页的按钮和状态 chip 用法；`TabBar` 在移动端允许换行，避免账号管理页窄屏横向溢出；`AccountList` 改读 `window.localStorage`，规避 Node/Vitest 全局 localStorage 与 jsdom 冲突。新增 `DESIGN.md` 自包含设计系统文档与主题 contrast 回归测试（`DESIGN.md`、`web/src/index.css`、`web/tailwind.config.ts`、`web/src/App.tsx`、`web/src/components/AccountList.tsx`、`tests/unit/web/theme.test.ts`、`web/src/App.test.tsx`、`web/src/components/AccountList.test.tsx`）
+
 - Logs 页面窄屏布局改为移动端纵向堆叠，日志表格保留内部横向滚动，不再让整页在 390px viewport 下产生页面级横向溢出；补 `LogsPage` 回归测试锁住表格滚动容器与详情面板响应式宽度（`web/src/pages/LogsPage.tsx`、`web/src/pages/__tests__/logs.test.tsx`）
+
 - 账号"已限速"状态与上游 cachedQuota 双真理漂移彻底修复（free 用户尤甚，本地锁可长达一周不释放）：proxy 此前同时维护 `entry.usage.rate_limit_until` + `entry.status === "rate_limited"`（来自 429 retry-after 的本地锁）和 `entry.cachedQuota.<bucket>.limit_reached/reset_at`（来自上游 rate_limits header 被动收集）两套独立信号。`refresh-scheduler.ts:196/236/291` 和 `services/account-mutation.ts:59` 的 `markStatus(_, "active")` 调用会把 status 从 "rate_limited" 翻回 "active" 但不动 `rate_limit_until`，导致后者成为孤儿字段——dashboard 显示"已限速 / 5h 0% 已使用"自相矛盾，且对 free 账号"7d 主窗口"语义下，孤儿 lock 可比上游真实重置时间晚出整整一个周期。修复：(1) 删除 `markRateLimited` / `clearRateLimit` / `markQuotaExhausted` 三个旧方法，新增 `applyRateLimit429(entryId, { retryAfterSec?, resetsAtSec?, countRequest? })`，把 429 retry-after 直接写到 `cachedQuota.rate_limit.{limit_reached=true, reset_at}`，永不缩短已有 reset_at（下一次 passive header 采集会修正 bucket），不再 mutate `entry.status`；(2) `AccountStatus` 枚举去掉 `"rate_limited"`（只剩 `active / expired / quota_exhausted / refreshing / disabled / banned`，纯轮转状态机）；(3) 重写 `proxy-error-handler.ts:91` / `proxy-handler.ts:545` 走新方法；(4) `refreshStatus` 删掉 rate-limit 清理分支（`resetExpiredQuotaWindow` 已 cover 窗口到期自动清 `limit_reached`）；(5) `isAuthenticated` / `getPoolSummary` 加 `hasReachedCachedQuota` 检查，避免全 quota 耗尽时误报 authenticated；(6) `accounts.json` 一次性 migration：`migrateLegacyRateLimit` 在 `loadPersisted` 里把 `status="rate_limited" + rate_limit_until` 老条目转成 `status="active" + 合成 cachedQuota.rate_limit`（仅当本地 lock 比 cachedQuota 新鲜时才覆盖），下一次 persist 自动丢字段；(7) `web/src/lib/accountStatus.ts` 新增 `derivedStatus(account)`，dashboard `AccountCard` / `AccountList` 都按 cachedQuota → "rate_limited" 派生 badge，"已达上限"账号现在如实显示而不是错标"活跃"；新增 `tests/unit/auth/account-pool-rate-limit-429.test.ts`（9 个）+ `tests/unit/auth/account-persistence-migration.test.ts`（7 个），改写约 20 处旧 `markRateLimited` / `markQuotaExhausted` 断言用 `applyRateLimit429` + `isQuotaExhausted(account.quota)`，full suite 1927 全绿（`src/auth/account-registry.ts`、`src/auth/account-pool.ts`、`src/auth/account-persistence.ts`、`src/auth/types.ts`、`src/auth/quota-skip.ts`、`src/routes/shared/proxy-error-handler.ts`、`src/routes/shared/proxy-handler.ts`、`web/src/lib/accountStatus.ts`、`web/src/components/AccountCard.tsx`、`web/src/components/AccountTable.tsx`、`web/src/components/AccountList.tsx`、`web/src/pages/AccountManagement.tsx`）
+
 - `src/routes/shared/proxy-handler.ts` 对 `EmptyResponseError` 与"上游 reasoning 中途断流"两类错误未区分，前者会 cross-account retry（吃 3 个号），后者重试也一定会再次撞同样的上游 120s 硬上限——一次"上游 reasoning 没在 ~120s 内 emit 任何 output_text"会消耗整池 360s 的号。新增 `UpstreamPrematureCloseError`（`src/translation/codex-event-extractor.ts`），`collectCodexResponse`（`src/translation/codex-to-openai.ts`）检测到 stream 无 `response.completed`/`response.failed`/`error` 任一 terminal 事件时抛新类型，proxy-handler 接住直接 504 fail-fast 不跨号重试。背景：调查中观察到上游 chatgpt.com 在 HTTP/1.1 chunked encoding 的 chunk 之间硬切 TCP，不发 0-length 终止 chunk 也不发 SSE `[DONE]`（hyper 透出 `error decoding response body: unexpected EOF during chunk size line`），触发条件为模型在 `effort=xhigh` 下推理超过 ~120s 仍未开始 output——属于上游 backend 行为不是 proxy bug；proxy 现在做的是不让该故障吃光账号池（`src/translation/codex-event-extractor.ts`、`src/translation/codex-to-openai.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/translation/codex-to-openai.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
 - `src/utils/debug-dump.ts` 把 dump 文件路径硬编码 `/tmp/codex-proxy-dump-*.jsonl`，Windows 没有 `/tmp` 目录，`fs.appendFileSync` ENOENT 直接被外层 try/catch 吞掉——Windows 用户即使设了 `CODEX_PROXY_DEBUG_DUMP=1` 也拿不到任何 dump 输出，且没有任何 warning。改用 `os.tmpdir()` 解析（macOS `/var/folders/.../T`、Linux `/tmp`、Windows `C:\Users\<u>\AppData\Local\Temp`），跨平台一致。新增 `tests/unit/utils/debug-dump.test.ts` 把"dump path must live under os.tmpdir()"freeze 成显式断言，防止以后再有人为了"看着短"重新硬编码 `/tmp`
+
 - v2.0.73 用户在 8080 端口被占时弹 `Uncaught Exception: Error: listen EADDRINUSE: address already in use 127.0.0.1:8080`：根因是 `@hono/node-server.serve()` 同步返回 Server 对象但 `listen()` 是异步，`startServer()` 在 socket 真正 bind 之前就 resolve 了，main.ts 那个`try { await startServer(...) } catch { startServer({ port: 0 }) }` 的随机端口 fallback 永远不触发——EADDRINUSE 在 `await` 之外异步抛，逃出 catch 范围变成 uncaughtException 弹给 Electron 用户。同一个 race 在 #486 smoke 健康探测里以另一种形态出现过（grep 命中 "Server started" 后 curl 立刻 connect refused），当时只在外层 retry 上吸收了，没动产品代码；这次把根因修在 src 层。新增 `src/utils/await-listening.ts` 暴露 `awaitServerListening(server)`，监听 `listening` / `error` 二选一并自清 listener；`startServer()` 在 `serve()` 后插一行 `await awaitServerListening(server)` 把 bind 错误真正变成 startServer 的拒绝。配套 `tests/unit/utils/await-listening.test.ts` 5 个单测覆盖 listening / error / 已 listening / 双向不泄漏 listener。修复后 main.ts 的随机端口 fallback 真正生效，8080 被占时会自动换一个端口（`src/utils/await-listening.ts`、`src/index.ts`、`tests/unit/utils/await-listening.test.ts`）
+
 - Electron auto-updater 真正尊重 `autoUpdate` 选项：`packages/electron/electron/auto-updater.ts` 里 `const isAutoUpdate = options.autoUpdate ?? true` 这个变量声明了但**从来没被使用过**——后续的 `setTimeout(initial check, 30s)` 与 `setInterval(periodic check, 4h)` 直接无条件运行，于是用户即便配了 `autoUpdate: false` 也照样后台 ping 上游 latest release 检查更新。把这两个定时器包到 `if (isAutoUpdate)` 内才让开关真的生效。补 `packages/electron/__tests__/auto-updater.test.ts` 两个 case：(1) `autoUpdate: false` 时 advance fake timer 不会触发任何 `checkForUpdates`；(2) `allowPrerelease: true` 真的写到 `mockAutoUpdater.allowPrerelease`
+
 - 清掉 web 前端几处 type 与 prop 不一致：(1) `web/src/App.tsx` 给 `<AccountList>` 传了 `onAddByRefreshToken={accounts.addByRefreshToken}`，但 `AccountList.tsx` 根本没接受这个 prop —— dead prop，删掉避免误导未来读者；(2) `web/src/components/SettingsTab.tsx` 的 `modelFamilies` prop 标成 `Record<string, string[]>`，但调用方传入的是 `useStatus()` 返回的 `ModelFamily[]`（`shared/hooks/use-status.ts:11` 已 export 该接口），prop 类型与实参不一致——改为 `ModelFamily[]`；同时把 `selectedSpeed` / `onSpeedChange` 拓宽到 `string | null` 与实际语义对齐；(3) `shared/hooks/use-accounts.ts` 的导入解析里 `parsed.accounts` 直接访问 unknown 字段，在 strict 模式下不安全，先窄化成 `Record<string, unknown>` 再读 `accounts`，避免 runtime 拿到非对象 JSON 时炸；(4) `web/src/components/AccountList.test.tsx` 第 111 行 `[...makeAccounts(12, "active"), makeAccounts(2, "expired")]` 漏了 spread —— 把第二组 helper 的返回值（数组）当成单个元素塞进列表，直接破坏断言前提。改成 `...makeAccounts(2, ...)`（`web/src/App.tsx`、`web/src/components/SettingsTab.tsx`、`web/src/components/AccountList.test.tsx`、`shared/hooks/use-accounts.ts`）
+
 - `scripts/build/extract-fingerprint.ts` 的 `ROOT` 解析比 sibling 脚本（`apply-update.ts` / `check-update.ts` / `full-update.ts`）少一层 `..`，原写法是 `resolve(import.meta.dirname, "..")`，得到的是 `scripts/` 而不是 repo root，导致后续 `data/extracted-fingerprint.json`、`data/extracted-prompts/`、`config/extraction-patterns.yaml` 这些路径全部锚错位置——脚本表面上能跑，但读写的全是 `scripts/data/...` 这种"幽灵目录"，真实 repo 根下的 `data/` 拿不到任何更新。改为 `resolve(import.meta.dirname, "..", "..")` 与 sibling 一致；新增 `tests/unit/update-scripts-path.test.ts` 把"`scripts/build/*` 必须用 `..,..` 解析 ROOT"这条隐式约定 freeze 成显式断言，防止以后再有人复制粘贴漏一层
+
 - Electron 端 WS transport 触发时抛 `Dynamic require of "events" is not supported`：`packages/electron/electron/build.mjs` 把 backend bundle 成 ESM `server.mjs` 时 esbuild 把 CJS `ws` 整个打进来，包内 `require("events")` / `require("https")` 等被改写成内部 `__require` shim；ESM 模块里 `require` 是 undefined，shim 走「typeof require === undefined」分支直接 throw。WS path 只有 `previous_response_id` 才走，#468 拆分 sub-agent prev_id 链后 WS 触发频率上来才暴露这个一直存在的 bundling bug。修复：build.mjs 给 ESM build 加 `banner.js` 注入 `import { createRequire } from "module"; const require = createRequire(import.meta.url);`，让 `__require` 命中真 `require` 路径，Node builtins 正常解析；新增 `packages/electron/__tests__/build.test.ts` 中 banner 回归断言（`packages/electron/electron/build.mjs`、`packages/electron/__tests__/build.test.ts`、`src/proxy/ws-transport.ts` 注释订正）
+
 - Anthropic（Claude Code）路径 cache 命中率长期被 sub-agent / 并行 tool call 拖低：根因是同一个 `x-claude-code-session-id` 下不同 system + tools 的请求共享同一个 WS pool slot 与 prev_response_id 链，sub-agent 抢不到 pool 里的 WS（`per-WS strict serial`）→ `ws=bypass(busy)` → 新 WS 被上游 LB hash 到不同后端实例 → `previous_response_not_found` → strip-and-retry → 全冷重发，sub-agent 每一轮都是冷启动。修复：(1) 新增 `src/routes/shared/variant-hash.ts`，用 `sha256(instructions + JSON.stringify(tools)).slice(0,12)` 算 12 字符 variantHash 作为请求"形状指纹"；(2) WS pool key 从 `entryId:convId` 扩成 `entryId:convId:variantHash`，同 conv 内不同 variant 各自独占 WS / 后端实例，互不挤占；(3) `SessionAffinityMap.record` / `lookupLatestResponseIdByConversationId` 增加可选 `variantHash` 维度（不传保持原行为，兼容 `[Responses]` / `[Chat]` / `[Gemini]` 路径），让 sub-agent 续到自己的 prev id 链而不是误读主对话的；(4) implicit-resume 查 affinity 时同时传 `IMPLICIT_RESUME_MAX_AGE_MS = 55 * 60 * 1000`（贴 `ws-pool` 自身 55min `max_age_ms` 上限），超过这个时间窗的 prev id 直接当 null，避免发已被上游驱逐的 id 触发必败 round-trip。客户端可见的 `prompt_cache_key` 不变，variantHash 只在 proxy 内部用于隔离。实测 36 个 Claude Code 请求覆盖 4 个 variant：`previous_response_not_found` 从一日 35 次 → 0、`ws=bypass(busy/factory_error)` 从一日 76 次 → 0、命中率 < 50% 的请求占比从 7% → 0%（`src/routes/shared/proxy-handler.ts`、`src/auth/session-affinity.ts`、`src/routes/shared/variant-hash.ts`、`tests/unit/routes/shared/variant-hash.test.ts`、`tests/unit/auth/session-affinity.test.ts`、`tests/unit/routes/implicit-resume-from-derived-key.test.ts`）
+
 - 同一 session 下多个 subagent / 并行 agent 的隐式续链隔离再加固：`variantHash` 现在纳入本地-only `variantIdentity`（`x-codex-window-id`，以及显式 session / `prompt_cache_key` 场景下的首条 user anchor），保证上游 `prompt_cache_key` 仍共享同一缓存键，但 proxy 本地 `previous_response_id` 链和 WS pool slot 不会把同形 subagent 串到一起。补回归测试覆盖单对话多轮、多个对话交错、无显式 session、同 session 同 system/tools 不同任务，以及“请求内容完全相同、仅 Codex window id 不同”的 subagent 隔离（`src/routes/shared/proxy-handler.ts`、`src/routes/shared/variant-hash.ts`、`tests/unit/routes/implicit-resume-from-derived-key.test.ts`、`tests/unit/routes/shared/variant-hash.test.ts`）
+
 - `/v1/responses` streaming 提前断流时不再让客户端只看到裸 EOF：HTTP/WS passthrough 现在追踪 `response.completed` / `response.failed` / `error` 终止事件；上游在终止事件前结束或 WebSocket 首帧后中断时，会合成 `response.failed`（`code=stream_disconnected`）或让上层转换为该失败事件，避免 Codex CLI 报 `stream disconnected before completion: stream closed before response.completed` 且没有结构化错误
+
 - 恢复模型名 `-fast` 后缀的上游出口语义：`gpt-5.4-high-fast` / `codex-fast` 仍先解析为标准模型名 + `service_tier=fast`，最终发往 Codex backend 时再映射成官方接受的 `service_tier="priority"`（HTTP SSE 与 WebSocket 路径一致）；补回单测和 `/v1/responses` E2E，防止 PR #453 的 review quota plumbing 再次把 `service_tier` 丢掉
+
 - Dashboard 更新状态兼容旧响应：`/admin/update-status` 尚未返回 `settings` 字段时，前端默认按 `show_update_dialog=false` 处理，避免读取 `settings.show_update_dialog` 抛错导致页面白屏
+
 - Official Codex app-server bridge 审计加固：首批并发请求现在复用同一个 WebSocket 连接与 `initialize` 流程，避免 CONNECTING 阶段重复建连/覆盖 `this.ws`；并发 turn SSE 改为串行执行，避免共享 notification queue 把 A/B 两个 turn 的 delta/completed 交叉发错；`/official-agent/*` 改用独立 `official_agent.api_key`，不再复用通用 `server.proxy_api_key`，并限制 `approvalPolicy` 只能是 `untrusted` / `on-request` / `on-failure` / `never`
+
 - 隐式续链反向校验缺失导致客户端持续看到上游 `invalid_request_error: No tool output found for function call call_X`：`evaluateImplicitResume` 此前只做 forward 检查（新输入里的 `function_call_output.call_id` 必须命中上一轮 stored function_call），漏了反向（上一轮 stored function_call 必须在新输入里有 output）。当上一轮模型并发吐 N 个 tool_use、客户端只回 N-1 个 tool_result 时，proxy 仍然 resume + `previous_response_id` 发出去，上游存的 context 里那个未回复的 function_call 触发 400。新增反向检查 → 走完整重放（`reason: "unanswered_tool_calls"`），同时 `error-classification.ts` 加 `isUnansweredFunctionCallError`，proxy-handler catch 块兜底：strip `previous_response_id` + 完整历史重放 + 同账号重试一次（与 `previous_response_not_found` 同款），避免 ws/sse 路径上的 400 静默吞掉变成 502
+
 - `codex-to-anthropic.ts` / `codex-to-openai.ts` / `codex-to-gemini.ts` 非流式 collect 路径里把上游错误事件抛成 `new Error(...)`，丢失 status 信息，handleNonStreaming 的 collectErr 再通过正则匹配 `HTTP/X.X NNN` 状态码必然失败 → 一律 502 兜底，客户端拿到的是模糊的 502 而不是上游真实的 400/429。改为统一 `codexApiErrorFromEvent(evt.error)` 抛 `CodexApiError(status, body)`，按 error code 映射到 400/401/402/403/429（默认 502）；handleNonStreaming 的 collectErr 也加一条 `instanceof CodexApiError` 分支直接透传 status，不再走正则降级
+
 - `streamResponse` 流式路径里上游错误此前只往 SSE 写一条 `stream_error` 事件、零日志，客户端能看到错误但 proxy `dev-YYYY-MM-DD.log` 里完全没记录，排查时无证据链。catch 块加 `console.warn` 打 `status / msg / body`，留下 call_id 等关键现场
 
-### Changed
-
-- `handleProxyRequest` / `handleDirectRequest` 改为 named options object 调用契约，顺带把 private `handleNonStreaming` 的 20 个位置参数收敛成内部 options object，避免后续新增可选上下文时错位；所有 route 调用与直接 handler 测试同步迁移，并补 direct upstream route guard 锁住 adapter/raw model/format tag 传递（`src/routes/shared/proxy-handler.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/upstream-auth-bypass.test.ts`）
-- `FormatAdapter.streamTranslator` / `collectTranslator` 改为 single options object 契约，替换原先 9 个 / 6 个位置参数，避免 `tupleSchema` / `usageHint` / `onResponseMetadata` / `streamContext` 后续扩展时错位；Chat / Messages / Gemini / Responses adapter wrapper 保持下游 translator 行为不变，并补 streaming、Codex collect、direct collect 三条 guard 测试锁住 options object 传递（`src/routes/shared/proxy-handler.ts`、`src/routes/shared/response-processor.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/response-processor.test.ts`、`tests/integration/proxy-handler.test.ts`、`tests/unit/routes/shared/error-forwarding.test.ts`）
-- `streamResponse` 改为 named options object 调用契约，替换原先 11 个位置参数，避免 `tupleSchema` / `onResponseId` / `usageHint` / `onResponseMetadata` / `diagnostics` 后续继续错位；Codex streaming 与 direct streaming 两个 caller 同步迁移，并补 caller-level guard 锁住 `streamContext` 的 Codex vs direct provider/path 归因（`src/routes/shared/response-processor.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/response-processor.test.ts`、`tests/integration/proxy-handler.test.ts`、`tests/unit/routes/shared/error-forwarding.test.ts`）
-- request diagnostics 输出从 `proxy-handler.ts` 收敛进 `proxy-request-diagnostics.ts`，主 handler 不再直接 `console.log` / `console.warn` summary 与 large-payload warning，只负责传入已解析的 session / resume / affinity 上下文；新增 logging wrapper 行为测试和边界测试锁住 warning 输出仍由 diagnostics 模块负责（`src/routes/shared/proxy-request-diagnostics.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-request-diagnostics.test.ts`、`tests/unit/routes/shared/proxy-request-diagnostics-boundary.test.ts`）
-- 非流式 collect/retry 路径从 `proxy-handler.ts` 抽到独立 `non-streaming-handler.ts`，并把 `buildCodexApi`、image generation usage 标记、Codex error prefix 清理收敛到 `proxy-handler-utils.ts`，降低主 handler 对 empty-response retry / premature-close / affinity 逻辑的耦合；新增模块边界测试、collect 阶段 `previous_response_not_found` strip-retry guard、non-stream affinity metadata guard（`src/routes/shared/non-streaming-handler.ts`、`src/routes/shared/proxy-handler-utils.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
-- non-streaming success usage 日志格式化从 `non-streaming-handler.ts` 抽到独立 `non-streaming-usage-log.ts`，先只收敛 cached/uncached/reasoning/hit-rate 与 high-input warning，不移动 affinity、release 或 HTTP rendering 边界；新增 helper 行为测试和 handler AST/import 边界测试，锁住现有日志格式（`src/routes/shared/non-streaming-usage-log.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-usage-log.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
-- streaming / non-streaming usage log 格式化共用 `proxy-usage-log.ts`，streaming handler 不再内联 cached/uncached/hit-rate/image/high-input warning 拼接，non-streaming 继续通过 wrapper 保持原日志输出语义；新增 helper 行为测试和 streaming handler 边界测试锁住 image token 与 reasoning warning 仅在 streaming 路径启用（`src/routes/shared/proxy-usage-log.ts`、`src/routes/shared/non-streaming-usage-log.ts`、`src/routes/shared/streaming-handler.ts`、`tests/unit/routes/shared/proxy-usage-log.test.ts`、`tests/unit/routes/shared/non-streaming-usage-log.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
-- non-streaming success affinity record 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-affinity.ts`，只负责把 responseId/entry/conversation/turnState/instructions/input_tokens/functionCallIds/variantHash 写入 `SessionAffinityMap`；保留 responseId/conversationId 缺失时不记录、function call id 去重、variant 隔离与 input_tokens=0 语义，不移动 usage log、release、retry 或 HTTP rendering 边界（`src/routes/shared/non-streaming-affinity.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-affinity.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
-- non-streaming generic collect error response planning 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-error-response.ts`，只负责 `Error.message` / `Unknown error` 与 `HTTP/X.X NNN` 状态解析，handler 继续拥有 Hono status/json 渲染、retry 与账号生命周期；新增 helper 行为测试、handler AST/import 边界测试与集成测试锁住 embedded upstream status 透传（`src/routes/shared/non-streaming-collect-error-response.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-error-response.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
-- non-streaming EmptyResponse 最终耗尽路径从 `non-streaming-handler.ts` 抽到独立 `non-streaming-empty-response-exhausted.ts`，集中处理最终账号 release、email fallback warning、`recordEmptyResponse` 和 502 response plan；handler 继续拥有 collect loop 与 Hono status/json 渲染。新增 helper 行为测试锁住 release → log → record 顺序、image-generation 失败标记与 release 幂等，边界测试防止 exhausted 细节回流到 handler（`src/routes/shared/non-streaming-empty-response-exhausted.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-empty-response-exhausted.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
-- non-streaming generic collect failure 终止处理从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-failure.ts`，集中处理失败账号 release、image-generation 失败标记与复用 collect error response plan；handler 继续只负责 Hono status/json 渲染，不接管 retry、upstream send 或成功路径 release。新增 helper 行为测试和边界测试锁住 release 幂等、`Unknown error` fallback 与 embedded upstream status 透传（`src/routes/shared/non-streaming-collect-failure.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-failure.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
-- non-streaming collect 阶段的 `CodexApiError` 日志与原样 rethrow 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-codex-api-error.ts`，集中处理 status 日志、`Codex API error (...)` 前缀剥离和 200 字截断；handler 继续只负责 `instanceof CodexApiError` 分支判断，不释放账号、不渲染 HTTP 响应，保持外层统一错误分类/重试路径接管。新增 helper 行为测试和边界测试锁住原对象 rethrow、日志格式与 helper 不接管 account lifecycle / retry / Hono 渲染（`src/routes/shared/non-streaming-codex-api-error.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-codex-api-error.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
-- non-streaming 成功路径的账号 release 与 image-generation usage 标记从 `non-streaming-handler.ts` 抽到独立 `non-streaming-success-release.ts`；handler 继续保留 success 编排、affinity、usage log 与 JSON 返回，helper 只负责复用 release guard 并在成功 usage 上标记 image request outcome。新增 helper 行为测试和边界测试锁住 release 幂等、image usage clone 语义，以及 helper 不接管 HTTP 渲染、retry、日志或 affinity（`src/routes/shared/non-streaming-success-release.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-success-release.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
-- streaming / non-streaming response metadata 的 function-call id 收集从两个 handler 内联 Set/callback 抽到共享 `response-metadata-collector.ts`，消除重复并让 handler 只负责把收集结果交给 affinity 记录；新增 helper 行为测试与 streaming / non-streaming 边界测试，锁住 function-call id 去重、缺失 metadata 容忍，以及 helper 不接管 response handling 或账号生命周期（`src/routes/shared/response-metadata-collector.ts`、`src/routes/shared/non-streaming-handler.ts`、`src/routes/shared/streaming-handler.ts`、`tests/unit/routes/shared/response-metadata-collector.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
-- non-streaming collectTranslator 调用与 response metadata collector 绑定从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-response.ts`；helper 只负责调用 adapter、透传 tupleSchema/usageHint、返回 result + function-call ids，错误原样抛回，handler 继续拥有 retry、Hono 渲染、affinity、usage log 与账号 release。新增 helper 行为测试和边界测试锁住 metadata 透传、错误原样 rethrow，以及 helper 不接管 HTTP 渲染、retry 或账号生命周期（`src/routes/shared/non-streaming-collect-response.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-response.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
-- `proxy-handler.ts` 的共享类型契约抽到独立 `proxy-handler-types.ts`，route / helper / test helper 统一从类型模块导入 `ProxyRequest`、`FormatAdapter`、translator options 与 handler options，避免 `response-processor.ts` / `non-streaming-handler.ts` 为类型依赖反向指向运行时 orchestrator；新增 structural guard 锁住完整契约导出、handler 不再声明共享接口、以及禁止从 `proxy-handler.js` 混入这些共享类型（`src/routes/shared/proxy-handler-types.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/shared/response-processor.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/proxy-handler-type-boundary.test.ts`）
-- API-key direct upstream 路径从 `proxy-handler.ts` 抽到独立 `direct-request-handler.ts`，route 层直接导入 direct handler，`proxy-handler.ts` 专注账号池 acquire / retry / release 编排；流式错误 SSE helper 抽到 `stream-error-response.ts` 供 Codex proxy 与 direct upstream 共用，并新增 structural guard 防止 `handleDirectRequest` 回流到 `proxy-handler.js`（`src/routes/shared/direct-request-handler.ts`、`src/routes/shared/stream-error-response.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/direct-request-handler-boundary.test.ts`）
-- prompt-cache identity、implicit-resume 判定、continuation input / function-call-output helper 从 `proxy-handler.ts` 抽到独立 `proxy-session-helpers.ts`，让主 handler 只保留编排与状态变更；原 implicit-resume 单测改为直接覆盖 helper 模块，并新增 structural guard 防止这些 session helper 回流到 `proxy-handler.js`（`src/routes/shared/proxy-session-helpers.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts`、`tests/unit/routes/shared/proxy-session-helpers-boundary.test.ts`）
-- implicit-resume lifecycle 从 `proxy-handler.ts` 抽到独立 `proxy-implicit-resume-lifecycle.ts`，集中处理 resume eligibility、跳过原因日志、request apply/restore、usage hint 清理，以及 `PreviousResponseWebSocketError` 后完整历史回放；主 handler 只保留 acquire/retry/fallback 编排。新增 lifecycle 行为测试与边界测试，锁住 request mutation helper、session helper、fallback/retry/response handler 的模块边界（`src/routes/shared/proxy-implicit-resume-lifecycle.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-implicit-resume-lifecycle.test.ts`、`tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts`、`tests/unit/routes/shared/proxy-session-helpers-boundary.test.ts`）
-- fallback account retry 从 `proxy-handler.ts` 抽到独立 `proxy-fallback-account-retry.ts`，集中处理 fallback availability、账号池耗尽响应计划、下一账号 acquire、CodexApi rebuild 与 fallback 日志；主 handler 只保留 release/restore、active account state 更新和 stagger 编排。新增 helper 行为测试与边界测试，防止 retry plan、account reacquire、response handler 和 implicit-resume restore 边界回流（`src/routes/shared/proxy-fallback-account-retry.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-fallback-account-retry.test.ts`、`tests/unit/routes/shared/proxy-fallback-account-retry-boundary.test.ts`）
-- same-account retry recovery 的应用副作用从 `proxy-handler.ts` 收敛进 `proxy-retry-recovery.ts`，让 previous-response-not-found / unanswered-function-call 的日志、stale affinity 清理、implicit-resume restore、`previous_response_id` / `turnState` 清空与纯分类决策待在同一模块；主 handler 只保留 loop guard 与 continue 编排。新增行为测试与边界测试，防止这些 recovery side effects 回流到 orchestrator（`src/routes/shared/proxy-retry-recovery.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-retry-recovery.test.ts`、`tests/unit/routes/shared/proxy-retry-recovery-boundary.test.ts`）
-- CodexApiError retry transition 从 `proxy-handler.ts` 抽到独立 `proxy-error-retry-transition.ts`，集中处理 terminal decision release、model-not-supported release-before-retry、implicit-resume restore、`modelRetried` 更新与 fallback account retry；主 handler 继续负责 HTTP error rendering、active account/codexApi 更新和 stagger。新增 helper 行为测试与边界测试，锁住 429/401/403 fallback 不额外 release、model-not-supported 只释放旧账号、fallback respond 只返回计划不渲染（`src/routes/shared/proxy-error-retry-transition.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-error-retry-transition.test.ts`、`tests/unit/routes/shared/proxy-error-retry-transition-boundary.test.ts`）
-- 流式响应生命周期从 `proxy-handler.ts` 抽到独立 `streaming-handler.ts`，集中处理 Hono SSE header / client abort / affinity 记录 / usage 日志 / release guard，让主 handler 的 streaming 分支只负责路由到流式或非流式处理；新增行为测试覆盖 stream usage / response metadata affinity、final abort 与 release-with-usage，并用 AST/import 边界测试防止 `streamResponse`、stream close 记录逻辑回流到 orchestrator（`src/routes/shared/streaming-handler.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/streaming-handler.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
-- proxy 终端错误响应格式化从 `proxy-handler.ts` 抽到独立 `proxy-error-response.ts`，集中处理 no-account、stream-vs-json error、429 formatter 与账号池耗尽详情拼接，让主 handler catch 分支继续专注错误分类、释放与 fallback 编排；新增行为测试与 AST/import 边界测试防止 `stream-error-response` / `StatusCode` 渲染细节回流到 orchestrator（`src/routes/shared/proxy-error-response.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-error-response.test.ts`、`tests/unit/routes/shared/proxy-error-response-boundary.test.ts`）
-- Codex 上游 rate-limit header / WS event 的账号池同步逻辑从 `proxy-handler.ts` 抽到独立 `proxy-rate-limit.ts`，集中处理 `ParsedRateLimit` → cached quota、primary window sync 与 exhausted-primary 的 `applyRateLimit429` side effect；新增行为测试锁住 future reset 才主动限速、无 primary reset 不同步窗口，并用 AST/import 边界测试防止 `rateLimitToQuota` 回流到主 orchestrator（`src/routes/shared/proxy-rate-limit.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-rate-limit.test.ts`、`tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts`）
-- 请求间隔 stagger helper 从 `proxy-handler.ts` 抽到独立 `proxy-stagger.ts`，让 Codex passthrough compact route 不再为了复用工具函数反向导入 runtime orchestrator；新增行为测试锁住 disabled/null/elapsed/remaining wait 与 `jitterInt(interval, 0.3)` 语义，并用 AST/import 边界测试防止 `getConfig` / `jitterInt` 回流到主 handler（`src/routes/shared/proxy-stagger.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/proxy-stagger.test.ts`、`tests/unit/routes/shared/proxy-stagger-boundary.test.ts`）
-- WebSocket pool context builder 从 `proxy-handler.ts` 抽到独立 `proxy-ws-context.ts`，由主 handler 显式传入已解析的 chain conversation id、variantHash、当前 entryId、requestId 与 route tag，避免 helper 重新推导会话身份或提前创建 pool singleton；新增行为测试锁住 poolKey、延迟 `getWsPool()`、decision 日志标签，并用 AST/import 边界测试防止 `getWsPool` 回流到主 orchestrator（`src/routes/shared/proxy-ws-context.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-ws-context.test.ts`、`tests/unit/routes/shared/proxy-ws-context-boundary.test.ts`）
-- 请求诊断日志格式化从 `proxy-handler.ts` 抽到独立 `proxy-request-diagnostics.ts`，集中生成账号/会话/prev/resume/payload summary 与大 payload per-item warning，让主 handler 继续只负责 acquire/retry/release 编排；新增行为测试锁住 explicit/implicit prev、affinity、reasoning、large payload warning，并用 AST/import 边界测试防止诊断字符串拼接回流到 orchestrator（`src/routes/shared/proxy-request-diagnostics.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-request-diagnostics.test.ts`、`tests/unit/routes/shared/proxy-request-diagnostics-boundary.test.ts`）
-- opt-in request debug dump 从 `proxy-handler.ts` 抽到独立 `proxy-debug-dump.ts`，把 `debugDumpEnabled()` / `debugDump("request")` wiring 移出 retry loop；新增行为测试锁住 disabled no-op、payload 引用、conversation null 化与 caller-provided resume reason，并用 AST/import 边界测试防止 debug dump utility 回流到主 orchestrator（`src/routes/shared/proxy-debug-dump.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-debug-dump.test.ts`、`tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts`）
-- Codex upstream egress audit log 记录从 `proxy-handler.ts` 抽到独立 `proxy-egress-log.ts`，集中维护 `/codex/responses`、provider/status/latency 与 request metadata 字段，让 retry loop 只保留 timing 起点和 helper 调用；新增行为测试锁住 latency、stream/useWebSocket 元数据与 nullable status，并用 AST/import 边界测试防止 `enqueueLogEntry` 回流到主 orchestrator（`src/routes/shared/proxy-egress-log.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-egress-log.test.ts`、`tests/unit/routes/shared/proxy-egress-log-boundary.test.ts`）
-- 更新提示默认不再弹窗：新增 `update.show_update_dialog`（默认 `false`），Dashboard 设置页可手动开启“显示更新弹窗”。Web 自更新弹窗与 Electron 自动更新的系统对话框都受该开关控制；更新检查和托盘/菜单入口仍保留，避免默认后台检查打断使用
-- `src/routes/api-keys.ts` 简化第三方 API key 绑定路由：合并 add/import 的重复 Zod schema，统一 JSON 解析与校验错误返回，复用按 `models` 展开写入的逻辑，并新增 `tests/unit/routes/api-keys.test.ts` 覆盖添加、导入、导出、custom provider 校验与批量删除，确保行为不变
-- README / README_EN 的 Codex CLI + Codex Desktop 两节示例从 `env_key = "PROXY_API_KEY"` 改成 `[model_providers.proxy_codex.http_headers]` 内嵌 `Authorization = "Bearer ..."`：原写法在 GUI 客户端启动时会因为 macOS / Windows GUI 进程不继承 shell rc 的环境变量而报 `Missing environment variable: PROXY_API_KEY`，普通用户得额外学 `launchctl setenv` 或 LaunchAgent 才能让 Codex Desktop 看到环境变量；http_headers 把 key 直接写在 config 文件里，重启 Codex 即用。`env_key` 写法作为「需要密钥从配置文件解耦」（多人共享 / 仓库提交）场景的备选保留在文档说明里
-
-### Fixed
-
 - `promote-dev-to-master.yml` 与 `bump-electron.yml` 末尾各补一步 `gh workflow run docker-publish.yml --ref master`：GitHub Actions 安全策略禁止默认 `GITHUB_TOKEN` 触发的 push 事件再触发其他 workflow（防递归），导致 promote 把 dev fast-forward 到 master、bump 提交版本号 commit + tag 之后，`docker-publish.yml` 的 `on: push: branches: [master]` 全部静默不跑——表象就是 ghcr.io 上的 `:latest` / `:vX.Y.Z` 长期停留在最后一次"人手 push master"的时刻（最近一次是 2026-04-30，期间 master 已经吃下 4 天的 promote）。`workflow_dispatch` 是 GITHUB_TOKEN 允许触发的少数事件之一，所以两条管道收尾各 dispatch 一次即可衔接；docker-publish 已有 `concurrency: cancel-in-progress: true`，promote + bump 两次 dispatch 在窗口期重叠时后者直接接管，最终镜像反映 bump 后的新版本号。配套把 promote 的 `permissions: actions` 从 `read` 升到 `write`（dispatch 需要）
-
-### Added
-
-- Dev 默认把 stdout/stderr tee 到 `logs/dev-YYYY-MM-DD.log`（`src/utils/log-file.ts` + `src/utils/install-dev-logger.ts`，`src/index.ts` 顶部 side-effect 引入）：之前 dev 日志只活在 `tsx watch` terminal 的 scrollback 里，关窗或滚出去就找不到，排查上游偶发 422 之类的错误拿不到证据。新模块按天打开 append fd，patch `process.stdout.write` / `process.stderr.write` 同步写入文件 + 调原函数；prod (`NODE_ENV=production`) / 测试 (`VITEST` / `NODE_ENV=test`) / `CODEX_PROXY_FILE_LOG=0` 三档 opt-out，`logs/` 已被 `*.log` gitignore 覆盖。`tests/unit/utils/log-file.test.ts` 7 个用例覆盖 stdout/stderr tee、目录递归创建、uninstall 还原、append 不截断、默认文件名格式
-- Dashboard 用量页新增「时段命中率（Range Hit Rate）」卡片：基于当前选中时间窗口聚合 `cached_tokens / input_tokens`，与原本的全局累计「Cache Hit Rate」卡并列，方便对比近窗口与历史命中率（`web/src/pages/UsageStats.tsx`、`shared/i18n/translations.ts`）
-- Dashboard 用量页新增独立的「Hit Rate Over Time」图：每个 bucket 渲染命中率折线 + 数据点 dot，hover 可见 `cached / input`；`input=0` 的 bucket 自动跳过（不渲染 0% 假命中），单数据点也用 dot 保证可见性（`web/src/components/UsageChart.tsx`）
-- Usage history `five_min` granularity（5 分钟桶）+ Dashboard 新增「5 min」粒度选项与「Last 1h / 6h」时间窗：snapshot 默认 5 分钟一记，新粒度等同于一桶一快照，方便排查刚发生的请求；旧的 hourly/daily 不变，按 granularity 自动收敛兼容窗口（`src/auth/usage-stats.ts`、`src/routes/admin/usage-stats.ts`、`shared/hooks/use-usage-stats.ts`、`web/src/pages/UsageStats.tsx`）
-- 共享纯函数 `formatHitRate` / `sumWindow` / `formatUsageNumber` 抽到 `shared/utils/usage-stats.ts`，配套 vitest 单测覆盖边界（input=0 → "—"、<0.01% 截断、windowed 求和等），UsageChart 与 UsageStats 复用同一份格式化逻辑（`shared/utils/usage-stats.ts`、`shared/utils/__tests__/usage-stats.test.ts`）
-- WebSocket 连接池新增 keepalive ping + liveness 检测（`src/proxy/ws-pool.ts`）：每个 `PersistentWs` 默认 25 s 发一次 WS ping 帧（`DEFAULT_PING_INTERVAL_MS`），抵消上游 LB / NAT / 防火墙的 idle timeout 静默 RST；同时跟踪 `lastActivityAt`（pong 或任何 message 都算 proof of life），超过 `livenessTimeoutMs`（默认 = 2.5 × ping interval ≈ 62.5 s）无上游信号则主动 `markDead`，避免下次 acquire 复用一个已经"OPEN 但实际死了"的连接。E2E 验证（设备 a → 本机 8080）：单 WS 撑满 10 轮 + 70 s idle gap，turn 6 跨越 gap 后 hit 仍 99.6%（与 turn 5 持平），0 次 `liveness timeout` 误杀。Busy 时跳 ping（streaming data frame 已 keepalive）。`pingIntervalMs: 0` 或 `livenessTimeoutMs: 0` 各自独立可禁用（`tests/unit/proxy/ws-pool.test.ts` 共 11 个新单测覆盖：ping 节奏 / dead 后停 / readyState 守卫 / busy 跳过 / 错误吞咽 / liveness 误杀 / pong 重置 / message 重置 / 默认值边界等）
-- `promote-dev-to-master.yml` 新增 `force_skip_soak` 手动 input（`.github/workflows/promote-dev-to-master.yml`）：原本 soak 检查取的是 dev HEAD 的 commit timestamp ≥ 24 h，正常 merge 节奏下每次新 commit 都会 reset 时钟，导致 master 长期卡死收不到 dev 的更新（实测多个 PR 堵了一周没晋升）。新 input 仅在手动 `workflow_dispatch` 时可用、默认 false（保持原 soak 行为）；schedule cron 走默认 false 不受影响。仅在 sync-back / merge commit "时间新但内容稳定" 的紧急晋升场景使用
-
-### Fixed
 
 - **WebSocket 连接池**（`src/proxy/ws-pool.ts` + `src/proxy/ws-transport.ts` + `src/routes/shared/proxy-handler.ts`）：上游 chatgpt.com 的 WS gateway 按"连接 ID"做负载均衡 hash，过去 codex-proxy 对每个 WS 请求都 `new WebSocket(url)`，导致同一会话同一账号的 prompt cache 命中率在 5%~99% 之间剧烈抖动（同一逻辑会话被路由到不同 backend，每个 backend 各自缓存了不同长度的前缀；实测 cached_tokens 反复出现 1920/2432/24448/40320/47488 等离散"checkpoint"）。引入 per-`(entryId, conversationId)` 的持久 WS 连接池：
   - 单 WS 上 strict request/response 串行（codex 协议要求），busy 时旁路开新一次性 WS 而非排队（避免死锁）
@@ -234,21 +345,154 @@
   - 入口日志加 `ws=reuse:<id>` / `ws=new:<id>` / `ws=bypass(<reason>)` / `ws=retry-after-stale-reuse:<id>` 字段，配合 `rid` 可对照 cache 命中率
   - 集成测：`tests/integration/ws-pool-reuse.test.ts` 起本地 `ws.Server` 验证 5 turn 同会话只触发 1 次 `connection`
 
-### Changed
-
-- `src/routes/shared/proxy-handler.ts` 入口与 Usage 日志补充诊断字段：入口行新增 `rid` / `conv` / `key` / `prev=<src>:<tail8>` / `tools=N` / `resume=on|off:<reason>`（reason 含 `no_pref_entry`/`acct_mismatch`/`instr_diff`/`missing_tool_calls`/`cont_start_eq_len`），Usage 行带 `rid` 与 `hit=X.X%`，便于对照 prompt-cache 命中率为何偏低、或同一会话请求是否落到同一 cache key
-- 上游请求补 `x-codex-installation-id` header 与 body 内 `client_metadata: { "x-codex-installation-id": <uuid> }`（HTTP + WS + compact 三条路径）：对齐真实 Codex CLI（`core/src/client.rs:874`），让上游 LB 能拿到稳定客户端身份做粘性路由提示。优先复用 `~/.codex/installation_id`，没有则在 `data/installation_id` 持久化新生成的 UUID（`src/proxy/installation-id.ts`、`src/proxy/codex-api.ts`、`src/proxy/codex-types.ts`、`src/proxy/ws-transport.ts`、`config/fingerprint.yaml`）
-- `evaluateImplicitResume()` 取代 `shouldActivateImplicitResume()` 内部判定：返回 `{ active, reason }`，便于在拒绝时给出具体原因（`src/routes/shared/proxy-handler.ts`）。原 `shouldActivateImplicitResume()` 保持向后兼容，作为 `.active` 的薄包装
-
-### Fixed
-
 - Self-update 双重安全护栏（`src/self-update.ts`）：`applyProxySelfUpdate` 之前会无条件 `git checkout -- .` + `git pull origin master`，导致 ① 工作目录任何未提交改动被静默丢弃；② 在 `dev` 等非 master 分支上把 master 合进来，破坏 dev→master promote 流程。本地 dev 服跑着的时候每次 tsx watch 重启都会触发：新进程启动 → 10s 后 update check → `auto_update: true` → 把开发者刚保存的代码当垃圾扫掉。修复：进入 `applyProxySelfUpdate` 先校验 ① 当前分支必须是 `master`/`main`，② `git status --porcelain` 必须为空；任一失败立刻 abort 并返回错误，**不再调用** `git checkout -- .`
+
 - Anthropic → Codex 工具 schema 转换：检测到 `name === "Read"` 时，在 `pages` 字段的 description 末尾追加 "Omit this field entirely for non-PDF files; do not pass an empty string."。上游 gpt-5.x 在生成 Read tool_use 时倾向于把可选 string 字段填成 `""` 而非省略，Claude Code harness 把 `pages: ""` 当作"已传入"走到 PDF 分支报错；改 description 是最轻量的引导（不破坏忠实转发原则、对其他工具零影响），幂等可重复调用
+
 - `bump-electron.yml`：checkout 时显式 `ref: master`。default branch 切到 `dev` 之后，schedule 触发的 stable bump 落到 dev 工作树，`git push origin master --follow-tags` 报 `src refspec master does not match any` 连续 fail，stable 卡在 v2.0.66（2026-04-24）补不上来。修复后下一次 16:00 UTC 自动续上
 
+- 多后端流量的 cache 命中率被低估到 0%：`OpenAI` / `Anthropic` / `Gemini` 上游适配器在合成 `response.completed` 时全都硬编码 `input_tokens_details: {}`,丢掉了上游原本返回的缓存字段。`openai-upstream.ts` 现在抽 `usage.prompt_tokens_details.cached_tokens`,`anthropic-upstream.ts` 抽 `message_start.usage.cache_read_input_tokens`(也兜底从 `message_delta.usage` 读),`gemini-upstream.ts` 抽 `usageMetadata.cachedContentTokenCount`。修复后 `/admin/usage-stats/summary` 的 `total_cached_tokens` 在多后端模式下不再常驻 0,Dashboard 缓存命中率卡片可以正常工作
+
+- Dashboard 缓存命中率显示精度自适应:`formatHitRate` 在 < 1% 时切两位小数(`0.02%`),< 0.01% 显 `<0.01%`,= 0 显 `0%` —— 以前 `pct.toFixed(1)` 把 < 0.05% 全压成 "0.0%",看不到真实值
+
+- 上游返回 `previous_response_not_found`(response 由别的账号创建 / `SessionAffinityMap` 过期或重启丢失 / 跨账号轮转)时端到端恢复:
+  - `ws-transport.ts:36` `ROTATABLE_ERROR_CODES` 增补 `previous_response_not_found: 400`，让 WS 首帧 in-stream error 转成 `CodexApiError` reject —— 之前因为不在白名单里直接被流式透传到客户端，绕过了 catch
+  - `proxy-handler.ts` catch 块新增 strip-and-retry：剥掉 `previous_response_id` + `turnState`，在同一账号上重试一次，并把 ID 从 affinity map 清掉防止后续请求继续命中错路由；重试仍失败时降级返回原错误
+  - 隐式续链场景通过已有的 `restoreImplicitResumeRequest()` 路径回放完整 input，无损恢复；显式续链（客户端传 `previous_response_id`）会丢服务端历史，但请求仍能完成
+  - 新增分类器 `isPreviousResponseNotFoundError` + `SessionAffinityMap.forget()`（`src/proxy/error-classification.ts`、`src/auth/session-affinity.ts`、`src/routes/shared/proxy-handler.ts`、`src/proxy/ws-transport.ts`）
+
+- `release.yml` 让 electron-builder 用 tag 名当版本（`--config.extraMetadata.version="${TAG#v}"`），不再依赖 `package.json`。修复 `bump-electron-beta.yml` 故意不写 `package.json` 时 beta 包被跳过上传的问题（"existing type not compatible with publishing type"）；同步在 `release` job 给 prerelease tag 兜底 `--prerelease` flag (#413)
+
+- `release.yml` 的 `Pack` 步骤强制 `shell: bash`，让 Windows runner（默认 pwsh）正确解析 bash 多行续行符 `\` (#414)
+
+- WebSocket 路径首帧若为上游 `usage_limit_reached` / `rate_limit*` / `quota_exhausted` / 鉴权类终止错误，转换为 `CodexApiError` 抛出，复用 HTTP 路径已有的账号轮转逻辑；恢复 2.0.62 的"智能切换"行为（`src/proxy/ws-transport.ts`）。错误若发生在已有内容流出之后，仍按当前行为透传给客户端
+
+- 无可用账号时不再执行无意义的重试，直接返回描述性错误信息（含各状态账号计数：rate-limited / expired / banned / disabled）(#362)
+
+- API Key 路由（OpenAI/Anthropic/Gemini）上游返回错误时，透传原始 JSON 响应体，而非包装为代理自有格式；Codex 账号路由仍使用代理格式 (#367)
+
+- `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
+
+- 默认不再发送 `reasoning.effort`：移除 `modelInfo.defaultReasoningEffort` 自动兜底，`default_reasoning_effort` 默认改为 `null`，彻底消除简单对话触发 medium 推理导致的 token 暴涨；Dashboard 新增 "Disabled (no reasoning)" 选项，用户可按需开启
+
+- 上游 401 时立即触发 RT→AT 刷新，而非等待定时器（修复 token 被提前作废后账号一直显示 expired 的问题）
+
+- Dashboard session 滑动窗口续期：每次有效请求自动延长过期时间，不再固定 TTL 后断连
+
+- Dashboard 前端全局 401 拦截：session 过期后自动跳回登录页，不再卡死在空白页
+
+- Add Account 对话框新增 Cancel 按钮，OAuth 流程中可随时关闭对话框 (#319)
+
+- Electron 打包前清空旧 public/ 目录，防止残留旧版前端资源导致显示异常 (#320)
+
+- 修复 `service_tier` 在 WebSocket 和 HTTP 两条路径均被丢弃的 bug — 现在正确转发给后端
+
+- 修复 `PUT /api/proxies/settings` 被 `PUT /api/proxies/:id` 路由参数 shadow 的 bug（Hono 按注册顺序匹配）
+
+- 导入/导出按钮图标反了——导入改为下箭头、导出改为上箭头（#191）
+
+- Windows 桌面端按钮溢出——Electron 最小宽度从 680px 提高到 800px，覆盖 Tailwind md: 断点（#192）
+
+- `local.yaml` 的 `server.host` 覆盖已有测试验证，Electron 模式下正确生效（#190）
+
 ### Changed
 
+- Dashboard 日志页面完善深色模式适配，补齐筛选控件、统计卡片、详情抽屉和 JSON 代码块的深色状态；复制 JSON 成功后改为绿色反馈（`web/src/pages/LogsPage.tsx`）。
+
+- 默认模型与 Claude/Anthropic 推荐档位切换到 GPT-5.6 家族：`config/default.yaml` 默认模型改为 `gpt-5.6-sol`；Dashboard Anthropic Setup 预设与 Claude Code 指南改为 Opus → `gpt-5.6-sol` / Sonnet → `gpt-5.6-terra` / Haiku → `gpt-5.6-luna`；README / API 文档模型表与客户端示例同步更新（`config/default.yaml`、`web/src/components/AnthropicSetup.tsx`、`.github/guides/claude-code-setup.md`、`README.md`、`README_EN.md`、`API.md`、`API_CN.md`）
+
+- 账号持久化从 `accounts.json` 主存储迁移到 `accounts.sqlite`，启动时自动从旧 JSON 迁移并继续保留 `accounts.json` 镜像用于降级/回滚；批量导入改为持久化批处理，避免每个账号同步重写整份 JSON 导致大批量导入卡死。（#657）
+
+- 重构：消除类型守卫 `isRecord` 的多处重复声明（收拢翻译层与路由层到 `shared-utils.ts`）
+
+- 重构：合并推理预算映射表 `REASONING_EFFORT_BUDGET`（提取为 `shared-utils.ts` 的公共常量）
+
+- 重构：精简别名（删除 `gemini-to-codex.ts` 里的 `flattenParts` 别名）
+
+- 重构：治理并归并过度拆分的文件（收拢 `src/routes/shared/` 下的 `non-streaming-*.ts` 为统一的 `non-streaming-helpers.ts` 并更新对应测试）
+
+- 重构：抽象路由层的 JSON 拦截与 API Key 校验（提取统一的 API Key 提取器 `extractProxyApiKey`；由全局 `errorHandler` 统一拦截 SyntaxError 带来的 JSON 解析失败并返回 400）
+
+- 更新 `README_EN.md` 中过时的模型推荐说明以匹配最新的模型别名映射（`README_EN.md`）
+
+- 修复局域网/非 HTTPS 环境下分发密钥创建后复制报错与第三方 API Key 探测误退出的问题：`ClientKeysPage` / `LogsPage` / `UpdateModal` 统一接入 `clipboardCopy` 安全剪贴板降级（含 `readOnly` 与字号保护适配移动端），解决 `navigator.clipboard` 在 non-secure context 下为 `undefined` 导致的 `TypeError: Cannot read properties of undefined (reading 'writeText')`；`dashboardAuth` 中间件注入并暴露 `X-Dashboard-Auth: required` 响应头，`use-dashboard-auth` 精确基于该响应头判定会话过期，彻底杜绝添加第三方 Key 或非会话 401 响应时被误踢回登录页。（`src/middleware/dashboard-auth.ts`、`shared/hooks/use-dashboard-auth.ts`、`shared/utils/clipboard.ts`、`web/src/pages/ClientKeysPage.tsx`、`web/src/pages/LogsPage.tsx`、`web/src/components/UpdateModal.tsx`）
+
+- 修复分发 Key（Client Access Keys）页面创建与编辑弹窗背景透明问题：修正非标准 Tailwind 类名（`bg-surface-light`、`bg-surface-dark`、`border-border-light` 等），采用标准 `bg-white dark:bg-card-dark` 与 `border-slate-200 dark:border-border-dark` 确保弹窗遮罩及背景不透明显示。（`web/src/pages/ClientKeysPage.tsx`）
+
+- `handleProxyRequest` / `handleDirectRequest` 改为 named options object 调用契约，顺带把 private `handleNonStreaming` 的 20 个位置参数收敛成内部 options object，避免后续新增可选上下文时错位；所有 route 调用与直接 handler 测试同步迁移，并补 direct upstream route guard 锁住 adapter/raw model/format tag 传递（`src/routes/shared/proxy-handler.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/upstream-auth-bypass.test.ts`）
+
+- `FormatAdapter.streamTranslator` / `collectTranslator` 改为 single options object 契约，替换原先 9 个 / 6 个位置参数，避免 `tupleSchema` / `usageHint` / `onResponseMetadata` / `streamContext` 后续扩展时错位；Chat / Messages / Gemini / Responses adapter wrapper 保持下游 translator 行为不变，并补 streaming、Codex collect、direct collect 三条 guard 测试锁住 options object 传递（`src/routes/shared/proxy-handler.ts`、`src/routes/shared/response-processor.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/response-processor.test.ts`、`tests/integration/proxy-handler.test.ts`、`tests/unit/routes/shared/error-forwarding.test.ts`）
+
+- `streamResponse` 改为 named options object 调用契约，替换原先 11 个位置参数，避免 `tupleSchema` / `onResponseId` / `usageHint` / `onResponseMetadata` / `diagnostics` 后续继续错位；Codex streaming 与 direct streaming 两个 caller 同步迁移，并补 caller-level guard 锁住 `streamContext` 的 Codex vs direct provider/path 归因（`src/routes/shared/response-processor.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/response-processor.test.ts`、`tests/integration/proxy-handler.test.ts`、`tests/unit/routes/shared/error-forwarding.test.ts`）
+
+- request diagnostics 输出从 `proxy-handler.ts` 收敛进 `proxy-request-diagnostics.ts`，主 handler 不再直接 `console.log` / `console.warn` summary 与 large-payload warning，只负责传入已解析的 session / resume / affinity 上下文；新增 logging wrapper 行为测试和边界测试锁住 warning 输出仍由 diagnostics 模块负责（`src/routes/shared/proxy-request-diagnostics.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-request-diagnostics.test.ts`、`tests/unit/routes/shared/proxy-request-diagnostics-boundary.test.ts`）
+
+- 非流式 collect/retry 路径从 `proxy-handler.ts` 抽到独立 `non-streaming-handler.ts`，并把 `buildCodexApi`、image generation usage 标记、Codex error prefix 清理收敛到 `proxy-handler-utils.ts`，降低主 handler 对 empty-response retry / premature-close / affinity 逻辑的耦合；新增模块边界测试、collect 阶段 `previous_response_not_found` strip-retry guard、non-stream affinity metadata guard（`src/routes/shared/non-streaming-handler.ts`、`src/routes/shared/proxy-handler-utils.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
+- non-streaming success usage 日志格式化从 `non-streaming-handler.ts` 抽到独立 `non-streaming-usage-log.ts`，先只收敛 cached/uncached/reasoning/hit-rate 与 high-input warning，不移动 affinity、release 或 HTTP rendering 边界；新增 helper 行为测试和 handler AST/import 边界测试，锁住现有日志格式（`src/routes/shared/non-streaming-usage-log.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-usage-log.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
+
+- streaming / non-streaming usage log 格式化共用 `proxy-usage-log.ts`，streaming handler 不再内联 cached/uncached/hit-rate/image/high-input warning 拼接，non-streaming 继续通过 wrapper 保持原日志输出语义；新增 helper 行为测试和 streaming handler 边界测试锁住 image token 与 reasoning warning 仅在 streaming 路径启用（`src/routes/shared/proxy-usage-log.ts`、`src/routes/shared/non-streaming-usage-log.ts`、`src/routes/shared/streaming-handler.ts`、`tests/unit/routes/shared/proxy-usage-log.test.ts`、`tests/unit/routes/shared/non-streaming-usage-log.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
+
+- non-streaming success affinity record 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-affinity.ts`，只负责把 responseId/entry/conversation/turnState/instructions/input_tokens/functionCallIds/variantHash 写入 `SessionAffinityMap`；保留 responseId/conversationId 缺失时不记录、function call id 去重、variant 隔离与 input_tokens=0 语义，不移动 usage log、release、retry 或 HTTP rendering 边界（`src/routes/shared/non-streaming-affinity.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-affinity.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
+- non-streaming generic collect error response planning 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-error-response.ts`，只负责 `Error.message` / `Unknown error` 与 `HTTP/X.X NNN` 状态解析，handler 继续拥有 Hono status/json 渲染、retry 与账号生命周期；新增 helper 行为测试、handler AST/import 边界测试与集成测试锁住 embedded upstream status 透传（`src/routes/shared/non-streaming-collect-error-response.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-error-response.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
+- non-streaming EmptyResponse 最终耗尽路径从 `non-streaming-handler.ts` 抽到独立 `non-streaming-empty-response-exhausted.ts`，集中处理最终账号 release、email fallback warning、`recordEmptyResponse` 和 502 response plan；handler 继续拥有 collect loop 与 Hono status/json 渲染。新增 helper 行为测试锁住 release → log → record 顺序、image-generation 失败标记与 release 幂等，边界测试防止 exhausted 细节回流到 handler（`src/routes/shared/non-streaming-empty-response-exhausted.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-empty-response-exhausted.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
+- non-streaming generic collect failure 终止处理从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-failure.ts`，集中处理失败账号 release、image-generation 失败标记与复用 collect error response plan；handler 继续只负责 Hono status/json 渲染，不接管 retry、upstream send 或成功路径 release。新增 helper 行为测试和边界测试锁住 release 幂等、`Unknown error` fallback 与 embedded upstream status 透传（`src/routes/shared/non-streaming-collect-failure.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-failure.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/integration/proxy-handler.test.ts`）
+
+- non-streaming collect 阶段的 `CodexApiError` 日志与原样 rethrow 从 `non-streaming-handler.ts` 抽到独立 `non-streaming-codex-api-error.ts`，集中处理 status 日志、`Codex API error (...)` 前缀剥离和 200 字截断；handler 继续只负责 `instanceof CodexApiError` 分支判断，不释放账号、不渲染 HTTP 响应，保持外层统一错误分类/重试路径接管。新增 helper 行为测试和边界测试锁住原对象 rethrow、日志格式与 helper 不接管 account lifecycle / retry / Hono 渲染（`src/routes/shared/non-streaming-codex-api-error.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-codex-api-error.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
+
+- non-streaming 成功路径的账号 release 与 image-generation usage 标记从 `non-streaming-handler.ts` 抽到独立 `non-streaming-success-release.ts`；handler 继续保留 success 编排、affinity、usage log 与 JSON 返回，helper 只负责复用 release guard 并在成功 usage 上标记 image request outcome。新增 helper 行为测试和边界测试锁住 release 幂等、image usage clone 语义，以及 helper 不接管 HTTP 渲染、retry、日志或 affinity（`src/routes/shared/non-streaming-success-release.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-success-release.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
+
+- streaming / non-streaming response metadata 的 function-call id 收集从两个 handler 内联 Set/callback 抽到共享 `response-metadata-collector.ts`，消除重复并让 handler 只负责把收集结果交给 affinity 记录；新增 helper 行为测试与 streaming / non-streaming 边界测试，锁住 function-call id 去重、缺失 metadata 容忍，以及 helper 不接管 response handling 或账号生命周期（`src/routes/shared/response-metadata-collector.ts`、`src/routes/shared/non-streaming-handler.ts`、`src/routes/shared/streaming-handler.ts`、`tests/unit/routes/shared/response-metadata-collector.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
+
+- non-streaming collectTranslator 调用与 response metadata collector 绑定从 `non-streaming-handler.ts` 抽到独立 `non-streaming-collect-response.ts`；helper 只负责调用 adapter、透传 tupleSchema/usageHint、返回 result + function-call ids，错误原样抛回，handler 继续拥有 retry、Hono 渲染、affinity、usage log 与账号 release。新增 helper 行为测试和边界测试锁住 metadata 透传、错误原样 rethrow，以及 helper 不接管 HTTP 渲染、retry 或账号生命周期（`src/routes/shared/non-streaming-collect-response.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/non-streaming-collect-response.test.ts`、`tests/unit/routes/shared/non-streaming-handler-boundary.test.ts`）
+
+- `proxy-handler.ts` 的共享类型契约抽到独立 `proxy-handler-types.ts`，route / helper / test helper 统一从类型模块导入 `ProxyRequest`、`FormatAdapter`、translator options 与 handler options，避免 `response-processor.ts` / `non-streaming-handler.ts` 为类型依赖反向指向运行时 orchestrator；新增 structural guard 锁住完整契约导出、handler 不再声明共享接口、以及禁止从 `proxy-handler.js` 混入这些共享类型（`src/routes/shared/proxy-handler-types.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/shared/response-processor.ts`、`src/routes/shared/non-streaming-handler.ts`、`tests/unit/routes/shared/proxy-handler-type-boundary.test.ts`）
+
+- API-key direct upstream 路径从 `proxy-handler.ts` 抽到独立 `direct-request-handler.ts`，route 层直接导入 direct handler，`proxy-handler.ts` 专注账号池 acquire / retry / release 编排；流式错误 SSE helper 抽到 `stream-error-response.ts` 供 Codex proxy 与 direct upstream 共用，并新增 structural guard 防止 `handleDirectRequest` 回流到 `proxy-handler.js`（`src/routes/shared/direct-request-handler.ts`、`src/routes/shared/stream-error-response.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/chat.ts`、`src/routes/messages.ts`、`src/routes/gemini.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/direct-request-handler-boundary.test.ts`）
+
+- prompt-cache identity、implicit-resume 判定、continuation input / function-call-output helper 从 `proxy-handler.ts` 抽到独立 `proxy-session-helpers.ts`，让主 handler 只保留编排与状态变更；原 implicit-resume 单测改为直接覆盖 helper 模块，并新增 structural guard 防止这些 session helper 回流到 `proxy-handler.js`（`src/routes/shared/proxy-session-helpers.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-handler-implicit-resume.test.ts`、`tests/unit/routes/shared/proxy-session-helpers-boundary.test.ts`）
+
+- implicit-resume lifecycle 从 `proxy-handler.ts` 抽到独立 `proxy-implicit-resume-lifecycle.ts`，集中处理 resume eligibility、跳过原因日志、request apply/restore、usage hint 清理，以及 `PreviousResponseWebSocketError` 后完整历史回放；主 handler 只保留 acquire/retry/fallback 编排。新增 lifecycle 行为测试与边界测试，锁住 request mutation helper、session helper、fallback/retry/response handler 的模块边界（`src/routes/shared/proxy-implicit-resume-lifecycle.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-implicit-resume-lifecycle.test.ts`、`tests/unit/routes/shared/proxy-implicit-resume-request-boundary.test.ts`、`tests/unit/routes/shared/proxy-session-helpers-boundary.test.ts`）
+
+- fallback account retry 从 `proxy-handler.ts` 抽到独立 `proxy-fallback-account-retry.ts`，集中处理 fallback availability、账号池耗尽响应计划、下一账号 acquire、CodexApi rebuild 与 fallback 日志；主 handler 只保留 release/restore、active account state 更新和 stagger 编排。新增 helper 行为测试与边界测试，防止 retry plan、account reacquire、response handler 和 implicit-resume restore 边界回流（`src/routes/shared/proxy-fallback-account-retry.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-fallback-account-retry.test.ts`、`tests/unit/routes/shared/proxy-fallback-account-retry-boundary.test.ts`）
+
+- same-account retry recovery 的应用副作用从 `proxy-handler.ts` 收敛进 `proxy-retry-recovery.ts`，让 previous-response-not-found / unanswered-function-call 的日志、stale affinity 清理、implicit-resume restore、`previous_response_id` / `turnState` 清空与纯分类决策待在同一模块；主 handler 只保留 loop guard 与 continue 编排。新增行为测试与边界测试，防止这些 recovery side effects 回流到 orchestrator（`src/routes/shared/proxy-retry-recovery.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-retry-recovery.test.ts`、`tests/unit/routes/shared/proxy-retry-recovery-boundary.test.ts`）
+
+- CodexApiError retry transition 从 `proxy-handler.ts` 抽到独立 `proxy-error-retry-transition.ts`，集中处理 terminal decision release、model-not-supported release-before-retry、implicit-resume restore、`modelRetried` 更新与 fallback account retry；主 handler 继续负责 HTTP error rendering、active account/codexApi 更新和 stagger。新增 helper 行为测试与边界测试，锁住 429/401/403 fallback 不额外 release、model-not-supported 只释放旧账号、fallback respond 只返回计划不渲染（`src/routes/shared/proxy-error-retry-transition.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-error-retry-transition.test.ts`、`tests/unit/routes/shared/proxy-error-retry-transition-boundary.test.ts`）
+
+- 流式响应生命周期从 `proxy-handler.ts` 抽到独立 `streaming-handler.ts`，集中处理 Hono SSE header / client abort / affinity 记录 / usage 日志 / release guard，让主 handler 的 streaming 分支只负责路由到流式或非流式处理；新增行为测试覆盖 stream usage / response metadata affinity、final abort 与 release-with-usage，并用 AST/import 边界测试防止 `streamResponse`、stream close 记录逻辑回流到 orchestrator（`src/routes/shared/streaming-handler.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/streaming-handler.test.ts`、`tests/unit/routes/shared/streaming-handler-boundary.test.ts`）
+
+- proxy 终端错误响应格式化从 `proxy-handler.ts` 抽到独立 `proxy-error-response.ts`，集中处理 no-account、stream-vs-json error、429 formatter 与账号池耗尽详情拼接，让主 handler catch 分支继续专注错误分类、释放与 fallback 编排；新增行为测试与 AST/import 边界测试防止 `stream-error-response` / `StatusCode` 渲染细节回流到 orchestrator（`src/routes/shared/proxy-error-response.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-error-response.test.ts`、`tests/unit/routes/shared/proxy-error-response-boundary.test.ts`）
+
+- Codex 上游 rate-limit header / WS event 的账号池同步逻辑从 `proxy-handler.ts` 抽到独立 `proxy-rate-limit.ts`，集中处理 `ParsedRateLimit` → cached quota、primary window sync 与 exhausted-primary 的 `applyRateLimit429` side effect；新增行为测试锁住 future reset 才主动限速、无 primary reset 不同步窗口，并用 AST/import 边界测试防止 `rateLimitToQuota` 回流到主 orchestrator（`src/routes/shared/proxy-rate-limit.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-rate-limit.test.ts`、`tests/unit/routes/shared/proxy-rate-limit-boundary.test.ts`）
+
+- 请求间隔 stagger helper 从 `proxy-handler.ts` 抽到独立 `proxy-stagger.ts`，让 Codex passthrough compact route 不再为了复用工具函数反向导入 runtime orchestrator；新增行为测试锁住 disabled/null/elapsed/remaining wait 与 `jitterInt(interval, 0.3)` 语义，并用 AST/import 边界测试防止 `getConfig` / `jitterInt` 回流到主 handler（`src/routes/shared/proxy-stagger.ts`、`src/routes/shared/proxy-handler.ts`、`src/routes/responses.ts`、`tests/unit/routes/shared/proxy-stagger.test.ts`、`tests/unit/routes/shared/proxy-stagger-boundary.test.ts`）
+
+- WebSocket pool context builder 从 `proxy-handler.ts` 抽到独立 `proxy-ws-context.ts`，由主 handler 显式传入已解析的 chain conversation id、variantHash、当前 entryId、requestId 与 route tag，避免 helper 重新推导会话身份或提前创建 pool singleton；新增行为测试锁住 poolKey、延迟 `getWsPool()`、decision 日志标签，并用 AST/import 边界测试防止 `getWsPool` 回流到主 orchestrator（`src/routes/shared/proxy-ws-context.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-ws-context.test.ts`、`tests/unit/routes/shared/proxy-ws-context-boundary.test.ts`）
+
+- 请求诊断日志格式化从 `proxy-handler.ts` 抽到独立 `proxy-request-diagnostics.ts`，集中生成账号/会话/prev/resume/payload summary 与大 payload per-item warning，让主 handler 继续只负责 acquire/retry/release 编排；新增行为测试锁住 explicit/implicit prev、affinity、reasoning、large payload warning，并用 AST/import 边界测试防止诊断字符串拼接回流到 orchestrator（`src/routes/shared/proxy-request-diagnostics.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-request-diagnostics.test.ts`、`tests/unit/routes/shared/proxy-request-diagnostics-boundary.test.ts`）
+
+- opt-in request debug dump 从 `proxy-handler.ts` 抽到独立 `proxy-debug-dump.ts`，把 `debugDumpEnabled()` / `debugDump("request")` wiring 移出 retry loop；新增行为测试锁住 disabled no-op、payload 引用、conversation null 化与 caller-provided resume reason，并用 AST/import 边界测试防止 debug dump utility 回流到主 orchestrator（`src/routes/shared/proxy-debug-dump.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-debug-dump.test.ts`、`tests/unit/routes/shared/proxy-debug-dump-boundary.test.ts`）
+
+- Codex upstream egress audit log 记录从 `proxy-handler.ts` 抽到独立 `proxy-egress-log.ts`，集中维护 `/codex/responses`、provider/status/latency 与 request metadata 字段，让 retry loop 只保留 timing 起点和 helper 调用；新增行为测试锁住 latency、stream/useWebSocket 元数据与 nullable status，并用 AST/import 边界测试防止 `enqueueLogEntry` 回流到主 orchestrator（`src/routes/shared/proxy-egress-log.ts`、`src/routes/shared/proxy-handler.ts`、`tests/unit/routes/shared/proxy-egress-log.test.ts`、`tests/unit/routes/shared/proxy-egress-log-boundary.test.ts`）
+
+- 更新提示默认不再弹窗：新增 `update.show_update_dialog`（默认 `false`），Dashboard 设置页可手动开启“显示更新弹窗”。Web 自更新弹窗与 Electron 自动更新的系统对话框都受该开关控制；更新检查和托盘/菜单入口仍保留，避免默认后台检查打断使用
+
+- `src/routes/api-keys.ts` 简化第三方 API key 绑定路由：合并 add/import 的重复 Zod schema，统一 JSON 解析与校验错误返回，复用按 `models` 展开写入的逻辑，并新增 `tests/unit/routes/api-keys.test.ts` 覆盖添加、导入、导出、custom provider 校验与批量删除，确保行为不变
+
+- README / README_EN 的 Codex CLI + Codex Desktop 两节示例从 `env_key = "PROXY_API_KEY"` 改成 `[model_providers.proxy_codex.http_headers]` 内嵌 `Authorization = "Bearer ..."`：原写法在 GUI 客户端启动时会因为 macOS / Windows GUI 进程不继承 shell rc 的环境变量而报 `Missing environment variable: PROXY_API_KEY`，普通用户得额外学 `launchctl setenv` 或 LaunchAgent 才能让 Codex Desktop 看到环境变量；http_headers 把 key 直接写在 config 文件里，重启 Codex 即用。`env_key` 写法作为「需要密钥从配置文件解耦」（多人共享 / 仓库提交）场景的备选保留在文档说明里
+
+- `src/routes/shared/proxy-handler.ts` 入口与 Usage 日志补充诊断字段：入口行新增 `rid` / `conv` / `key` / `prev=<src>:<tail8>` / `tools=N` / `resume=on|off:<reason>`（reason 含 `no_pref_entry`/`acct_mismatch`/`instr_diff`/`missing_tool_calls`/`cont_start_eq_len`），Usage 行带 `rid` 与 `hit=X.X%`，便于对照 prompt-cache 命中率为何偏低、或同一会话请求是否落到同一 cache key
+
+- 上游请求补 `x-codex-installation-id` header 与 body 内 `client_metadata: { "x-codex-installation-id": <uuid> }`（HTTP + WS + compact 三条路径）：对齐真实 Codex CLI（`core/src/client.rs:874`），让上游 LB 能拿到稳定客户端身份做粘性路由提示。优先复用 `~/.codex/installation_id`，没有则在 `data/installation_id` 持久化新生成的 UUID（`src/proxy/installation-id.ts`、`src/proxy/codex-api.ts`、`src/proxy/codex-types.ts`、`src/proxy/ws-transport.ts`、`config/fingerprint.yaml`）
+
+- `evaluateImplicitResume()` 取代 `shouldActivateImplicitResume()` 内部判定：返回 `{ active, reason }`，便于在拒绝时给出具体原因（`src/routes/shared/proxy-handler.ts`）。原 `shouldActivateImplicitResume()` 保持向后兼容，作为 `.active` 的薄包装
+
 - `bump-electron-beta.yml` 触发改为定时 cron（每天 04:00 / 12:00 UTC，北京 12:00 / 20:00），不再随每次 dev push 即时打 beta tag。聚合多个 PR 进同一 beta，避免 beta channel 一天弹多次更新；紧急可手动 `gh workflow run bump-electron-beta.yml`
+
 - Ollama bridge cleanup（#403 review followups, closes #405 #406 #407）：
   - `src/ollama/bridge.ts` 不再重复实现 `normalizeHostname` / `isLoopbackHostname`，统一从 `src/utils/host.ts` 引入；`shared/utils/host.ts` 改为薄 re-export 以兼容前端的现有 import (#405)
   - `proxyOpenAIRequest` 转发头扩展到 `Content-Type` / `Accept` / `User-Agent` / `X-Request-Id` / `traceparent` / `tracestate`（#403 review #2）；`/v1/*` 路径剥离改用 `path.replace(/^\/v1/, "")` 替代 `slice(3)`
@@ -258,240 +502,85 @@
   - `POST /admin/ollama-settings` 移除多余的 `checkApiKey`，与其他 admin POST 一致由 `dashboardAuth` 中间件统一鉴权（#406）
   - 删除根目录开发日志 `OLLAMA_BRIDGE_INTEGRATION.md`（Phase 1/2 scope 已并入 CHANGELOG，git 历史保留原文）
 
-### Added
-
-- 图像生成请求计数（成功 / 失败分流）：`AccountUsage` 新增 `image_request_count` / `image_request_failed_count`（含 window 维度）。请求时检测 `tools[].type === "image_generation"`，release 时按 `tool_usage.image_gen.output_tokens` 是否 > 0 分流到成功 / 失败计数；Free 账号被静默剥工具、上游 4xx/5xx、EmptyResponse 等失败路径也会写入 failed 计数。`/admin/usage-stats/summary` 新增 `total_image_request_count` / `total_image_request_failed_count`，Dashboard 用量页新增「Image Requests」卡片显示 `N ok · M failed`，AccountCard 在有图像活动时显示窗口请求成功 / 失败行
-- 图像生成 token 独立计数：上游 `tool_usage.image_gen.{input_tokens, output_tokens}`（`gpt-image-2` 单独账）从前一直被丢弃，现在贯穿全链路 —— `parseResponseData` / `extractImageGenUsage` 解析、`AccountUsage` 累加（含 window 维度）、`UsageSnapshot` / `UsageBaseline` 持久化、`/admin/usage-stats/summary` 暴露 `total_image_input_tokens` / `total_image_output_tokens`、Dashboard 用量页新增「Image Tokens (in/out)」卡片，AccountCard 在该账号有图像消费时多显示一行窗口图像 token；老 `usage-history.json` 缺新字段以 0 兜底，向后兼容
-- 图像生成真实压测：`tests/real/image-generation.test.ts`（vitest, `npm run test:real`）跑 `{gpt-5.4-mini, gpt-5.5} × {1024×1024, 3840×2160}` 矩阵，每组合 2 并发 × 2 轮断言 SSE 完整事件链 + 图片 base64 长度阈值 + `tool_usage.image_gen.output_tokens > 0`，最后校验 `/admin/usage-stats/summary` 的 image token 增量；`tests/bench/image-gen-bench.ts` 提供同矩阵的 p50/p95/min/max + 图像与主模型 token 均值 markdown 表
-- Dashboard 用量统计新增「缓存命中率」卡片：聚合所有账号 `cached_tokens / input_tokens` 比例，附带绝对值提示。后端 `AccountUsage` 与 `UsageSnapshot` 持久化 cached tokens（含 window 维度），`/admin/usage-stats/summary` 与 `/history` 同步暴露 `total_cached_tokens` / `cached_tokens` 字段；老数据以 0 兜底
-- 发版流程引入 `dev` 分支 + beta channel：`bump-electron-beta.yml` 在 dev push 时打 `vX.Y.Z-beta.SHA` tag 出预发布包；`promote-dev-to-master.yml` 每天 14:00 UTC 检查 dev soak ≥24h + CI 绿后 fast-forward 到 master，再由现有 `bump-electron.yml` 出 stable tag (`.github/workflows/`)
-- `update.allow_prerelease` 配置项（默认 `false`）：开启后本地 Electron 通过 electron-updater 接收 beta channel 推送的预发布版本，便于自己的安装实测 dev 改动 (`src/config-schema.ts`、`packages/electron/electron/auto-updater.ts`、`config/default.yaml`)
-- `config/models.yaml`: `gpt-5.5` (Plus-only general-purpose chat) and `gpt-image-2` (Plus-only image-generation backend) entered the static catalog
-- `CodexModelInfo.outputModalities` optional field on the model catalog interface to flag image-gen models apart from chat models (`src/models/model-store.ts`, `BackendModelEntry.output_modalities` also added for backend passthrough). `/v1/models/catalog` defaults missing values to `["text"]` so API output matches the documented contract.
-- README 新增图像生成小节 + 模型表 Output 列；`API.md` / `API_CN.md` 补 `image_generation` 工具参数矩阵、事件流、编辑模式文档
-- Dashboard: new Logs tab to inspect ingress/egress requests, with enable/pause controls, filters, search, and details panel.
-- 控制台新增日志页面：支持启用/暂停、方向筛选、搜索与详情查看，便于排查请求流向。
-- `auth.tier_priority` 配置项：按 plan 类型排序账号选择优先级（如 `["plus", "pro", "team", "free"]`），高优先级 tier 的账号在有可用时始终优先选择；默认 `null`（不启用），与所有轮转策略兼容 (#348)
-
-- `server.trust_proxy` config option (default `false`): when enabled, the real client IP is read from `X-Forwarded-For` / `X-Real-IP` headers instead of the raw socket address. Required for users who expose codex-proxy via tunnel software (frp, ngrok, etc.) so that dashboard auth works correctly — previously all tunnel traffic appeared as `127.0.0.1` and bypassed authentication even when `proxy_api_key` was set (#350)
-
-### Fixed
-
-- 多后端流量的 cache 命中率被低估到 0%：`OpenAI` / `Anthropic` / `Gemini` 上游适配器在合成 `response.completed` 时全都硬编码 `input_tokens_details: {}`,丢掉了上游原本返回的缓存字段。`openai-upstream.ts` 现在抽 `usage.prompt_tokens_details.cached_tokens`,`anthropic-upstream.ts` 抽 `message_start.usage.cache_read_input_tokens`(也兜底从 `message_delta.usage` 读),`gemini-upstream.ts` 抽 `usageMetadata.cachedContentTokenCount`。修复后 `/admin/usage-stats/summary` 的 `total_cached_tokens` 在多后端模式下不再常驻 0,Dashboard 缓存命中率卡片可以正常工作
-- Dashboard 缓存命中率显示精度自适应:`formatHitRate` 在 < 1% 时切两位小数(`0.02%`),< 0.01% 显 `<0.01%`,= 0 显 `0%` —— 以前 `pct.toFixed(1)` 把 < 0.05% 全压成 "0.0%",看不到真实值
-- 上游返回 `previous_response_not_found`(response 由别的账号创建 / `SessionAffinityMap` 过期或重启丢失 / 跨账号轮转)时端到端恢复:
-  - `ws-transport.ts:36` `ROTATABLE_ERROR_CODES` 增补 `previous_response_not_found: 400`，让 WS 首帧 in-stream error 转成 `CodexApiError` reject —— 之前因为不在白名单里直接被流式透传到客户端，绕过了 catch
-  - `proxy-handler.ts` catch 块新增 strip-and-retry：剥掉 `previous_response_id` + `turnState`，在同一账号上重试一次，并把 ID 从 affinity map 清掉防止后续请求继续命中错路由；重试仍失败时降级返回原错误
-  - 隐式续链场景通过已有的 `restoreImplicitResumeRequest()` 路径回放完整 input，无损恢复；显式续链（客户端传 `previous_response_id`）会丢服务端历史，但请求仍能完成
-  - 新增分类器 `isPreviousResponseNotFoundError` + `SessionAffinityMap.forget()`（`src/proxy/error-classification.ts`、`src/auth/session-affinity.ts`、`src/routes/shared/proxy-handler.ts`、`src/proxy/ws-transport.ts`）
-- `release.yml` 让 electron-builder 用 tag 名当版本（`--config.extraMetadata.version="${TAG#v}"`），不再依赖 `package.json`。修复 `bump-electron-beta.yml` 故意不写 `package.json` 时 beta 包被跳过上传的问题（"existing type not compatible with publishing type"）；同步在 `release` job 给 prerelease tag 兜底 `--prerelease` flag (#413)
-- `release.yml` 的 `Pack` 步骤强制 `shell: bash`，让 Windows runner（默认 pwsh）正确解析 bash 多行续行符 `\` (#414)
-- WebSocket 路径首帧若为上游 `usage_limit_reached` / `rate_limit*` / `quota_exhausted` / 鉴权类终止错误，转换为 `CodexApiError` 抛出，复用 HTTP 路径已有的账号轮转逻辑；恢复 2.0.62 的"智能切换"行为（`src/proxy/ws-transport.ts`）。错误若发生在已有内容流出之后，仍按当前行为透传给客户端
-- 无可用账号时不再执行无意义的重试，直接返回描述性错误信息（含各状态账号计数：rate-limited / expired / banned / disabled）(#362)
-- API Key 路由（OpenAI/Anthropic/Gemini）上游返回错误时，透传原始 JSON 响应体，而非包装为代理自有格式；Codex 账号路由仍使用代理格式 (#367)
-
-- `least_used` 策略不再将 `window_reset_at = null` 的新账号（从未收到限速响应头）视为 Infinity 而永久排在已有窗口账号之后；现在两者都进入 `request_count` 比较，新账号（0 请求）可正确轮转到，`__cf_bm` cookie 也能正常写入 (#342)
-
-- 默认不再发送 `reasoning.effort`：移除 `modelInfo.defaultReasoningEffort` 自动兜底，`default_reasoning_effort` 默认改为 `null`，彻底消除简单对话触发 medium 推理导致的 token 暴涨；Dashboard 新增 "Disabled (no reasoning)" 选项，用户可按需开启
-
-- 上游 401 时立即触发 RT→AT 刷新，而非等待定时器（修复 token 被提前作废后账号一直显示 expired 的问题）
-- Dashboard session 滑动窗口续期：每次有效请求自动延长过期时间，不再固定 TTL 后断连
-- Dashboard 前端全局 401 拦截：session 过期后自动跳回登录页，不再卡死在空白页
-- Add Account 对话框新增 Cancel 按钮，OAuth 流程中可随时关闭对话框 (#319)
-- Electron 打包前清空旧 public/ 目录，防止残留旧版前端资源导致显示异常 (#320)
-
-### Changed
-
 - Default model switched from `gpt-5.3-codex` → `gpt-5.4` (`config/default.yaml`, `config/models.yaml.isDefault`, Zod schema default in `src/config-schema.ts`). Removed the `codex` alias — clients must use full model IDs. Sonnet mapping in Anthropic preset/README 推荐表保持 `gpt-5.3-codex` 不变（编程场景更贴位）
+
 - Static `isDefault` and `outputModalities` on `config/models.yaml` entries now survive the backend dynamic fetch merge (previously the spread of normalized `undefined`/`false` silently clobbered YAML-declared values)
+
 - Dashboard session TTL 由 `session.ttl_minutes` 控制；当前默认配置为 60 分钟
 
-### Added
-
-- 第三方 API Key 管理：支持 Anthropic / OpenAI / Gemini / OpenRouter 预设模型 + 自定义 provider，每个 key 绑定一个具体模型，运行时动态路由（优先于 config 固定 key），LRU 轮转多 key 负载均衡
-  - REST API：`GET/POST /auth/api-keys`、`GET /auth/api-keys/catalog`、`POST /auth/api-keys/import`、`GET /auth/api-keys/export`、批量删除、label/status 管理
-  - Dashboard 新增 API Keys tab：表单添加（御三家下拉选模型 / custom 手填）、import/export、toggle 启停、删除
-  - 持久化 `data/api-keys.json`，UpstreamRouter 优先级 0 匹配 pool entry
-- 加强伪装：Rust native transport（reqwest + rustls），TLS 指纹精确匹配真实 Codex Desktop；补齐 `x-openai-internal-codex-residency`、`x-client-request-id`、`x-codex-turn-state` 请求头
-- 账号探活：`POST /auth/accounts/health-check` 批量健康检查 + `POST /auth/accounts/:id/refresh` 单账号刷新，通过 OAuth refresh 探测存活状态，带 stagger 延迟和并发控制
-- Session affinity：同一对话链路由到同一账号，修复 `previous_response_id` 跨账号失效问题
-- `prompt_cache_key`：每个对话链生成唯一 UUID 传递给后端，启用 prompt cache
-- WebSocket 请求新增 `include: ["reasoning.encrypted_content"]`（reasoning 开启时自动设置）
-- 请求级监控日志：affinity hit/miss、payload 大小、usage 统计、大 payload 告警
-- E2E 测试：proxy-routes（36 cases）、dashboard-auth（9）、batch-label（11）、admin-general（11）、debug-routes（5）—— 覆盖率从 51% 提升至 ~75%
-- 单元测试：config-loader（16 cases）、config-schema（10）、codex-models（9）
-- account-import service 测试补充 RT rotation/fallback 2 cases
-
-### Fixed
-
-- 修复 `service_tier` 在 WebSocket 和 HTTP 两条路径均被丢弃的 bug — 现在正确转发给后端
-- 修复 `PUT /api/proxies/settings` 被 `PUT /api/proxies/:id` 路由参数 shadow 的 bug（Hono 按注册顺序匹配）
-
-### Changed
-
 - 删除冗余测试文件：`self-update-auto.test.ts`（superset 覆盖）、`account-import-refresh.test.ts`（迁移到 service 层）
+
 - 重命名 `model-plan-routing.test.ts` → `plan-routing-integration.test.ts` 以区分作用域
+
 - libcurl FFI 连接复用：macOS/Linux 自动构建 dylib，通过 CURLSH 共享连接缓存 + SSL session，消除每次请求的 TCP/TLS 握手开销（~2.9s → ~100-300ms）
+
 - setup 脚本自动下载静态库、编译 C wrapper、生成 dylib + cacert.pem
+
 - 自动更新（热更新）功能，默认开启，用户可在 Dashboard 设置中关闭
   - Git 模式：检测到更新后自动 pull → install → build → 重启
   - Electron (Win/Linux)：自动下载更新，退出时安装；dock/任务栏显示下载进度条
   - Electron (macOS)：自动打开 release 页面（平台限制无法自动安装）
   - 配置项 `update.auto_update`，持久化到 `data/local.yaml`
 
-### Removed
-
-- 删除废弃的 `packages/electron/desktop/` UI（Electron 已直接加载 web/ UI），消除 18 个重复组件
-- 删除 `public-desktop/` 构建产物目录及 `/desktop` 路由
-- 删除 `web/src/` 中 6 个未被引用的死文件（hooks/utils/i18n/theme，~443 LOC）
-
-### Changed
-
 - 提取 `src/proxy/error-classification.ts`：`isBanError`/`isTokenInvalidError`/`isModelNotSupportedError`/`extractRetryAfterSec` 从 proxy-handler 和 usage-refresher 中去重，19 个新测试
+
 - `scripts/` 按用途分类到 `infra/`、`build/`、`poc/`、`manual-test/` 子目录
+
 - 新增 `src/context.ts`（AppContext 容器），fingerprint/manager、codex-api、codex-usage、codex-models 支持可选 DI 参数（fallback 到全局单例）
+
 - `ModelStore` 从模块级单例重构为 class，自由函数 wrapper 保持后向兼容，新增 `getModelStore()` / `setModelStoreForTesting()`
+
 - Transport 加入 AppContext，codex-api/codex-usage/codex-models/proxy-pool/curl-fetch 支持可选 transport 注入
+
 - CookieJar critical cookie 写入从 `writeFileSync`（阻塞 10-50ms）改为 `writeFile`（async 非阻塞）
+
 - `proxy-handler.ts`（353 LOC）拆分为 3 个独立可测试模块：`account-acquisition.ts`（acquire/release + 幂等 guard）、`proxy-error-handler.ts`（4 种错误分类 + 池状态变更）、`response-processor.ts`（流式/非流式响应），26 个新测试
+
 - `AccountPool`（673 LOC）拆分为 `AccountRegistry`（状态 + CRUD + 查询，423 LOC）+ `AccountLifecycle`（锁 + 轮换，154 LOC），facade 219 LOC 编排。37 个 importer 零改动
+
 - `model-fetcher.ts` 和 `usage-refresher.ts` 从模块级单例重构为 `ModelFetcher` / `UsageRefresher` class，自由函数 wrapper 保持后向兼容
+
 - Dashboard 改为 4-tab 布局（概览/管理账号/代理分配/设置），设置面板从首页移至独立 tab，首页保留账号卡片 + 代理池
+
 - AccountCard 响应式修复：窄屏时操作按钮自动换行不再溢出
-
-### Fixed
-
-- 导入/导出按钮图标反了——导入改为下箭头、导出改为上箭头（#191）
-- Windows 桌面端按钮溢出——Electron 最小宽度从 680px 提高到 800px，覆盖 Tailwind md: 断点（#192）
-- `local.yaml` 的 `server.host` 覆盖已有测试验证，Electron 模式下正确生效（#190）
-
-### Changed
 
 - 版本号从 1.0.x 跳到 2.0.0，CI bump workflow 改为从 package.json 读取 major.minor 系列
 
+### Removed
+
+- 删除废弃的 `packages/electron/desktop/` UI（Electron 已直接加载 web/ UI），消除 18 个重复组件
+
+- 删除 `public-desktop/` 构建产物目录及 `/desktop` 路由
+
+- 删除 `web/src/` 中 6 个未被引用的死文件（hooks/utils/i18n/theme，~443 LOC）
+
+## [v1.0.x](https://github.com/icebear0828/codex-proxy/releases?q=1.0) - 2026-03-04 至 2026-03-25
+
+### Changed
+
 - **Phase 3 — Service 层提取**：`src/routes/accounts.ts` 从 518 行降至 172 行（-67%），业务逻辑拆分到 `src/services/account-import.ts`、`account-query.ts`、`account-mutation.ts` 三个 service 类，全部通过 constructor DI，29 个新测试零 `vi.mock()`
+
 - **Phase 2 — Config DI**：`src/config.ts` 新增 `setConfigForTesting()`/`resetConfigForTesting()`，AccountPool constructor 支持 `rotationStrategy`/`initialToken`/`rateLimitBackoffSeconds` 注入，translation 函数支持 `modelConfig` 可选参数。测试中 `vi.mock("config.js")` 从 9 处降至 2 处
+
 - AccountList 头部重做：标题行 + 导航标签 + 操作工具栏三层分离，按钮带文字标签，分页信息更清晰（`10 / 908` + 展开全部）
+
 - 暗色主题修复：图表 SVG 线条颜色改用 CSS 变量（dark mode 下更亮）、代码块 light mode 背景修正、Toggle 开关 thumb 对比度提升
 
-### Added
-
-- 账号标签（label）：支持为每个账号设置自定义标签（如 "Team Alpha"、"个人"），解决同一邮箱加入多个 team 无法区分的问题。AccountCard 有标签时显示标签为主标题，hover 显示编辑按钮
-- Refresh-token-only 导入：批量导入现在支持只传 `refreshToken`（无需有效 JWT），后端自动用 RT 换取 AT 后添加账号
-- 导入模板下载：AccountImportExport 工具栏新增模板下载按钮，包含 token-only、RT-only、label 等示例格式
-- 导入支持 label 字段：批量导入时可为每条记录指定 label
-- Claude Code Setup 卡片：Dashboard 按 Opus/Sonnet/Haiku/自定义 层级一键复制环境变量（推荐模型 gpt-5.4 / gpt-5.3-codex / gpt-5.4-mini）
-- 账号启用/禁用 toggle：AccountCard 和 AccountTable 新增 per-account 开关，无需批量操作即可快速切换账号状态
-- Codex CLI 配置说明：README 新增 `~/.codex/config.toml` 配置示例
-- Token 刷新并发控制（`auth.refresh_concurrency`，默认 2）：多账号同时到期时限制并发数，避免上游限流
-- Dashboard 基础设置新增「刷新并发数」配置项
-- README 添加局域网访问说明（`0.0.0.0` 配置 + Electron 路径）
-
-### Fixed
-
-- Electron 模式下 `data/local.yaml` 中的 `server.host` 配置不生效——Electron 硬编码 `127.0.0.1` 覆盖了用户配置，现在 `local.yaml` 显式设置的 host 优先于启动参数（#175）
-- Dashboard 清空上游代理后 reload 被环境变量 `HTTPS_PROXY` 覆盖回来——`local.yaml` 显式设置的 `proxy_url` 现在优先于环境变量
-- Release 资产命名统一：`artifactName` 模板强制 `Codex-Proxy-{version}-{os}-{arch}.{ext}`，消除 `Codex.Proxy` vs `Codex-Proxy` 重复，x64 DMG 现在明确标注架构（`mac-x64`）
-- macOS x64 构建前清理旧资产，避免 release 页面出现重复文件
-
-### Changed
-
 - TLS 指纹对齐：curl-impersonate 升级支持 chrome144 profile（v1.5.1），`KNOWN_CHROME_PROFILES` 新增 133/142
+
 - 默认协议从 HTTP/1.1 改为 HTTP/2，匹配真实 Codex Desktop 行为
+
 - 指纹版本同步至 v26.318.11754（build 1100）
+
 - 配额自动刷新默认关闭（`refresh_interval_minutes: 0`），用户在 Dashboard 自行设置
+
 - 配额刷新改为有限并发（默认 10，可配 `quota.concurrency`），不再全量并发
+
 - Token 刷新走账号分配的代理，永久错误需连续 2 次才标 expired
+
 - **⚠️ 密钥变更**：首次启动自动创建 `data/local.yaml` 并设置默认密钥 `pwd`。所有自定义配置请通过 Dashboard 修改（自动保存到 `data/local.yaml`，更新不覆盖）
+
 - `suppress_desktop_directives` 默认值改为 `false`
-
-### Added
-
-- Dashboard「基础设置」面板：端口、代理、HTTP/1.1、默认模型、推理等级、注入/压制、Token 刷新开关
-- Dashboard「配额设置」面板：新增并发数配置
-- 代理池 YAML 导入导出（`/api/proxies/export`、`/api/proxies/import`）
-- 账号列表分页（默认显示 10 个，可展开）
-- Token 自动刷新开关（`auth.refresh_enabled`）
-- HTTP/2 自动降级：curl 因 H2 错误失败时自动切换 HTTP/1.1（TTL 10 分钟后重试 H2）
-  - exit code 16（H2 专属）无条件触发；其他 exit code 需 stderr 含 H2 关键词
-  - `force_http11` 配置仍可手动强制 HTTP/1.1
-
-### Fixed
-
-- 配置 overlay 机制：Dashboard 设置写入 `data/local.yaml`（gitignored），不再修改 `config/default.yaml`
-  - `git pull` 不会覆盖用户自定义设置（proxy_api_key、rotation_strategy、quota 等）
-  - `config/default.yaml` 的 `proxy_api_key` 默认值改为 `null`（自动生成）
-
-### Fixed
-
-- 额度恢复后账号仍显示"已限速"（#162）
-  - usage-refresher 发现 `limit_reached: false` 时主动调用 `clearRateLimit()` 恢复 active 并清除 `rate_limit_until`
-- Anthropic `/v1/messages` 截图场景 400 报错：`tool_result.content` 不支持 image block
-  - Schema 放行 image block；翻译层将图片提取为紧随 `function_call_output` 的 user message（`input_image`）
-- 代理自动检测使用 `host.docker.internal` 主机名导致 curl 无法解析（#114）
-  - 探测成功后通过 DNS lookup 解析为 IP 地址，避免 curl subprocess DNS 解析失败
-- OAuth 登录失败后重试报 "Invalid or expired session"（#154）
-  - Session 改为 peek → exchange 成功 → delete 生命周期，exchange 失败时 session 保留可重试
-- `withDirectFallback` 未捕获 curl exit code 5（代理解析失败），不会 fallback 直连
-  - `isProxyNetworkError` 新增 `could not resolve proxy` 和 `curl exited with code 5` 匹配
-- curl error 61：fingerprint 的 `Accept-Encoding: br, zstd` 覆盖了 `--compressed` 自动协商，系统 curl 不支持 br/zstd 时解压失败
-  - curl-cli-transport 统一跳过 `Accept-Encoding` header，由 `--compressed` 按 curl 实际能力协商
-- 系统 curl 不支持 `--compressed` 时启动报错
-  - 启动时探测支持情况，不支持则跳过该 flag 并提示安装 curl-impersonate
-- 模型列表启动时不更新：token 刷新与 model fetch 存在竞态，初始 fetch 跳过后直接等 1 小时
-  - model-fetcher 改为 fast-retry（10s 间隔，最多 12 次），账号就绪后立即拉取
-  - `config/models.yaml` 补回 gpt-5.4/5.4-mini/5.3-codex（3/18 后端已恢复）
-
-### Added
-
-- Dashboard 登录门（#141）：当 `proxy_api_key` 已配置且请求来自非 localhost 时，需输入密码才能访问控制台
-  - Cookie-based session，TTL 由 `session.ttl_minutes` 控制（默认 60 分钟）
-  - `POST /auth/dashboard-login`、`POST /auth/dashboard-logout`、`GET /auth/dashboard-status` 端点
-  - API 路由（`/v1/*`）不受影响，Electron（localhost）自动跳过
-  - 简单防暴力：同 IP 5 次/60s 限制
-  - HTTPS 自动检测：反代 `X-Forwarded-Proto: https` 时 cookie 加 `Secure` flag
-  - 远程 session 禁止清空 `proxy_api_key`（防止误操作导致登录门失效）
-  - Header 显示条件性退出按钮
-- 账号封禁检测：上游返回非 Cloudflare 的 403 时自动标记为 `banned` 状态
-  - Dashboard 卡片/表格显示玫红色 `Banned`/`已封禁` 状态徽章
-  - 状态筛选下拉新增 `Banned` 选项
-  - 被封账号自动跳过（`acquire()` 仅选 active），请求时自动切换到其他账号
-  - 后台额度刷新周期性重试 banned 账号，成功即自动解封
-- 上游 401 token 吊销（"token has been invalidated"）自动标记过期并切换下一个账号
-  - 之前 401 直接透传给客户端，不标记也不重试
-- Usage Stats 页面（`#/usage-stats`）：累计 token 用量汇总 + 时间趋势图
-  - 后台每 5 分钟记录用量快照，保留 7 天历史
-  - `GET /admin/usage-stats/summary` 实时累计汇总
-  - `GET /admin/usage-stats/history?granularity=hourly|daily&hours=N` 时间序列增量
-  - 纯 SVG 折线图（input/output tokens + 请求数），无外部图表库
-  - 支持按小时/按天粒度，24h/3d/7d 时间范围切换
-- Account Management 页面（`#/account-management`）：批量删除、批量改状态（active/disabled）、导入导出
-  - `POST /auth/accounts/batch-delete` 和 `POST /auth/accounts/batch-status` 批量端点
-  - 状态摘要条可点击筛选，复用 AccountTable 选择/分页/Shift 多选
-
-### Fixed
-
-- 运行时缓存（模型目录同步、版本检测结果）直接写入 git 跟踪的 `config/` 文件，导致仓库频繁变脏
-  - `model-store` 的 `syncStaticModels()` 改写 `data/models-cache.yaml`（gitignored）
-  - `update-checker` 的 `applyVersionUpdate()` 改写 `data/version-state.json`（gitignored）
-  - `config/` 目录现在对运行时操作只读，仅 admin API 设置变更例外
-
-- Responses SSE 新事件（`response.output_item.added` with `item.type=message`、`response.content_part.added/done`）未被识别，导致 `[CodexEvents] Unknown event` 日志刷屏
-- 新模型（如 `gpt-5.4-mini`）无法被动态发现的问题
-  - 移除 `isCodexCompatibleId()` 白名单过滤，信任后端 `/codex/models` 返回
-- 同一 Team 的多个账号因共享 `chatgpt_account_id` 只能添加一个的问题（#126）
-  - 去重逻辑改为 `accountId + userId` 组合键，Team 成员各自保留独立条目
-  - `AccountEntry` 新增 `userId` 字段，持久化层自动回填
-- 额度耗尽账号仍显示「活跃」并接收请求的问题（#115）
-  - `markQuotaExhausted()` 现在可以覆盖 `rate_limited` 状态（仅延长，不缩短 reset 时间）
-  - 后台额度刷新现在同时检查 `rate_limited` 账号，防止因 429 短暂 backoff 导致漏检
-- `/v1/responses` 不再强制要求 `instructions` 字段，未传时默认空字符串（#71）
-  - 修复 Cherry 等第三方客户端不传 `instructions` 时返回 400 的兼容性问题
-- CI 构建修复：WebSocket 传输 `instructions` 类型不匹配（TS2322）导致 Electron/Docker 编译失败
-- `shared/i18n/translations.ts` 移除中英文重复 `selectAll` key（Vite 警告）
-- `sync-changelog.yml` 推送步骤加 rebase 重试（解决与 bump-electron 并行推送竞态）
-
-### Changed
 
 - 架构重构：降低模块耦合、改善可测试性
   - 提取 `codex-types.ts`：API 类型定义与类实现分离，20+ 文件只需类型不需类
@@ -501,7 +590,90 @@
   - 拆分 `codex-api.ts`：SSE 解析（`codex-sse.ts`）、用量查询（`codex-usage.ts`）、模型发现（`codex-models.ts`）独立为纯函数模块（10 新测试）
   - 所有提取模块通过 re-export 保持现有 import 路径兼容
 
+- Electron 桌面端从独立分支迁移为 npm workspace（`packages/electron/`），消除 master→electron 分支同步冲突；删除 `sync-electron.yml`，release.yml 改为 workspace 感知构建
+
+- `scripts/setup-curl.ts`：加入 GITHUB_TOKEN 认证避免 CI rate limit；Windows DLL 名适配 v1.5+（`libcurl-impersonate.dll`）；tar 解压 bsdtar/GNU tar 自动 fallback
+
+- Light mode 背景色从 `#f6f8f6` 改为纯白 `#ffffff`，增大亮/暗主题视觉差异
+
+- 提取管道强化：`extract-fingerprint.ts` 新增 fallback 扫描（`.vite/build/*.js` 全文件回退）和 webview 模型发现（`webview/assets/*.js`），pattern 失败不再中断整个流程
+
+- 模型/别名自动添加降级为 semi-auto：后端已通过 `isCodexCompatibleId()` 自动合并新模型，`apply-update.ts` 不再自动写入 `models.yaml`（避免 `mutateYaml` 破坏 YAML 格式）
+
+- Codex Desktop 版本更新至 v26.309.31024 (build 962)
+
+- Dashboard 模型选择器去重：移除 Anthropic SDK Setup 的独立模型下拉框，统一使用 API Configuration 的 Default Model
+
+- 模型管理从纯静态 YAML 迁移至静态+动态混合架构（后端优先，YAML 兜底）
+
+- 默认模型改为 `gpt-5.2-codex`
+
+- Dashboard "Claude Code Quick Setup" 重命名为 "Anthropic SDK Setup"
+
+- `/health` 端点精简，仅返回 pool 摘要（total / active）
+
 ### Added
+
+- 账号标签（label）：支持为每个账号设置自定义标签（如 "Team Alpha"、"个人"），解决同一邮箱加入多个 team 无法区分的问题。AccountCard 有标签时显示标签为主标题，hover 显示编辑按钮
+
+- Refresh-token-only 导入：批量导入现在支持只传 `refreshToken`（无需有效 JWT），后端自动用 RT 换取 AT 后添加账号
+
+- 导入模板下载：AccountImportExport 工具栏新增模板下载按钮，包含 token-only、RT-only、label 等示例格式
+
+- 导入支持 label 字段：批量导入时可为每条记录指定 label
+
+- 账号启用/禁用 toggle：AccountCard 和 AccountTable 新增 per-account 开关，无需批量操作即可快速切换账号状态
+
+- Codex CLI 配置说明：README 新增 `~/.codex/config.toml` 配置示例
+
+- Token 刷新并发控制（`auth.refresh_concurrency`，默认 2）：多账号同时到期时限制并发数，避免上游限流
+
+- Dashboard 基础设置新增「刷新并发数」配置项
+
+- README 添加局域网访问说明（`0.0.0.0` 配置 + Electron 路径）
+
+- Dashboard「基础设置」面板：端口、代理、HTTP/1.1、默认模型、推理等级、注入/压制、Token 刷新开关
+
+- Dashboard「配额设置」面板：新增并发数配置
+
+- 代理池 YAML 导入导出（`/api/proxies/export`、`/api/proxies/import`）
+
+- 账号列表分页（默认显示 10 个，可展开）
+
+- Token 自动刷新开关（`auth.refresh_enabled`）
+
+- HTTP/2 自动降级：curl 因 H2 错误失败时自动切换 HTTP/1.1（TTL 10 分钟后重试 H2）
+  - exit code 16（H2 专属）无条件触发；其他 exit code 需 stderr 含 H2 关键词
+  - `force_http11` 配置仍可手动强制 HTTP/1.1
+
+- Dashboard 登录门（#141）：当 `proxy_api_key` 已配置且请求来自非 localhost 时，需输入密码才能访问控制台
+  - Cookie-based session，TTL 由 `session.ttl_minutes` 控制（默认 60 分钟）
+  - `POST /auth/dashboard-login`、`POST /auth/dashboard-logout`、`GET /auth/dashboard-status` 端点
+  - API 路由（`/v1/*`）不受影响，Electron（localhost）自动跳过
+  - 简单防暴力：同 IP 5 次/60s 限制
+  - HTTPS 自动检测：反代 `X-Forwarded-Proto: https` 时 cookie 加 `Secure` flag
+  - 远程 session 禁止清空 `proxy_api_key`（防止误操作导致登录门失效）
+  - Header 显示条件性退出按钮
+
+- 账号封禁检测：上游返回非 Cloudflare 的 403 时自动标记为 `banned` 状态
+  - Dashboard 卡片/表格显示玫红色 `Banned`/`已封禁` 状态徽章
+  - 状态筛选下拉新增 `Banned` 选项
+  - 被封账号自动跳过（`acquire()` 仅选 active），请求时自动切换到其他账号
+  - 后台额度刷新周期性重试 banned 账号，成功即自动解封
+
+- 上游 401 token 吊销（"token has been invalidated"）自动标记过期并切换下一个账号
+  - 之前 401 直接透传给客户端，不标记也不重试
+
+- Usage Stats 页面（`#/usage-stats`）：累计 token 用量汇总 + 时间趋势图
+  - 后台每 5 分钟记录用量快照，保留 7 天历史
+  - `GET /admin/usage-stats/summary` 实时累计汇总
+  - `GET /admin/usage-stats/history?granularity=hourly|daily&hours=N` 时间序列增量
+  - 纯 SVG 折线图（input/output tokens + 请求数），无外部图表库
+  - 支持按小时/按天粒度，24h/3d/7d 时间范围切换
+
+- Account Management 页面（`#/account-management`）：批量删除、批量改状态（active/disabled）、导入导出
+  - `POST /auth/accounts/batch-delete` 和 `POST /auth/accounts/batch-status` 批量端点
+  - 状态摘要条可点击筛选，复用 AccountTable 选择/分页/Shift 多选
 
 - Sticky rotation strategy（#107）：新增 `sticky` 账号轮换策略，持续使用同一账号直到限速或额度耗尽
   - `src/config.ts`：`rotation_strategy` 枚举新增 `"sticky"` 选项
@@ -510,94 +682,39 @@
   - Dashboard：RotationSettings 组件（粘滞 vs 轮换两层 radio group）
   - i18n：中英文翻译（策略名称 + 描述）
   - 13 个新测试覆盖 sticky 选择逻辑 + 路由端点
+
 - `POST /admin/refresh-models` 端点：手动触发模型列表刷新，解决 model-fetcher ~1h 缓存过时导致新模型不可用的问题；支持 Bearer auth（当配置 proxy_api_key 时）
+
 - Plan routing integration tests：通过 proxy handler 完整路径验证 free/team 账号的模型路由（7 cases），覆盖 plan map 更新后请求解除阻塞的场景
-
-### Changed
-
-- Electron 桌面端从独立分支迁移为 npm workspace（`packages/electron/`），消除 master→electron 分支同步冲突；删除 `sync-electron.yml`，release.yml 改为 workspace 感知构建
-- `scripts/setup-curl.ts`：加入 GITHUB_TOKEN 认证避免 CI rate limit；Windows DLL 名适配 v1.5+（`libcurl-impersonate.dll`）；tar 解压 bsdtar/GNU tar 自动 fallback
-
-### Added
 
 - Dashboard 额度设置面板：可在 Web UI 直接调整额度刷新间隔、主/次预警阈值、自动跳过耗尽账号开关，无需手动编辑 YAML；API `GET/POST /admin/quota-settings` 支持鉴权 (#92)
 
-### Fixed
-
-- 删除账号后额度预警横幅未清除：`DELETE /auth/accounts/:id` 漏调 `clearWarnings()`，导致已删除账号的 quota warning 残留在前端 (#100)
-- macOS Electron 桌面版登录报 `spawn Unknown system error -86`：CI 在 arm64 runner 上同时构建 arm64/x64 DMG，但只下载 arm64 的 curl-impersonate，导致 Intel Mac 用户 spawn 失败（EBADARCH）；拆分为 per-arch 构建 + `setup-curl.ts` 支持 `--arch` 交叉下载；错误提示改为明确的架构不匹配诊断 (#96)
-- 默认关闭 desktop context 注入：之前每次请求注入 ~1500 token 的 Codex Desktop 系统提示，导致 prompt_tokens 虚高；新增 `model.inject_desktop_context` 配置项（默认 `false`），需要时可手动开启 (#95)
-
-### Added
-
 - 额度自动刷新 + 分层预警：后台每 5 分钟（可配置）定时拉取所有账号的官方额度，缓存到 AccountEntry 供 Dashboard 即时读取；额度达到阈值（默认 80%/90%，可自定义）时显示 warning/critical 横幅；额度耗尽的账号自动标记为 rate_limited 跳过分配，到期自动恢复 (#92)
+
 - Docker 镜像自动发布：push master 自动构建多架构（amd64/arm64）镜像到 GHCR（`ghcr.io/icebear0828/codex-proxy`），docker-compose.yml 切换为预构建镜像，支持 Watchtower 自动更新
+
 - 双窗口配额显示：Dashboard 账号卡片同时展示主窗口（小时限制）和次窗口（周限制）的用量百分比、进度条和重置时间，后端 `secondary_window` 不再被忽略
+
 - 更新弹窗 + 自动重启：点击"有可用更新"弹出 Modal 显示 changelog，一键更新后服务器自动重启、前端自动刷新，零人工干预（git 模式 spawn 新进程、Docker/Electron 显示对应操作指引）
+
 - Model-aware 多计划账号路由：不同 plan（free/plus/business）的账号自动路由到各自支持的模型，business 账号可继续使用 gpt-5.4 等高端模型 (#57)
+
 - Structured Outputs 支持：`/v1/chat/completions` 支持 `response_format`（`json_object` / `json_schema`），Gemini 端点支持 `responseMimeType` + `responseSchema`，自动翻译为 Codex Responses API 的 `text.format`；`/v1/responses` 直通 `text` 字段
 
 - 模型列表自动同步：后端动态 fetch 成功后自动回写 `config/models.yaml`，静态配置不再滞后；前端每 60s 轮询模型列表，新模型无需刷新页面即可选择
+
 - Tuple Schema 支持：`prefixItems`（JSON Schema 2020-12 tuple）自动转换为等价 object schema 发给上游，响应侧还原为数组；OpenAI / Gemini / Responses 三端点统一支持
+
 - WebSocket 传输 + `previous_response_id` 多轮支持：`/v1/responses` 端点自动通过 WebSocket 连接上游，服务端持久化 response，客户端可通过 `previous_response_id` 引用前轮对话实现增量多轮；WebSocket 失败自动降级回 HTTP SSE (#83)
+
 - 账号批量导入导出：Dashboard 支持导出全部账号到 JSON 文件（含 token，用于备份/迁移），支持从 JSON 文件批量导入账号，自动去重 (#82)
-
-### Fixed
-
-- 前端缓存问题：`index.html` 设置 `Cache-Control: no-cache` 防止浏览器缓存旧页面，`/assets/*` 设置 immutable 长缓存（Vite content hash）
-
-### Changed
-
-- Light mode 背景色从 `#f6f8f6` 改为纯白 `#ffffff`，增大亮/暗主题视觉差异
-- 提取管道强化：`extract-fingerprint.ts` 新增 fallback 扫描（`.vite/build/*.js` 全文件回退）和 webview 模型发现（`webview/assets/*.js`），pattern 失败不再中断整个流程
-- 模型/别名自动添加降级为 semi-auto：后端已通过 `isCodexCompatibleId()` 自动合并新模型，`apply-update.ts` 不再自动写入 `models.yaml`（避免 `mutateYaml` 破坏 YAML 格式）
-- Codex Desktop 版本更新至 v26.309.31024 (build 962)
-
-### Fixed
-
-- 自动更新重启可靠性：移除 `.restart-helper.cjs` 临时脚本方案，改为直接 spawn 新进程 + 复用 `index.ts` 内置 EADDRINUSE 重试（10 次 × 1s）；新增 nodeExe 存在性校验防止无声死亡，子进程输出写入 `.restart.log` 便于排查启动失败
-
-### Fixed (pipeline)
-
-- Prompt 提取括号定位修复：`extractPrompts()` 的 `lastIndexOf("[")` 无限回溯导致匹配到无关 `[`，截取错误代码片段产出乱码；改为 50 字符窗口内搜索
-- Prompt 覆写安全校验：`savePrompt()` 和 `applyAutoChanges()` 新增内容验证（最小长度 50 字符、乱码行数 ≤3），拒绝将损坏数据写入 `config/prompts/`
-- `title-generation.md` 修复：还原因提取 bug 损坏的 title 生成 prompt（第 17-35 行乱码）
-
-### Changed (previous)
-
-- 模型目录大幅更新：后端移除 free 账号的 `gpt-5.4`、`gpt-5.3-codex` 全系列（plus 及以上仍可用），新旗舰模型为 `gpt-5.2-codex`（`codex` 别名指向此模型）
-- 新增模型：`gpt-5.2`、`gpt-5.1-codex`、`gpt-5.1`、`gpt-5-codex`、`gpt-5`、`gpt-oss-120b`、`gpt-oss-20b`、`gpt-5-codex-mini`
-- 模型目录从 23 个静态模型精简为 11 个（匹配后端实际返回）
-
-### Fixed
-
-- 429 真实冷却时间：从 429 错误响应体解析 `resets_in_seconds` / `resets_at`，账号按后端实际冷却期（如 free 计划 5.5 天）标记限速，不再使用硬编码 60s 默认值 (#65)
-- 429 自动降级：收到 429 后自动尝试下一个可用账号，所有账号耗尽后才返回 429 给客户端 (#65)
-- 调度优先级优化：`least_used` 策略新增 `window_reset_at` 二级排序，配额窗口更早重置的账号优先使用 (#65)
-- JSON Schema `additionalProperties` 递归注入：`injectAdditionalProperties()` 递归注入 `additionalProperties: false` 到 JSON Schema 所有 object 节点，覆盖 `properties`、`patternProperties`、`$defs`/`definitions`、`items`、`prefixItems`、组合器（`oneOf`/`anyOf`/`allOf`）、条件（`if`/`then`/`else`），含循环检测；三个端点（OpenAI/Gemini/Responses passthrough）统一调用 (#64)
-- CONNECT tunnel header 解析：循环跳过中间 header block（CONNECT 200、100 Continue），修复代理模式下 tunnel 的 `HTTP/1.1 200` 被当作真实状态码导致上游 4xx 错误被掩盖为 502 的问题 (#64)
-- 上游 HTTP 状态码透传：非流式 collect 路径从错误消息提取真实 HTTP 状态码，不再硬编码 502；提取 `toErrorStatus()` 辅助函数统一 4 处 StatusCode 转换 (#64)
-- Dashboard 中英文切换按钮宽度跳变：`StableText` 的 `reference` 从英文硬编码改为 `t()` 动态取值，按钮宽度跟随当前语言自适应
-- Dashboard "指纹更新中..." 按钮竖排显示：更新状态按钮添加 `whitespace-nowrap`，防止 CJK 字符逐字换行
-- CI 版本跳号（v1.0.28 → v1.0.30）：`sync-electron.yml` 的 `cancel-in-progress` 改为 `false`，避免 workflow 被取消后 tag 已推送但版本号未同步回 master；合并两次 `git push` 为一次减少部分推送窗口
-- 混合 plan 账号路由失败：free 和 team/plus 账号混用时，请求 plan 受限模型（如 `gpt-5.4`）可能 fallback 到不兼容的 free 账号导致 400 错误，现在严格按 plan 过滤，无匹配账号时返回明确错误而非降级 (#54)
-- `cached_tokens` / `reasoning_tokens` 透传：从 Codex API 响应的 `input_tokens_details` 和 `output_tokens_details` 中提取，传递到 OpenAI（`prompt_tokens_details`）、Anthropic（`cache_read_input_tokens`）、Gemini（`cachedContentTokenCount`）三种格式，覆盖流式和非流式模式 (#55, #58)
-- Dashboard 模型选择器使用后端 catalog 的 `isDefault` 字段，替代硬编码 `gpt-5.4`
-- Docker 端口修复：锁定容器内 `PORT=8080`（`environment` 覆盖 `env_file`），HEALTHCHECK 固定检查 8080，`.env` 的 PORT 仅控制宿主机暴露端口，修复自定义 PORT 时健康检查失败和端口映射不匹配的问题 (#40)
-- Docker Compose 暴露 OAuth 回调端口 1455，修复容器内登录时 "Operation timed out" 的问题
-- README Docker 快速开始补充 `cp .env.example .env` 步骤，修复新用户因缺少 `.env` 文件导致 `docker compose up -d` 启动失败的问题 (#38)
-- 识别 `response.output_item.done`、`response.incomplete`、`response.queued` Codex SSE 事件，消除 "Unknown event" 日志噪音
-- 剥离 `service_tier` 字段：Codex 后端不接受请求体中的 `service_tier`，现在 proxy 在发送前自动移除，修复 `-fast` 后缀导致 "Unsupported service_tier" 报错
-- 更新 gpt-5.4 推理等级：`minimal` → `none`，新增 `xhigh`（与后端实际支持的值对齐）
-- 添加 `OpenAI-Beta` 请求头：与 Codex Desktop 保持一致（`responses_websockets=2026-02-06`）
-- 流式 SSE 请求不再设置 `--max-time` 墙钟超时，修复思考链（reasoning/thinking）在 60 秒处中断的问题；连接保护由 header 超时 + AbortSignal 提供，非流式请求（models、usage）超时不受影响
-
-### Added
 
 - `/v1/responses` 端点：Codex Responses API 直通，无格式转换，支持原始 SSE 事件流和多账号负载均衡
 
 - 模型名后缀系统：通过模型名嵌入推理等级和速度模式（如 `gpt-5.4-high-fast`），CLI 工具（Claude Code、opencode 等）无需额外参数即可控制推理强度和 Fast 模式
+
 - `service_tier` 后缀解析：通过 `-fast`/`-flex` 模型名后缀解析，保留在 proxy 层元数据中（Codex 后端不接受 `service_tier` 请求体字段，Desktop 在 app-server 层处理）
+
 - Dashboard Speed 切换：模型选择器下方新增 Standard / Fast 速度切换按钮
 
 - 代理分配管理页面（`#/proxy-settings`）：双栏矩阵式布局，批量管理数百账号的代理分配
@@ -618,73 +735,246 @@
   - 全套 REST API：`/api/proxies` CRUD + `/api/proxies/assign` 分配管理
   - 持久化：`data/proxies.json`（原子写入，与 cookies.json 同模式）
   - Transport 层支持 per-request 代理：`TlsTransport` 接口新增可选 `proxyUrl` 参数
+
 - Dashboard GitHub Star 徽章：Header 新增醒目的 ⭐ Star 按钮（amber 药丸样式），点击跳转 GitHub 仓库页面，方便用户收藏和获取更新
+
 - Dashboard 检查更新功能：Footer 显示 Proxy 版本+commit 和 Codex Desktop 指纹版本，提供"检查更新"按钮同时检查两种更新
   - Proxy 自更新（CLI 模式）：通过 `git fetch` 检查新提交，自动执行 `git pull + npm install + npm run build`，完成后提示重启
   - Codex 指纹更新：手动触发现有 appcast 检查，自动应用指纹/模型配置变更
   - Docker 兼容：指纹可自动更新，代理代码提示手动 `docker compose up -d --build`
   - Electron 兼容：显示版本信息，更新由桌面应用管理
+
 - `GET /admin/update-status` 端点：返回 proxy 和 codex 两种更新的当前状态
+
 - `POST /admin/check-update` 端点：同时触发 proxy 自检 + codex 指纹检查，自动应用可用更新
+
 - `src/self-update.ts`：Proxy 自更新模块（git 子进程实现，支持检查/拉取/构建）
+
 - GPT-5.4 + Codex Spark 模型支持：新增 `gpt-5.4`（4 种 effort: minimal/low/medium/high）和 `gpt-5.3-codex-spark`（minimal/low），`codex` 别名更新为 `gpt-5.4`
+
 - 扩展推理等级：支持 `minimal`、`xhigh` 等新 effort 值，客户端发送的任意 `reasoning_effort` 均透传到后端
+
 - 模型家族矩阵选择器：Dashboard 模型选择从平面下拉改为家族列表 + 推理等级按钮组，通过 `/v1/models/catalog` 端点获取完整目录
+
 - 泛化模型识别：`isCodexCompatibleId()` 同时匹配 `gpt-X.Y-codex-*` 和裸 `gpt-X.Y` 格式，确保新模型命名规范变化时自动接入
+
 - 代码示例动态 reasoning_effort：CodeExamples 组件根据选中的推理等级自动插入 `reasoning_effort` 参数
+
 - Reasoning/Thinking 输出支持：始终向 Codex API 发送 `summary: "auto"` 以获取推理摘要事件；OpenAI 路由在客户端发送 `reasoning_effort` 时以 `reasoning_content` 输出；Anthropic 路由在客户端发送 `thinking.type: enabled/adaptive` 时以 thinking block 输出；未知 SSE 事件记录到 debug 日志以便发现新事件类型
+
 - 图片输入支持：OpenAI、Anthropic、Gemini 三种格式的图片内容现在可以正确透传到 Codex 后端（`input_image` + data URI），此前图片被静默丢弃
+
 - 每窗口使用量计数器：Dashboard 主显示当前窗口内的请求数和 Token 用量，累计总量降为次要灰色小字；窗口过期时自动归零（时间驱动，零 API 开销），后端同步作为双保险校正
+
 - 窗口时长显示：从后端同步 `limit_window_seconds`，AccountCard header 显示窗口时长 badge（如 `3h`），重置时间行追加窗口时长文字
+
 - Dashboard 账号列表新增手动刷新按钮：点击重新拉取额度数据，刷新中按钮旋转并禁用；独立 `refreshing` 状态确保刷新时列表不清空；标题行右侧显示"更新于 HH:MM:SS"时间戳（桌面端可见）
+
 - 空响应计数器：每个账号追踪 `empty_response_count`，通过 `GET /auth/accounts` 可查看，窗口重置时自动归零
+
 - 空响应日志增强：日志中显示账号邮箱（`Account xxxx (email) | Empty response`），便于定位问题账号
+
 - 空响应检测 + 自动换号重试：Codex API 返回 HTTP 200 但无内容时，非流式自动切换账号重试（最多 3 次），流式注入错误提示文本
+
 - 自动提取 Chromium 版本：`extract-fingerprint.ts` 从 `package.json` 读取 Electron 版本，通过 `electron-to-chromium` 映射为 Chromium 大版本，`apply-update.ts` 自动更新 `chromium_version` 和 TLS impersonate profile
+
 - 动态模型列表：后台从 Codex 后端自动获取模型目录，与静态 YAML 合并（`src/models/model-store.ts`、`src/models/model-fetcher.ts`）
+
 - `/debug/models` 诊断端点，展示模型来源（static/backend）与刷新状态
+
 - 完整 Codex 模型目录：GPT-5.3/5.2/5.1 全系列 base/high/mid/low/max/mini 变体（23 个静态模型）
+
 - OpenCode 平台支持（`opencode.json` 配置文件）
+
 - Vitest 测试框架（account-pool、codex-api、codex-event-extractor 单元测试）
+
 - request-id 中间件注入全局请求链路 ID
+
 - Dockerfile 安全加固（非 root 用户运行、HEALTHCHECK 探针）
-
-### Changed
-
-- Dashboard 模型选择器去重：移除 Anthropic SDK Setup 的独立模型下拉框，统一使用 API Configuration 的 Default Model
-- 模型管理从纯静态 YAML 迁移至静态+动态混合架构（后端优先，YAML 兜底）
-- 默认模型改为 `gpt-5.2-codex`
-- Dashboard "Claude Code Quick Setup" 重命名为 "Anthropic SDK Setup"
-- `/health` 端点精简，仅返回 pool 摘要（total / active）
 
 ### Fixed
 
+- Electron 模式下 `data/local.yaml` 中的 `server.host` 配置不生效——Electron 硬编码 `127.0.0.1` 覆盖了用户配置，现在 `local.yaml` 显式设置的 host 优先于启动参数（#175）
+
+- Dashboard 清空上游代理后 reload 被环境变量 `HTTPS_PROXY` 覆盖回来——`local.yaml` 显式设置的 `proxy_url` 现在优先于环境变量
+
+- Release 资产命名统一：`artifactName` 模板强制 `Codex-Proxy-{version}-{os}-{arch}.{ext}`，消除 `Codex.Proxy` vs `Codex-Proxy` 重复，x64 DMG 现在明确标注架构（`mac-x64`）
+
+- macOS x64 构建前清理旧资产，避免 release 页面出现重复文件
+
+- 配置 overlay 机制：Dashboard 设置写入 `data/local.yaml`（gitignored），不再修改 `config/default.yaml`
+  - `git pull` 不会覆盖用户自定义设置（proxy_api_key、rotation_strategy、quota 等）
+  - `config/default.yaml` 的 `proxy_api_key` 默认值改为 `null`（自动生成）
+
+- 额度恢复后账号仍显示"已限速"（#162）
+  - usage-refresher 发现 `limit_reached: false` 时主动调用 `clearRateLimit()` 恢复 active 并清除 `rate_limit_until`
+
+- Anthropic `/v1/messages` 截图场景 400 报错：`tool_result.content` 不支持 image block
+  - Schema 放行 image block；翻译层将图片提取为紧随 `function_call_output` 的 user message（`input_image`）
+
+- 代理自动检测使用 `host.docker.internal` 主机名导致 curl 无法解析（#114）
+  - 探测成功后通过 DNS lookup 解析为 IP 地址，避免 curl subprocess DNS 解析失败
+
+- OAuth 登录失败后重试报 "Invalid or expired session"（#154）
+  - Session 改为 peek → exchange 成功 → delete 生命周期，exchange 失败时 session 保留可重试
+
+- `withDirectFallback` 未捕获 curl exit code 5（代理解析失败），不会 fallback 直连
+  - `isProxyNetworkError` 新增 `could not resolve proxy` 和 `curl exited with code 5` 匹配
+
+- curl error 61：fingerprint 的 `Accept-Encoding: br, zstd` 覆盖了 `--compressed` 自动协商，系统 curl 不支持 br/zstd 时解压失败
+  - curl-cli-transport 统一跳过 `Accept-Encoding` header，由 `--compressed` 按 curl 实际能力协商
+
+- 系统 curl 不支持 `--compressed` 时启动报错
+  - 启动时探测支持情况，不支持则跳过该 flag 并提示安装 curl-impersonate
+
+- 模型列表启动时不更新：token 刷新与 model fetch 存在竞态，初始 fetch 跳过后直接等 1 小时
+  - model-fetcher 改为 fast-retry（10s 间隔，最多 12 次），账号就绪后立即拉取
+  - `config/models.yaml` 补回 gpt-5.4/5.4-mini/5.3-codex（3/18 后端已恢复）
+
+- 运行时缓存（模型目录同步、版本检测结果）直接写入 git 跟踪的 `config/` 文件，导致仓库频繁变脏
+  - `model-store` 的 `syncStaticModels()` 改写 `data/models-cache.yaml`（gitignored）
+  - `update-checker` 的 `applyVersionUpdate()` 改写 `data/version-state.json`（gitignored）
+  - `config/` 目录现在对运行时操作只读，仅 admin API 设置变更例外
+
+- Responses SSE 新事件（`response.output_item.added` with `item.type=message`、`response.content_part.added/done`）未被识别，导致 `[CodexEvents] Unknown event` 日志刷屏
+
+- 新模型（如 `gpt-5.4-mini`）无法被动态发现的问题
+  - 移除 `isCodexCompatibleId()` 白名单过滤，信任后端 `/codex/models` 返回
+
+- 同一 Team 的多个账号因共享 `chatgpt_account_id` 只能添加一个的问题（#126）
+  - 去重逻辑改为 `accountId + userId` 组合键，Team 成员各自保留独立条目
+  - `AccountEntry` 新增 `userId` 字段，持久化层自动回填
+
+- 额度耗尽账号仍显示「活跃」并接收请求的问题（#115）
+  - `markQuotaExhausted()` 现在可以覆盖 `rate_limited` 状态（仅延长，不缩短 reset 时间）
+  - 后台额度刷新现在同时检查 `rate_limited` 账号，防止因 429 短暂 backoff 导致漏检
+
+- `/v1/responses` 不再强制要求 `instructions` 字段，未传时默认空字符串（#71）
+  - 修复 Cherry 等第三方客户端不传 `instructions` 时返回 400 的兼容性问题
+
+- CI 构建修复：WebSocket 传输 `instructions` 类型不匹配（TS2322）导致 Electron/Docker 编译失败
+
+- `shared/i18n/translations.ts` 移除中英文重复 `selectAll` key（Vite 警告）
+
+- `sync-changelog.yml` 推送步骤加 rebase 重试（解决与 bump-electron 并行推送竞态）
+
+- 删除账号后额度预警横幅未清除：`DELETE /auth/accounts/:id` 漏调 `clearWarnings()`，导致已删除账号的 quota warning 残留在前端 (#100)
+
+- macOS Electron 桌面版登录报 `spawn Unknown system error -86`：CI 在 arm64 runner 上同时构建 arm64/x64 DMG，但只下载 arm64 的 curl-impersonate，导致 Intel Mac 用户 spawn 失败（EBADARCH）；拆分为 per-arch 构建 + `setup-curl.ts` 支持 `--arch` 交叉下载；错误提示改为明确的架构不匹配诊断 (#96)
+
+- 默认关闭 desktop context 注入：之前每次请求注入 ~1500 token 的 Codex Desktop 系统提示，导致 prompt_tokens 虚高；新增 `model.inject_desktop_context` 配置项（默认 `false`），需要时可手动开启 (#95)
+
+- 前端缓存问题：`index.html` 设置 `Cache-Control: no-cache` 防止浏览器缓存旧页面，`/assets/*` 设置 immutable 长缓存（Vite content hash）
+
+- 自动更新重启可靠性：移除 `.restart-helper.cjs` 临时脚本方案，改为直接 spawn 新进程 + 复用 `index.ts` 内置 EADDRINUSE 重试（10 次 × 1s）；新增 nodeExe 存在性校验防止无声死亡，子进程输出写入 `.restart.log` 便于排查启动失败
+
+- 429 真实冷却时间：从 429 错误响应体解析 `resets_in_seconds` / `resets_at`，账号按后端实际冷却期（如 free 计划 5.5 天）标记限速，不再使用硬编码 60s 默认值 (#65)
+
+- 429 自动降级：收到 429 后自动尝试下一个可用账号，所有账号耗尽后才返回 429 给客户端 (#65)
+
+- 调度优先级优化：`least_used` 策略新增 `window_reset_at` 二级排序，配额窗口更早重置的账号优先使用 (#65)
+
+- JSON Schema `additionalProperties` 递归注入：`injectAdditionalProperties()` 递归注入 `additionalProperties: false` 到 JSON Schema 所有 object 节点，覆盖 `properties`、`patternProperties`、`$defs`/`definitions`、`items`、`prefixItems`、组合器（`oneOf`/`anyOf`/`allOf`）、条件（`if`/`then`/`else`），含循环检测；三个端点（OpenAI/Gemini/Responses passthrough）统一调用 (#64)
+
+- CONNECT tunnel header 解析：循环跳过中间 header block（CONNECT 200、100 Continue），修复代理模式下 tunnel 的 `HTTP/1.1 200` 被当作真实状态码导致上游 4xx 错误被掩盖为 502 的问题 (#64)
+
+- 上游 HTTP 状态码透传：非流式 collect 路径从错误消息提取真实 HTTP 状态码，不再硬编码 502；提取 `toErrorStatus()` 辅助函数统一 4 处 StatusCode 转换 (#64)
+
+- Dashboard 中英文切换按钮宽度跳变：`StableText` 的 `reference` 从英文硬编码改为 `t()` 动态取值，按钮宽度跟随当前语言自适应
+
+- Dashboard "指纹更新中..." 按钮竖排显示：更新状态按钮添加 `whitespace-nowrap`，防止 CJK 字符逐字换行
+
+- CI 版本跳号（v1.0.28 → v1.0.30）：`sync-electron.yml` 的 `cancel-in-progress` 改为 `false`，避免 workflow 被取消后 tag 已推送但版本号未同步回 master；合并两次 `git push` 为一次减少部分推送窗口
+
+- 混合 plan 账号路由失败：free 和 team/plus 账号混用时，请求 plan 受限模型（如 `gpt-5.4`）可能 fallback 到不兼容的 free 账号导致 400 错误，现在严格按 plan 过滤，无匹配账号时返回明确错误而非降级 (#54)
+
+- `cached_tokens` / `reasoning_tokens` 透传：从 Codex API 响应的 `input_tokens_details` 和 `output_tokens_details` 中提取，传递到 OpenAI（`prompt_tokens_details`）、Anthropic（`cache_read_input_tokens`）、Gemini（`cachedContentTokenCount`）三种格式，覆盖流式和非流式模式 (#55, #58)
+
+- Dashboard 模型选择器使用后端 catalog 的 `isDefault` 字段，替代硬编码 `gpt-5.4`
+
+- Docker 端口修复：锁定容器内 `PORT=8080`（`environment` 覆盖 `env_file`），HEALTHCHECK 固定检查 8080，`.env` 的 PORT 仅控制宿主机暴露端口，修复自定义 PORT 时健康检查失败和端口映射不匹配的问题 (#40)
+
+- Docker Compose 暴露 OAuth 回调端口 1455，修复容器内登录时 "Operation timed out" 的问题
+
+- README Docker 快速开始补充 `cp .env.example .env` 步骤，修复新用户因缺少 `.env` 文件导致 `docker compose up -d` 启动失败的问题 (#38)
+
+- 识别 `response.output_item.done`、`response.incomplete`、`response.queued` Codex SSE 事件，消除 "Unknown event" 日志噪音
+
+- 剥离 `service_tier` 字段：Codex 后端不接受请求体中的 `service_tier`，现在 proxy 在发送前自动移除，修复 `-fast` 后缀导致 "Unsupported service_tier" 报错
+
+- 更新 gpt-5.4 推理等级：`minimal` → `none`，新增 `xhigh`（与后端实际支持的值对齐）
+
+- 添加 `OpenAI-Beta` 请求头：与 Codex Desktop 保持一致（`responses_websockets=2026-02-06`）
+
+- 流式 SSE 请求不再设置 `--max-time` 墙钟超时，修复思考链（reasoning/thinking）在 60 秒处中断的问题；连接保护由 header 超时 + AbortSignal 提供，非流式请求（models、usage）超时不受影响
+
 - Anthropic 路由 `thinking`/`redacted_thinking` content block 验证失败：Claude Code `/compact` 发送含 extended thinking 的对话历史时触发 400 Zod 错误，现已添加到 schema
+
 - Anthropic 路由上下文 token 始终显示 0%：`message_delta` 事件缺少 `input_tokens`，Claude Code 无法计算上下文占比，现在从 `response.completed` 提取后一并返回
+
 - 工具 schema 缺少 `properties` 字段导致 400 错误：MCP 工具发送 `{"type":"object"}` 无 `properties` 时，Codex 后端拒绝请求；现在所有格式转换器（OpenAI/Anthropic/Gemini）统一注入 `properties: {}`（PR #22）
+
 - 额度窗口刷新后 Dashboard 仍显示累计 Token：本地计数器从未按窗口重置，现在 `refreshStatus()` 每次 acquire/getAccounts 时检查 `window_reset_at`，过期自动归零窗口计数器
+
 - 空响应重试循环中账号双重释放：外层 catch 使用原始 `entryId` 而非当前活跃账号，导致换号重试失败时 double-release（`proxy-handler.ts`）
+
 - `apply-update.ts` 模型比较不再误报删除：静态提取只含 2 个硬编码模型，与 YAML 的 24 个比较会产生 22 个假删除，现在只报新增
+
 - `update-checker.ts` 子进程超时保护：`fork()` 添加 5 分钟 kill timer，防止挂起导致 `_updateInProgress` 永久锁定
+
 - `model-fetcher.ts` 初始定时器添加 try/finally，防止异常中断刷新循环
+
 - `apply-update.ts` 移除 `any` 类型（`mutateYaml` 回调参数）
+
 - `ExtractedFingerprint` 接口统一：提取到 `scripts/types.ts` 共享，`extract-fingerprint.ts` 和 `apply-update.ts` 共用
+
 - 强化提示词注入防护：`SUPPRESS_PROMPT` 从弱 "ignore" 措辞改为声明式覆盖（"NOT applicable"、"standard OpenAI API model"），解决 mini 模型仍泄露 Codex Desktop 身份的问题
+
 - 非流式请求错误处理：`collectTranslator` 抛出 generic Error 时返回 502 JSON 而非 500 HTML（`proxy-handler.ts`）
+
 - `desktop-context.md` 提取损坏修复：`extractPrompts()` 的 end marker 从 `` `; `` 改为 `` `[,;)] `` 正则，防止压缩 JS 代码注入 instructions 导致 tool_calls 失效（#13）
+
 - 清除 `config/prompts/desktop-context.md` 中第 71 行起被污染的 ~7KB JS 垃圾代码
+
 - TLS 伪装 profile 确定性解析：用已知 Chrome profile 列表（`KNOWN_CHROME_PROFILES`）替代不可靠的 runtime 检测，确保 `--impersonate` 目标始终有效（如 `chrome137` → `chrome136`）
+
 - FFI transport 硬编码 `"chrome136"` 改为使用统一解析的 profile（`getResolvedProfile()`）
+
 - `getModels()` 死代码：`allModels` 作用域修复，消除不可达分支
+
 - `reloadAllConfigs()` 异步 lazy import 改为同步直接导入，避免日志时序不准
+
 - 模型合并 reasoning efforts 判断逻辑从 `length > 1` 改为显式标志
+
 - `scheduleNext()` 添加 try/finally 防止异常中断刷新循环
+
 - 未认证启动时抑制无意义的 warn 日志
+
 - `getModelCatalog()` / `getModelAliases()` 返回浅拷贝，防止外部意外修改
+
 - `ClaudeCodeSetup.tsx` 文件名与导出名不一致，重命名为 `AnthropicSetup.tsx`
+
 - Dashboard 模型偏好从硬编码 `gpt-5.2-codex` 改为使用 `codex` 别名
+
 - 构建脚本 `vite build --root web` 兼容性问题，改用 `npm run build:web`
+
 - Docker 容器内代理自动检测失败：`detectLocalProxy()` 现在同时探测 `127.0.0.1`（裸机）和 `host.docker.internal`（Docker 容器→宿主机），零配置即生效
+
+### Fixed (pipeline)
+
+- Prompt 提取括号定位修复：`extractPrompts()` 的 `lastIndexOf("[")` 无限回溯导致匹配到无关 `[`，截取错误代码片段产出乱码；改为 50 字符窗口内搜索
+
+- Prompt 覆写安全校验：`savePrompt()` 和 `applyAutoChanges()` 新增内容验证（最小长度 50 字符、乱码行数 ≤3），拒绝将损坏数据写入 `config/prompts/`
+
+- `title-generation.md` 修复：还原因提取 bug 损坏的 title 生成 prompt（第 17-35 行乱码）
+
+### Changed (previous)
+
+- 模型目录大幅更新：后端移除 free 账号的 `gpt-5.4`、`gpt-5.3-codex` 全系列（plus 及以上仍可用），新旗舰模型为 `gpt-5.2-codex`（`codex` 别名指向此模型）
+
+- 新增模型：`gpt-5.2`、`gpt-5.1-codex`、`gpt-5.1`、`gpt-5-codex`、`gpt-5`、`gpt-oss-120b`、`gpt-oss-20b`、`gpt-5-codex-mini`
+
+- 模型目录从 23 个静态模型精简为 11 个（匹配后端实际返回）
 
 ## [v0.8.0](https://github.com/icebear0828/codex-proxy/releases/tag/v0.8.0) - 2026-02-24
 

--- a/tests/unit/ci/changelog-series.test.ts
+++ b/tests/unit/ci/changelog-series.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSeries, syncChangelogSeries } from "../../../.github/scripts/sync-changelog-series.mjs";
+
+describe("syncChangelogSeries", () => {
+  it("moves unreleased entries into the active existing series", () => {
+    const current = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Adds a release-safe changelog synchronizer.
+
+## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
+
+### Fixed
+
+- Keeps prior release history.
+`;
+
+    expect(syncChangelogSeries(current, "2.1")).toBe(`# Changelog
+
+## [Unreleased]
+
+> 暂无已记录的变更。
+
+## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
+
+### Added
+
+- Adds a release-safe changelog synchronizer.
+
+### Fixed
+
+- Keeps prior release history.
+`);
+  });
+
+  it("creates the active series heading when a new major.minor series starts", () => {
+    const current = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Restores release visibility.
+`;
+
+    expect(syncChangelogSeries(current, "3.0")).toBe(`# Changelog
+
+## [Unreleased]
+
+> 暂无已记录的变更。
+
+## [v3.0.x](https://github.com/icebear0828/codex-proxy/releases?q=3.0) - Unreleased
+
+### Fixed
+
+- Restores release visibility.
+`);
+  });
+
+  it("is idempotent after synchronization", () => {
+    const current = `# Changelog
+
+## [Unreleased]
+
+> 暂无已记录的变更。
+
+## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
+`;
+
+    expect(syncChangelogSeries(current, "2.1")).toBe(current);
+  });
+
+  it("merges matching categories instead of duplicating their headings", () => {
+    const current = `# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Restores the current release.
+
+## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
+
+### Fixed
+
+- Keeps prior release history.
+`;
+
+    const updated = syncChangelogSeries(current, "2.1");
+    expect(updated.match(/^### Fixed$/gm)).toHaveLength(1);
+    expect(updated).toContain("- Restores the current release.\n\n- Keeps prior release history.");
+  });
+
+  it("derives the release series from a semantic version", () => {
+    expect(resolveSeries("2.1.5")).toBe("2.1");
+    expect(resolveSeries("3.0.0-beta.1")).toBe("3.0");
+    expect(() => resolveSeries("2.1")).toThrow("Expected a semantic version");
+  });
+});

--- a/tests/unit/ci/package-boundary.test.ts
+++ b/tests/unit/ci/package-boundary.test.ts
@@ -143,6 +143,16 @@ describe("root package boundary", () => {
     // It must still create and push the release tag.
     expect(workflow).toContain('git tag -a "$NEW_TAG"');
     expect(workflow).toContain('git push origin "$NEW_TAG"');
+    expect(workflow.match(/sync-changelog-series\.mjs --check --series "\$SERIES"/g)).toHaveLength(2);
+  });
+
+  it("syncs unreleased changelog entries on dev before a stable bump can run", () => {
+    const workflow = readFileSync(resolve(ROOT, ".github/workflows/sync-changelog-series.yml"), "utf-8");
+
+    expect(workflow).toContain("branches: [dev]");
+    expect(workflow).toContain("ref: dev");
+    expect(workflow).toContain("node .github/scripts/sync-changelog-series.mjs");
+    expect(workflow).toContain("git push origin HEAD:dev");
   });
 
   it("keeps release-note workflow fixes from triggering app releases", () => {

--- a/web/src/components/AccountBulkActions.tsx
+++ b/web/src/components/AccountBulkActions.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "preact/hooks";
 import { useT } from "../../../shared/i18n/context";
+import { accountToolbarControlClass } from "../lib/account-toolbar";
 
 interface AccountBulkActionsProps {
   selectedCount: number;
@@ -34,17 +35,17 @@ export function AccountBulkActions({
 
   return (
     <div class="sticky bottom-0 z-40 bg-white dark:bg-card-dark border-t border-gray-200 dark:border-border-dark shadow-lg px-4 py-3">
-      <div class="flex items-center gap-3 flex-wrap">
+      <div class="flex items-center gap-2 flex-wrap">
         <span class="text-sm font-medium text-slate-700 dark:text-text-main shrink-0">
           {selectedCount} {t("accountsCount")} {t("selected")}
         </span>
 
-        <div class="h-4 w-px bg-gray-200 dark:bg-border-dark hidden sm:block" />
+        <div class="h-4 w-px bg-gray-200 dark:bg-border-dark hidden sm:block mx-1" />
 
         <button
           onClick={onSetActive}
           disabled={loading}
-          class="px-3 py-1.5 text-xs font-medium rounded-lg border border-success/30 bg-success-container text-success hover:bg-success-container/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class={accountToolbarControlClass}
         >
           {t("setActive")}
         </button>
@@ -52,12 +53,12 @@ export function AccountBulkActions({
         <button
           onClick={onSetDisabled}
           disabled={loading}
-          class="px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-200 dark:border-slate-700/40 bg-slate-50 dark:bg-slate-800/20 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          class={accountToolbarControlClass}
         >
           {t("setDisabled")}
         </button>
 
-        <div class="h-4 w-px bg-gray-200 dark:bg-border-dark hidden sm:block" />
+        <div class="h-4 w-px bg-gray-200 dark:bg-border-dark hidden sm:block mx-1" />
 
         {confirming ? (
           <div class="flex items-center gap-2">
@@ -71,7 +72,7 @@ export function AccountBulkActions({
             <button
               onClick={cancelConfirm}
               disabled={loading}
-              class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark text-slate-600 dark:text-text-dim hover:bg-slate-50 dark:hover:bg-border-dark/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              class={accountToolbarControlClass}
             >
               {t("cancel")}
             </button>
@@ -80,7 +81,7 @@ export function AccountBulkActions({
           <button
             onClick={handleDelete}
             disabled={loading}
-            class="px-3 py-1.5 text-xs font-medium rounded-lg border border-danger/30 bg-danger-container text-danger hover:bg-danger-container/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            class={`${accountToolbarControlClass} hover:text-red-500 hover:border-red-300 hover:bg-red-50 dark:hover:bg-red-900/20`}
           >
             {t("batchDelete")}
           </button>

--- a/web/src/components/ApiKeyManager.tsx
+++ b/web/src/components/ApiKeyManager.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useRef } from "preact/hooks";
 import { useApiKeys } from "../../../shared/hooks/use-api-keys";
 import { useT } from "../../../shared/i18n/context";
 import type { ApiKeyCapability, ApiKeyProvider, ApiKeyWire, ApiKeyEntry, CatalogModel } from "../../../shared/hooks/use-api-keys";
+import { accountToolbarIconClass } from "../lib/account-toolbar";
 
 /** Providers whose upstream wire protocol is selectable. */
 const WIRE_SELECTABLE_PROVIDERS: ReadonlySet<ApiKeyProvider> = new Set(["openai", "openrouter", "custom"]);
@@ -504,7 +505,7 @@ export function ApiKeyManager() {
           <button
             onClick={() => fileRef.current?.click()}
             title={t("importApiKeys")}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10"
+            class={accountToolbarIconClass}
           >
             <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12M12 16.5V3" />
@@ -513,7 +514,7 @@ export function ApiKeyManager() {
           <button
             onClick={() => setShowForm(!showForm)}
             title={t("addApiKey")}
-            class="p-1.5 text-slate-400 dark:text-text-dim hover:text-primary transition-colors rounded-md hover:bg-primary/10"
+            class={accountToolbarIconClass}
           >
             <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />

--- a/web/src/components/ProxyPool.tsx
+++ b/web/src/components/ProxyPool.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "preact/hooks";
 import { useT } from "../../../shared/i18n/context";
 import type { TranslationKey } from "../../../shared/i18n/translations";
 import type { ProxiesState } from "../../../shared/hooks/use-proxies";
+import { accountToolbarIconClass } from "../lib/account-toolbar";
 
 const PROTOCOLS = ["http", "https", "socks5", "socks5h"] as const;
 
@@ -174,30 +175,42 @@ export function ProxyPool({ proxies }: ProxyPoolProps) {
             <>
               <button
                 onClick={handleExport}
-                class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
+                title={t("proxyExport")}
+                class={accountToolbarIconClass}
               >
-                {t("proxyExport")}
+                <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+                </svg>
               </button>
               <button
                 onClick={handleCheckAll}
                 disabled={checkingAll}
-                class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors disabled:opacity-50"
+                title={checkingAll ? "..." : t("checkAllHealth")}
+                class={accountToolbarIconClass}
               >
-                {checkingAll ? "..." : t("checkAllHealth")}
+                <svg class={`size-[18px] ${checkingAll ? "animate-pulse" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
               </button>
             </>
           )}
           <button
             onClick={() => setShowImport(!showImport)}
-            class="px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-200 dark:border-border-dark hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
+            title={t("proxyImport")}
+            class={accountToolbarIconClass}
           >
-            {t("proxyImport")}
+            <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12M12 16.5V3" />
+            </svg>
           </button>
           <button
             onClick={() => setShowAdd(!showAdd)}
-            class="px-3 py-1.5 text-xs font-medium rounded-lg bg-primary-action text-white hover:bg-primary-action-hover transition-colors"
+            title={t("addProxy")}
+            class={accountToolbarIconClass}
           >
-            {t("addProxy")}
+            <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+            </svg>
           </button>
         </div>
       </div>
@@ -411,29 +424,39 @@ export function ProxyPool({ proxies }: ProxyPoolProps) {
                     <button
                       onClick={() => handleCheck(proxy.id)}
                       disabled={isChecking}
-                      class="px-2 py-1 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-border-dark transition-colors disabled:opacity-50"
+                      class={accountToolbarIconClass}
                       title={t("checkHealth")}
                     >
-                      {isChecking ? "..." : t("checkHealth")}
+                      <svg class={`size-4 ${isChecking ? "animate-pulse" : ""}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      </svg>
                     </button>
                     {proxy.status === "disabled" ? (
                       <button
                         onClick={() => proxies.enableProxy(proxy.id)}
-                        class="px-2 py-1 text-xs rounded-md hover:bg-green-50 dark:hover:bg-green-900/20 text-green-600 transition-colors"
+                        title={t("enableProxy")}
+                        class={accountToolbarIconClass}
                       >
-                        {t("enableProxy")}
+                        <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 1 0 12.728 12.728 9 9 0 0 0-12.728-12.728Z" />
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 8.25v7.5M13.5 8.25v7.5" />
+                        </svg>
                       </button>
                     ) : (
                       <button
                         onClick={() => proxies.disableProxy(proxy.id)}
-                        class="px-2 py-1 text-xs rounded-md hover:bg-slate-100 dark:hover:bg-border-dark text-slate-500 transition-colors"
+                        title={t("disableProxy")}
+                        class={accountToolbarIconClass}
                       >
-                        {t("disableProxy")}
+                        <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M5.636 5.636a9 9 0 1 0 12.728 12.728 9 9 0 0 0-12.728-12.728Z" />
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 0 1 0 .656l-5.603 3.113a.375.375 0 0 1-.557-.328V8.887c0-.286.307-.466.557-.328l5.603 3.113Z" />
+                        </svg>
                       </button>
                     )}
                     <button
                       onClick={() => handleDelete(proxy.id)}
-                      class="p-1 text-slate-400 dark:text-text-dim hover:text-red-500 transition-colors rounded-md hover:bg-red-50 dark:hover:bg-red-900/20"
+                      class={accountToolbarIconClass}
                       title={t("deleteProxy")}
                     >
                       <svg

--- a/web/src/pages/AccountManagement.tsx
+++ b/web/src/pages/AccountManagement.tsx
@@ -123,7 +123,7 @@ export function AccountManagement({ embedded }: { embedded?: boolean } = {}) {
       )}
 
       {/* Import/Export toolbar (always shown) */}
-      <div class="flex items-center justify-end mb-3">
+      <div class="flex items-center gap-1.5 justify-end mb-3">
         <AccountImportExport
           onExport={exportAccounts}
           onImport={importAccounts}

--- a/web/src/pages/ErrorsPage.tsx
+++ b/web/src/pages/ErrorsPage.tsx
@@ -5,6 +5,7 @@ import {
   type ErrorGroup,
 } from "../../../shared/hooks/use-error-logs";
 import { useT } from "../../../shared/i18n/context";
+import { accountToolbarControlClass, accountToolbarIconClass } from "../lib/account-toolbar";
 
 function sourceBadgeClass(source: string): string {
   switch (source) {
@@ -102,16 +103,23 @@ export function ErrorsPage() {
         <div class="flex items-center gap-2">
           <button
             onClick={() => void refresh()}
-            class="px-3 py-1.5 rounded-lg border border-gray-200 dark:border-border-dark text-xs font-medium text-slate-600 dark:text-text-dim hover:bg-slate-50 dark:hover:bg-border-dark transition-colors"
+            class={accountToolbarIconClass}
+            title={t("errorsRefresh")}
           >
-            {t("errorsRefresh")}
+            <svg class="size-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
           </button>
           {count.unread > 0 && (
             <button
               onClick={() => void markAllSeen()}
-              class="px-3 py-1.5 rounded-lg bg-primary/10 hover:bg-primary/20 text-primary text-xs font-semibold transition-colors"
+              class={accountToolbarControlClass}
             >
-              {t("errorsMarkSeen")} ({count.unread})
+              <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+              <span class="hidden sm:inline">{t("errorsMarkSeen")} ({count.unread})</span>
             </button>
           )}
           {groups.length > 0 && (
@@ -120,7 +128,7 @@ export function ErrorsPage() {
               onClick={() => void clearAll()}
               aria-label={t("errorsClear")}
               title={t("errorsClear")}
-              class="inline-flex size-8 items-center justify-center rounded-lg border border-red-200 text-red-600 hover:bg-red-50 dark:border-red-700/30 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors"
+              class={accountToolbarIconClass}
             >
               <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 6h18" />


### PR DESCRIPTION
## Summary

各页面工具栏按钮风格不一致，部分使用独立颜色类，部分使用通用 ccountToolbarControlClass / ccountToolbarIconClass。本 PR 将管理账号、API Keys、代理池、错误页面的顶部与行内按钮统一改用共享工具类，与首页账号列表工具栏保持一致。

## Changes

- **AccountBulkActions** — 「设为激活」「设为禁用」「取消」「批量删除」按钮改用 ccountToolbarControlClass，删除按钮 hover 时保留红色语义提示
- **ApiKeyManager** — 导入、添加两个图标按钮改用 ccountToolbarIconClass（原为独立 p-1.5 类）
- **ProxyPool** — 顶部导出/检查/导入/添加文字按钮改为 ccountToolbarIconClass 图标按钮；行内每条代理的检查、启用/禁用、删除按钮同步改为图标按钮
- **AccountManagement** — 导入导出工具栏容器补充 gap-1.5
- **ErrorsPage** — 刷新改为图标按钮，标记已读改为图标+文字（移动端隐藏文字），清空改为 ccountToolbarIconClass

## Test Plan

- [x] \
pm run build:web\ — ✅ 81 modules transformed, 0 errors
- [ ] 手动验证：首页、管理账号、API Keys、代理池、错误页面各按钮视觉一致
- [ ] 功能验证：所有按钮点击行为正常（导入/导出/检查/批量操作）

## Notes

- config/default.yaml 中的 pp_version / uild_number 更新未纳入本 PR，保留在工作区。
- 所有图标按钮均通过 	itle 属性保留 tooltip，无障碍访问不受影响。