### PR TITLE
fix(lite): the zip entries were actually stored, not deflated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Fixed
 
+- 修复 No-Node Lite zip 制品全部条目以 STORE（不压缩）模式写入的问题：传给 `writestr()` 的 `ZipInfo` 会忽略归档级压缩配置并默认 `ZIP_STORED`，导致制品体积约为正常 deflate -9 的两倍以上（实测 18.8MB → 3.6MB 量级）；现在为每个文件条目显式设置 `compress_type = ZIP_DEFLATED` 与 `compresslevel=9`，归档级测试新增"文件条目必须为 deflate 且压缩率有效"的防回归断言（`scripts/portable/build-portable.mjs`、`scripts/portable/test-portable.mjs`）。
 - 修复 Dashboard 底栏在更新状态尚未缓存时无法显示 Codex Desktop 版本的问题，并更新 2026 年版权文案。
 
 - 修复速率限制重置卡（Reset Cards）在请求转发后从控制台消失的问题：被动响应头更新 quota 时保留已知的 `reset_credits_available`，并在重置卡查询与消耗逻辑中同步更新账号配额缓存（`src/auth/account-registry.ts`、`src/auth/active-quota-refresher.ts`、`src/routes/accounts.ts`）。

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -252,10 +252,13 @@ function createZip(stage, archive) {
   // Python's zipfile is the only cross-platform deflate implementation with an
   // explicit compression level that the Windows/macOS/Linux runners share; the
   // archive test harness already requires Python 3 for metadata checks.
+  // A ZipInfo passed to writestr() ignores the archive-level compression and
+  // compresslevel and uses ZipInfo's own compress_type, which defaults to
+  // ZIP_STORED — set both explicitly on every file entry.
   const pythonScript = [
     "import os, sys, zipfile",
     "stage, output = sys.argv[1:3]",
-    "with zipfile.ZipFile(output, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:",
+    "with zipfile.ZipFile(output, 'w') as archive:",
     "    for root, dirs, files in os.walk(stage):",
     "        dirs.sort()",
     "        rel_root = os.path.relpath(root, stage).replace('\\\\', '/')",
@@ -269,10 +272,11 @@ function createZip(stage, archive) {
     "            rel = prefix + name",
     "            mode = 0o755 if (rel == 'codex-proxy.sh' or rel.endswith('/codex-proxy.sh')) else 0o644",
     "            info = zipfile.ZipInfo(rel)",
+    "            info.compress_type = zipfile.ZIP_DEFLATED",
     "            info.create_system = 3",
     "            info.external_attr = mode << 16",
     "            with open(os.path.join(root, name), 'rb') as source:",
-    "                archive.writestr(info, source.read())",
+    "                archive.writestr(info, source.read(), compresslevel=9)",
   ].join("\n");
   for (const python of ["python", "python3"]) {
     if (!commandExists(python)) continue;

--- a/scripts/portable/test-portable.mjs
+++ b/scripts/portable/test-portable.mjs
@@ -103,7 +103,7 @@ function extractArchive(archive, destination) {
     "launcher = os.path.join(destination, 'codex-proxy.sh')",
     "if os.path.exists(launcher):",
     "    os.chmod(launcher, os.stat(launcher).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)",
-    "print(json.dumps([{'name': m.filename, 'mode': (m.external_attr >> 16) & 0o7777, 'size': m.file_size, 'isfile': not m.is_dir()} for m in infos]))",
+    "print(json.dumps([{'name': m.filename, 'mode': (m.external_attr >> 16) & 0o7777, 'size': m.file_size, 'packed': m.compress_size, 'method': m.compress_type, 'isfile': not m.is_dir()} for m in infos]))",
   ].join("\n");
   const result = runSync(python, ["-c", script, archive, destination], { timeout: 30_000 });
   if (result.error || result.status !== 0) {
@@ -183,6 +183,26 @@ function archiveContract(entries, extract, options) {
   assert(
     (shellEntry.mode & 0o777) === 0o755,
     "codex-proxy.sh must have mode 0755 in the archive (mode " + shellEntry.mode.toString(8) + ")",
+  );
+
+  // Every regular file must actually be deflated. A regression to ZIP_STORED
+  // (method 0) silently doubles the download size; directory entries stay
+  // stored because they hold no data.
+  const storedFiles = [...files.values()].filter((entry) => entry.method !== 8);
+  if (storedFiles.length > 0) {
+    const worst = [...files.values()].reduce((a, b) => (a.size > b.size ? a : b));
+    assert(false,
+      "Portable archive contains non-deflated file entries (method " +
+      storedFiles.map((entry) => entry.method).join(", ") + "); first offender: " +
+      storedFiles[0].name + "; largest entry " + worst.name + " packs " +
+      worst.packed + "/" + worst.size + " bytes");
+  }
+  const deflatedBytes = [...files.values()].reduce((sum, entry) => sum + entry.packed, 0);
+  const rawBytes = [...files.values()].reduce((sum, entry) => sum + entry.size, 0);
+  assert(
+    rawBytes === 0 || deflatedBytes / rawBytes < 0.95,
+    "Portable archive ratio " + (deflatedBytes / rawBytes).toFixed(3) +
+    " looks like an uncompressed archive; deflate -9 must be effective",
   );
 
   const manifest = JSON.parse(readFileSync(join(extract, "app", "manifest.json"), "utf8"));

--- a/tests/unit/portable/portable-contract.test.ts
+++ b/tests/unit/portable/portable-contract.test.ts
@@ -101,6 +101,7 @@ describe("No-Node Lite distribution contract", () => {
     expect(source).not.toContain('copyDirectory(resolve(ROOT, "native")');
     expect(source).toContain("zipfile.ZipFile");
     expect(source).toContain("compresslevel=9");
+    expect(source).toContain("info.compress_type = zipfile.ZIP_DEFLATED");
     expect(source).toContain("0o755 << 16");
     expect(source).toContain('"--version"');
     expect(source).toContain("PORTABLE_VERSION");
@@ -130,6 +131,7 @@ describe("No-Node Lite distribution contract", () => {
     const source = readFileSync(resolve(PORTABLE, "test-portable.mjs"), "utf8");
     expect(source).toContain("--archive");
     expect(source).toContain("zipfile");
+    expect(source).toContain("non-deflated file entries");
     expect(source).toContain("codex-proxy.sh is not executable");
     expect(source).toContain("CODEX_PROXY_READY=");
     expect(source).toContain("--portable");


### PR DESCRIPTION
While checking the 2.1.6 package I noticed it was suspiciously large (18.8 MB), so I dug in with `zipfile` — turns out **every single entry was STORED (method 0)**. Not one byte was actually compressed. 😅

The root cause is a subtle `zipfile` gotcha on my part: when you pass a `ZipInfo` to `writestr()`, the archive-level `compression=` / `compresslevel=` are ignored and the `ZipInfo`'s own `compress_type` is used — which defaults to `ZIP_STORED`. Since #785 sets the exec bit via `ZipInfo`, every entry silently went through that path. My smoke tests couldn't catch it because a STORE zip is still a perfectly valid zip — the tests just never asserted the compression method.

This PR sets `compress_type = ZIP_DEFLATED` and `compresslevel=9` explicitly on each file entry (directories stay stored, they're empty anyway), and adds two regression assertions to the archive test:

- every regular file entry must use deflate (method 8)
- overall packed/raw ratio must be < 0.95, so "deflate" that compresses nothing also fails

I verified the new assertions do catch the old behavior (a STORE archive fails with the offending entry named).

Size comparison, same content:

| | size |
|---|---|
| stored (broken 2.1.6) | 18.8 MB |
| deflated -9 (this PR, full all-platforms artifact from CI) | 8.5 MB |
| tar.xz for reference | ~4.9 MB |

Also double-checked the CI-built artifact by hand: 32 file entries all deflated, `codex-proxy.sh` keeps mode 0755, CRC check clean, and Windows built-in bsdtar extracts it fine with the launcher still executable.

Lite CI on my fork is green (native matrix + package + cross-platform smoke + musl): the only cancelled job is the macOS runtime smoke, which I cancelled by accident re-dispatching the workflow — happy to re-run it if needed.

Sorry for missing this in #785 — the `-9` in the build log was just the compressor name, and I took it at face value instead of checking the actual output.