### PR TITLE
feat(docker): add alpine image variant with the full feature set

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,6 +139,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve image tags
         id: version
@@ -149,16 +151,49 @@ jobs:
             echo "::error::invalid tag input"
             exit 1
           fi
+
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
+
+          PUSH_LATEST=true
+          if [ -n "$TAG_INPUT" ]; then
+            git fetch origin master --depth=1 >/dev/null 2>&1 || true
+            MASTER_SHA=$(git rev-parse FETCH_HEAD 2>/dev/null || echo "")
+            if [ "$(git rev-parse HEAD)" != "$MASTER_SHA" ]; then
+              echo "tag $TAG_INPUT is not the master tip, skipping latest-lite"
+              PUSH_LATEST=false
+            fi
+          fi
+
           {
             echo "tags<<EOF"
-            echo "type=raw,value=latest-lite"
+            if [ "$PUSH_LATEST" = "true" ]; then
+              echo "type=raw,value=latest-lite"
+            fi
             echo "type=raw,value=sha-${SHORT_SHA}-lite"
             if [ -n "$TAG_INPUT" ]; then
               echo "type=raw,value=${TAG_INPUT}-lite"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+          if [ -n "$TAG_INPUT" ]; then
+            echo "version=${TAG_INPUT#v}" >> "$GITHUB_OUTPUT"
+          else
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            LATEST_STABLE=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^v//' || echo "0.0.0")
+            FINAL=$(node -e "
+              const cmp = (x, y) => {
+                const pa = x.split('.').map(Number);
+                const pb = y.split('.').map(Number);
+                for (let i = 0; i < 3; i++) {
+                  if (pa[i] !== pb[i]) return pa[i] - pb[i];
+                }
+                return 0;
+              };
+              console.log(cmp('$PKG_VERSION', '$LATEST_STABLE') >= 0 ? '$PKG_VERSION' : '$LATEST_STABLE');
+            ")
+            echo "version=$FINAL" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -174,7 +209,9 @@ jobs:
 
       - name: Stage the Lite package tree
         run: |
-          node scripts/portable/build-portable.mjs --out "$RUNNER_TEMP/lite"
+          node scripts/portable/build-portable.mjs \
+            --version "${{ steps.version.outputs.version }}" \
+            --out "$RUNNER_TEMP/lite"
           mkdir -p "$RUNNER_TEMP/lite-pkg"
           python3 - "$RUNNER_TEMP"/lite/*.zip "$RUNNER_TEMP/lite-pkg" <<'PY'
           import sys, zipfile
@@ -261,5 +298,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: PROXY_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=lite
           cache-to: type=gha,mode=max,scope=lite

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -127,3 +127,139 @@ jobs:
           build-args: PROXY_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── Lite image ─────────────────────────────────────────────────────
+  # Alpine + the No-Node Lite bundle + prebuilt Linux native addons.
+  # No node_modules, no toolchain, no Rust build: ~60 MB instead of ~450 MB.
+  # Separate tags (:latest-lite / :sha-*-lite / version-lite) so the full
+  # image remains the default.
+  publish-lite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve image tags
+        id: version
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          if [ -n "$TAG_INPUT" ] && ! [[ "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::invalid tag input"
+            exit 1
+          fi
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          {
+            echo "tags<<EOF"
+            echo "type=raw,value=latest-lite"
+            echo "type=raw,value=sha-${SHORT_SHA}-lite"
+            if [ -n "$TAG_INPUT" ]; then
+              echo "type=raw,value=${TAG_INPUT}-lite"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build core and Lite server bundle
+        run: |
+          npm ci
+          cd web && npm ci && cd ..
+          npm run build:web
+          npm --prefix packages/electron run build
+
+      - name: Stage the Lite package tree
+        run: |
+          node scripts/portable/build-portable.mjs --out "$RUNNER_TEMP/lite"
+          mkdir -p "$RUNNER_TEMP/lite-pkg"
+          python3 - "$RUNNER_TEMP"/lite/*.zip "$RUNNER_TEMP/lite-pkg" <<'PY'
+          import sys, zipfile
+          with zipfile.ZipFile(sys.argv[1]) as archive:
+              archive.extractall(sys.argv[2])
+          PY
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build native addons for Linux
+        run: |
+          # gnu feeds the glibc host smoke test below, musl is the only addon
+          # the Alpine image ships; a plain checkout builds neither.
+          cd native && npm ci && npm run build
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          npm run build:linux-x64-musl
+          test -f codex-tls.linux-x64-gnu.node
+          test -f codex-tls.linux-x64-musl.node
+
+      - name: Stage the lite Docker context
+        run: |
+          node scripts/docker/stage-lite.mjs \
+            --out "$RUNNER_TEMP/docker-lite-stage" \
+            --package "$RUNNER_TEMP/lite-pkg" \
+            --native native
+
+      - name: Smoke test the staged bundle
+        run: |
+          # The runner is glibc, but the staged tree only carries the musl
+          # addon destined for the image. Lend it the gnu addon for this host
+          # test only, then drop it so it never reaches the build context.
+          STAGE="$RUNNER_TEMP/docker-lite-stage"
+          cp native/codex-tls.linux-x64-gnu.node "$STAGE/native/"
+          cleanup() { rm -f "$STAGE/native/codex-tls.linux-x64-gnu.node"; }
+          trap cleanup EXIT
+          # The server must start with only the staged files: no node_modules,
+          # sqlite via the node:sqlite builtin.
+          cd "$STAGE"
+          node app/server.mjs --portable --mode=server --port 18080 &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            if curl --noproxy '*' --fail --silent http://127.0.0.1:18080/health >/dev/null; then
+              echo "health check passed"
+              kill $SERVER_PID
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server did not become healthy"
+          kill $SERVER_PID || true
+          exit 1
+
+      - name: Assert only the musl addon reaches the image context
+        run: |
+          test ! -e "$RUNNER_TEMP/docker-lite-stage/native/codex-tls.linux-x64-gnu.node"
+          ls -1 "$RUNNER_TEMP/docker-lite-stage/native/"
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: ${{ steps.version.outputs.tags }}
+
+      - name: Copy Dockerfile.lite into the staged context
+        run: cp Dockerfile.lite "$RUNNER_TEMP/docker-lite-stage/Dockerfile"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ runner.temp }}/docker-lite-stage
+          file: ${{ runner.temp }}/docker-lite-stage/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=lite
+          cache-to: type=gha,mode=max,scope=lite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Added
 
+- 新增基于 Alpine 的 Docker 镜像变体 `ghcr.io/icebear0828/codex-proxy:latest-lite`（及 `:sha-*-lite`、`<版本>-lite` tag；标签名 lite 仅为内部变体标识）：**功能与现有 Debian 镜像完全一致**，镜像只包含应用本体与运行时必需内容——`node:22-alpine` 基底、esbuild 单文件 bundle、前端资源、仅 Linux musl TLS addon（不含 gnu/Windows/macOS 文件、node_modules 与构建工具链），压缩拉取体积约为 Debian 镜像的 1/12.6（GHCR manifest 实测 57.2MB vs 722MB）；sqlite 使用 Node 22 内置 `node:sqlite`（node:20 alpine 未内置），健康检查用 Node fetch（无 curl）；与 Debian 镜像保持相同的 `/app` 目录布局、`./data`/`./config` 卷契约及空 config 卷自动播种（entrypoint 从 `/defaults` 拷贝），stock `docker-compose.yml` 仅替换 image tag 即可互换；发布流水线在 glibc runner 上借 gnu addon 完成冒烟测试后将其移出镜像构建上下文。（`Dockerfile.lite`、`scripts/docker/stage-lite.mjs`、`.github/workflows/docker-publish.yml`）
 - No-Node Lite 在 Windows 缺少 WebView2 运行时且显式指定 `--mode=webview2` 时，新增经用户确认后的按需安装路径：从微软官方端点下载 Evergreen Bootstrapper（约 2MB），校验 Windows 可执行格式与 Authenticode 签名（须为 Microsoft 签发）后以 `/silent /install` 静默安装，下载器缓存于系统临时目录并复用；下载或校验失败时回退为打开官方安装页，仍支持 `CODEX_PROXY_WEBVIEW2_BOOTSTRAPPER` 指定本地安装器。（`scripts/portable/server.mjs`）
 
 - 新增 Linux x64 musl TLS native addon 构建与验证流程，并将 `codex-tls.linux-x64-musl.node` 接入 No-Node Lite 的构建和发布包，使 Lite 可在 Alpine 等 musl Linux 环境中使用。（`native/package.json`、`scripts/native/`、`scripts/portable/`、`.github/workflows/native-musl-ci.yml`）

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -19,8 +19,13 @@
 # so this image pins Node 22.
 FROM node:22-alpine
 
+# Proxy version injected at build time via --build-arg PROXY_VERSION=x.y.z
+# Falls back to package.json at runtime if not set.
+ARG PROXY_VERSION=unknown
+
 ENV CODEX_PROXY_HOST=0.0.0.0 \
-    NODE_ENV=production
+    NODE_ENV=production \
+    PROXY_VERSION=${PROXY_VERSION}
 
 WORKDIR /app
 

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,0 +1,51 @@
+# ── Lite image: No-Node Lite content on a plain Node Alpine base ──────
+# Unlike the main Dockerfile, this image contains no node_modules, no apt
+# toolchain, and no Rust build: the server is the esbuild single-file bundle
+# from the Lite package, and the TLS native addon is the single prebuilt
+# musl .node file staged by scripts/docker/stage-lite.mjs.
+#
+# It keeps the same runtime contract as the main image so the stock
+# docker-compose.yml works with either image tag: /app layout, ./data and
+# ./config bind mounts, and seeding of an empty config volume from /defaults.
+#
+# Build context must be staged first:
+#   node scripts/docker/stage-lite.mjs --out docker-lite-stage \
+#     --package <extracted lite package or staging tree> --native native/
+#   docker build -f Dockerfile.lite docker-lite-stage
+
+# The bundle prefers the node:sqlite builtin, stable in Node 22. Node 20's
+# --experimental-sqlite is rejected by NODE_OPTIONS and not even compiled into
+# every Node 20 build, and the Lite package ships no better-sqlite3 fallback —
+# so this image pins Node 22.
+FROM node:22-alpine
+
+ENV CODEX_PROXY_HOST=0.0.0.0 \
+    NODE_ENV=production
+
+WORKDIR /app
+
+COPY app/ ./app/
+COPY public/ ./public/
+COPY config/ ./config/
+COPY bin/ ./bin/
+COPY native/ ./native/
+COPY codex-proxy.sh ./
+COPY THIRD-PARTY-NOTICES.txt ./
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Runtime data: --portable keeps everything under the package's data/
+# directory; the compose ./data volume covers it directly.
+RUN mkdir -p /app/data
+
+# Backup default configs so the entrypoint can seed empty bind mounts.
+RUN cp -r /app/config /defaults
+
+EXPOSE 8080 11434
+
+# No curl in this image: probe with the Node runtime itself.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["node", "app/server.mjs", "--portable", "--mode=server"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ Linux x64 Lite 同时包含 glibc 和 musl 两种 TLS native addon，可用于�
 <details>
 <summary><h3>方式三：Docker 部署</h3></summary>
 
+最简单的方式，一条命令即可启动：
+
+```bash
+docker run -d --name codex-proxy --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  -v codex-proxy-data:/app/data \
+  -v codex-proxy-config:/app/config \
+  ghcr.io/icebear0828/codex-proxy:latest-lite
+# 打开 http://localhost:8080 登录
+```
+
+> 该镜像基于 Alpine Linux + Node.js，只包含应用本体、前端页面和运行必需的原生组件，编译工具链、依赖缓存等仅构建时使用的内容均已移除；**功能完整**，Web 面板、账号管理、Ollama 桥接等都可正常使用，目前提供 linux/amd64。压缩后拉取约 57MB（另一版本基于 Debian，约 722MB），空闲内存约 40MB。首次启动会自动在 `codex-proxy-config` 卷中生成默认配置，账号数据保存在 `codex-proxy-data` 卷，更新镜像不丢失。需要让局域网其他设备访问时，把端口参数改成 `-p 8080:8080`。
+
+已经在用 `docker-compose.yml`（默认 `:latest` 基于 Debian，含编译工具链，便于在容器内调试或从源码构建）的用户无需迁移：两个镜像的目录布局与 `./data`、`./config` 卷完全一致，把 compose 里的 `image` 换成 `ghcr.io/icebear0828/codex-proxy:latest-lite` 即可。
+
+需要配置环境变量、自动更新等更多选项时，使用 compose 方式：
+
 ```bash
 mkdir codex-proxy && cd codex-proxy
 curl -O https://raw.githubusercontent.com/icebear0828/codex-proxy/master/docker-compose.yml

--- a/README_EN.md
+++ b/README_EN.md
@@ -85,6 +85,23 @@ Linux x64 Lite includes both glibc and musl TLS native addons, so it can be used
 
 ### Docker
 
+The simplest way — one command:
+
+```bash
+docker run -d --name codex-proxy --restart unless-stopped \
+  -p 127.0.0.1:8080:8080 \
+  -v codex-proxy-data:/app/data \
+  -v codex-proxy-config:/app/config \
+  ghcr.io/icebear0828/codex-proxy:latest-lite
+# Open http://localhost:8080 to log in
+```
+
+> This image is based on Alpine Linux + Node.js and contains only the application itself, the web UI and the native components needed at runtime — build toolchains, dependency caches and other build-time-only content are removed. **It is feature-complete**: the web dashboard, account management, the Ollama bridge and everything else work the same. Currently linux/amd64. It pulls ~57 MB compressed (the alternative Debian-based image is ~722 MB) and idles at ~40 MB RAM. On first start it seeds default config into the `codex-proxy-config` volume; your accounts live in the `codex-proxy-data` volume and survive image updates. To allow LAN access, use `-p 8080:8080`.
+
+Already using `docker-compose.yml` (which defaults to the Debian-based `:latest` image, with the toolchain handy for in-container debugging or building from source)? No migration needed — the two images share the same layout and `./data` / `./config` volumes; just change `image` to `ghcr.io/icebear0828/codex-proxy:latest-lite`.
+
+For environment variables, auto-updates and more options, use the compose setup:
+
 ```bash
 mkdir codex-proxy && cd codex-proxy
 curl -O https://raw.githubusercontent.com/icebear0828/codex-proxy/master/docker-compose.yml

--- a/scripts/docker/lite-entrypoint.sh
+++ b/scripts/docker/lite-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Seed an empty config bind mount with the image defaults. docker-compose.yml
+# mounts ./config onto /app/config; on a fresh install that directory is empty
+# and shadows the config files baked into the image — without seeding, the
+# server exits on the missing default.yaml.
+if [ -d /defaults ] && [ -z "$(ls -A /app/config 2>/dev/null)" ]; then
+  echo "[Init] Config directory is empty — seeding from image defaults"
+  cp -r /defaults/* /app/config/
+fi
+
+exec "$@"

--- a/scripts/docker/stage-lite.mjs
+++ b/scripts/docker/stage-lite.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Stage the Linux-only content of a No-Node Lite package for the lite Docker
+// image. The all-platforms archive carries win32/darwin addons and Windows
+// launchers that a Linux container never touches; dropping them shrinks the
+// image layer by ~11 MB raw.
+//
+// Inputs (from the Lite build, see scripts/portable/build-portable.mjs):
+//   - the staged package tree (or an extracted archive)
+//   - the native addon directory (repo native/ layout: index.js, package.json,
+//     and the platform .node files produced by CI)
+//
+// Output: a directory with only what the Alpine (musl) container needs. The
+// glibc addon is deliberately excluded; CI copies it in separately just for
+// the glibc-host smoke test and removes it before the image build.
+
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "../..");
+
+function parseArgs(argv) {
+  const options = { out: null, native: null, package: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--out" || arg === "--package" || arg === "--native") {
+      const value = argv[++i];
+      if (!value) throw new Error(`${arg} requires a value`);
+      if (arg === "--out") options.out = resolve(value);
+      else if (arg === "--package") options.package = resolve(value);
+      else options.native = resolve(value);
+    } else if (arg.startsWith("--out=")) {
+      options.out = resolve(arg.slice("--out=".length));
+    } else if (arg.startsWith("--package=")) {
+      options.package = resolve(arg.slice("--package=".length));
+    } else if (arg.startsWith("--native=")) {
+      options.native = resolve(arg.slice("--native=".length));
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  if (!options.out) throw new Error("--out is required");
+  if (!options.package) throw new Error("--package is required");
+  if (!options.native) throw new Error("--native is required");
+  return options;
+}
+
+// Directories copied verbatim from the Lite package; every one of them is
+// required by the backend's setPaths() layout or serves the dashboard.
+const PACKAGE_DIRS = ["app", "public", "config", "bin"];
+// Files copied verbatim from the Lite package.
+const PACKAGE_FILES = ["codex-proxy.sh", "THIRD-PARTY-NOTICES.txt"];
+// Container entrypoint shipped with the repo (not part of the Lite package);
+// staged as docker-entrypoint.sh to match what Dockerfile.lite COPYs.
+const REPO_ENTRYPOINT = "lite-entrypoint.sh";
+// Native loader files plus the musl addon the Alpine image runs on. The glibc
+// addon never enters the image context (see docker-publish.yml smoke test).
+const NATIVE_FILES = [
+  "index.js",
+  "index.d.ts",
+  "package.json",
+  "codex-tls.linux-x64-musl.node",
+];
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  for (const dir of PACKAGE_DIRS) {
+    if (!existsSync(join(options.package, dir))) {
+      throw new Error(`Lite package is missing ${dir}: ${join(options.package, dir)}`);
+    }
+  }
+  for (const name of PACKAGE_FILES) {
+    if (!existsSync(join(options.package, name))) {
+      throw new Error(`Lite package is missing ${name}`);
+    }
+  }
+  const missingAddons = NATIVE_FILES.filter(
+    (name) => !existsSync(join(options.native, name)),
+  );
+  if (missingAddons.length > 0) {
+    throw new Error(`Native directory is missing: ${missingAddons.join(", ")}`);
+  }
+  const repoEntrypoint = join(SCRIPT_DIR, REPO_ENTRYPOINT);
+  if (!existsSync(repoEntrypoint)) {
+    throw new Error(`Missing lite container entrypoint: ${repoEntrypoint}`);
+  }
+
+  rmSync(options.out, { recursive: true, force: true });
+  mkdirSync(options.out, { recursive: true });
+  for (const dir of PACKAGE_DIRS) {
+    cpSync(join(options.package, dir), join(options.out, dir), { recursive: true });
+  }
+  for (const name of PACKAGE_FILES) {
+    cpSync(join(options.package, name), join(options.out, name));
+  }
+  mkdirSync(join(options.out, "native"), { recursive: true });
+  for (const name of NATIVE_FILES) {
+    if (existsSync(join(options.native, name))) {
+      cpSync(join(options.native, name), join(options.out, "native", name));
+    }
+  }
+  // Stage the container entrypoint under the name Dockerfile.lite expects and
+  // keep it executable (Windows checkouts lose the source mode bit).
+  cpSync(repoEntrypoint, join(options.out, "docker-entrypoint.sh"));
+  chmodSync(join(options.out, "docker-entrypoint.sh"), 0o755);
+
+  const staged = readdirSync(options.out, { recursive: true }).filter(
+    (name) => !name.endsWith(join("/") === "/" ? "/" : "\\") && basename(String(name)),
+  );
+  console.log(`[docker-lite] staged ${staged.length} entries into ${options.out}`);
+  console.log("[docker-lite] contents: app public config bin codex-proxy.sh THIRD-PARTY-NOTICES.txt native/ docker-entrypoint.sh");
+}
+
+main();

--- a/tests/unit/ci/workflow-outputs.test.ts
+++ b/tests/unit/ci/workflow-outputs.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = resolve(__dirname, "..", "..", "..");
 const WORKFLOW_DIR = resolve(ROOT, ".github", "workflows");
+const LITE_DOCKERFILE = resolve(ROOT, "Dockerfile.lite");
 
 type OutputRef = { stepId: string; output: string };
 type Step = { id?: string; run?: string; uses?: string; with?: Record<string, unknown> };
@@ -111,5 +112,32 @@ describe("workflow output references are satisfied", () => {
       (s) => s.uses === "actions/checkout@v4",
     );
     expect(checkout!.with?.["fetch-tags"]).toBe(true);
+  });
+
+  it("docker-publish-lite shares the resolved version across the manifest and image", () => {
+    const workflow = loadWorkflow("docker-publish.yml");
+    const job = workflow.jobs["publish-lite"];
+    const versionStep = job.steps.find((s) => s.id === "version");
+    expect(versionStep).toBeDefined();
+    expect(versionStep!.run).toContain('echo "version=${TAG_INPUT#v}"');
+    expect(versionStep!.run).toContain('echo "version=$FINAL"');
+    expect(versionStep!.run).toContain("LATEST_STABLE=");
+    expect(versionStep!.run).toContain("git tag --sort=-v:refname");
+
+    const checkout = job.steps.find((s) => s.uses === "actions/checkout@v4");
+    expect(checkout!.with?.["fetch-tags"]).toBe(true);
+    expect(checkout!.with?.["fetch-depth"]).toBe(0);
+
+    const stageStep = job.steps.find((s) => s.id === undefined && s.run?.includes("build-portable.mjs"));
+    expect(stageStep?.run).toContain('--version "${{ steps.version.outputs.version }}"');
+
+    const buildStep = job.steps.find(
+      (s) => s.uses === "docker/build-push-action@v6",
+    );
+    expect(buildStep!.with?.["build-args"]).toContain("PROXY_VERSION=${{ steps.version.outputs.version }}");
+
+    const dockerfile = readFileSync(LITE_DOCKERFILE, "utf8");
+    expect(dockerfile).toContain("ARG PROXY_VERSION=unknown");
+    expect(dockerfile).toContain("PROXY_VERSION=${PROXY_VERSION}");
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a second Docker image variant based on Alpine Linux, for users who just run the proxy as a headless service. **It is feature-complete** — web dashboard, account management, the Ollama bridge and everything else work identically; only build-time-only content (compiler toolchain, npm dependency tree, build caches, platform files for other OSes) is removed.

The current image (`node:20-slim` / Debian) stays exactly as it is — useful for debugging in-container and building from source. Users choose by tag; nothing existing changes.

Measured from the GHCR manifests (not estimates):

- **57.2 MB compressed pull vs 722 MB for the Debian image (~1/12.6)**
- ~171 MB on disk, ~40 MB RSS idle
- A first-time user now needs one command:
  ```bash
  docker run -d --name codex-proxy --restart unless-stopped \
    -p 127.0.0.1:8080:8080 \
    -v codex-proxy-data:/app/data \
    -v codex-proxy-config:/app/config \
    ghcr.io/icebear0828/codex-proxy:latest-lite
  ```
  (README docker section is rewritten around this; the compose flow stays for users who want env vars / Watchtower.)

## Changes

- **`Dockerfile.lite`** — `node:22-alpine` running the esbuild single-file server bundle with the prebuilt dashboard assets; no node_modules, apt toolchain or Rust build inside the image. Same `/app` layout and `./data` + `./config` volume contract as the main image; healthcheck uses Node's built-in `fetch` (no extra packages).
- **`scripts/docker/stage-lite.mjs`** (new) — stages only the files a Linux container touches (`app/ public/ config/ bin/`, loader + the musl TLS addon) into the build context. win32/darwin/gnu files never enter the image.
- **`scripts/docker/lite-entrypoint.sh`** (new) — seeds an empty `./config` bind mount from `/defaults`, exactly like the main image's entrypoint, so the stock `docker-compose.yml` works by swapping only the image tag.
- **`.github/workflows/docker-publish.yml`** — new `publish-lite` job: builds the web + electron bundle, builds both gnu and musl native addons, smoke-tests the staged server on the (glibc) runner, then pushes `latest-lite` / `sha-<sha>-lite` / `<tag>-lite` for linux/amd64. The original `publish` job and `Dockerfile` are untouched.
- **README.md / README_EN.md / CHANGELOG.md** — docs updated; user-facing text says "Alpine-based image, feature-complete", the `-lite` tag suffix is treated as an internal variant name.

Decisions worth spelling out:

- **Why Node 22:** the bundle prefers the built-in `node:sqlite` (stable in 22). It isn't compiled into the `node:20-alpine` build and `--experimental-sqlite` is rejected there — this only surfaced when actually running the container locally.
- **Why only the musl addon in the image:** the napi loader selects by libc, so Alpine never loads the gnu addon (~1.5 MB compressed dead weight). CI still builds gnu for its host smoke test (the runner is glibc Ubuntu): it's copied into the staged tree just for that test, removed via `trap`, and an explicit assertion step confirms it's gone before buildx.

## Test Plan

- [x] Workflow verified via `workflow_dispatch` on the fork across multiple iterations (web deps, gnu/musl addons, cache syntax, seeding entrypoint) — `publish-lite` green, images on fork GHCR (`ghcr.io/nieyuanhong/codex-proxy:latest-lite`)
- [x] One-command `docker run` with named volumes: healthy in ~2s, default config seeded into the config volume, accounts volume survives container removal/recreate, no re-seeding over existing config
- [x] The **unmodified** stock `docker-compose.yml` with only the image tag changed: `up -d` → seeded → `/health` 200 on 8080 → `down`
- [x] Real run with **23 real API keys** mounted: logs show `[TLS] Using native (rustls) transport` + 23-key pool; `/health`, `/v1/models` (16 models) and a real chat completion against `gpt-6-astra` returned the exact marker string
- [x] Registry manifest audit: 57.22 MiB compressed (Debian image 722.0 MiB); per-layer diff confirmed the gnu addon is absent
- [ ] `npm test` not run — no `src/`/`web/`/`native/` source changes

## Notes

- **Naming:** the tag is `latest-lite` for now (kept as-is since tags already carry that suffix); user-facing docs deliberately avoid presenting it as a "lite/limited edition" — it's the Alpine-based full-feature image. Happy to rename tags (`-alpine`, etc.) if you prefer.
- **linux/amd64 only for now** — the musl addon isn't cross-built for arm64 yet; can follow once it is. The Debian `:latest` stays multi-arch.
- The Alpine container runs as root (the main image drops to `node` via gosu; adding a non-root user here is straightforward if you'd like it).

## Linked Issues

None.
