### PR TITLE
fix(pricing): resolve -max/-ultra tiers and bare gpt-6 naming for usage cost

### DIFF
--- a/config/model-pricing.yaml
+++ b/config/model-pricing.yaml
@@ -53,6 +53,10 @@ models:
     input_usd_per_million: 0.2
     cached_input_usd_per_million: 0.02
     output_usd_per_million: 1.2
+  gpt-6:
+    input_usd_per_million: 10
+    cached_input_usd_per_million: 1
+    output_usd_per_million: 50
   gpt-6-astra:
     input_usd_per_million: 10
     cached_input_usd_per_million: 1

--- a/src/auth/usage-pricing.ts
+++ b/src/auth/usage-pricing.ts
@@ -21,7 +21,7 @@ export interface ModelPricing {
 export type PricingCatalog = Readonly<Record<string, ModelPricing>>;
 
 const PRICE_FILE = "model-pricing.yaml";
-const MODEL_SUFFIX_PATTERN = /-(?:fast|flex|none|minimal|low|medium|high|xhigh)$/;
+const MODEL_SUFFIX_PATTERN = /-(?:fast|flex|max|ultra|none|minimal|low|medium|high|xhigh)$/;
 
 export function createPricingCatalog(entries: Record<string, ModelPricing>): PricingCatalog {
   const catalog: Record<string, ModelPricing> = {};

--- a/tests/unit/auth/usage-pricing.test.ts
+++ b/tests/unit/auth/usage-pricing.test.ts
@@ -35,6 +35,36 @@ describe("usage pricing", () => {
     expect(calculateUsageCostUsd("not-in-catalog", { input_tokens: 1_000_000, output_tokens: 1_000_000 }, catalog)).toBe(0);
   });
 
+  it("resolves -max and -ultra reasoning tiers to the base model pricing", () => {
+    const tierCatalog = createPricingCatalog({
+      "gpt-test": {
+        input_usd_per_million: 2,
+        cached_input_usd_per_million: 0.2,
+        output_usd_per_million: 8,
+      },
+    });
+    expect(calculateUsageCostUsd("gpt-test-max", { input_tokens: 1_000_000, output_tokens: 0 }, tierCatalog)).toBe(2);
+    expect(calculateUsageCostUsd("gpt-test-ultra", { input_tokens: 1_000_000, output_tokens: 0 }, tierCatalog)).toBe(2);
+  });
+
+  it("matches bare model names for custom upstream requests", () => {
+    const bareCatalog = createPricingCatalog({
+      "gpt-6": {
+        input_usd_per_million: 10,
+        cached_input_usd_per_million: 1,
+        output_usd_per_million: 50,
+      },
+      "gpt-6-astra": {
+        input_usd_per_million: 10,
+        cached_input_usd_per_million: 1,
+        output_usd_per_million: 50,
+      },
+    });
+    expect(calculateUsageCostUsd("gpt-6", { input_tokens: 1_000_000, output_tokens: 1_000_000 }, bareCatalog)).toBeCloseTo(60, 10);
+    expect(calculateUsageCostUsd("gpt-6-astra-max", { input_tokens: 1_000_000, output_tokens: 0 }, bareCatalog)).toBe(10);
+    expect(calculateUsageCostUsd("gpt-6-astra-ultra", { input_tokens: 1_000_000, output_tokens: 0 }, bareCatalog)).toBe(10);
+  });
+
   it("calculates image generation tokens using default image pricing when host model has no image pricing", () => {
     const multiCatalog = createPricingCatalog({
       "gpt-test": {


### PR DESCRIPTION
Closes #806. Fixes usage cost reported as \ for bare \gpt-6\ (via custom upstream/direct request) and for \-max\/\-ultra\ reasoning tiers (e.g. \gpt-6-astra-max\, \gpt-6-astra-ultra\).

## Changes
- config/model-pricing.yaml: add bare \gpt-6\ pricing entry.
- src/auth/usage-pricing.ts: extend MODEL_SUFFIX_PATTERN with \-max\ and \-ultra\.
- tests/unit/auth/usage-pricing.test.ts: add coverage for tier resolution and bare gpt-6 lookups.

## Test plan
- npx vitest run tests/unit/auth/usage-pricing.test.ts -> 8 passed.
- npx tsc --noEmit -> clean.