### PR TITLE
chore(release): sync package.json version to 2.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-proxy",
-  "version": "2.1.1",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-proxy",
-      "version": "2.1.1",
+      "version": "2.1.6",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-proxy",
-  "version": "2.1.1",
+  "version": "2.1.6",
   "description": "Reverse proxy that exposes Codex Desktop Responses API as OpenAI-compatible /v1/chat/completions",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary

- Bump the root `package.json` version from `2.1.1` to `2.1.6` (the current latest release) and sync `package-lock.json`.

## Problem

The `version` field was never bumped when 2.1.4 / 2.1.5 / 2.1.6 shipped, so every new version still reports `2.1.1` in the dashboard and in auto-update detection logic (`getProxyInfo()` reads `package.json` when the git tag / `PROXY_VERSION` is not available, e.g. the packaged Electron/Lite builds).

Closes #794.

## Test plan

- `package.json` and `package-lock.json` (both the top-level `version` and the root workspace `packages[""].version`) are now `2.1.6`.
- No behavioral change; the fix only corrects the reported version.