### PR TITLE
fix(ci): build lite musl addon in Alpine and smoke-test the pushed image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -222,14 +222,41 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build native addons for Linux
+      - name: Build musl native addon in Alpine
         run: |
-          # gnu feeds the glibc host smoke test below, musl is the only addon
-          # the Alpine image ships; a plain checkout builds neither.
+          # The musl addon must be linked against musl. Cross-building with
+          # the musl target on the glibc runner links C dependencies (aws-lc)
+          # against glibc, producing a hybrid binary that crashes in the
+          # Alpine image with "ld-linux-x86-64.so.2 not found" (#805). Build
+          # inside the same Alpine container the Lite release workflows use.
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE/native:/build" \
+            -v "$GITHUB_WORKSPACE/scripts:/scripts:ro" \
+            -w /build \
+            ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine \
+            sh -lc 'set -eu; apk add --no-cache build-base linux-headers; rustup toolchain install 1.88.0 --profile minimal --no-self-update; rustup target add x86_64-unknown-linux-musl --toolchain 1.88.0; export RUSTUP_TOOLCHAIN=1.88.0; export CC_x86_64_unknown_linux_musl=gcc; export CXX_x86_64_unknown_linux_musl=g++; export AWS_LC_SYS_CC_x86_64_unknown_linux_musl=gcc; export AWS_LC_SYS_CXX_x86_64_unknown_linux_musl=g++; npm ci --include=dev --ignore-scripts --no-audit --no-fund; npm run build:linux-x64-musl; node /scripts/native/test-linux-x64-musl.mjs /build/codex-tls.linux-x64-musl.node'
+
+      - name: Verify musl addon is not glibc-linked
+        run: |
+          addon="native/codex-tls.linux-x64-musl.node"
+          file "$addon"
+          if readelf -d "$addon" | grep -Eq 'libc\.so\.6|ld-linux-x86-64\.so\.2'; then
+            echo "::error::musl addon unexpectedly depends on glibc"
+            exit 1
+          fi
+          if readelf --version-info "$addon" 2>/dev/null | grep -q 'GLIBC_'; then
+            echo "::error::musl addon contains a GLIBC symbol requirement"
+            exit 1
+          fi
+
+      - name: Build glibc native addon for the host smoke test
+        run: |
+          # gnu only feeds the glibc-runner staged-bundle smoke test below;
+          # it never enters the Alpine image. The Alpine container wrote
+          # root-owned node_modules/target via the bind mount — hand them
+          # back to the runner user before the host npm ci.
+          sudo chown -R "$(id -u):$(id -g)" native
           cd native && npm ci && npm run build
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
-          rustup target add x86_64-unknown-linux-musl
-          npm run build:linux-x64-musl
           test -f codex-tls.linux-x64-gnu.node
           test -f codex-tls.linux-x64-musl.node
 
@@ -301,3 +328,42 @@ jobs:
           build-args: PROXY_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=lite
           cache-to: type=gha,mode=max,scope=lite
+
+      - name: Smoke test the pushed lite image
+        run: |
+          # Pull the exact image that was just pushed and test it as a user
+          # would run it. The host smoke test above uses the gnu addon on
+          # glibc and cannot catch a mislinked musl addon — that gap shipped
+          # the crash-loop in #805, so verify the real artifact here.
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY}:sha-${SHORT_SHA}-lite"
+          docker pull "$IMAGE"
+
+          # 1. The musl addon must dlopen under the image's own Node.
+          docker run --rm "$IMAGE" node -e \
+            "require('/app/native/codex-tls.linux-x64-musl.node'); console.log('musl addon loads under alpine node')"
+
+          # 2. Fresh named volumes: entrypoint must seed defaults, server must
+          #    start healthy inside the real image.
+          docker volume create lite-smoke-config >/dev/null
+          docker volume create lite-smoke-data >/dev/null
+          cid=$(docker run -d -p 18080:8080 \
+            -v lite-smoke-config:/app/config \
+            -v lite-smoke-data:/app/data \
+            "$IMAGE")
+          cleanup() {
+            docker rm -f "$cid" >/dev/null 2>&1 || true
+            docker volume rm lite-smoke-config lite-smoke-data >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          for i in $(seq 1 30); do
+            if curl --noproxy '*' --fail --silent http://127.0.0.1:18080/health >/dev/null; then
+              echo "pushed lite image is healthy"
+              docker logs "$cid" | grep -E "Using native \(rustls\)|API key pool" || true
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "pushed lite image did not become healthy"
+          docker logs "$cid"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ## [Unreleased]
 
-> 暂无已记录的变更。
+### Fixed
+
+- 修复 `latest-lite` 等 Alpine 镜像在 x86_64 上启动即崩溃（`Error loading shared library ld-linux-x86-64.so.2: No such file or directory`，#805）：镜像发布流水线此前在 glibc runner 上以 musl target 交叉编译 `codex-tls.linux-x64-musl.node`，aws-lc 等 C 依赖仍被链接到 glibc，产出名为 musl 实为 glibc 的二进制，在 Alpine 中无法加载。现改为在 `napi-rs/nodejs-rust:lts-alpine` 容器内原生构建（与 Lite zip / Release 流水线一致），并新增 readelf glibc 依赖断言与**对推送后真实镜像**的冒烟测试（镜像自带 Node 下 dlopen addon + 空卷启动 + `/health`）。（`.github/workflows/docker-publish.yml`）
 
 ## [v2.1.x](https://github.com/icebear0828/codex-proxy/releases?q=2.1) - 2026-09-01 至 2026-09-07
 


### PR DESCRIPTION
## Summary

Fixes #805. The `latest-lite` / `*-lite` images crash-loop on startup with

```
Error loading shared library ld-linux-x86-64.so.2: No such file or directory
(needed by /app/native/codex-tls.linux-x64-musl.node)
```

The file carried the musl name but was actually linked against glibc. The `publish-lite` job added in #800 built the addon on the **glibc** Ubuntu runner by installing the musl target (`apt install musl-tools` + `cargo build --target x86_64-unknown-linux-musl`). The target makes the Rust output musl, but the C dependencies pulled in through `aws-lc-sys` still resolve against the host glibc, so the result is a hybrid binary the Alpine image cannot load. The Debian `:latest` image builds the addon in its own multi-stage Dockerfile and was never affected.

## Changes

- Build the musl addon natively inside `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine`, with the musl-gcc / `AWS_LC_SYS_*` environment the other pipelines already use — the same approach `lite-ci.yml` and `release.yml` already take for the Lite zip. The docker-publish job had drifted from it by cross-compiling on the runner.
- Assert linkage with readelf: the job fails if the addon has a `NEEDED` `libc.so.6` / `ld-linux-x86-64.so.2` or any `VERNEED` GLIBC symbol.
- Build the gnu addon afterwards (first handing the container's root-owned bind-mount files back to the runner user) for the existing staged-bundle smoke test on the glibc host; it still never enters the image.
- After the buildx push, smoke-test the actual pushed image: pull `:sha-<sha>-lite`, `require()` the addon under the image's own Node, then start it with fresh named volumes and require `/health`. The old host smoke test loaded the **gnu** addon on glibc and never dlopened the musl file, so the mislinked binary passed CI.

The Debian `publish` job is untouched.

## Test plan

- [x] Reproduced #805 against the published `latest-lite`: requiring the addon under the image's Node fails with the exact `ld-linux-x86-64.so.2` error.
- [x] Rebuilt the addon with the new Alpine step locally: `readelf -d` now shows only `libgcc_s.so.1` and `libc.musl-x86_64.so.1`, no glibc reference.
- [x] Rebuilt the lite image from it: addon loads under the image's Node; fresh-volume start is healthy in about a second with `[TLS] Using native (rustls) transport`.
- [x] Real run with 23 API keys mounted: chat completion against `gpt-6-astra` returned the expected marker string.
- [x] Full fork run of the updated workflow — all steps green, including "Build musl native addon in Alpine", "Verify musl addon is not glibc-linked" and "Smoke test the pushed lite image". Pulled the resulting `sha-3b9a1d5-lite` from the fork registry: addon loads, no glibc loader string in the binary.
- [x] `tests/unit/ci/workflow-outputs.test.ts` passes (10/10).

## Notes

Users on the broken tag can either stay on the Debian `:latest` (same feature set) or, before this lands in a release, use the image built by the fixed pipeline on the fork: `ghcr.io/nieyuanhong/codex-proxy:sha-3b9a1d5-lite` (same content as this PR; switch back to the official tag after the release). Once the fix ships, repulling `latest-lite` is enough. I'll leave the same pointer on #805.

## Linked issues

Fixes #805.
