### PR TITLE
fix(docker): stamp image package version

### DIFF
--- a/.github/scripts/sync-package-version.mjs
+++ b/.github/scripts/sync-package-version.mjs
@@ -1,4 +1,4 @@
-// 用法: node .github/scripts/sync-package-version.mjs 2.1.7
+// 用法: node .github/scripts/sync-package-version.mjs 2.1.7[-beta.1]
 //
 // 幂等地把新版本写入 package.json 顶层、package-lock.json 顶层以及根
 // workspace 入口（packages[""].version）。仅改版本字段，保留依赖/workspaces
@@ -6,8 +6,8 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
 const version = process.argv[2];
-if (!/^\d+\.\d+\.\d+$/.test(version ?? "")) {
-  console.error(`usage: sync-package-version.mjs <x.y.z> (got "${version ?? ""}")`);
+if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version ?? "")) {
+  console.error(`usage: sync-package-version.mjs <x.y.z[-prerelease]> (got "${version ?? ""}")`);
   process.exit(2);
 }
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "Dockerfile"
+      - "Dockerfile.lite"
       - "docker-entrypoint.sh"
       - "docker-healthcheck.sh"
       - "docker-compose.yml"
@@ -33,8 +34,9 @@ jobs:
 
       - name: Build Docker image
         run: |
-          PKG_VER=$(node -p "require('./package.json').version")
-          docker build -t codex-proxy:smoke --build-arg PROXY_VERSION="$PKG_VER" .
+          SMOKE_VERSION=99.99.99
+          docker build -t codex-proxy:smoke --build-arg PROXY_VERSION="$SMOKE_VERSION" .
+          echo "SMOKE_VERSION=$SMOKE_VERSION" >> "$GITHUB_ENV"
 
       - name: Start container
         run: |
@@ -79,12 +81,13 @@ jobs:
 
       - name: Verify PROXY_VERSION is injected
         run: |
-          PKG_VER=$(node -p "require('./package.json').version")
           CONTAINER_VER=$(docker run --rm codex-proxy:smoke \
             node -e "const m=require('./dist/self-update.js'); process.stdout.write(m.getProxyInfo().version ?? '')")
-          echo "Expected: $PKG_VER  Got: $CONTAINER_VER"
-          if [ "$CONTAINER_VER" != "$PKG_VER" ]; then
-            echo "::error::PROXY_VERSION mismatch: expected $PKG_VER, got $CONTAINER_VER"
+          PACKAGE_VER=$(docker run --rm codex-proxy:smoke \
+            node -p "require('./package.json').version")
+          echo "Expected: $SMOKE_VERSION  Runtime: $CONTAINER_VER  Package: $PACKAGE_VER"
+          if [ "$CONTAINER_VER" != "$SMOKE_VERSION" ] || [ "$PACKAGE_VER" != "$SMOKE_VERSION" ]; then
+            echo "::error::Docker version mismatch: expected $SMOKE_VERSION, runtime $CONTAINER_VER, package $PACKAGE_VER"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ## [Unreleased]
 
-> 暂无已记录的变更。
+### Fixed
+
+- 修复发布 Docker 镜像内根 `package.json` / `package-lock.json` 仍保留旧版本的问题：构建时将解析出的 `PROXY_VERSION` 同步写入包元数据，并让 Docker smoke test 校验运行时版本与包元数据一致（`Dockerfile`、`.github/scripts/sync-package-version.mjs`、`.github/workflows/ci-docker.yml`）。
 
 ## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,13 @@ RUN cd web && npm ci
 # 3) Copy source
 COPY . .
 
+# Release tags are authoritative for Docker images, while package.json on the
+# tagged master commit may intentionally lag behind under the tag-only release
+# flow. Keep package metadata inside the image aligned with the baked version.
+RUN if [ "$PROXY_VERSION" != "unknown" ]; then \
+      node .github/scripts/sync-package-version.mjs "$PROXY_VERSION"; \
+    fi
+
 # 4) Copy native addon from builder stage (overwrite macOS .node if present)
 COPY --from=native-builder /native/codex-tls.linux-*.node /app/native/
 

--- a/tests/unit/ci/workflow-outputs.test.ts
+++ b/tests/unit/ci/workflow-outputs.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const ROOT = resolve(__dirname, "..", "..", "..");
 const WORKFLOW_DIR = resolve(ROOT, ".github", "workflows");
+const DOCKERFILE = resolve(ROOT, "Dockerfile");
 const LITE_DOCKERFILE = resolve(ROOT, "Dockerfile.lite");
 
 type OutputRef = { stepId: string; output: string };
@@ -112,6 +113,16 @@ describe("workflow output references are satisfied", () => {
       (s) => s.uses === "actions/checkout@v4",
     );
     expect(checkout!.with?.["fetch-tags"]).toBe(true);
+
+    const dockerfile = readFileSync(DOCKERFILE, "utf8");
+    expect(dockerfile).toContain('sync-package-version.mjs "$PROXY_VERSION"');
+  });
+
+  it("docker smoke test rejects version metadata drift", () => {
+    const ciDocker = readFileSync(resolve(WORKFLOW_DIR, "ci-docker.yml"), "utf8");
+    expect(ciDocker).toContain("SMOKE_VERSION=99.99.99");
+    expect(ciDocker).toContain("PACKAGE_VER=$(docker run --rm codex-proxy:smoke");
+    expect(ciDocker).toContain("Docker version mismatch");
   });
 
   it("docker-publish-lite shares the resolved version across the manifest and image", () => {


### PR DESCRIPTION
## Summary / 摘要

Published Docker images now keep their root package metadata aligned with the version baked into `PROXY_VERSION`. This removes the remaining mismatch where the dashboard/runtime could report the release version while `/app/package.json` still contained the previous version.

发布的 Docker 镜像现在会把根包元数据同步为镜像内置的 `PROXY_VERSION`，修复运行时显示发布版本但 `/app/package.json` 仍停留在旧版本的问题。

## Changes / 变更

- Stamp `package.json`, the root `package-lock.json` version, and its workspace root version after the Docker source is copied, while preserving the tag-only release flow (`Dockerfile`, `.github/scripts/sync-package-version.mjs`).
- Allow the existing version sync script to accept prerelease versions used by Docker tag inputs.
- Make Docker smoke CI use an independent synthetic version and verify both `getProxyInfo()` and `/app/package.json`, so a stale package fallback cannot pass (`.github/workflows/ci-docker.yml`).
- Add the fix to the Unreleased changelog and static workflow regression coverage.

- Docker 构建完成源码拷贝后，同步 `package.json`、根 `package-lock.json` 及 workspace 根版本，不改变现有 tag-only 发版流程（`Dockerfile`、`.github/scripts/sync-package-version.mjs`）。
- 版本同步脚本支持 Docker tag 输入可能使用的 prerelease 版本。
- Docker smoke CI 使用独立测试版本，同时检查 `getProxyInfo()` 与容器内 `/app/package.json`，防止旧包版本回退后仍误判通过（`.github/workflows/ci-docker.yml`）。
- 增加 Unreleased 变更记录和静态回归覆盖。

## Test Plan / 测试计划

- [x] `npm exec -- vitest run tests/unit/ci/workflow-outputs.test.ts` — 10 tests passed
- [x] `node --check .github/scripts/sync-package-version.mjs`
- [x] Temporary-directory validation of `sync-package-version.mjs 2.1.7-beta.1` — package and lock metadata all synchronized
- [x] `git diff --check`
- [ ] Docker build — Docker CLI is unavailable in the local Windows environment; the updated GitHub Actions Docker smoke workflow must provide the build/runtime verification

## Notes / 备注

The current GHCR `latest` and `v2.1.7` images were independently inspected before this change and already had `PROXY_VERSION=2.1.7`; this PR closes the remaining package-metadata drift and strengthens the regression test.

本地没有 Docker CLI，无法在工作站构建镜像；已核验当前 GHCR 镜像环境变量为 `PROXY_VERSION=2.1.7`，本 PR 补齐镜像包元数据同步并加强回归检查。

## Linked Issues / 关联 Issue

Refs #676, #794