### PR TITLE
fix(auth): expose master key in /auth/status without OAuth session

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -29,12 +29,16 @@ export function createAuthRoutes(
     const authenticated = pool.isAuthenticated();
     const userInfo = pool.getUserInfo();
     const config = getConfig();
-    const proxyApiKey = config.server.proxy_api_key ?? pool.getProxyApiKey();
+    // The static master key (server.proxy_api_key) must stay visible even when
+    // there is no OAuth session, so the dashboard can authenticate admin
+    // operations (e.g. client access keys) against it. Only the per-account key
+    // is OAuth-conditional.
+    const proxyApiKey = config.server.proxy_api_key ?? (authenticated ? pool.getProxyApiKey() : null);
     const summary = pool.getPoolSummary();
     return c.json({
       authenticated,
       user: authenticated ? userInfo : null,
-      proxy_api_key: authenticated ? proxyApiKey : null,
+      proxy_api_key: proxyApiKey,
       pool: summary,
     });
   });

--- a/tests/e2e/auth-routes.test.ts
+++ b/tests/e2e/auth-routes.test.ts
@@ -10,6 +10,7 @@ import "@helpers/e2e-setup.js";
 import { createValidJwt, createExpiredJwt } from "@helpers/jwt.js";
 
 import { Hono } from "hono";
+import { getConfig } from "@src/config.js";
 import { requestId } from "@src/middleware/request-id.js";
 import { errorHandler } from "@src/middleware/error-handler.js";
 import { createAuthRoutes } from "@src/routes/auth.js";
@@ -37,6 +38,7 @@ afterAll(() => {
 
 beforeEach(() => {
   pool.clearToken();
+  getConfig().server.proxy_api_key = null;
 });
 
 // ── GET /auth/status ─────────────────────────────────────────────
@@ -88,6 +90,19 @@ describe("GET /auth/status", () => {
     expect(body.pool).toHaveProperty("active");
     expect(body.pool).toHaveProperty("expired");
     expect(body.pool).toHaveProperty("rate_limited");
+  });
+
+  it("exposes the configured master proxy_api_key even without an OAuth session", async () => {
+    getConfig().server.proxy_api_key = "master-secret";
+
+    const res = await app.request("/auth/status");
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      authenticated: boolean;
+      proxy_api_key: string | null;
+    };
+    expect(body.authenticated).toBe(false);
+    expect(body.proxy_api_key).toBe("master-secret");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes creating client access keys (分发 Key) failing with "Master API key required to manage client access keys" whenever no OAuth session is active but `server.proxy_api_key` is configured.

## Root cause

`/auth/status` returned `proxy_api_key` only when `authenticated` (OAuth) was true:

```
proxy_api_key: authenticated ? proxyApiKey : null
```

The static master key `server.proxy_api_key` is independent of OAuth. When only it was configured (no OAuth login) — the normal case for a proxy protected by a master key, including localhost/Electron where the dashboard login gate is bypassed — the frontend received `null`, fell back to the literal `"any-string"`, and sent `Authorization: Bearer any-string`, which never matches the backend master key, producing the 401.

## Fix

Expose the configured `server.proxy_api_key` unconditionally and keep only the per-account derived key gated behind `authenticated`, matching what the client-key admin auth (`getMaster`) actually accepts.

## Test

Added a regression test in `tests/e2e/auth-routes.test.ts` asserting `/auth/status` returns the configured master key even with no OAuth session.

Fixes #788