### PR TITLE
ci(release): auto-sync package.json version back to dev on stable release

### DIFF
--- a/.github/scripts/sync-package-version.mjs
+++ b/.github/scripts/sync-package-version.mjs
@@ -1,0 +1,22 @@
+// 用法: node .github/scripts/sync-package-version.mjs 2.1.7
+//
+// 幂等地把新版本写入 package.json 顶层、package-lock.json 顶层以及根
+// workspace 入口（packages[""].version）。仅改版本字段，保留依赖/workspaces
+// 等其余内容。由 bump-electron.yml 在稳定发版打 tag 后调用。
+import { readFileSync, writeFileSync } from "node:fs";
+
+const version = process.argv[2];
+if (!/^\d+\.\d+\.\d+$/.test(version ?? "")) {
+  console.error(`usage: sync-package-version.mjs <x.y.z> (got "${version ?? ""}")`);
+  process.exit(2);
+}
+
+for (const f of ["package.json", "package-lock.json"]) {
+  const json = JSON.parse(readFileSync(f, "utf8"));
+  json.version = version;
+  if (f === "package-lock.json" && json.packages?.[""]) {
+    json.packages[""].version = version; // 根 workspace 入口
+  }
+  // 保持 2 空格缩进 + 末尾换行，与现有文件格式一致
+  writeFileSync(f, `${JSON.stringify(json, null, 2)}\n`);
+}

--- a/.github/workflows/bump-electron.yml
+++ b/.github/workflows/bump-electron.yml
@@ -107,11 +107,13 @@ jobs:
             exit 0
           fi
 
-          # Tag-only: do NOT commit package.json onto master. The release
-          # version is read from the tag (release.yml extraMetadata.version),
-          # and a version-bump commit on master cannot FF back to an
-          # always-ahead dev — that drift is what kept breaking promote and
-          # made package.json regress on the next dev→master reconcile.
+          # Tag-only on master: the release version is read from the tag
+          # (release.yml extraMetadata.version). We deliberately do NOT commit
+          # package.json onto master — a version-bump commit there would break
+          # the dev→master fast-forward promote precondition (master would get
+          # a commit dev lacks). Instead, the version is written back to dev in
+          # the "Sync version to dev" step below, so dev always stays ahead of
+          # master by that version-sync commit and promote keeps its FF.
           # major.minor (series) is maintained by developers on dev and flows
           # in via promote; patch is owned entirely by the tag. This mirrors
           # bump-electron-beta.yml, which has always been tag-only.
@@ -149,3 +151,46 @@ jobs:
         # tag input → docker-publish builds FROM the tag and also publishes
         # the ghcr.io vX.Y.Z version image (branch pushes are latest-only).
         run: gh workflow run docker-publish.yml --ref master -f tag="$NEW_TAG"
+
+      - name: Sync version to dev (after new stable tag)
+        # Only runs when a new tag was actually created. The version is written
+        # back to dev (not master): master's package.json always flows up from
+        # dev via promote ff, so a direct master commit would break that FF.
+        # Dev stays ahead of master by this version-sync commit instead.
+        if: steps.bump.outputs.new_tag != ''
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          NEW_VERSION="${NEW_TAG#v}"
+
+          # checkout by default only carries master history — fetch dev explicitly.
+          git fetch origin dev:refs/remotes/origin/dev
+          git switch --detach origin/dev
+
+          node .github/scripts/sync-package-version.mjs "$NEW_VERSION"
+
+          if git diff --quiet -- package.json package-lock.json; then
+            echo "dev 上 package.json 已是 $NEW_VERSION，无需提交"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(version): sync package.json version to $NEW_VERSION [skip ci]"
+
+          # Concurrent dev pushes may make this a non-ff push — retry with
+          # rebase. If it still fails, warn only (do not block the release we
+          # already dispatched): the next stable release will re-sync at a
+          # higher patch and self-heal.
+          for i in 1 2 3; do
+            if git push -q origin HEAD:dev; then
+              echo "已把 package.json 同步到 $NEW_VERSION 提交到 dev"
+              exit 0
+            fi
+            echo "dev push 失败 (第 $i/3 次)，fetch+rebase 后重试..."
+            git fetch origin dev:refs/remotes/origin/dev
+            git rebase origin/dev
+          done
+          echo "::warning::3 次尝试后仍无法把版本同步推送到 dev（下次发版会补上）"


### PR DESCRIPTION
## Summary

- Add `.github/scripts/sync-package-version.mjs`, an idempotent script that writes a given version into `package.json` (top-level) and `package-lock.json` (top-level + root workspace entry `packages[""].version`).
- Wire it into `bump-electron.yml` via a new **"Sync version to dev"** step that runs only when a new stable tag is created.

## Problem

`bump-electron.yml` is tag-only and never updates `package.json`'s `version` field, so it stays stuck at `2.1.1` while `2.1.4/2.1.5/2.1.6` ship. In packaged (Electron/Lite) builds that lack git / `PROXY_VERSION`, `getProxyInfo()` (dashboard UI + auto-update detection) therefore reports a stale version. This is the root cause of #794.

## Why write the version to `dev` (not master)?

`promote-dev-to-master.yml` fast-forwards dev → master and requires `origin/master` to be an ancestor of `origin/dev`. A version-bump commit directly on master would add a commit dev lacks and break that FF precondition (the historical lesson behind the tag-only comment). Writing the version-sync commit to dev keeps dev always ahead of master by that one commit, preserving FF while keeping package.json accurate.

## Behavior

- Failure to push to dev is **warn-only** (3 rebase-retries), it never blocks the already-dispatched release; the next stable release re-syncs at a higher patch and self-heals.
- Commit message `chore(version): ... [skip ci]` matches the release-skip regex, so it won't trigger an extra release or appear in release notes.
- GITHUB_TOKEN pushes don't cascade downstream workflows, so no recursion risk.

Closes #794 (root cause, as a companion to the one-time sync in #798).

## Test plan

- Locally ran the script with `9.9.9`: confirmed `package.json.version`, `package-lock.json.version`, and `package-lock.json.packages[""].version` all updated and **noting else changed** (dependencies/workspaces intact); second run produced no diff (idempotent). Reverted afterwards.
- `js-yaml` parse of `bump-electron.yml` confirms the workflow structure/expression is valid.