### PR TITLE
fix(ci): restore PROXY_VERSION injection in docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,11 @@ jobs:
           # ("max(package.json, latest stable tag)") rebuilt vX.Y.Z from
           # newer-than-tag code and silently clobbered the version image.
           ref: ${{ inputs.tag || github.ref }}
+          # Full history + tags: the version step reads stable tags to pick
+          # PROXY_VERSION on branch pushes (package.json patch is stale by
+          # design under the tag-only release scheme).
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve image tags
         id: version
@@ -66,11 +71,35 @@ jobs:
               echo "type=raw,value=latest"
             fi
             echo "type=raw,value=sha-${SHORT_SHA}"
-            if [ -n "$TAG_INPUT" ]; then
-              echo "type=raw,value=${TAG_INPUT}"
-            fi
-            echo "EOF"
+          if [ -n "$TAG_INPUT" ]; then
+            echo "type=raw,value=${TAG_INPUT}"
+          fi
+          echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+          # PROXY_VERSION baked into the image (ENV consumed by
+          # getProxyInfo() — containers have no .git, so without this they
+          # fall back to the stale package.json version). Tag dispatches
+          # report the tag itself; branch pushes report the higher of
+          # package.json and the newest stable tag.
+          if [ -n "$TAG_INPUT" ]; then
+            echo "version=${TAG_INPUT#v}" >> "$GITHUB_OUTPUT"
+          else
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            LATEST_STABLE=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^v//' || echo "0.0.0")
+            FINAL=$(node -e "
+              const cmp = (x, y) => {
+                const pa = x.split('.').map(Number);
+                const pb = y.split('.').map(Number);
+                for (let i = 0; i < 3; i++) {
+                  if (pa[i] !== pb[i]) return pa[i] - pb[i];
+                }
+                return 0;
+              };
+              console.log(cmp('$PKG_VERSION', '$LATEST_STABLE') >= 0 ? '$PKG_VERSION' : '$LATEST_STABLE');
+            ")
+            echo "version=$FINAL" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: docker/setup-qemu-action@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Fixed
 
+- 修复 Docker 镜像版本号显示错误（容器内始终回退到过期的 `package.json` 版本而非实际发布版本，#794）：#673 重构 `docker-publish.yml` 时移除了产生 `outputs.version` 的步骤，而 #677 引入的 `--build-arg PROXY_VERSION` 仍引用该输出，导致注入值为空。恢复 "Resolve image tags" 步骤的 `version` 输出（tag 构建取 tag 本身，分支构建取 `package.json` 与最新 stable tag 的较大者），并在 checkout 中启用 `fetch-tags` 以保证分支构建能读到历史 tag；新增 workflow 输出引用完整性测试防止同类回归。（`.github/workflows/docker-publish.yml`、`tests/unit/ci/workflow-outputs.test.ts`）
 - 修复 No-Node Lite zip 制品全部条目以 STORE（不压缩）模式写入的问题：传给 `writestr()` 的 `ZipInfo` 会忽略归档级压缩配置并默认 `ZIP_STORED`，导致制品体积约为正常 deflate -9 的两倍以上（实测 18.8MB → 3.6MB 量级）；现在为每个文件条目显式设置 `compress_type = ZIP_DEFLATED` 与 `compresslevel=9`，归档级测试新增"文件条目必须为 deflate 且压缩率有效"的防回归断言（`scripts/portable/build-portable.mjs`、`scripts/portable/test-portable.mjs`）。
 - 修复 Dashboard 底栏在更新状态尚未缓存时无法显示 Codex Desktop 版本的问题，并更新 2026 年版权文案。
 

--- a/tests/unit/ci/workflow-outputs.test.ts
+++ b/tests/unit/ci/workflow-outputs.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(__dirname, "..", "..", "..");
+const WORKFLOW_DIR = resolve(ROOT, ".github", "workflows");
+
+type OutputRef = { stepId: string; output: string };
+type Step = { id?: string; run?: string; with?: Record<string, unknown> };
+
+function loadWorkflow(name: string) {
+  const yaml = require("js-yaml") as typeof import("js-yaml");
+  return yaml.load(readFileSync(resolve(WORKFLOW_DIR, name), "utf-8")) as {
+    jobs: Record<string, { steps: Step[] }>;
+  };
+}
+
+/**
+ * Extract steps.X.outputs.Y references from a step's run script or `with`.
+ * GitHub Actions interpolates ${{ steps.<id>.outputs.<name> }} anywhere in a
+ * composite value, so scan raw text rather than parsing structure.
+ */
+function collectOutputRefs(value: unknown): OutputRef[] {
+  const text = typeof value === "string" ? value : JSON.stringify(value) ?? "";
+  const refs: OutputRef[] = [];
+  const pattern = /\$\{\{\s*steps\.([A-Za-z_][\w-]*)\.outputs\.([\w-]+)\s*\}\}/g;
+  for (const match of text.matchAll(pattern)) {
+    refs.push({ stepId: match[1], output: match[2] });
+  }
+  return refs;
+}
+
+/**
+ * v2.1.0–v2.1.6 Docker images shipped with a stale version display
+ * (issue #794): #673 deleted the "Resolve version" step that produced
+ * `outputs.version`, while #677 still passed
+ * `PROXY_VERSION=${{ steps.version.outputs.version }}` to docker build —
+ * an empty value, so containers silently fell back to package.json.
+ * Guard every workflow against dangling steps.*.outputs.* references.
+ */
+describe("workflow output references are satisfied", () => {
+  const workflowFiles = [
+    "docker-publish.yml",
+    "bump-electron.yml",
+    "bump-electron-beta.yml",
+    "release.yml",
+    "promote-dev-to-master.yml",
+    "lite-ci.yml",
+    "ci-docker.yml",
+  ];
+
+  for (const file of workflowFiles) {
+    it(`${file}: every referenced step output is produced by an earlier step`, () => {
+      const workflow = loadWorkflow(file);
+      const producers = new Map<string, Set<string>>();
+      const consumers: { job: string; stepIndex: number; refs: OutputRef[] }[] = [];
+
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        for (const [stepIndex, step] of (job.steps ?? []).entries()) {
+          const refs = [
+            ...collectOutputRefs(step.run),
+            ...collectOutputRefs(step.with),
+          ];
+          if (refs.length > 0) consumers.push({ job: jobName, stepIndex, refs });
+
+          // A step both producing and consuming outputs (inline scripts
+          // writing to GITHUB_OUTPUT) is legal; record its declared id
+          // for later consumers only after collecting its references.
+          if (step.id) {
+            if (!producers.has(step.id)) producers.set(step.id, new Set());
+            producers.get(step.id)!.add("__declared__");
+          }
+        }
+      }
+
+      for (const { job, stepIndex, refs } of consumers) {
+        for (const ref of refs) {
+          const produced = producers.get(ref.stepId);
+          // The step must be declared somewhere in the workflow. We cannot
+          // statically prove which GITHUB_OUTPUT keys a script writes, so a
+          // declared step satisfies any output — but a reference to a
+          // NEVER-declared step id (the #794 failure mode) must fail.
+          expect(
+            produced,
+            `${file}: job "${job}" step #${stepIndex} references ` +
+              `steps.${ref.stepId}.outputs.${ref.output}, but no step with id ` +
+              `"${ref.stepId}" exists (dangling output reference — version ` +
+              `display regression #794 class)`,
+          ).toBeDefined();
+        }
+      }
+    });
+  }
+
+  it("docker-publish bakes a non-empty PROXY_VERSION into the image", () => {
+    const workflow = loadWorkflow("docker-publish.yml");
+    const versionStep = workflow.jobs.publish.steps.find((s) => s.id === "version");
+    expect(versionStep).toBeDefined();
+    // Both selection branches must write a version output: tag dispatch
+    // (echo "version=${TAG_INPUT#v}") and branch push (max of package.json
+    // and newest stable tag).
+    expect(versionStep!.run).toContain('echo "version=${TAG_INPUT#v}"');
+    expect(versionStep!.run).toContain('echo "version=$FINAL"');
+
+    const buildStep = workflow.jobs.publish.steps.find(
+      (s) => s.uses === "docker/build-push-action@v6",
+    );
+    expect(buildStep!.with?.["build-args"]).toContain("PROXY_VERSION=");
+    // Checkout must fetch tags so branch pushes can read stable tags.
+    const checkout = workflow.jobs.publish.steps.find(
+      (s) => s.uses === "actions/checkout@v4",
+    );
+    expect(checkout!.with?.["fetch-tags"]).toBe(true);
+  });
+});

--- a/tests/unit/ci/workflow-outputs.test.ts
+++ b/tests/unit/ci/workflow-outputs.test.ts
@@ -6,7 +6,7 @@ const ROOT = resolve(__dirname, "..", "..", "..");
 const WORKFLOW_DIR = resolve(ROOT, ".github", "workflows");
 
 type OutputRef = { stepId: string; output: string };
-type Step = { id?: string; run?: string; with?: Record<string, unknown> };
+type Step = { id?: string; run?: string; uses?: string; with?: Record<string, unknown> };
 
 function loadWorkflow(name: string) {
   const yaml = require("js-yaml") as typeof import("js-yaml");


### PR DESCRIPTION
## Summary

Docker 镜像自 v2.1.0 起版本号显示错误(容器内始终回退到过期的 `package.json` 版本而非实际发布版本,#794)。#673 重构 `docker-publish.yml` 时移除了产生 `outputs.version` 的步骤,而 #677 引入的 `--build-arg PROXY_VERSION` 仍引用该输出,注入值一直是空;容器内没有 `.git`,`getProxyInfo()` 静默回退到 master 上早已停更的 `package.json`(2.1.1)。

## Changes

- `.github/workflows/docker-publish.yml`:
  - "Resolve image tags" 步骤恢复 `version` 输出:tag 构建取 tag 本身(`${TAG_INPUT#v}`),分支构建取 `package.json` 与最新 stable tag 的较大者(恢复 #676 修复时的原始语义);
  - checkout 恢复 `fetch-depth: 0` + `fetch-tags: true`,否则浅克隆下 `git tag` 读不到历史 tag,分支构建会退化到过期的 package.json 值。
- `tests/unit/ci/workflow-outputs.test.ts`(新增):扫描 7 个 workflow,任何 `steps.X.outputs.Y` 引用指向不存在的 step id 即失败;并断言 docker-publish 的 PROXY_VERSION 两个分支都有取值、checkout 开启 fetch-tags。已验证对修复前的 workflow 正确失败。
- `CHANGELOG.md`:Unreleased/Fixed 补充条目。

## Test Plan

- [x] `npx vitest run tests/unit/ci/workflow-outputs.test.ts tests/unit/ci/package-boundary.test.ts`(21 passed)
- [x] 模拟 GitHub Actions 环境实跑 version 步骤:tag dispatch 输出 tag 版本;branch push 在 package.json 高于/低于最新 tag 两种场景均取较大者
- [x] 对修复前的 workflow 版本(stash 验证)新测试正确失败(防回归有效)
- [x] fork CI quality gate 全绿(pull_request 触发,run 34303526619):package-boundary / backend-tests(307 test files 全过,含新增 workflow-outputs 8 例)/ frontend-tests 三个 job 均 success

## Notes

- 修复只让之后构建的镜像版本号正确;已发布的 v2.1.0–v2.1.6 镜像不变。用户升级到修复后版本时 `getProxyInfo()` 取更高版本的逻辑会让更新检测恢复正常,无需迁移。
- Electron(extraMetadata)、Lite(manifest.json)、源码安装(git describe)链路不受影响,仅 Docker 链路损坏。

## Linked Issues

Closes #794
